### PR TITLE
fix(cli): removed unused `react-native` dependency

### DIFF
--- a/change/@rnx-kit-cli-ce8c3ae9-ba9d-4c1e-a0ae-19c2369b803f.json
+++ b/change/@rnx-kit-cli-ce8c3ae9-ba9d-4c1e-a0ae-19c2369b803f.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Declare dependency on @react-native-community/cli",
+  "comment": "Removed unused react-native dependency",
   "packageName": "@rnx-kit/cli",
   "email": "4123478+tido64@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,6 @@
     "test": "rnx-kit-scripts test"
   },
   "dependencies": {
-    "@react-native-community/cli": ">= 4.0.0",
     "@rnx-kit/config": "0.2.6",
     "@rnx-kit/dep-check": "^1.1.8",
     "@rnx-kit/third-party-notices": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1624,7 +1624,7 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-4.10.1.tgz#d68a2dcd1649d3b3774823c64e5e9ce55bfbe1c9"
   integrity sha512-ael2f1onoPF3vF7YqHGWy7NnafzGu+yp88BbFbP0ydoCP2xGSUzmZVw0zakPTC040Id+JQ9WeFczujMkDy6jYQ==
 
-"@react-native-community/cli@>= 4.0.0", "@react-native-community/cli@^4.10.0":
+"@react-native-community/cli@^4.10.0":
   version "4.14.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-4.14.0.tgz#bb106a98341bfa2db36060091ff90bfe82ea4f55"
   integrity sha512-EYJKBuxFxAu/iwNUfwDq41FjORpvSh1wvQ3qsHjzcR5uaGlWEOJrd3uNJDuKBAS0TVvbEesLF9NEXipjyRVr4Q==


### PR DESCRIPTION
It doesn't seem like cli has a dependency on `react-native`, but rather on `@react-native-community/cli`.