### PR TITLE
fix(metro-config): sibling packages resolve wrong react-native

### DIFF
--- a/change/@rnx-kit-metro-config-e1ae885c-4e30-4755-b176-1456fd27f5d3.json
+++ b/change/@rnx-kit-metro-config-e1ae885c-4e30-4755-b176-1456fd27f5d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix sibling packages resolving to wrong react-native copy",
+  "packageName": "@rnx-kit/metro-config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/metro-config/test/__fixtures__/awesome-repo/node_modules/react/package.json
+++ b/packages/metro-config/test/__fixtures__/awesome-repo/node_modules/react/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "react",
+  "version": "17.0.2",
+  "description": "React is a JavaScript library for building user interfaces.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/react.git",
+    "directory": "packages/react"
+  }
+}

--- a/packages/metro-config/tsconfig.json
+++ b/packages/metro-config/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
Addresses the scenario where a package with a local copy of `react-native` imports another package that doesn't, but also depends on `react-native`:

```
workspace
├── node_modules
│   └── react-native@0.62.2  <-- should be ignored
└── packages
    ├── my-awesome-package
    │   └── node_modules
    │       └── react-native@0.61.5  <-- should take precedence
    └── another-awesome-package  <-- imported by my-awesome-package,
                                     but uses workspace's react-native
```

Tests:
```
 PASS  test/index.test.js
  @rnx-kit/metro-config
    ✓ defaultWatchFolders() returns an empty list outside a monorepo (6 ms)
    ✓ defaultWatchFolders() returns packages in a monorepo (36 ms)
    ✓ excludeExtraCopiesOf() throws if a package is not found (4 ms)
    ✓ exclusionList() ignores extra copies of react and react-native (4 ms)
    ✓ exclusionList() returns additional exclusions (2 ms)
    ✓ makeBabelConfig() returns default Babel config (1 ms)
    ✓ makeBabelConfig() returns a Babel config with additional plugins
    ✓ makeMetroConfig() returns a default Metro config (284 ms)
    ✓ makeMetroConfig() merges Metro configs (4 ms)
    ✓ makeMetroConfig() merges `extraNodeModules` (1 ms)
    ✓ packs only necessary files (416 ms)

----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |     100 |    91.67 |     100 |     100 |                   
 index.js |     100 |    91.67 |     100 |     100 | 48,235            
----------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        1.74 s, estimated 2 s
Ran all test suites.
✨  Done in 2.40s.
```