### PR TITLE
feat: remove `rnx-start` command

### DIFF
--- a/change/@rnx-kit-cli-2ed64794-8eef-407b-b2b3-ed54641e550e.json
+++ b/change/@rnx-kit-cli-2ed64794-8eef-407b-b2b3-ed54641e550e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Removed `rnx-start`",
+  "packageName": "@rnx-kit/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/react-native.config.js
+++ b/packages/cli/react-native.config.js
@@ -95,16 +95,5 @@ module.exports = {
         },
       ],
     },
-    {
-      name: "rnx-start",
-      description: "Starts a bundle webserver for your react-native experience",
-      func: cli.rnxStart,
-      options: [
-        {
-          name: "--port [port]",
-          parse: parseInt,
-        },
-      ],
-    },
   ],
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,4 @@
-import { MetroBundleOptions, metroBundle, metroStart } from "./metro";
+import { MetroBundleOptions, metroBundle } from "./metro";
 import { getKitConfig, AllPlatforms, BundleParameters } from "@rnx-kit/config";
 import chalk from "chalk";
 
@@ -20,10 +20,6 @@ type CliBundleOptions = {
   resetCache?: boolean;
   readGlobalCache?: boolean;
   config?: string;
-};
-
-type CliStartOptions = {
-  port?: number;
 };
 
 export function parseBoolean(val: string): boolean {
@@ -101,12 +97,4 @@ export function rnxBundle(
   bundleOptions.configPath = options.config;
 
   metroBundle(bundleConfig, bundleOptions, bundleOverrides);
-}
-
-export function rnxStart(
-  _argv: Array<string>,
-  _config: Object /*: ConfigT*/,
-  options: CliStartOptions
-): void {
-  metroStart(options);
 }

--- a/packages/cli/src/metro.ts
+++ b/packages/cli/src/metro.ts
@@ -64,16 +64,6 @@ export type MetroBundleOptions = {
   configPath?: string;
 };
 
-/**
- * options for starting a metro server
- */
-export type MetroStartOptions = {
-  /**
-   * port override
-   */
-  port?: number;
-};
-
 function yarnSync(args: string[]): void {
   const yarnCommand = os.platform() === "win32" ? "yarn.cmd" : "yarn";
   const spawnOptions = { cwd: process.cwd(), stdio: "inherit" as const };
@@ -195,12 +185,4 @@ export function metroBundle(
       ...optionalParam("--config", configPath),
     ]);
   }
-}
-
-export function metroStart(options: MetroStartOptions): void {
-  const { port } = options;
-
-  console.log("Starting metro server...");
-
-  yarnSync(["react-native", "start", ...optionalParam("--port", port)]);
 }


### PR DESCRIPTION
This command currently does not provide any additional value over `react-native start`.

Resolves #101.

Follow-up: #140