### PR TITLE
fix(babel-preset-metro-react-native): forward options to Metro

### DIFF
--- a/change/@rnx-kit-babel-preset-metro-react-native-1a9289dc-5f83-4c92-9041-b39888e609bd.json
+++ b/change/@rnx-kit-babel-preset-metro-react-native-1a9289dc-5f83-4c92-9041-b39888e609bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow forwarding options to Metro",
+  "packageName": "@rnx-kit/babel-preset-metro-react-native",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-preset-metro-react-native/README.md
+++ b/packages/babel-preset-metro-react-native/README.md
@@ -28,3 +28,54 @@ module.exports = {
   ],
 };
 ```
+
+## Notes on Bundle Size
+
+If you're looking to reduce the bundle size, here are a couple of things you can
+try.
+
+### Enable experimental import/export support
+
+In your `metro.config.js`, enable `experimentalImportSupport`:
+
+```js
+module.exports = {
+  transformer: {
+    getTransformOptions: async () => ({
+      transform: {
+        experimentalImportSupport: true,
+        inlineRequires: true,
+      },
+    }),
+  },
+};
+```
+
+And disable import/export transformation in your `babel.config.js`:
+
+```js
+module.exports = {
+  presets: [
+    [
+      "@rnx-kit/babel-preset-metro-react-native",
+      { disableImportExportTransform: true },
+    ],
+  ],
+};
+```
+
+Doing this will help the minifier strip out some unused code, but make sure that
+your app still works after enabling it.
+
+### `babel-plugin-lodash`
+
+If you're using [Lodash](https://lodash.com), you can get some reduction with
+[babel-plugin-lodash](https://github.com/lodash/babel-plugin-lodash). Add it to
+your `babel.config.js` like below:
+
+```js
+module.exports = {
+  presets: ["@rnx-kit/babel-preset-metro-react-native"],
+  plugins: ["lodash"],
+};
+```

--- a/packages/babel-preset-metro-react-native/src/index.js
+++ b/packages/babel-preset-metro-react-native/src/index.js
@@ -6,13 +6,24 @@
  * @typedef {import("@babel/core").ConfigAPI} ConfigAPI
  * @typedef {import("@babel/core").PluginItem} PluginItem
  * @typedef {import("@babel/core").TransformOptions} TransformOptions
- * @typedef {{ additionalPlugins?: PluginItem[]; }} PresetOptions
+ *
+ * @typedef {{
+ *   dev?: boolean;
+ *   disableImportExportTransform?: boolean;
+ *   enableBabelRuntime?: boolean;
+ *   lazyImportExportTransform?: boolean | string[];
+ *   unstable_transformProfile?: "default" | "hermes-canary" | "hermes-stable";
+ *   useTransformReactJSXExperimental?: boolean;
+ *   withDevTools?: boolean;
+ * }} MetroPresetOptions
+ *
+ * @typedef {MetroPresetOptions & { additionalPlugins?: PluginItem[]; }} PresetOptions
  */
 
 /** @type {(api?: ConfigAPI, opts?: PresetOptions) => TransformOptions} */
-module.exports = (_, opts = {}) => {
+module.exports = (_, { additionalPlugins, ...options } = {}) => {
   return {
-    presets: ["module:metro-react-native-babel-preset"],
+    presets: [["module:metro-react-native-babel-preset", options]],
     overrides: [
       {
         test: /\.tsx?$/,
@@ -22,9 +33,7 @@ module.exports = (_, opts = {}) => {
           // for more details.
           "const-enum",
 
-          ...(Array.isArray(opts.additionalPlugins)
-            ? opts.additionalPlugins
-            : []),
+          ...(Array.isArray(additionalPlugins) ? additionalPlugins : []),
         ],
       },
     ],

--- a/packages/babel-preset-metro-react-native/test/index.test.js
+++ b/packages/babel-preset-metro-react-native/test/index.test.js
@@ -7,9 +7,16 @@ describe("@rnx-kit/babel-preset-metro-react-native", () => {
   const prettier = require("prettier");
   const preset = require("../src/index");
 
+  const optionsWithAdditionalPlugins = {
+    additionalPlugins: [
+      "my-extra-plugin",
+      ["additional-plugin", { options: {} }],
+    ],
+  };
+
   test("returns default Babel preset with one additional TypeScript plugin", () => {
-    expect(preset(undefined)).toEqual({
-      presets: ["module:metro-react-native-babel-preset"],
+    expect(preset()).toEqual({
+      presets: [["module:metro-react-native-babel-preset", {}]],
       overrides: [
         {
           test: /\.tsx?$/,
@@ -20,18 +27,47 @@ describe("@rnx-kit/babel-preset-metro-react-native", () => {
   });
 
   test("returns preset with additional TypeScript plugins", () => {
-    const opts = {
-      additionalPlugins: [
-        "my-extra-plugin",
-        ["additional-plugin", { options: {} }],
-      ],
-    };
-    expect(preset(undefined, opts)).toEqual({
-      presets: ["module:metro-react-native-babel-preset"],
+    expect(preset(undefined, optionsWithAdditionalPlugins)).toEqual({
+      presets: [["module:metro-react-native-babel-preset", {}]],
       overrides: [
         {
           test: /\.tsx?$/,
-          plugins: ["const-enum", ...opts.additionalPlugins],
+          plugins: [
+            "const-enum",
+            ...optionsWithAdditionalPlugins.additionalPlugins,
+          ],
+        },
+      ],
+    });
+  });
+
+  test("forwards options to `metro-react-native-babel-preset`", () => {
+    const metroOptions = { disableImportExportTransform: true };
+
+    expect(preset(undefined, metroOptions)).toEqual({
+      presets: [["module:metro-react-native-babel-preset", metroOptions]],
+      overrides: [
+        {
+          test: /\.tsx?$/,
+          plugins: ["const-enum"],
+        },
+      ],
+    });
+
+    expect(
+      preset(undefined, {
+        ...optionsWithAdditionalPlugins,
+        ...metroOptions,
+      })
+    ).toEqual({
+      presets: [["module:metro-react-native-babel-preset", metroOptions]],
+      overrides: [
+        {
+          test: /\.tsx?$/,
+          plugins: [
+            "const-enum",
+            ...optionsWithAdditionalPlugins.additionalPlugins,
+          ],
         },
       ],
     });


### PR DESCRIPTION
Allows forwarding options to `metro-react-native-babel-preset`. This enables use of `disableImportExportTransform` which will help Terser/Uglify remove some unused code.