### PR TITLE
fix(dep-check): libraries should not re-declare transitive dependencies

### DIFF
--- a/change/@rnx-kit-dep-check-bea73e5a-b95a-42f3-aa2a-ae1e2c3d9eac.json
+++ b/change/@rnx-kit-dep-check-bea73e5a-b95a-42f3-aa2a-ae1e2c3d9eac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Libraries should not re-declare transitive dependencies",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dep-check/src/check.ts
+++ b/packages/dep-check/src/check.ts
@@ -46,7 +46,7 @@ export function checkPackageManifest(
   const {
     reactNativeVersion,
     capabilities: requiredCapabilities,
-  } = getRequirements(targetReactNativeVersion, manifest, projectRoot);
+  } = getRequirements(targetReactNativeVersion, kitType, manifest, projectRoot);
   requiredCapabilities.push(...targetCapabilities);
 
   const badPackages = findBadPackages(manifest);

--- a/packages/dep-check/test/__snapshots__/check.test.ts.snap
+++ b/packages/dep-check/test/__snapshots__/check.test.ts.snap
@@ -4,10 +4,6 @@ exports[`checkPackageManifest({ kitType: 'library' }) prints warnings when detec
 Array [
   Array [
     "warn:",
-    "Unable to resolve module 'react-native-linear-gradient'",
-  ],
-  Array [
-    "warn:",
     "Known bad packages are found:
     react-native-linear-gradient@*: This package is unmaintained and causes significant degradation in app start up time.",
   ],
@@ -16,10 +12,6 @@ Array [
 
 exports[`checkPackageManifest({ kitType: 'library' }) prints warnings when detecting bad packages 1`] = `
 Array [
-  Array [
-    "warn:",
-    "Unable to resolve module 'react-native-linear-gradient'",
-  ],
   Array [
     "warn:",
     "Known bad packages are found:

--- a/packages/dep-check/test/dependencies.test.ts
+++ b/packages/dep-check/test/dependencies.test.ts
@@ -107,6 +107,7 @@ describe("getRequirements()", () => {
     const manifest = JSON.parse(manifestJson);
     const { reactNativeVersion, capabilities } = getRequirements(
       "^0.63 || ^0.64",
+      "app",
       manifest,
       fixture
     );
@@ -127,6 +128,7 @@ describe("getRequirements()", () => {
     expect(() =>
       getRequirements(
         "0.60.6",
+        "app",
         {
           name: "@rnx-kit/dep-check",
           version: "1.0.0",


### PR DESCRIPTION
If a library A depends on another library B, A should not have to re-declare all of B's dependencies.