### PR TITLE
fix(metro-config): extract Babel config as preset

### DIFF
--- a/change/@rnx-kit-babel-preset-metro-react-native-22371671-cb60-47a0-8cad-ea28c1d658a7.json
+++ b/change/@rnx-kit-babel-preset-metro-react-native-22371671-cb60-47a0-8cad-ea28c1d658a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Introduce Babel preset for React Native applications",
+  "packageName": "@rnx-kit/babel-preset-metro-react-native",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-preset-metro-react-native/README.md
+++ b/packages/babel-preset-metro-react-native/README.md
@@ -1,0 +1,30 @@
+# @rnx-kit/babel-preset-metro-react-native
+
+`@rnx-kit/babel-preset-metro-react-native` provides a Babel preset for React
+Native applications that you can use as a drop-in replacement for
+[`metro-react-native-babel-preset`](https://github.com/facebook/metro/tree/master/packages/metro-react-native-babel-preset)).
+
+## Usage
+
+Add `@rnx-kit/babel-preset-metro-react-native` to your `babel.config.js`:
+
+```js
+module.exports = {
+  preset: ["@rnx-kit/babel-preset-metro-react-native"],
+};
+```
+
+If you want to add additional plugins, you can pass an options object:
+
+```js
+module.exports = {
+  preset: [
+    [
+      "@rnx-kit/babel-preset-metro-react-native",
+      {
+        additionalPlugins: ["const-enum"],
+      },
+    ],
+  ],
+};
+```

--- a/packages/babel-preset-metro-react-native/just.config.js
+++ b/packages/babel-preset-metro-react-native/just.config.js
@@ -1,0 +1,2 @@
+const { configureJust } = require("rnx-kit-scripts");
+configureJust();

--- a/packages/babel-preset-metro-react-native/package.json
+++ b/packages/babel-preset-metro-react-native/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@rnx-kit/babel-preset-metro-react-native",
+  "version": "1.0.0-alpha",
+  "description": "Babel preset for React Native applications",
+  "homepage": "https://github.com/microsoft/rnx-kit/tree/main/packages/babel-preset-metro-react-native#rnx-kitbabel-preset-metro-react-native",
+  "license": "MIT",
+  "files": [
+    "src/*"
+  ],
+  "main": "src/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/rnx-kit",
+    "directory": "packages/babel-preset-metro-react-native"
+  },
+  "scripts": {
+    "build": "rnx-kit-scripts build",
+    "format": "prettier --write src/*.js test/*.js",
+    "test": "rnx-kit-scripts test"
+  },
+  "dependencies": {
+    "babel-plugin-const-enum": "^1.0.0"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0",
+    "metro-react-native-babel-preset": "*"
+  },
+  "devDependencies": {
+    "@types/babel__core": "^7.0.0",
+    "@types/jest": "^26.0.0",
+    "prettier": "^2.0.0",
+    "rnx-kit-scripts": "*",
+    "typescript": "^4.0.0"
+  },
+  "jest": {
+    "roots": [
+      "test"
+    ],
+    "testRegex": "/test/.*\\.test\\.js$"
+  }
+}

--- a/packages/babel-preset-metro-react-native/src/index.js
+++ b/packages/babel-preset-metro-react-native/src/index.js
@@ -1,0 +1,32 @@
+/* jshint esversion: 8, node: true */
+// @ts-check
+"use strict";
+
+/**
+ * @typedef {import("@babel/core").ConfigAPI} ConfigAPI
+ * @typedef {import("@babel/core").PluginItem} PluginItem
+ * @typedef {import("@babel/core").TransformOptions} TransformOptions
+ * @typedef {{ additionalPlugins?: PluginItem[]; }} PresetOptions
+ */
+
+/** @type {(api?: ConfigAPI, opts?: PresetOptions) => TransformOptions} */
+module.exports = (_, opts = {}) => {
+  return {
+    presets: ["module:metro-react-native-babel-preset"],
+    overrides: [
+      {
+        test: /\.tsx?$/,
+        plugins: [
+          // @babel/plugin-transform-typescript doesn't support `const enum`s.
+          // See https://babeljs.io/docs/en/babel-plugin-transform-typescript#caveats
+          // for more details.
+          "const-enum",
+
+          ...(Array.isArray(opts.additionalPlugins)
+            ? opts.additionalPlugins
+            : []),
+        ],
+      },
+    ],
+  };
+};

--- a/packages/babel-preset-metro-react-native/test/index.test.js
+++ b/packages/babel-preset-metro-react-native/test/index.test.js
@@ -1,0 +1,36 @@
+// @ts-check
+"use strict";
+
+describe("@rnx-kit/babel-preset-metro-react-native", () => {
+  const preset = require("../src/index");
+
+  test("returns default Babel preset with one additional TypeScript plugin", () => {
+    expect(preset(undefined)).toEqual({
+      presets: ["module:metro-react-native-babel-preset"],
+      overrides: [
+        {
+          test: /\.tsx?$/,
+          plugins: ["const-enum"],
+        },
+      ],
+    });
+  });
+
+  test("returns preset with additional TypeScript plugins", () => {
+    const opts = {
+      additionalPlugins: [
+        "my-extra-plugin",
+        ["additional-plugin", { options: {} }],
+      ],
+    };
+    expect(preset(undefined, opts)).toEqual({
+      presets: ["module:metro-react-native-babel-preset"],
+      overrides: [
+        {
+          test: /\.tsx?$/,
+          plugins: ["const-enum", ...opts.additionalPlugins],
+        },
+      ],
+    });
+  });
+});

--- a/packages/babel-preset-metro-react-native/tsconfig.json
+++ b/packages/babel-preset-metro-react-native/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "rnx-kit-scripts/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
`makeBabelConfig()` doesn't make much sense in `@rnx-kit/metro-config`. Extracting it and making it a Babel preset to be more idiomatic.

This change only introduces the package. We will remove `makeBabelConfig()` in a separate PR.