### PR TITLE
fix(dep-check): ignore whitespace differences

### DIFF
--- a/change/@rnx-kit-dep-check-a5a9434f-75ad-4e48-b7d7-ffd479a4c97f.json
+++ b/change/@rnx-kit-dep-check-a5a9434f-75ad-4e48-b7d7-ffd479a4c97f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ignore whitespace differences",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dep-check/src/check.ts
+++ b/packages/dep-check/src/check.ts
@@ -68,13 +68,14 @@ export function checkPackageManifest(
     getProfilesFor(reactNativeDevVersion),
     kitType
   );
-  const updatedManifestJson =
-    JSON.stringify(updatedManifest, undefined, 2) + "\n";
-  const normalizedManifestJson = manifestJson.replace(/\r/g, "");
+
+  // Don't fail when manifests only have whitespace differences.
+  const updatedManifestJson = JSON.stringify(updatedManifest, undefined, 2);
+  const normalizedManifestJson = JSON.stringify(manifest, undefined, 2);
 
   if (updatedManifestJson !== normalizedManifestJson) {
     if (write) {
-      fs.writeFileSync(manifestPath, updatedManifestJson);
+      fs.writeFileSync(manifestPath, updatedManifestJson + "\n");
     } else {
       const diff = diffLinesUnified(
         normalizedManifestJson.split("\n"),


### PR DESCRIPTION
Some scripts aren't correctly adding EOL to `package.json` when updating them. This change makes sure to ignore them and not fail the check.