### PR TITLE
fix(dep-check): bump react-native-test-app to 0.5.9

### DIFF
--- a/change/@rnx-kit-dep-check-9c082e82-8f6c-4b3e-b049-0af0d0b446fe.json
+++ b/change/@rnx-kit-dep-check-9c082e82-8f6c-4b3e-b049-0af0d0b446fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump react-native-test-app to 0.5.9 to address an issue with linters complaining about an old version of Dagger being used.",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dep-check/src/profiles/profile-0.61.ts
+++ b/packages/dep-check/src/profiles/profile-0.61.ts
@@ -123,7 +123,7 @@ const profile: Profile = {
   },
   "test-app": {
     name: "react-native-test-app",
-    version: "^0.5.8",
+    version: "^0.5.9",
     devOnly: true,
   },
   webview: {

--- a/packages/dep-check/src/profiles/profile-0.64.ts
+++ b/packages/dep-check/src/profiles/profile-0.64.ts
@@ -123,7 +123,7 @@ const profile: Profile = {
   },
   "test-app": {
     name: "react-native-test-app",
-    version: "^0.5.8",
+    version: "^0.5.9",
     devOnly: true,
   },
   webview: {


### PR DESCRIPTION
Android:
- Addresses an issue with linters complaining about an old version of
  Dagger being used.