### PR TITLE
chore: bump lage and reduce console noise

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 15.x
-      - name: Install Yarn
-        run: npm install -g yarn
       - name: Cache /.yarn-offline-mirror
         uses: actions/cache@v2
         with:
@@ -33,8 +31,8 @@ jobs:
       - name: Install package dependencies
         run: yarn ci
       - name: Build and test packages
-        run: yarn buildci
+        run: yarn build:ci
       - name: Bundle packages
-        run: yarn bundle
+        run: yarn bundle:ci
       - name: Publish
         run: yarn run publish:beachball --yes --token ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Check for change files
         run: yarn run check
       - name: Build and test packages
-        run: yarn buildci
+        run: yarn build:ci
       - name: Bundle packages
-        run: yarn bundle
+        run: yarn bundle:ci

--- a/package.json
+++ b/package.json
@@ -12,17 +12,18 @@
     "url": "https://github.com/Microsoft/rnx-kit.git"
   },
   "scripts": {
-    "build": "lage build --verbose --grouped",
-    "buildci": "lage buildci --verbose --grouped",
-    "build-tools": "lage build-tools --verbose --grouped",
+    "build": "lage build --grouped",
+    "build:ci": "lage build:ci --verbose --grouped",
+    "build-tools": "lage build-tools --log-level warn --grouped",
     "bump-versions": "beachball bump",
-    "bundle": "lage bundle --verbose --grouped",
+    "bundle": "lage bundle --grouped",
+    "bundle:ci": "lage bundle --verbose --grouped",
     "change": "beachball change",
     "check": "beachball check --branch origin/main --changehint \"Run 'yarn run change' from root of repo to generate a change file.\"",
     "ci": "yarn --cache-folder .yarn-offline-mirror --prefer-offline --frozen-lockfile --non-interactive",
-    "clean": "lage clean --verbose --grouped",
-    "depcheck": "lage depcheck --verbose --grouped",
-    "lint": "lage lint --verbose --grouped",
+    "clean": "lage clean --log-level warn --grouped",
+    "depcheck": "lage depcheck --log-level warn --grouped",
+    "lint": "lage lint --log-level warn --grouped",
     "preinstall": "node ./scripts/preinstall.js",
     "postinstall": "node ./scripts/postinstall.js",
     "publish:beachball": "beachball publish --bump-deps -m\"📦 applying package updates ***NO_CI***\"",
@@ -30,7 +31,7 @@
   },
   "devDependencies": {
     "beachball": "^1.53.1",
-    "lage": "^0.27.0"
+    "lage": "^0.29.0"
   },
   "workspaces": {
     "packages": [
@@ -48,7 +49,7 @@
         "build-tools",
         "^build"
       ],
-      "buildci": [
+      "build:ci": [
         "build",
         "test"
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5863,10 +5863,10 @@ kleur@^3.0.2, kleur@^3.0.3:
   resolved "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-lage@^0.27.0:
-  version "0.27.1"
-  resolved "https://registry.npmjs.org/lage/-/lage-0.27.1.tgz#c8e26c5b86d8930dc7ac311b9273ca496773c9e5"
-  integrity sha512-hOqFVIzE2WW7+EkeEf2XO3I+DGX1KzFOrv0beoxgUTXnp+iwmVDOf/7i1UpU81HVLa6xg2SLDN/aIVLlgKaGBA==
+lage@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/lage/-/lage-0.29.0.tgz#60820354be3abc8cf8ec5fb62eb0fbc23113c154"
+  integrity sha512-ePx6Hh3+q5nYrvO1FXrXKbr17j9ip4NioFDf2lJqXCA07ENz8CIpynI6WEaSOY3jfqyJfI25FQczGF7OtLFewg==
   dependencies:
     "@microsoft/task-scheduler" "^2.7.0"
     abort-controller "^3.0.0"


### PR DESCRIPTION
The verbose output from lage makes it difficult to spot actual warning and error messages.