### PR TITLE
feat: introduce `metro-serializer` for plugin support

### DIFF
--- a/change/@rnx-kit-metro-serializer-932f2be0-a97d-410a-8948-50b96a0bdf44.json
+++ b/change/@rnx-kit-metro-serializer-932f2be0-a97d-410a-8948-50b96a0bdf44.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "MetroSerializer is Metro's default JavaScript bundle serializer but with plugin support",
+  "packageName": "@rnx-kit/metro-serializer",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/metro-serializer/README.md
+++ b/packages/metro-serializer/README.md
@@ -1,0 +1,31 @@
+# @rnx-kit/metro-serializer
+
+`@rnx-kit/metro-serializer` is Metro's default JavaScript bundle serializer, but
+with support for plugins.
+
+## Usage
+
+Import and set the serializer to `serializer.customSerializer` in your
+`metro.config.js`, then add your desired plugins. For instance, to add
+`CyclicDependencies` and `DuplicateDependencies` plugins:
+
+```js
+const { makeMetroConfig } = require("@rnx-kit/metro-config");
+const {
+  CyclicDependencies,
+} = require("@rnx-kit/metro-plugin-cyclic-dependencies-detector");
+const {
+  DuplicateDependencies,
+} = require("@rnx-kit/metro-plugin-duplicates-checker");
+const { MetroSerializer } = require("@rnx-kit/metro-serializer");
+
+module.exports = makeMetroConfig({
+  projectRoot: __dirname,
+  serializer: {
+    customSerializer: MetroSerializer([
+      CyclicDependencies(),
+      DuplicateDependencies(),
+    ]),
+  },
+});
+```

--- a/packages/metro-serializer/babel.config.js
+++ b/packages/metro-serializer/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ["@babel/preset-env", { targets: { node: "current" } }],
+    "@babel/preset-typescript",
+  ],
+};

--- a/packages/metro-serializer/just.config.js
+++ b/packages/metro-serializer/just.config.js
@@ -1,0 +1,2 @@
+const { configureJust } = require("rnx-kit-scripts");
+configureJust();

--- a/packages/metro-serializer/package.json
+++ b/packages/metro-serializer/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@rnx-kit/metro-serializer",
+  "version": "1.0.0-alpha",
+  "description": "Metro's default JavaScript bundle serializer but with plugin support",
+  "homepage": "https://github.com/microsoft/rnx-kit/tree/main/packages/metro-serializer#rnx-kitmetro-serializer",
+  "license": "MIT",
+  "files": [
+    "lib/*"
+  ],
+  "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/rnx-kit",
+    "directory": "packages/metro-serializer"
+  },
+  "scripts": {
+    "build": "rnx-kit-scripts build",
+    "format": "prettier --write src/*.ts test/*.ts",
+    "test": "rnx-kit-scripts test"
+  },
+  "dependencies": {
+    "semver": "^7.0.0"
+  },
+  "peerDependencies": {
+    "metro": ">=0.58.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^26.0.0",
+    "@types/semver": "^7.0.0",
+    "prettier": "^2.0.0",
+    "rnx-kit-scripts": "*",
+    "typescript": "^4.0.0"
+  },
+  "jest": {
+    "roots": [
+      "test"
+    ],
+    "testRegex": "/test/.*\\.test\\.ts$"
+  }
+}

--- a/packages/metro-serializer/src/index.ts
+++ b/packages/metro-serializer/src/index.ts
@@ -1,0 +1,38 @@
+import type {
+  Graph,
+  MetroPlugin,
+  Module,
+  Serializer,
+  SerializerOptions,
+} from "./types";
+import * as semver from "semver";
+
+export * from "./types";
+
+/**
+ * Metro's default bundle serializer.
+ *
+ * Note that the return type changed to a `Promise` in
+ * [0.60](https://github.com/facebook/metro/commit/d6b9685c730d0d63577db40f41369157f28dfa3a).
+ *
+ * @see https://github.com/facebook/metro/blob/af23a1b27bcaaff2e43cb795744b003e145e78dd/packages/metro/src/Server.js#L228
+ */
+export function MetroSerializer(plugins: MetroPlugin[]): Serializer {
+  const baseJSBundle = require("metro/src/DeltaBundler/Serializers/baseJSBundle");
+  const bundleToString = require("metro/src/lib/bundleToString");
+
+  const { version } = require("metro/package.json");
+  const shouldReturnPromise = semver.satisfies(version, ">=0.60.0");
+
+  return (
+    entryPoint: string,
+    preModules: ReadonlyArray<Module>,
+    graph: Graph,
+    options: SerializerOptions
+  ): string | Promise<string> => {
+    plugins.forEach((plugin) => plugin(entryPoint, preModules, graph, options));
+    const bundle = baseJSBundle(entryPoint, preModules, graph, options);
+    const bundleCode = bundleToString(bundle).code;
+    return shouldReturnPromise ? Promise.resolve(bundleCode) : bundleCode;
+  };
+}

--- a/packages/metro-serializer/src/types.ts
+++ b/packages/metro-serializer/src/types.ts
@@ -1,0 +1,74 @@
+export type MixedOutput = {
+  data: unknown;
+  type: string;
+};
+
+export type TransformResultDependency = {
+  /**
+   * The literal name provided to a require or import call. For example 'foo' in
+   * case of `require('foo')`.
+   */
+  name: string;
+};
+
+export type BundleCodeWithSourceMap = {
+  code: string;
+  map: string;
+};
+
+export type BundleCode = string | BundleCodeWithSourceMap;
+
+export type Dependency = {
+  absolutePath: string;
+  data: TransformResultDependency;
+  [key: string]: unknown;
+};
+
+export type Dependencies<T = MixedOutput> = Map<string, Module<T>>;
+
+export type Graph<T = MixedOutput> = {
+  dependencies: Dependencies<T>;
+  importBundleNames: Set<string>;
+  entryPoints: ReadonlyArray<string>;
+};
+
+export type Module<T = MixedOutput> = {
+  dependencies: Map<string, Dependency>;
+  inverseDependencies: Set<string>;
+  output: ReadonlyArray<T>;
+  path: string;
+  getSource: () => Buffer;
+};
+
+export type SerializerOptions<T = MixedOutput> = {
+  asyncRequireModulePath: string;
+  createModuleId: (filePath: string) => number;
+  dev: boolean;
+  getRunModuleStatement: (moduleId: string | number) => string;
+  inlineSourceMap?: boolean;
+  modulesOnly: boolean;
+  processModuleFilter: (module: Module<T>) => boolean;
+  projectRoot: string;
+  runBeforeMainModule: ReadonlyArray<string>;
+  runModule: boolean;
+  sourceMapUrl?: string;
+  sourceUrl?: string;
+};
+
+export type MetroPlugin<T = MixedOutput> = (
+  entryPoint: string,
+  preModules: ReadonlyArray<Module<T>>,
+  graph: Graph<T>,
+  options: SerializerOptions<T>
+) => void;
+
+/**
+ * Note that the return type changed to a `Promise` in
+ * [0.60](https://github.com/facebook/metro/commit/d6b9685c730d0d63577db40f41369157f28dfa3a).
+ */
+export type Serializer<T = MixedOutput> = (
+  entryPoint: string,
+  preModules: ReadonlyArray<Module<T>>,
+  graph: Graph<T>,
+  options: SerializerOptions<T>
+) => BundleCode | Promise<BundleCode>;

--- a/packages/metro-serializer/test/index.test.ts
+++ b/packages/metro-serializer/test/index.test.ts
@@ -1,0 +1,59 @@
+import { MetroSerializer } from "../src/index";
+import type { BundleCode, Graph, SerializerOptions } from "../src/types";
+
+jest.mock("metro/src/DeltaBundler/Serializers/baseJSBundle");
+jest.mock("metro/src/lib/bundleToString");
+
+function isPromise<T>(obj: T | Promise<T>): obj is Promise<T> {
+  return (
+    Object.prototype.hasOwnProperty.call(obj, "then") &&
+    typeof obj["then"] === "function"
+  );
+}
+
+async function getBundleCode(
+  bundle: BundleCode | Promise<BundleCode>
+): Promise<string> {
+  if (isPromise(bundle)) {
+    return getBundleCode(await bundle);
+  }
+
+  if (typeof bundle === "string") {
+    return bundle;
+  }
+
+  throw new Error(`Expected 'string', got '${typeof bundle}'`);
+}
+
+describe("MetroSerializer", () => {
+  const baseJSBundle = require("metro/src/DeltaBundler/Serializers/baseJSBundle");
+  baseJSBundle.mockImplementation(() => undefined);
+
+  const bundleToString = require("metro/src/lib/bundleToString");
+  bundleToString.mockImplementation(() => ({
+    code: "code",
+    map: undefined,
+  }));
+
+  const mockGraph = {} as Graph;
+  const mockOptions = {} as SerializerOptions;
+
+  test("works without plugins", async () => {
+    const serializer = MetroSerializer([]);
+    const result = serializer("entryPoint", [], mockGraph, mockOptions);
+    expect(await getBundleCode(result)).toBe("code");
+  });
+
+  test("calls plugins in specified order", async () => {
+    const callOrder = [];
+    const serializer = MetroSerializer([
+      () => callOrder.push(1),
+      () => callOrder.push(2),
+      () => callOrder.push(3),
+    ]);
+    const result = serializer("entryPoint", [], mockGraph, mockOptions);
+    expect(callOrder).toEqual(callOrder.sort());
+
+    expect(await getBundleCode(result)).toBe("code");
+  });
+});

--- a/packages/metro-serializer/tsconfig.json
+++ b/packages/metro-serializer/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "rnx-kit-scripts/tsconfig.json",
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1888,6 +1888,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
   integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
+"@types/semver@^7.0.0":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.4.tgz#43d7168fec6fa0988bb1a513a697b29296721afb"
+  integrity sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"


### PR DESCRIPTION
This package enables plugin support in Metro. It does the exact same thing Metro does when serialising the JS bundle, but after running through specified plugins. Example usage:

```js
const { makeMetroConfig } = require("@rnx-kit/metro-config");
const {
  CyclicDependencies,
} = require("@rnx-kit/metro-plugin-cyclic-dependencies-detector");
const { MetroSerializer } = require("@rnx-kit/metro-serializer");

module.exports = makeMetroConfig({
  projectRoot: __dirname,
  serializer: {
    customSerializer: MetroSerializer([
      CyclicDependencies(),
    ]),
  },
});
```