### PR TITLE
chore: address warnings during install

### DIFF
--- a/change/@rnx-kit-babel-preset-metro-react-native-3fa1e563-3609-4864-9d6f-a70bd5975caa.json
+++ b/change/@rnx-kit-babel-preset-metro-react-native-3fa1e563-3609-4864-9d6f-a70bd5975caa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Move @babel/core to dependencies.",
+  "packageName": "@rnx-kit/babel-preset-metro-react-native",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -30,8 +30,12 @@
     "test": "lage test --verbose --grouped"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "beachball": "^2.2.0",
-    "lage": "^0.29.0"
+    "lage": "^0.29.0",
+    "metro": "^0.59.0",
+    "metro-config": "^0.59.0",
+    "metro-react-native-babel-preset": "^0.59.0"
   },
   "workspaces": {
     "packages": [

--- a/packages/babel-preset-metro-react-native/package.json
+++ b/packages/babel-preset-metro-react-native/package.json
@@ -19,10 +19,10 @@
     "test": "rnx-kit-scripts test"
   },
   "dependencies": {
+    "@babel/core": "^7.0.0",
     "babel-plugin-const-enum": "^1.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0",
     "metro-react-native-babel-preset": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
```
warning " > metro-react-native-babel-preset@0.59.0" has unmet peer dependency "@babel/core@*".
warning " > @rnx-kit/babel-preset-metro-react-native@1.0.2" has unmet peer dependency "@babel/core@^7.0.0".
warning " > @rnx-kit/babel-preset-metro-react-native@1.0.2" has unmet peer dependency "metro-react-native-babel-preset@*".
warning " > @rnx-kit/metro-config@1.1.3" has unmet peer dependency "metro-config@>=0.58.0".
warning " > @rnx-kit/metro-serializer@1.0.0" has unmet peer dependency "metro@>=0.58.0".
```