### PR TITLE
fix(cli): exit with code if an error was encountered

### DIFF
--- a/change/@rnx-kit-cli-f5f5e391-7b0d-4f21-8917-e609c2d15cc7.json
+++ b/change/@rnx-kit-cli-f5f5e391-7b0d-4f21-8917-e609c2d15cc7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Exit with code if an error was encountered",
+  "packageName": "@rnx-kit/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/metro.ts
+++ b/packages/cli/src/metro.ts
@@ -75,7 +75,10 @@ export interface MetroStartOptions {
 function yarnSync(args: string[]): void {
   const yarnCommand = os.platform() === "win32" ? "yarn.cmd" : "yarn";
   const spawnOptions = { cwd: process.cwd(), stdio: "inherit" } as any;
-  spawnSync(yarnCommand, args, spawnOptions);
+  const { status } = spawnSync(yarnCommand, args, spawnOptions);
+  if (status !== 0) {
+    process.exit(status || 1);
+  }
 }
 
 function optionalParam(name: string, value: any): Array<any> {


### PR DESCRIPTION
Resolves #100.

Example output:
```
% yarn bundle:ci
yarn run v1.22.10
$ lage bundle --verbose --grouped
info Lage task runner - let's make it
verb filterPackages running with dependents
info ▶️ start rnx-kit-scripts build-tools
info ⏭️ skip rnx-kit-scripts build-tools - 5ee362115f70d4931f96cc6116155de630c38619
info ▶️ start @rnx-kit/test-app bundle
verb |  hash: 728c65b6fe22e052f330d12ca52bf627349be07e, cache hit? false
verb |  Running /var/folders/qc/zygl93h53zb3ctbyw0f0jbzm0000gn/T/yarn--1617710502846-0.10241816030586426/yarn run bundle
$ react-native rnx-bundle
verb |  Generating metro bundle(s)...
$ /~/node_modules/.bin/react-native bundle --platform ios --entry-file ./lib/src/index.js --bundle-output /~/packages/test-app/dist/main.ios.jsbundle --assets-dest ./dist --dev true --sourcemap-output /~/packages/test-app/dist/main.ios.jsbundle.map
verb |                   Welcome to React Native!
verb |                  Learn once, write anywhere
verb |  
verb |  error The resource `/~/packages/test-app/src/lib/src/index.js` was not found. Run CLI with --verbose flag for more details.
verb |  Error: The resource `/~/packages/test-app/src/lib/src/index.js` was not found.
verb |      at /~/node_modules/metro/src/IncrementalBundler.js:157:26
verb |      at gotStat (fs.js:1782:21)
verb |      at FSReqCallback.oncomplete (fs.js:168:21)
error Command failed with exit code 1.
verb |  info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
verb |  error Command failed with exit code 1.
verb |  info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
info ❌ fail @rnx-kit/test-app bundle
info ----------------------------------------------
info 🏗 Summary
info 
verb rnx-kit-scripts build-tools skipped, took 0.00s
verb @rnx-kit/test-app bundle failed, took 1.61s
info [Tasks Count] success: 0, skipped: 1, incomplete: 1
info ----------------------------------------------
ERR! [@rnx-kit/test-app bundle] ERROR DETECTED
ERR! started
ERR! hash: 728c65b6fe22e052f330d12ca52bf627349be07e, cache hit? false
ERR! Running /var/folders/qc/zygl93h53zb3ctbyw0f0jbzm0000gn/T/yarn--1617710502846-0.10241816030586426/yarn run bundle
$ react-native rnx-bundle
ERR! Generating metro bundle(s)...
$ /~/node_modules/.bin/react-native bundle --platform ios --entry-file ./lib/src/index.js --bundle-output /~/packages/test-app/dist/main.ios.jsbundle --assets-dest ./dist --dev true --sourcemap-output /~/packages/test-app/dist/main.ios.jsbundle.map
ERR!                  Welcome to React Native!
ERR!                 Learn once, write anywhere
ERR! 
ERR! error The resource `/~/packages/test-app/src/lib/src/index.js` was not found. Run CLI with --verbose flag for more details.
ERR! Error: The resource `/~/packages/test-app/src/lib/src/index.js` was not found.
ERR!     at /~/node_modules/metro/src/IncrementalBundler.js:157:26
ERR!     at gotStat (fs.js:1782:21)
ERR!     at FSReqCallback.oncomplete (fs.js:168:21)
error Command failed with exit code 1.
ERR! info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
ERR! error Command failed with exit code 1.
ERR! info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
ERR! failed
info ----------------------------------------------
info Took a total of 1.94s to complete
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```