### PR TITLE
feat: cyclic dependencies plugin for Metro

### DIFF
--- a/change/@rnx-kit-metro-plugin-cyclic-dependencies-detector-1c5e33cc-27e2-4374-9eee-7ba2ec2af80b.json
+++ b/change/@rnx-kit-metro-plugin-cyclic-dependencies-detector-1c5e33cc-27e2-4374-9eee-7ba2ec2af80b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Cyclic dependencies detector for Metro",
+  "packageName": "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/metro-plugin-cyclic-dependencies-detector/README.md
+++ b/packages/metro-plugin-cyclic-dependencies-detector/README.md
@@ -1,0 +1,38 @@
+# @rnx-kit/metro-plugin-cyclic-dependencies-detector
+
+`@rnx-kit/metro-plugin-cyclic-dependencies-detector` detects cyclic import
+chains that may cause issues in your bundle.
+
+## Usage
+
+Import and add the plugin to `MetroSerializer` in your `metro.config.js`, and
+optionally configure it to your liking:
+
+```js
+const { makeMetroConfig } = require("@rnx-kit/metro-config");
+const {
+  CyclicDependencies,
+} = require("@rnx-kit/metro-plugin-cyclic-dependencies-detector");
+const { MetroSerializer } = require("@rnx-kit/metro-serializer");
+
+module.exports = makeMetroConfig({
+  projectRoot: __dirname,
+  serializer: {
+    customSerializer: MetroSerializer([
+      CyclicDependencies({
+        includeNodeModules: false,
+        linesOfContext: 1,
+        throwOnError: true,
+      }),
+    ]),
+  },
+});
+```
+
+## Options
+
+| Key                | Type    | Default | Description                                   |
+| :----------------- | :------ | :------ | :-------------------------------------------- |
+| includeNodeModules | boolean | `false` | Whether to scan `node_modules`.               |
+| linesOfContext     | number  | 1       | Number of extra modules to print for context. |
+| throwOnError       | boolean | `true`  | Whether to throw when cycles are detected.    |

--- a/packages/metro-plugin-cyclic-dependencies-detector/babel.config.js
+++ b/packages/metro-plugin-cyclic-dependencies-detector/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ["@babel/preset-env", { targets: { node: "current" } }],
+    "@babel/preset-typescript",
+  ],
+};

--- a/packages/metro-plugin-cyclic-dependencies-detector/just.config.js
+++ b/packages/metro-plugin-cyclic-dependencies-detector/just.config.js
@@ -1,0 +1,2 @@
+const { configureJust } = require("rnx-kit-scripts");
+configureJust();

--- a/packages/metro-plugin-cyclic-dependencies-detector/package.json
+++ b/packages/metro-plugin-cyclic-dependencies-detector/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+  "version": "1.0.0-alpha",
+  "description": "Cyclic dependencies detector for Metro",
+  "homepage": "https://github.com/microsoft/rnx-kit/tree/main/packages/metro-plugin-cyclic-dependencies-detector#rnx-kitmetro-plugin-cyclic-dependencies-detector",
+  "license": "MIT",
+  "files": [
+    "lib/*"
+  ],
+  "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/rnx-kit",
+    "directory": "packages/metro-plugin-cyclic-dependencies-detector"
+  },
+  "scripts": {
+    "build": "rnx-kit-scripts build",
+    "format": "prettier --write src/*.ts test/*.ts",
+    "test": "rnx-kit-scripts test"
+  },
+  "dependencies": {
+    "pkg-dir": "^5.0.0"
+  },
+  "devDependencies": {
+    "@rnx-kit/metro-serializer": "*",
+    "@types/jest": "^26.0.0",
+    "@types/node": "^12.0.0",
+    "prettier": "^2.0.0",
+    "rnx-kit-scripts": "*",
+    "typescript": "^4.0.0"
+  },
+  "jest": {
+    "roots": [
+      "test"
+    ],
+    "testRegex": "/test/.*\\.test\\.ts$"
+  }
+}

--- a/packages/metro-plugin-cyclic-dependencies-detector/src/detectCycles.ts
+++ b/packages/metro-plugin-cyclic-dependencies-detector/src/detectCycles.ts
@@ -1,0 +1,110 @@
+import * as path from "path";
+import type { Dependencies, Graph } from "@rnx-kit/metro-serializer";
+
+export type CyclicDependencies = Record<string, string[]>;
+
+export type PluginOptions = {
+  includeNodeModules?: boolean;
+  linesOfContext?: number;
+  throwOnError?: boolean;
+};
+
+export function packageRelativePath(
+  modulePath: string,
+  cache: Record<string, string>
+): string {
+  const cachedPath = cache[modulePath];
+  if (cachedPath) {
+    return cachedPath;
+  }
+
+  const pkgDir = require("pkg-dir");
+
+  const packagePath = pkgDir.sync(modulePath);
+  const { name } = require(path.join(packagePath, "package.json"));
+  const relativePath = `${name}/${path.relative(packagePath, modulePath)}`;
+  cache[modulePath] = relativePath;
+  return relativePath;
+}
+
+export function traverseDependencies(
+  currentModule: string,
+  dependencies: Dependencies,
+  options: PluginOptions,
+  cyclicDependencies: CyclicDependencies = {},
+  stack: string[] = []
+): CyclicDependencies {
+  if (!options.includeNodeModules && currentModule.includes("/node_modules/")) {
+    return cyclicDependencies;
+  }
+
+  if (stack.includes(currentModule)) {
+    cyclicDependencies[currentModule] = stack.slice();
+    return cyclicDependencies;
+  }
+
+  stack.push(currentModule);
+
+  dependencies.get(currentModule)?.dependencies?.forEach((dependency) => {
+    if (dependency["__rnxCyclicDependenciesChecked"]) {
+      return;
+    }
+
+    traverseDependencies(
+      dependency.absolutePath,
+      dependencies,
+      options,
+      cyclicDependencies,
+      stack
+    );
+
+    // Performance optimization: There is no need to traverse this module again.
+    dependency["__rnxCyclicDependenciesChecked"] = true;
+  });
+
+  stack.pop();
+  return cyclicDependencies;
+}
+
+export function detectCycles(
+  entryPoint: string,
+  { dependencies }: Graph,
+  options: PluginOptions
+): void {
+  const cyclicDependencies = traverseDependencies(
+    entryPoint,
+    dependencies,
+    options
+  );
+
+  const modulePaths = Object.keys(cyclicDependencies);
+  if (modulePaths.length === 0) {
+    return;
+  }
+
+  const { linesOfContext = 1, throwOnError = true } = options;
+  const cachedPaths: Record<string, string> = {};
+
+  modulePaths.forEach((modulePath) => {
+    const currentModule = packageRelativePath(modulePath, cachedPaths);
+    console.warn(currentModule);
+
+    const requirePath = cyclicDependencies[modulePath];
+    const start = Math.max(requirePath.indexOf(modulePath) - linesOfContext, 0);
+    requirePath
+      .slice(start)
+      .reverse()
+      .forEach((module, index) => {
+        const requiredBy = packageRelativePath(module, cachedPaths);
+        console.warn(`${"    ".repeat(index)}└── ${requiredBy}`);
+      });
+    console.log();
+  });
+
+  if (throwOnError) {
+    throw new Error("Import cycles detected");
+  } else {
+    console.error("❌ Import cycles detected!");
+    console.log();
+  }
+}

--- a/packages/metro-plugin-cyclic-dependencies-detector/src/index.ts
+++ b/packages/metro-plugin-cyclic-dependencies-detector/src/index.ts
@@ -1,0 +1,20 @@
+import { detectCycles, PluginOptions } from "./detectCycles";
+import type {
+  Graph,
+  Module,
+  MetroPlugin,
+  SerializerOptions,
+} from "@rnx-kit/metro-serializer";
+
+export function CyclicDependencies(
+  pluginOptions: PluginOptions = {}
+): MetroPlugin {
+  return (
+    entryPoint: string,
+    _preModules: ReadonlyArray<Module>,
+    graph: Graph,
+    _options: SerializerOptions
+  ) => {
+    detectCycles(entryPoint, graph, pluginOptions);
+  };
+}

--- a/packages/metro-plugin-cyclic-dependencies-detector/test/__snapshots__/detectCycles.test.ts.snap
+++ b/packages/metro-plugin-cyclic-dependencies-detector/test/__snapshots__/detectCycles.test.ts.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`traverseDependencies() returns cycles in \`node_modules\` 1`] = `
+Object {
+  "/~/node_modules/react-native/index.js": Array [
+    "/~/packages/test-app/lib/src/index.js",
+    "/~/node_modules/react-native/index.js",
+    "/~/node_modules/react-native/Libraries/ReactNative/AppRegistry.js",
+    "/~/node_modules/react-native/Libraries/LogBox/LogBoxInspectorContainer.js",
+  ],
+  "/~/packages/test-app/lib/src/App.js": Array [
+    "/~/packages/test-app/lib/src/index.js",
+    "/~/packages/test-app/lib/src/App.js",
+    "/~/packages/test-app/lib/src/cyclicExample.js",
+  ],
+}
+`;
+
+exports[`traverseDependencies() returns import paths causing a cycle 1`] = `
+Object {
+  "/~/packages/test-app/lib/src/App.js": Array [
+    "/~/packages/test-app/lib/src/index.js",
+    "/~/packages/test-app/lib/src/App.js",
+    "/~/packages/test-app/lib/src/cyclicExample.js",
+  ],
+}
+`;

--- a/packages/metro-plugin-cyclic-dependencies-detector/test/detectCycles.test.ts
+++ b/packages/metro-plugin-cyclic-dependencies-detector/test/detectCycles.test.ts
@@ -1,0 +1,147 @@
+import {
+  CyclicDependencies,
+  detectCycles,
+  traverseDependencies,
+} from "../src/detectCycles";
+import {
+  entryPoint,
+  graphWithCycles,
+  graphWithNoCycles,
+  repoRoot,
+} from "./testData";
+
+function stripRepoRootFromPaths(
+  cyclicDependencies: CyclicDependencies
+): CyclicDependencies {
+  const token = "/~";
+  return Object.entries(cyclicDependencies).reduce<CyclicDependencies>(
+    (cyclicDependencies, [modulePath, importPath]) => {
+      cyclicDependencies[
+        modulePath.replace(repoRoot, token)
+      ] = importPath.map((p) => p.replace(repoRoot, token));
+      return cyclicDependencies;
+    },
+    {}
+  );
+}
+
+describe("traverseDependencies()", () => {
+  test("returns nothing if there are no cycles", () => {
+    const cyclicDependencies = traverseDependencies(
+      entryPoint,
+      graphWithNoCycles().dependencies,
+      {}
+    );
+    expect(cyclicDependencies).toEqual({});
+  });
+
+  test("returns import paths causing a cycle", () => {
+    const cyclicDependencies = traverseDependencies(
+      entryPoint,
+      graphWithCycles().dependencies,
+      {}
+    );
+    expect(stripRepoRootFromPaths(cyclicDependencies)).toMatchSnapshot();
+  });
+
+  test("returns cycles in `node_modules`", () => {
+    const cyclicDependencies = traverseDependencies(
+      entryPoint,
+      graphWithCycles().dependencies,
+      { includeNodeModules: true }
+    );
+    expect(stripRepoRootFromPaths(cyclicDependencies)).toMatchSnapshot();
+  });
+});
+
+describe("detectCycles()", () => {
+  const consoleErrorSpy = jest.spyOn(global.console, "error");
+  const consoleLogSpy = jest.spyOn(global.console, "log");
+  const consoleWarnSpy = jest.spyOn(global.console, "warn");
+
+  beforeEach(() => {
+    consoleErrorSpy.mockReset();
+    consoleLogSpy.mockReset();
+    consoleWarnSpy.mockReset();
+  });
+
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  test("prints nothing if all is fine", () => {
+    detectCycles(entryPoint, graphWithNoCycles(), {});
+    expect(consoleWarnSpy).not.toBeCalled();
+    expect(consoleErrorSpy).not.toBeCalled();
+  });
+
+  test("prints if cycles are found in `node_modules`", () => {
+    detectCycles(entryPoint, graphWithNoCycles(), {
+      includeNodeModules: true,
+      throwOnError: false,
+    });
+    expect(consoleWarnSpy).toBeCalledTimes(5);
+    expect(consoleErrorSpy).toBeCalledTimes(1);
+  });
+
+  test("prints import paths causing a cycle", () => {
+    detectCycles(entryPoint, graphWithCycles(), { throwOnError: false });
+    expect(consoleWarnSpy).toBeCalledTimes(4);
+    expect(consoleErrorSpy).toBeCalledTimes(1);
+  });
+
+  test("prints import paths causing a cycle, including `node_modules`", () => {
+    detectCycles(entryPoint, graphWithCycles(), {
+      includeNodeModules: true,
+      throwOnError: false,
+    });
+    expect(consoleWarnSpy).toBeCalledTimes(9);
+    expect(consoleErrorSpy).toBeCalledTimes(1);
+  });
+
+  test("prints import paths causing a cycle with 0 context", () => {
+    detectCycles(entryPoint, graphWithCycles(), {
+      linesOfContext: 0,
+      throwOnError: false,
+    });
+    expect(consoleWarnSpy).toBeCalledTimes(3);
+    expect(consoleErrorSpy).toBeCalledTimes(1);
+  });
+
+  test("prints import paths causing a cycle with 0 context, including `node_modules`", () => {
+    detectCycles(entryPoint, graphWithCycles(), {
+      includeNodeModules: true,
+      linesOfContext: 0,
+      throwOnError: false,
+    });
+    expect(consoleWarnSpy).toBeCalledTimes(7);
+    expect(consoleErrorSpy).toBeCalledTimes(1);
+  });
+
+  test("prints import paths causing a cycle with more context", () => {
+    detectCycles(entryPoint, graphWithCycles(), {
+      linesOfContext: 10,
+      throwOnError: false,
+    });
+    expect(consoleWarnSpy).toBeCalledTimes(4);
+    expect(consoleErrorSpy).toBeCalledTimes(1);
+  });
+
+  test("prints import paths causing a cycle with more context, including `node_modules`", () => {
+    detectCycles(entryPoint, graphWithCycles(), {
+      includeNodeModules: true,
+      linesOfContext: 10,
+      throwOnError: false,
+    });
+    expect(consoleWarnSpy).toBeCalledTimes(9);
+    expect(consoleErrorSpy).toBeCalledTimes(1);
+  });
+
+  test("throws on cycle detection by default", () => {
+    expect(() => detectCycles(entryPoint, graphWithCycles(), {})).toThrow(
+      "Import cycles detected"
+    );
+    expect(consoleWarnSpy).toBeCalledTimes(4);
+    expect(consoleErrorSpy).not.toBeCalled();
+  });
+});

--- a/packages/metro-plugin-cyclic-dependencies-detector/test/testData.ts
+++ b/packages/metro-plugin-cyclic-dependencies-detector/test/testData.ts
@@ -1,0 +1,253 @@
+// istanbul ignore file
+
+import type { Dependency, Graph, Module } from "@rnx-kit/metro-serializer";
+
+export const repoRoot = require("pkg-dir").sync("../../");
+export const entryPoint = `${repoRoot}/packages/test-app/lib/src/index.js`;
+
+export function graphWithCycles(): Graph {
+  return {
+    dependencies: new Map<string, Module>([
+      [
+        entryPoint,
+        {
+          dependencies: new Map<string, Dependency>([
+            [
+              "react-native",
+              {
+                absolutePath: `${repoRoot}/node_modules/react-native/index.js`,
+                data: { name: "react-native" },
+              },
+            ],
+            [
+              "./App",
+              {
+                absolutePath: `${repoRoot}/packages/test-app/lib/src/App.js`,
+                data: { name: "./App" },
+              },
+            ],
+            [
+              "../app.json",
+              {
+                absolutePath: `${repoRoot}/packages/test-app/lib/app.json`,
+                data: { name: "../app.json" },
+              },
+            ],
+          ]),
+        } as Module,
+      ],
+      [
+        `${repoRoot}/node_modules/react-native/index.js`,
+        {
+          dependencies: new Map<string, Dependency>([
+            [
+              "./Libraries/ReactNative/AppRegistry",
+              {
+                absolutePath: `${repoRoot}/node_modules/react-native/Libraries/ReactNative/AppRegistry.js`,
+                data: { name: "./Libraries/ReactNative/AppRegistry" },
+              },
+            ],
+            [
+              "../LogBox/LogBoxInspectorContainer",
+              {
+                absolutePath: `${repoRoot}/node_modules/react-native/Libraries/LogBox/LogBoxInspectorContainer.js`,
+                data: { name: "../LogBox/LogBoxInspectorContainer" },
+              },
+            ],
+          ]),
+        } as Module,
+      ],
+      [
+        `${repoRoot}/node_modules/react-native/Libraries/ReactNative/AppRegistry.js`,
+        {
+          dependencies: new Map<string, Dependency>([
+            [
+              "../LogBox/LogBoxInspectorContainer",
+              {
+                absolutePath: `${repoRoot}/node_modules/react-native/Libraries/LogBox/LogBoxInspectorContainer.js`,
+                data: { name: "../LogBox/LogBoxInspectorContainer" },
+              },
+            ],
+          ]),
+        } as Module,
+      ],
+      [
+        `${repoRoot}/node_modules/react-native/Libraries/LogBox/LogBoxInspectorContainer.js`,
+        {
+          dependencies: new Map<string, Dependency>([
+            [
+              "react-native",
+              {
+                absolutePath: `${repoRoot}/node_modules/react-native/index.js`,
+                data: { name: "react-native" },
+              },
+            ],
+          ]),
+        } as Module,
+      ],
+      [
+        `${repoRoot}/packages/test-app/lib/src/App.js`,
+        {
+          dependencies: new Map<string, Dependency>([
+            [
+              "react-native",
+              {
+                absolutePath: `${repoRoot}/node_modules/react-native/index.js`,
+                data: { name: "react-native" },
+              },
+            ],
+            [
+              "./cyclicExample",
+              {
+                absolutePath: `${repoRoot}/packages/test-app/lib/src/cyclicExample.js`,
+                data: { name: "./cyclicExample" },
+              },
+            ],
+          ]),
+        } as Module,
+      ],
+      [
+        `${repoRoot}/packages/test-app/lib/src/cyclicExample.js`,
+        {
+          dependencies: new Map<string, Dependency>([
+            [
+              "./App",
+              {
+                absolutePath: `${repoRoot}/packages/test-app/lib/src/App.js`,
+                data: { name: "./App" },
+              },
+            ],
+          ]),
+        } as Module,
+      ],
+      [
+        `${repoRoot}/packages/test-app/lib/app.json`,
+        {
+          dependencies: new Map<string, Dependency>(),
+        } as Module,
+      ],
+    ]),
+    entryPoints: [`${repoRoot}/packages/test-app/lib/src/index.js"`],
+    importBundleNames: new Set<string>(),
+  };
+}
+
+export function graphWithNoCycles(): Graph {
+  return {
+    dependencies: new Map<string, Module>([
+      [
+        entryPoint,
+        {
+          dependencies: new Map<string, Dependency>([
+            [
+              "react-native",
+              {
+                absolutePath: `${repoRoot}/node_modules/react-native/index.js`,
+                data: { name: "react-native" },
+              },
+            ],
+            [
+              "./App",
+              {
+                absolutePath: `${repoRoot}/packages/test-app/lib/src/App.js`,
+                data: { name: "./App" },
+              },
+            ],
+            [
+              "../app.json",
+              {
+                absolutePath: `${repoRoot}/packages/test-app/lib/app.json`,
+                data: { name: "../app.json" },
+              },
+            ],
+          ]),
+        } as Module,
+      ],
+      [
+        `${repoRoot}/node_modules/react-native/index.js`,
+        {
+          dependencies: new Map<string, Dependency>([
+            [
+              "./Libraries/ReactNative/AppRegistry",
+              {
+                absolutePath: `${repoRoot}/node_modules/react-native/Libraries/ReactNative/AppRegistry.js`,
+                data: { name: "./Libraries/ReactNative/AppRegistry" },
+              },
+            ],
+            [
+              "../LogBox/LogBoxInspectorContainer",
+              {
+                absolutePath: `${repoRoot}/node_modules/react-native/Libraries/LogBox/LogBoxInspectorContainer.js`,
+                data: { name: "../LogBox/LogBoxInspectorContainer" },
+              },
+            ],
+          ]),
+        } as Module,
+      ],
+      [
+        `${repoRoot}/node_modules/react-native/Libraries/ReactNative/AppRegistry.js`,
+        {
+          dependencies: new Map<string, Dependency>([
+            [
+              "../LogBox/LogBoxInspectorContainer",
+              {
+                absolutePath: `${repoRoot}/node_modules/react-native/Libraries/LogBox/LogBoxInspectorContainer.js`,
+                data: { name: "../LogBox/LogBoxInspectorContainer" },
+              },
+            ],
+          ]),
+        } as Module,
+      ],
+      [
+        `${repoRoot}/node_modules/react-native/Libraries/LogBox/LogBoxInspectorContainer.js`,
+        {
+          dependencies: new Map<string, Dependency>([
+            [
+              "react-native",
+              {
+                absolutePath: `${repoRoot}/node_modules/react-native/index.js`,
+                data: { name: "react-native" },
+              },
+            ],
+          ]),
+        } as Module,
+      ],
+      [
+        `${repoRoot}/packages/test-app/lib/src/App.js`,
+        {
+          dependencies: new Map<string, Dependency>([
+            [
+              "react-native",
+              {
+                absolutePath: `${repoRoot}/node_modules/react-native/index.js`,
+                data: { name: "react-native" },
+              },
+            ],
+          ]),
+        } as Module,
+      ],
+      [
+        `${repoRoot}/packages/test-app/lib/src/cyclicExample.js`,
+        {
+          dependencies: new Map<string, Dependency>([
+            [
+              "./App",
+              {
+                absolutePath: `${repoRoot}/packages/test-app/lib/src/App.js`,
+                data: { name: "./App" },
+              },
+            ],
+          ]),
+        } as Module,
+      ],
+      [
+        `${repoRoot}/packages/test-app/lib/app.json`,
+        {
+          dependencies: new Map<string, Dependency>(),
+        } as Module,
+      ],
+    ]),
+    entryPoints: [`${repoRoot}/packages/test-app/lib/src/index.js"`],
+    importBundleNames: new Set<string>(),
+  };
+}

--- a/packages/metro-plugin-cyclic-dependencies-detector/tsconfig.json
+++ b/packages/metro-plugin-cyclic-dependencies-detector/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "rnx-kit-scripts/tsconfig.json",
+  "include": ["src"]
+}


### PR DESCRIPTION
Metro plugin for detecting cyclic dependencies. To use it, add it to `metro-serializer` introduced in #115:

```js
const { makeMetroConfig } = require("@rnx-kit/metro-config");
const {
  CyclicDependencies,
} = require("@rnx-kit/metro-plugin-cyclic-dependencies-detector");
const { MetroSerializer } = require("@rnx-kit/metro-serializer");

module.exports = makeMetroConfig({
  projectRoot: __dirname,
  serializer: {
    customSerializer: MetroSerializer([
      CyclicDependencies(),
    ]),
  },
});
```

Example output:
```
% yarn react-native bundle --platform ios --entry-file lib/src/index.js --bundle-output dist/main.ios.jsbundle --assets-dest dist --dev true --sourcemap-output dist/main.ios.jsbundle.map
yarn run v1.22.10
$ /~/rnx-kit/node_modules/.bin/react-native bundle --platform ios --entry-file lib/src/index.js --bundle-output dist/main.ios.jsbundle --assets-dest dist --dev true --sourcemap-output dist/main.ios.jsbundle.map
                 Welcome to React Native!
                Learn once, write anywhere


@rnx-kit/test-app/lib/src/App.js
└── @rnx-kit/test-app/lib/src/cyclicExample.js
    └── @rnx-kit/test-app/lib/src/App.js
        └── @rnx-kit/test-app/lib/src/index.js

error Require cycles detected. Run CLI with --verbose flag for more details.
Error: Require cycles detected
    at Object.detectCycles (/~/rnx-kit/packages/metro-plugin-cyclic-dependencies-detector/lib/detectCycles.js:82:15)
    at /~/rnx-kit/packages/metro-plugin-cyclic-dependencies-detector/lib/index.js:7:24
    at /~/rnx-kit/packages/metro-serializer/lib/index.js:42:37
    at Array.forEach (<anonymous>)
    at Object.customSerializer (/~/rnx-kit/packages/metro-serializer/lib/index.js:42:17)
    at /~/rnx-kit/node_modules/metro/src/Server.js:562:50
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (/~/rnx-kit/node_modules/metro/src/Server.js:99:24)
    at _next (/~/rnx-kit/node_modules/metro/src/Server.js:119:9)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Resolves #109.