### PR TITLE
fix(dep-check): bump react-native to address build issues

### DIFF
--- a/change/@rnx-kit-dep-check-a607fc2b-6650-4399-a6c5-9cbffe551295.json
+++ b/change/@rnx-kit-dep-check-a607fc2b-6650-4399-a6c5-9cbffe551295.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump react-native to address build issues with Xcode 12.5",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dep-check/src/profiles/profile-0.62.ts
+++ b/packages/dep-check/src/profiles/profile-0.62.ts
@@ -3,7 +3,7 @@ import type { Profile } from "../types";
 
 const reactNative = {
   name: "react-native",
-  version: "^0.62.2",
+  version: "^0.62.3",
 };
 
 const profile: Profile = {

--- a/packages/dep-check/src/profiles/profile-0.63.ts
+++ b/packages/dep-check/src/profiles/profile-0.63.ts
@@ -3,7 +3,7 @@ import type { Profile } from "../types";
 
 const reactNative = {
   name: "react-native",
-  version: "^0.63.4",
+  version: "^0.63.2",
 };
 
 const profile: Profile = {

--- a/packages/dep-check/src/profiles/profile-0.64.ts
+++ b/packages/dep-check/src/profiles/profile-0.64.ts
@@ -2,7 +2,7 @@ import type { Profile } from "../types";
 
 const reactNative = {
   name: "react-native",
-  version: "^0.64.0",
+  version: "^0.64.1",
 };
 
 const profile: Profile = {

--- a/packages/dep-check/test/__snapshots__/check.app.test.ts.snap
+++ b/packages/dep-check/test/__snapshots__/check.app.test.ts.snap
@@ -12,7 +12,7 @@ exports[`checkPackageManifest({ kitType: 'app' }) adds required dependencies 1`]
     \\"hermes-engine\\": \\"~0.7.0\\",
     \\"quaid\\": \\"1.0.0\\",
     \\"react\\": \\"17.0.1\\",
-    \\"react-native\\": \\"^0.64.0\\",
+    \\"react-native\\": \\"^0.64.1\\",
     \\"react-native-lazy-index\\": \\"^2.0.0\\",
     \\"react-native-reanimated\\": \\"^2.1.0\\",
     \\"react-native-webview\\": \\"^11.4.2\\"

--- a/packages/dep-check/test/check.test.ts
+++ b/packages/dep-check/test/check.test.ts
@@ -1,4 +1,6 @@
 import { checkPackageManifest, isManifest } from "../src/check";
+import profile_0_62 from "../src/profiles/profile-0.62";
+import profile_0_63 from "../src/profiles/profile-0.63";
 import profile_0_64 from "../src/profiles/profile-0.64";
 
 jest.mock("fs");
@@ -31,6 +33,12 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     name: "@rnx-kit/dep-check",
     version: "0.0.1",
   };
+
+  const v62_v63_v64 = [
+    profile_0_62["core-ios"].version,
+    profile_0_63["core-ios"].version,
+    profile_0_64["core-ios"].version,
+  ].join(" || ");
 
   beforeEach(() => {
     consoleErrorSpy.mockReset();
@@ -102,10 +110,10 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     fs.__setMockContent({
       ...mockManifest,
       peerDependencies: {
-        "react-native": "^0.64.0",
+        "react-native": profile_0_64["core-ios"].version,
       },
       devDependencies: {
-        "react-native": "^0.64.0",
+        "react-native": profile_0_64["core-ios"].version,
       },
     });
     rnxKitConfig.__setMockConfig({
@@ -125,10 +133,10 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     fs.__setMockContent({
       ...mockManifest,
       peerDependencies: {
-        "react-native": "^0.64.0",
+        "react-native": profile_0_64["core-ios"].version,
       },
       devDependencies: {
-        "react-native": "^0.64.0",
+        "react-native": profile_0_64["core-ios"].version,
       },
     });
     fs.__setMockFileWriter((p, _content) => {
@@ -182,10 +190,10 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     fs.__setMockContent({
       ...mockManifest,
       peerDependencies: {
-        "react-native": "^0.62.2 || ^0.63.4 || ^0.64.0",
+        "react-native": v62_v63_v64,
       },
       devDependencies: {
-        "react-native": "^0.62.2",
+        "react-native": profile_0_62["core-ios"].version,
       },
     });
     rnxKitConfig.__setMockConfig({
@@ -203,10 +211,10 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     fs.__setMockContent({
       ...mockManifest,
       peerDependencies: {
-        "react-native": "^0.62.2 || ^0.63.4 || ^0.64.0",
+        "react-native": v62_v63_v64,
       },
       devDependencies: {
-        "react-native": "^0.63.4",
+        "react-native": profile_0_63["core-ios"].version,
       },
     });
     rnxKitConfig.__setMockConfig({

--- a/packages/dep-check/test/manifest.test.ts
+++ b/packages/dep-check/test/manifest.test.ts
@@ -180,11 +180,11 @@ describe("updateDependencies()", () => {
     expect(
       updateDependencies(undefined, resolvedPackages, "development")
     ).toEqual({
-      react: "16.13.1",
-      "react-native": "^0.63.4",
-      "react-native-macos": "^0.63.0",
-      "react-native-test-app": "^0.5.5",
-      "react-native-windows": "^0.63.0",
+      react: profile_0_63["react"].version,
+      "react-native": profile_0_63["core-ios"].version,
+      "react-native-macos": profile_0_63["core-macos"].version,
+      "react-native-test-app": profile_0_63["test-app"].version,
+      "react-native-windows": profile_0_63["core-windows"].version,
     });
   });
 });


### PR DESCRIPTION
- 0.62
  - Bump react-native to 0.62.3 to address build issues with Xcode 12.5
- 0.63
  - Downgrade react-native from 0.63.4 to 0.63.2 to address build issues in repos that check in their Pods folder
- 0.64
  - Bump react-native to 0.64.1 to address build issues with Xcode 12.5