### PR TITLE
ci: ensure `yarn.lock` is deduplicated

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,6 +45,9 @@ jobs:
           node-version: 14
       - name: Checkout
         uses: actions/checkout@v2.3.4
+      - name: Deduplicate packages
+        run: |
+          npx yarn-deduplicate --list --fail
       - name: Cache /.yarn-offline-mirror
         uses: actions/cache@v2.1.6
         with:


### PR DESCRIPTION
### Description

I will be setting up msftbot to auto-merge PRs from Dependabot. We need to ensure that it doesn't introduce dupes in `yarn.lock`.

### Test plan

CI should pass.