### PR TITLE
fix(dep-check): failure when react-native dev version is a range

### DIFF
--- a/change/@rnx-kit-config-e7a582ee-624a-4bee-904d-8a7b36ae5369.json
+++ b/change/@rnx-kit-config-e7a582ee-624a-4bee-904d-8a7b36ae5369.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed error when React Native dev version is a range",
+  "packageName": "@rnx-kit/config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-dep-check-7dc9b2c0-f15c-48cd-9f08-5b0c7e157c76.json
+++ b/change/@rnx-kit-dep-check-7dc9b2c0-f15c-48cd-9f08-5b0c7e157c76.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed older yargs versions not ignoring flags with default values when looking for conflicts",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/config/src/getKitCapabilities.test.ts
+++ b/packages/config/src/getKitCapabilities.test.ts
@@ -51,6 +51,21 @@ describe("getKitCapabilities()", () => {
     ).toBe("^0.63 || ^0.64");
   });
 
+  test("returns declared React Native dev version", () => {
+    expect(
+      getKitCapabilities({
+        reactNativeVersion: "^0.63 || ^0.64",
+        reactNativeDevVersion: "0.64.0",
+      }).reactNativeDevVersion
+    ).toBe("0.64.0");
+    expect(
+      getKitCapabilities({
+        reactNativeVersion: "^0.63 || ^0.64",
+        reactNativeDevVersion: "^0.64.0",
+      }).reactNativeDevVersion
+    ).toBe("^0.64.0");
+  });
+
   test("returns minimum supported React Native version as dev version when unspecified", () => {
     expect(
       getKitCapabilities({

--- a/packages/config/src/getKitCapabilities.ts
+++ b/packages/config/src/getKitCapabilities.ts
@@ -32,7 +32,7 @@ export function getKitCapabilities({
 
   if (
     !reactNativeDevVersion ||
-    !semver.satisfies(reactNativeDevVersion, reactNativeVersion)
+    !semver.subset(reactNativeDevVersion, reactNativeVersion)
   ) {
     throw new Error(
       `'${reactNativeDevVersion}' is not a valid dev version because it does not satisfy supported version range '${reactNativeVersion}'`

--- a/packages/dep-check/src/cli.ts
+++ b/packages/dep-check/src/cli.ts
@@ -171,7 +171,7 @@ if (require.main === module) {
         description:
           "Writes an initial kit config to the specified 'package.json'.",
         choices: ["app", "library"],
-        conflicts: ["vigilant", "write"],
+        conflicts: ["vigilant"],
       },
       vigilant: {
         description:
@@ -184,7 +184,6 @@ if (require.main === module) {
         default: false,
         description: "Writes changes to the specified 'package.json'.",
         type: "boolean",
-        conflicts: ["init"],
       },
     },
     cli

--- a/packages/dep-check/test/check.test.ts
+++ b/packages/dep-check/test/check.test.ts
@@ -229,4 +229,26 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(consoleLogSpy).not.toBeCalled();
     expect(consoleWarnSpy).not.toBeCalled();
   });
+
+  test("handles development version ranges", () => {
+    fs.__setMockContent({
+      ...mockManifest,
+      peerDependencies: {
+        "react-native": v62_v63_v64,
+      },
+      devDependencies: {
+        "react-native": profile_0_63["core-ios"].version,
+      },
+    });
+    rnxKitConfig.__setMockConfig({
+      reactNativeVersion: "^0.62 || ^0.63 || ^0.64",
+      reactNativeDevVersion: "^0.63.4",
+      capabilities: ["core-ios"],
+    });
+
+    expect(checkPackageManifest("package.json")).toBe(0);
+    expect(consoleErrorSpy).not.toBeCalled();
+    expect(consoleLogSpy).not.toBeCalled();
+    expect(consoleWarnSpy).not.toBeCalled();
+  });
 });


### PR DESCRIPTION
Also fixes issue with older yargs versions not ignoring flags with default values when looking for conflicts.