### PR TITLE
Create node.js.yml to start running CIs in the reop

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [15.x]
+        node-version: [14.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Trying to add a starter CI via github actions. Note that this will likely require a few iterations to get right but will push this in to ensure things trigger correctly.