### PR TITLE
fix(metro-config): ignore hoisted react-native if a local copy exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 lib/
 local.properties
 node_modules/
+!**/__fixtures__/**/node_modules/

--- a/change/@rnx-kit-metro-config-c86ab028-d4b3-4c50-b422-a7869d681673.json
+++ b/change/@rnx-kit-metro-config-c86ab028-d4b3-4c50-b422-a7869d681673.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ignore hoisted react-native if a local copy exists",
+  "packageName": "@rnx-kit/metro-config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -18,9 +18,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "@babel/core": "^7.0.0",
-    "@babel/helper-plugin-utils": "^7.0.0",
-    "@babel/types": "^7.0.0",
     "babel-plugin-const-enum": "^1.0.0",
     "fast-glob": "^3.2.2",
     "find-up": "^4.1.0"
@@ -30,7 +27,6 @@
   },
   "devDependencies": {
     "@types/babel__core": "^7.0.0",
-    "@types/babel__helper-plugin-utils": "^7.0.0",
     "@types/jest": "^26.0.0",
     "jest": "^26.0.0",
     "metro-config": "^0.59.0",

--- a/packages/metro-config/test/__fixtures__/awesome-repo/node_modules/react-native/package.json
+++ b/packages/metro-config/test/__fixtures__/awesome-repo/node_modules/react-native/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "react-native",
+  "version": "1000.0.0",
+  "description": "A framework for building native apps using React",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:facebook/react-native.git"
+  }
+}

--- a/packages/metro-config/test/__fixtures__/awesome-repo/packages/john/node_modules/react-native/package.json
+++ b/packages/metro-config/test/__fixtures__/awesome-repo/packages/john/node_modules/react-native/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "react-native",
+  "version": "1000.0.0",
+  "description": "A framework for building native apps using React",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:facebook/react-native.git"
+  }
+}


### PR DESCRIPTION
```
$ jest --coverage
 PASS  test/index.test.js
  @rnx-kit/metro-config
    ✓ defaultWatchFolders() returns an empty list outside a monorepo (2 ms)
    ✓ defaultWatchFolders() returns packages in a monorepo (38 ms)
    ✓ exclusionList() ignores hoisted react-native if a local copy exists (2 ms)
    ✓ exclusionList() returns additional exclusions (1 ms)
    ✓ makeBabelConfig() returns default Babel config (1 ms)
    ✓ makeBabelConfig() returns a Babel config with additional plugins (1 ms)
    ✓ makeMetroConfig() returns a default Metro config (299 ms)
    ✓ makeMetroConfig() merges Metro configs (3 ms)
    ✓ packs only necessary files (440 ms)

----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |     100 |    93.33 |     100 |     100 |                   
 index.js |     100 |    93.33 |     100 |     100 | 44                
----------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        1.827 s, estimated 2 s
Ran all test suites.
✨  Done in 2.55s.
```

Resolves  #46.