### PR TITLE
chore: add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+* @afoxman @JasonVMo @tido64
+
+# Miscellaneous
+/CODE_OF_CONDUCT.md  @microsoftopensource
+/LICENSE             @microsoftopensource
+/SECURITY.md         @microsoftopensource


### PR DESCRIPTION
Code owners automatically get added as reviewers.

This is also saves some time if you often see this screen:

![image](https://user-images.githubusercontent.com/4123478/118786581-3e9acb00-b892-11eb-835c-20c873cf742b.png)
