### PR TITLE
chore: align on build tools

### DIFF
--- a/change/@rnx-kit-babel-plugin-import-path-remapper-8efd54b4-976b-409f-b04d-5f8950266d85.json
+++ b/change/@rnx-kit-babel-plugin-import-path-remapper-8efd54b4-976b-409f-b04d-5f8950266d85.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Align on build tools",
+  "packageName": "@rnx-kit/babel-plugin-import-path-remapper",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-config-752eb3d8-947b-428d-b5b0-004e9f62958f.json
+++ b/change/@rnx-kit-metro-config-752eb3d8-947b-428d-b5b0-004e9f62958f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Align on build tools",
+  "packageName": "@rnx-kit/metro-config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/babel-plugin-import-path-remapper/just.config.js
+++ b/packages/babel-plugin-import-path-remapper/just.config.js
@@ -1,0 +1,2 @@
+const { configureJust } = require("rnx-kit-scripts");
+configureJust();

--- a/packages/babel-plugin-import-path-remapper/package.json
+++ b/packages/babel-plugin-import-path-remapper/package.json
@@ -13,9 +13,9 @@
   "version": "1.0.0",
   "main": "src/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "rnx-kit-scripts build",
     "format": "prettier --write src/*.js test/*.js",
-    "test": "jest"
+    "test": "rnx-kit-scripts test"
   },
   "dependencies": {
     "@babel/core": "^7.0.0",
@@ -28,6 +28,7 @@
     "@types/jest": "^26.0.0",
     "jest": "^26.0.0",
     "prettier": "^2.0.0",
+    "rnx-kit-scripts": "*",
     "typescript": "^4.0.0"
   },
   "jest": {

--- a/packages/babel-plugin-import-path-remapper/tsconfig.json
+++ b/packages/babel-plugin-import-path-remapper/tsconfig.json
@@ -1,15 +1,13 @@
 {
+  "extends": "rnx-kit-scripts/tsconfig.json",
   "compilerOptions": {
-    "target": "ESNext",
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,
-    "strict": true,
-    "moduleResolution": "Node",
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "noUnusedLocals": true,
-    "resolveJsonModule": true
+    "strictBindCallApply": true,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/*.js"]
+  "include": ["src"]
 }

--- a/packages/metro-config/just.config.js
+++ b/packages/metro-config/just.config.js
@@ -1,0 +1,2 @@
+const { configureJust } = require("rnx-kit-scripts");
+configureJust();

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -13,9 +13,9 @@
   "version": "1.0.2",
   "main": "src/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "rnx-kit-scripts build",
     "format": "prettier --write src/*.js test/*.js",
-    "test": "jest"
+    "test": "rnx-kit-scripts test"
   },
   "dependencies": {
     "babel-plugin-const-enum": "^1.0.0",
@@ -31,6 +31,7 @@
     "jest": "^26.0.0",
     "metro-config": "^0.59.0",
     "prettier": "^2.0.0",
+    "rnx-kit-scripts": "*",
     "typescript": "^4.0.0"
   },
   "jest": {

--- a/packages/metro-config/test/index.test.js
+++ b/packages/metro-config/test/index.test.js
@@ -79,17 +79,22 @@ describe("@rnx-kit/metro-config", () => {
     const fixtureCopy = "..\\/..\\/node_modules\\/react-native\\/.*";
 
     // /rnx-kit/node_modules/react-native
-    const repoCopy = "..\\/..\\/..\\/..\\/..\\/..\\/..\\/node_modules\\/react-native\\/.*";
+    const repoCopy =
+      "..\\/..\\/..\\/..\\/..\\/..\\/..\\/node_modules\\/react-native\\/.*";
 
     // Conan does not have a local copy of react-native but since we're
     // in a monorepo, we'll find the repo's copy.
     setFixture("awesome-repo/packages/conan");
-    expect(exclusionList().source).toBe(`(${repoCopy}|${defaultExclusionList})$`);
+    expect(exclusionList().source).toBe(
+      `(${repoCopy}|${defaultExclusionList})$`
+    );
 
     // John has a local copy of react-native and should ignore the
     // hoisted copy (in addition to the repo's own copy).
     setFixture("awesome-repo/packages/john");
-    expect(exclusionList().source).toBe(`(${fixtureCopy}|${repoCopy}|${defaultExclusionList})$`);
+    expect(exclusionList().source).toBe(
+      `(${fixtureCopy}|${repoCopy}|${defaultExclusionList})$`
+    );
   });
 
   test("exclusionList() returns additional exclusions", () => {

--- a/packages/metro-config/tsconfig.json
+++ b/packages/metro-config/tsconfig.json
@@ -1,15 +1,13 @@
 {
+  "extends": "rnx-kit-scripts/tsconfig.json",
   "compilerOptions": {
-    "target": "ESNext",
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,
-    "strict": true,
-    "moduleResolution": "Node",
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "noUnusedLocals": true,
-    "resolveJsonModule": true
+    "strictBindCallApply": true,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/*.js"]
+  "include": ["src"]
 }


### PR DESCRIPTION
Aligns build tools for `babel-plugin-import-path-remapper` and
`metro-config`.

Resolves #51.