### PR TITLE
fix(metro-config): deprecate makeBabelConfig()

### DIFF
--- a/change/@rnx-kit-babel-plugin-import-path-remapper-a077ffe0-cdd0-40e5-a526-2579ab8f0f35.json
+++ b/change/@rnx-kit-babel-plugin-import-path-remapper-a077ffe0-cdd0-40e5-a526-2579ab8f0f35.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Cosmetical changes to package.json",
+  "packageName": "@rnx-kit/babel-plugin-import-path-remapper",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-config-4386121a-54eb-44a2-9e80-d570ce089fd7.json
+++ b/change/@rnx-kit-metro-config-4386121a-54eb-44a2-9e80-d570ce089fd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Removes makeBabelConfig() for @rnx-kit/babel-preset-metro-react-native",
+  "packageName": "@rnx-kit/metro-config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-plugin-import-path-remapper/package.json
+++ b/packages/babel-plugin-import-path-remapper/package.json
@@ -1,17 +1,18 @@
 {
   "name": "@rnx-kit/babel-plugin-import-path-remapper",
+  "version": "1.0.0",
   "description": "Babel plugin for remapping 'lib/' imports to 'src/'",
+  "homepage": "https://github.com/microsoft/rnx-kit/tree/main/packages/babel-plugin-import-path-remapper#rnx-kitbabel-plugin-import-path-remapper",
   "license": "MIT",
   "files": [
-    "src/*.js"
+    "src/*"
   ],
+  "main": "src/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",
     "directory": "packages/babel-plugin-import-path-remapper"
   },
-  "version": "1.0.0",
-  "main": "src/index.js",
   "scripts": {
     "build": "rnx-kit-scripts build",
     "format": "prettier --write src/*.js test/*.js",

--- a/packages/metro-config/README.md
+++ b/packages/metro-config/README.md
@@ -10,8 +10,9 @@ First, we need to add two files to the target package, `babel.config.js` and
 
 ```js
 // babel.config.js
-const { makeBabelConfig } = require("@rnx-kit/metro-config");
-module.exports = makeBabelConfig();
+module.exports = {
+  preset: ["@rnx-kit/babel-preset-metro-react-native"],
+};
 ```
 
 ```js
@@ -20,7 +21,6 @@ const { makeMetroConfig } = require("@rnx-kit/metro-config");
 
 module.exports = makeMetroConfig({
   projectRoot: __dirname,
-  resetCache: true, // optional, but circumvents stale cache issues
 });
 ```
 

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -1,24 +1,25 @@
 {
   "name": "@rnx-kit/metro-config",
+  "version": "1.0.4",
   "description": "Metro config for monorepos",
+  "homepage": "https://github.com/microsoft/rnx-kit/tree/main/packages/metro-config#rnx-kitmetro-config",
   "license": "MIT",
   "files": [
     "src/*"
   ],
+  "main": "src/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",
     "directory": "packages/metro-config"
   },
-  "version": "1.0.4",
-  "main": "src/index.js",
   "scripts": {
     "build": "rnx-kit-scripts build",
     "format": "prettier --write src/*.js test/*.js",
     "test": "rnx-kit-scripts test"
   },
   "dependencies": {
-    "babel-plugin-const-enum": "^1.0.0",
+    "@rnx-kit/babel-preset-metro-react-native": "^1.0.0",
     "fast-glob": "^3.2.2",
     "find-up": "^4.1.0"
   },

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -182,30 +182,6 @@ module.exports = {
   exclusionList,
 
   /**
-   * Helper function for configuring Babel.
-   * @param {string[]=} additionalPlugins
-   * @returns {import("@babel/core").TransformOptions}
-   */
-  makeBabelConfig: (additionalPlugins = []) => {
-    return {
-      presets: ["module:metro-react-native-babel-preset"],
-      overrides: [
-        {
-          test: /\.tsx?$/,
-          plugins: [
-            // @babel/plugin-transform-typescript doesn't support `const enum`s.
-            // See https://babeljs.io/docs/en/babel-plugin-transform-typescript#caveats
-            // for more details.
-            "const-enum",
-
-            ...additionalPlugins,
-          ],
-        },
-      ],
-    };
-  },
-
-  /**
    * Helper function for configuring Metro.
    * @param {MetroConfig=} customConfig
    * @returns {MetroConfig}

--- a/packages/metro-config/test/index.test.js
+++ b/packages/metro-config/test/index.test.js
@@ -10,16 +10,11 @@ describe("@rnx-kit/metro-config", () => {
     defaultWatchFolders,
     excludeExtraCopiesOf,
     exclusionList,
-    makeBabelConfig,
     makeMetroConfig,
   } = require("../src/index");
 
   const defaultExclusionList =
     ".*\\.ProjectImports\\.zip|node_modules\\/react\\/dist\\/.*|website\\/node_modules\\/.*|heapCapture\\/bundle\\.js|.*\\/__tests__\\/.*";
-
-  const babelConfigKeys = ["presets", "overrides"];
-  const babelConfigPresets = ["module:metro-react-native-babel-preset"];
-  const babelTypeScriptTest = "\\.tsx?$";
 
   const metroConfigKeys = [
     "resolver",
@@ -152,49 +147,6 @@ describe("@rnx-kit/metro-config", () => {
     expect(exclusionList([/.*[\/\\]__fixtures__[\/\\].*/]).source).toBe(
       `(${react}|${reactNative}|.*\\.ProjectImports\\.zip|.*[\\/\\\\]__fixtures__[\\/\\\\].*|node_modules\\/react\\/dist\\/.*|website\\/node_modules\\/.*|heapCapture\\/bundle\\.js|.*\\/__tests__\\/.*)$`
     );
-  });
-
-  test("makeBabelConfig() returns default Babel config", () => {
-    const config = makeBabelConfig();
-    expect(Object.keys(config)).toEqual(babelConfigKeys);
-    expect(config.presets).toEqual(babelConfigPresets);
-
-    if (!Array.isArray(config.overrides)) {
-      fail("Expected `config.overrides` to be an array");
-    }
-
-    expect(config.overrides.length).toBe(1);
-
-    if (!(config.overrides[0].test instanceof RegExp)) {
-      fail("Expected `config.overrides[0]` to be a RegExp");
-    }
-
-    expect(config.overrides[0].test.source).toBe(babelTypeScriptTest);
-    expect(config.overrides[0].plugins).toEqual(["const-enum"]);
-  });
-
-  test("makeBabelConfig() returns a Babel config with additional plugins", () => {
-    const config = makeBabelConfig([
-      "src/babel-plugin-import-path-remapper.js",
-    ]);
-    expect(Object.keys(config)).toEqual(babelConfigKeys);
-    expect(config.presets).toEqual(babelConfigPresets);
-
-    if (!Array.isArray(config.overrides)) {
-      fail("Expected `config.overrides` to be an array");
-    }
-
-    expect(config.overrides.length).toBe(1);
-
-    if (!(config.overrides[0].test instanceof RegExp)) {
-      fail("Expected `config.overrides[0]` to be a RegExp");
-    }
-
-    expect(config.overrides[0].test.source).toBe(babelTypeScriptTest);
-    expect(config.overrides[0].plugins).toEqual([
-      "const-enum",
-      "src/babel-plugin-import-path-remapper.js",
-    ]);
   });
 
   test("makeMetroConfig() returns a default Metro config", async () => {

--- a/packages/test-app/babel.config.js
+++ b/packages/test-app/babel.config.js
@@ -1,2 +1,3 @@
-const { makeBabelConfig } = require("@rnx-kit/metro-config");
-module.exports = makeBabelConfig();
+module.exports = {
+  preset: ["@rnx-kit/babel-preset-metro-react-native"],
+};

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -28,6 +28,7 @@
     "@babel/core": "^7.6.2",
     "@babel/runtime": "^7.6.2",
     "@react-native-community/eslint-config": "^0.0.5",
+    "@rnx-kit/babel-preset-metro-react-native": "*",
     "@rnx-kit/cli": "*",
     "@rnx-kit/metro-config": "*",
     "@types/react": "^17.0.2",


### PR DESCRIPTION
Removes `makeBabelConfig()` for `@rnx-kit/babel-preset-metro-react-native`.

Follow-up to #75.