### PR TITLE
fix(metro-config): exclusion rules should ignore symlinks

### DIFF
--- a/change/@rnx-kit-metro-config-b8abf3b4-6969-4022-9c72-9cc599f2cf9e.json
+++ b/change/@rnx-kit-metro-config-b8abf3b4-6969-4022-9c72-9cc599f2cf9e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Exclusion rules should ignore symlinks",
+  "packageName": "@rnx-kit/metro-config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/metro-config/README.md
+++ b/packages/metro-config/README.md
@@ -181,8 +181,8 @@ detects one by opening `localhost:8081` and checking for some keywords like
 will then think that it's not dealing with a React Native app and disable all
 related plugins.
 
-The fix is to move `index.html` elsewhere, but if you cannot do that, you
-can work around this issue by filtering out the offending packages in
+The fix is to move `index.html` elsewhere, but if you cannot do that, you can
+work around this issue by filtering out the offending packages in
 `metro.config.js`:
 
 ```js

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -76,20 +76,24 @@ function defaultWatchFolders(projectRoot) {
 
 /**
  * Returns the path to specified module; `undefined` if not found.
+ *
+ * Note that this function ignores symlinks. When creating rules to
+ * exclude extra copies, Metro will be unable to resolve packages
+ * because it doesn't resolve symlinks and all real paths are excluded.
+ *
  * @param {string} name
- * @param {string} projectRoot
+ * @param {string=} projectRoot
  * @returns {string | undefined}
  */
 function resolveModule(name, projectRoot) {
   const findUp = require("find-up");
   const path = require("path");
 
-  const result = findUp.sync(path.join("node_modules", name, "package.json"), {
+  return findUp.sync(path.join("node_modules", name), {
     cwd: projectRoot,
+    type: "directory",
+    allowSymlinks: false,
   });
-
-  // Strip `/package.json` from path before returning:
-  return result && path.dirname(result);
 }
 
 /**
@@ -103,7 +107,7 @@ function resolveModule(name, projectRoot) {
  * @see exclusionList for further information.
  *
  * @param {string} packageName
- * @param {string} projectRoot
+ * @param {string=} projectRoot
  * @returns {RegExp}
  */
 function excludeExtraCopiesOf(packageName, projectRoot) {

--- a/packages/metro-config/test/__fixtures__/awesome-repo/node_modules/react-native/package.json
+++ b/packages/metro-config/test/__fixtures__/awesome-repo/node_modules/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native",
   "version": "1000.0.0",
-  "description": "A framework for building native apps using React ",
+  "description": "A framework for building native apps using React",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/metro-config/test/__fixtures__/awesome-repo/packages/t-800/node_modules/react-native
+++ b/packages/metro-config/test/__fixtures__/awesome-repo/packages/t-800/node_modules/react-native
@@ -1,0 +1,1 @@
+../../../node_modules/react-native

--- a/packages/metro-config/test/index.test.js
+++ b/packages/metro-config/test/index.test.js
@@ -3,6 +3,7 @@
 
 describe("@rnx-kit/metro-config", () => {
   const { spawnSync } = require("child_process");
+  const fs = require("fs");
   const path = require("path");
   const {
     UNIQUE_PACKAGES,
@@ -82,6 +83,21 @@ describe("@rnx-kit/metro-config", () => {
       ...packages,
     ].sort();
     expect(folders.sort()).toEqual(expectedFolders);
+  });
+
+  test("excludeExtraCopiesOf() ignores symlinks", () => {
+    setFixture("awesome-repo/packages/t-800");
+
+    expect(
+      fs.lstatSync("node_modules/react-native").isSymbolicLink()
+    ).toBeTruthy();
+
+    const expr = excludeExtraCopiesOf("react-native");
+    expect(
+      expr.source.endsWith(
+        "\\/awesome-repo)\\/node_modules\\/react-native\\/.*"
+      )
+    ).toBeTruthy();
   });
 
   test("excludeExtraCopiesOf() throws if a package is not found", () => {


### PR DESCRIPTION
When a repo uses symlinks, all but the symlink are blocked. Since Metro doesn't resolve symlinks, it will fail to resolve the real package.