### PR TITLE
ci: mitigate race condition in publish step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,11 @@ jobs:
       - name: Bundle packages
         run: yarn bundle:ci
       - name: Publish
-        run: yarn run publish:beachball --yes --token ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [[ $(git rev-parse HEAD) == $(git ls-remote --quiet | grep HEAD | cut -f 1) ]]; then
+            yarn run publish:beachball --yes --token ${{ secrets.NPM_TOKEN }}
+          else
+            # Branches stored in GITHUB_REF are prefixed with 'refs/heads/'. We
+            # strip it to make the message a bit more legible.
+            echo "The local branch of '${GITHUB_REF#refs/heads/}' is behind the remote one, therefore a new version won't be published."
+          fi


### PR DESCRIPTION
Use `git ls-remote` to figure out whether we're on latest commit before publishing packages.

When upstream is more recent:

```
% [[ $(git rev-parse HEAD) == $(git ls-remote --quiet | grep HEAD | cut -f 1) ]] && echo publish
%
```

When the local clone is in sync with upstream:

```
% [[ $(git rev-parse HEAD) == $(git ls-remote --quiet | grep HEAD | cut -f 1) ]] && echo publish
publish
%
```

Resolves #168