### PR TITLE
Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "05:00"
+      timezone: "America/Los_Angeles"
+    versioning-strategy: "lockfile-only"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+      timezone: "America/Los_Angeles"


### PR DESCRIPTION
Add a dependabot configuration to keep dependency versions up to date, as well as Github Action script versions.

Dependency updates will be limited to what is in the lock file. Further, dependabot will only choose newer versions that fall within the semver spec originating from the associated package.json file(s).

Fixes #67.