### PR TITLE
fix(dep-check): dev-only dependencies should always be added

### DIFF
--- a/change/@rnx-kit-dep-check-6667d8f1-6c15-41e5-9351-8542330e1bb1.json
+++ b/change/@rnx-kit-dep-check-6667d8f1-6c15-41e5-9351-8542330e1bb1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow dev-only dependencies should always be added",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dep-check/src/profiles/profile-0.61.ts
+++ b/packages/dep-check/src/profiles/profile-0.61.ts
@@ -124,6 +124,7 @@ const profile: Profile = {
   "test-app": {
     name: "react-native-test-app",
     version: "^0.3.13",
+    devOnly: true,
   },
   webview: {
     name: "react-native-webview",

--- a/packages/dep-check/src/profiles/profile-0.63.ts
+++ b/packages/dep-check/src/profiles/profile-0.63.ts
@@ -59,6 +59,7 @@ const profile: Profile = {
   "test-app": {
     name: "react-native-test-app",
     version: "^0.5.5",
+    devOnly: true,
   },
   webview: {
     name: "react-native-webview",

--- a/packages/dep-check/src/profiles/profile-0.64.ts
+++ b/packages/dep-check/src/profiles/profile-0.64.ts
@@ -124,6 +124,7 @@ const profile: Profile = {
   "test-app": {
     name: "react-native-test-app",
     version: "^0.5.5",
+    devOnly: true,
   },
   webview: {
     name: "react-native-webview",

--- a/packages/dep-check/test/__snapshots__/check.app.test.ts.snap
+++ b/packages/dep-check/test/__snapshots__/check.app.test.ts.snap
@@ -24,7 +24,8 @@ exports[`checkPackageManifest({ kitType: 'app' }) adds required dependencies 1`]
       \\"hermes\\",
       \\"lazy-index\\"
     ]
-  }
+  },
+  \\"devDependencies\\": {}
 }
 "
 `;

--- a/packages/dep-check/test/manifest.test.ts
+++ b/packages/dep-check/test/manifest.test.ts
@@ -62,7 +62,7 @@ describe("updateDependencies()", () => {
       react: profile_0_64["react"].version,
       "react-native": profile_0_64["core-ios"].version,
       "react-native-macos": profile_0_64["core-macos"].version,
-      "react-native-test-app": profile_0_64["test-app"].version,
+      "react-native-test-app": "0.0.0",
       "react-native-windows": profile_0_64["core-windows"].version,
       typescript: "0.0.0",
     });
@@ -94,7 +94,7 @@ describe("updateDependencies()", () => {
       react: `${profile_0_63["react"].version} || ${profile_0_64["react"].version}`,
       "react-native": `${profile_0_63["core-ios"].version} || ${profile_0_64["core-ios"].version}`,
       "react-native-macos": `${profile_0_63["core-macos"].version} || ${profile_0_64["core-macos"].version}`,
-      "react-native-test-app": profile_0_64["test-app"].version,
+      "react-native-test-app": "0.0.0",
       "react-native-windows": `${profile_0_63["core-windows"].version} || ${profile_0_64["core-windows"].version}`,
       typescript: "0.0.0",
     });
@@ -123,7 +123,7 @@ describe("updateDependencies()", () => {
       react: profile_0_64["react"].version,
       "react-native": profile_0_64["core-ios"].version,
       "react-native-macos": profile_0_64["core-macos"].version,
-      "react-native-test-app": profile_0_64["test-app"].version,
+      "react-native-test-app": "0.0.0",
       "react-native-windows": profile_0_64["core-windows"].version,
       typescript: "0.0.0",
     });
@@ -157,7 +157,7 @@ describe("updateDependencies()", () => {
       react: `${profile_0_63["react"].version} || ${profile_0_64["react"].version}`,
       "react-native": `${profile_0_63["core-ios"].version} || ${profile_0_64["core-ios"].version}`,
       "react-native-macos": `${profile_0_63["core-macos"].version} || ${profile_0_64["core-macos"].version}`,
-      "react-native-test-app": profile_0_64["test-app"].version,
+      "react-native-test-app": "0.0.0",
       "react-native-windows": `${profile_0_63["core-windows"].version} || ${profile_0_64["core-windows"].version}`,
       typescript: "0.0.0",
     });
@@ -332,6 +332,34 @@ describe("updatePackageManifest()", () => {
     });
     expect(devDependencies).toEqual({
       "react-native": profile_0_64["core-ios"].version,
+    });
+  });
+
+  test("always sets dev-only dependencies", () => {
+    const {
+      dependencies,
+      devDependencies,
+      peerDependencies,
+    } = updatePackageManifest(
+      {
+        name: "Test",
+        version: "0.0.1",
+        dependencies: mockDependencies,
+        peerDependencies: {},
+        devDependencies: {},
+      },
+      ["core-android", "core-ios", "test-app"],
+      [profile_0_63, profile_0_64],
+      [profile_0_64],
+      "app"
+    );
+    expect(dependencies).toEqual({
+      ...mockDependencies,
+      "react-native": profile_0_64["core-ios"].version,
+    });
+    expect(peerDependencies).toEqual({});
+    expect(devDependencies).toEqual({
+      "react-native-test-app": profile_0_64["test-app"].version,
     });
   });
 });


### PR DESCRIPTION
The previous fix for dev-only dependencies (#205) had an unintentional side-effect that adds `react-native-test-app` to `peerDependencies`. This change makes it so that dev-only dependencies are always added. This will allow test app only packages to still use `react-native-test-app` even when `kitType: "app"`. It will also enable type definition packages should we add them in the future.