### PR TITLE
fix(test-app): dev server options conflict with bundling

### DIFF
--- a/change/@rnx-kit-cli-ea04ac98-a604-4af5-99d8-8be1a8273d81.json
+++ b/change/@rnx-kit-cli-ea04ac98-a604-4af5-99d8-8be1a8273d81.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fixed typings to avoid type casting",
+  "packageName": "@rnx-kit/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,9 +2,9 @@ import { MetroBundleOptions, metroBundle, metroStart } from "./metro";
 import { getKitConfig, AllPlatforms, BundleParameters } from "@rnx-kit/config";
 import chalk from "chalk";
 
-interface CliBundleOptions {
+type CliBundleOptions = {
   id?: string;
-  platform?: "ios" | "android" | "windows" | "win32" | "macos";
+  platform?: AllPlatforms;
   entryPath?: string;
   distPath?: string;
   assetsPath?: string;
@@ -20,11 +20,11 @@ interface CliBundleOptions {
   resetCache?: boolean;
   readGlobalCache?: boolean;
   config?: string;
-}
+};
 
-interface CliStartOptions {
+type CliStartOptions = {
   port?: number;
-}
+};
 
 export function parseBoolean(val: string): boolean {
   if (val === "false") {

--- a/packages/test-app/metro.config.js
+++ b/packages/test-app/metro.config.js
@@ -2,5 +2,5 @@ const { makeMetroConfig } = require("@rnx-kit/metro-config");
 const path = require("path");
 
 module.exports = makeMetroConfig({
-  projectRoot: path.join(__dirname, "src"),
+  projectRoot: __dirname,
 });

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -16,7 +16,7 @@
     "ios": "react-native run-ios",
     "macos": "react-native run-macos --scheme ReactTestApp",
     "windows": "react-native run-windows --sln windows\\SampleCrossApp.sln",
-    "start": "react-native rnx-start"
+    "start": "react-native start --projectRoot src"
   },
   "dependencies": {
     "react": "16.13.1",
@@ -45,9 +45,9 @@
   },
   "rnx-kit": {
     "bundle": {
-      "entryPath": "../lib/src/index.js",
-      "distPath": "./dist",
-      "assetsPath": "./dist",
+      "entryPath": "lib/src/index.js",
+      "distPath": "dist",
+      "assetsPath": "dist",
       "bundlePrefix": "main",
       "targets": [
         "ios",
@@ -57,7 +57,7 @@
       ],
       "platforms": {
         "android": {
-          "assetsPath": "./dist/res"
+          "assetsPath": "dist/res"
         }
       }
     }


### PR DESCRIPTION
Bundling fails if `projectRoot` is set to `./src`. Reverting it back to `.` will make the dev server fail because it cannot find the entry path.