### PR TITLE
feat(metro-config): replace scope for a test function

### DIFF
--- a/change/@rnx-kit-metro-config-21ff4967-60cb-4712-a9be-62f3c1b4abcb.json
+++ b/change/@rnx-kit-metro-config-21ff4967-60cb-4712-a9be-62f3c1b4abcb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Replace scope option for a test function",
+  "packageName": "@rnx-kit/metro-config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/metro-config/.npmignore
+++ b/packages/metro-config/.npmignore
@@ -1,4 +1,0 @@
-*.tgz
-coverage/
-test/
-tsconfig.json

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -2,16 +2,19 @@
   "name": "@rnx-kit/metro-config",
   "description": "Metro config for monorepos",
   "license": "MIT",
+  "files": [
+    "src/*"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",
     "directory": "packages/metro-config"
   },
-  "version": "0.0.1-dev",
+  "version": "1.0.0-alpha",
   "main": "src/index.js",
   "scripts": {
     "build": "tsc",
-    "format": "prettier --write src/*.js",
+    "format": "prettier --write src/*.js test/*.js",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/metro-config/test/index.test.js
+++ b/packages/metro-config/test/index.test.js
@@ -1,3 +1,6 @@
+// @ts-check
+"use strict";
+
 describe("@rnx-kit/metro-config", () => {
   const { spawnSync } = require("child_process");
   const path = require("path");
@@ -5,7 +8,7 @@ describe("@rnx-kit/metro-config", () => {
     defaultWatchFolders,
     exclusionList,
     makeBabelConfig,
-    makeMetroConfig
+    makeMetroConfig,
   } = require("../src");
 
   const babelConfigKeys = ["presets", "overrides"];
@@ -18,7 +21,7 @@ describe("@rnx-kit/metro-config", () => {
     "server",
     "symbolicator",
     "transformer",
-    "watchFolders"
+    "watchFolders",
   ];
 
   const currentWorkingDir = process.cwd();
@@ -58,12 +61,12 @@ describe("@rnx-kit/metro-config", () => {
     const repoRoot = path.dirname(path.dirname(process.cwd()));
     const folders = defaultWatchFolders(process.cwd());
 
-    const packages = ["conan", "dutch", "john", "quaid", "t-800"].map(p =>
+    const packages = ["conan", "dutch", "john", "quaid", "t-800"].map((p) =>
       path.join(repoRoot, "packages", p)
     );
     const expectedFolders = [
       path.join(repoRoot, "node_modules"),
-      ...packages
+      ...packages,
     ].sort();
     expect(folders.sort()).toEqual(expectedFolders);
   });
@@ -88,7 +91,7 @@ describe("@rnx-kit/metro-config", () => {
 
   test("makeBabelConfig() returns a Babel config with additional plugins", () => {
     const config = makeBabelConfig([
-      "../src/babel-plugin-import-path-remapper.js"
+      "src/babel-plugin-import-path-remapper.js",
     ]);
     expect(Object.keys(config)).toEqual(babelConfigKeys);
     expect(config.presets).toEqual(babelConfigPresets);
@@ -96,7 +99,7 @@ describe("@rnx-kit/metro-config", () => {
     expect(config.overrides[0].test.source).toBe(babelTypeScriptTest);
     expect(config.overrides[0].plugins).toEqual([
       "const-enum",
-      "../src/babel-plugin-import-path-remapper.js"
+      "src/babel-plugin-import-path-remapper.js",
     ]);
   });
 
@@ -111,7 +114,7 @@ describe("@rnx-kit/metro-config", () => {
     const transformerOptions = await config.transformer.getTransformOptions();
     expect(transformerOptions.transform).toEqual({
       experimentalImportSupport: false,
-      inlineRequires: false
+      inlineRequires: false,
     });
 
     expect(config.watchFolders.length).toBeGreaterThan(0);
@@ -120,7 +123,7 @@ describe("@rnx-kit/metro-config", () => {
   test("makeMetroConfig() merges Metro configs", async () => {
     const config = makeMetroConfig({
       projectRoot: __dirname,
-      resetCache: true
+      resetCache: true,
     });
 
     expect(Object.keys(config).sort()).toEqual(
@@ -137,7 +140,7 @@ describe("@rnx-kit/metro-config", () => {
     const transformerOptions = await config.transformer.getTransformOptions();
     expect(transformerOptions.transform).toEqual({
       experimentalImportSupport: false,
-      inlineRequires: false
+      inlineRequires: false,
     });
 
     expect(config.watchFolders.length).toBeGreaterThan(0);
@@ -150,11 +153,13 @@ describe("@rnx-kit/metro-config", () => {
         /[.\d]+k?B\s+([^\s]*)/g
       )
     );
-    expect(files.sort()).toEqual([
+    expect(
+      files.filter((file) => !file.startsWith("CHANGELOG")).sort()
+    ).toEqual([
       "README.md",
       "package.json",
       "src/babel-plugin-import-path-remapper.js",
-      "src/index.js"
+      "src/index.js",
     ]);
   });
 });


### PR DESCRIPTION
Replaces the `scope` option for a more generic test function.

```
% yarn test --coverage
yarn run v1.22.10
$ jest --coverage
 PASS  test/babel-plugin-import-path-remapper.test.js
 PASS  test/index.test.js
--------------------------------------|---------|----------|---------|---------|--------------------------
File                                  | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s        
--------------------------------------|---------|----------|---------|---------|--------------------------
All files                             |   83.12 |    82.98 |     100 |   82.89 |                          
 babel-plugin-import-path-remapper.js |      75 |    79.41 |     100 |      75 | 33-46,87,132-133,160-161 
 index.js                             |     100 |    92.31 |     100 |     100 | 44                       
--------------------------------------|---------|----------|---------|---------|--------------------------

Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        1.952 s, estimated 2 s
Ran all test suites.
✨  Done in 2.69s.
```