### PR TITLE
fix(dep-check): add link to documentation in output

### DIFF
--- a/change/@rnx-kit-dep-check-b4877c4b-4b53-4287-965e-11166d5350bd.json
+++ b/change/@rnx-kit-dep-check-b4877c4b-4b53-4287-965e-11166d5350bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added link to documentation in output",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dep-check/package.json
+++ b/packages/dep-check/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "rnx-kit-scripts build",
     "format": "rnx-kit-scripts format",
+    "lint": "rnx-kit-scripts lint",
     "test": "rnx-kit-scripts test",
     "update-readme": "node scripts/update-readme.js"
   },

--- a/packages/dep-check/src/check.ts
+++ b/packages/dep-check/src/check.ts
@@ -1,5 +1,5 @@
 import { getKitCapabilities, getKitConfig } from "@rnx-kit/config";
-import { error, warn } from "@rnx-kit/console";
+import { error, info, warn } from "@rnx-kit/console";
 import chalk from "chalk";
 import fs from "fs";
 import { diffLinesUnified } from "jest-diff";
@@ -96,12 +96,12 @@ export function checkPackageManifest(
       );
       console.log(diff);
 
-      const [_, depCheckPath, ...args] = process.argv;
-      const bin = path.basename(depCheckPath);
-      const command = [bin, "--write", ...args].join(" ");
       error(
-        `Changes are needed to satisfy all requirements. Run '${command}' to have ${bin} apply them.`
+        "Changes are needed to satisfy all requirements. Re-run with `--write` to have dep-check apply them."
       );
+
+      const url = chalk.bold("https://aka.ms/dep-check");
+      info(`Visit ${url} for more information about dep-check.`);
 
       return 1;
     }

--- a/packages/dep-check/test/__mocks__/chalk.js
+++ b/packages/dep-check/test/__mocks__/chalk.js
@@ -4,6 +4,9 @@ function passthrough(s) {
   return s;
 }
 
+chalk.bold = passthrough;
+chalk.cyan = passthrough;
+chalk.cyan.bold = passthrough;
 chalk.dim = passthrough;
 chalk.green = passthrough;
 chalk.red = passthrough;

--- a/packages/dep-check/test/check.test.ts
+++ b/packages/dep-check/test/check.test.ts
@@ -165,7 +165,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(checkPackageManifest("package.json")).not.toBe(0);
     expect(consoleErrorSpy).toBeCalledTimes(1);
     expect(consoleWarnSpy).not.toBeCalled();
-    expect(consoleLogSpy).toBeCalledTimes(1);
+    expect(consoleLogSpy).toBeCalledTimes(2);
   });
 
   test("writes changes back to 'package.json'", () => {

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -76,6 +76,7 @@
       "core-android",
       "core-ios",
       "core-windows",
+      "react",
       "test-app"
     ]
   }


### PR DESCRIPTION
### Description

The error output could use a link to the documentation.

### Test plan

1. Make a change that will trigger dep-check, e.g.
    ```diff
    diff --git a/packages/test-app/package.json b/packages/test-app/package.json
    index 0e1bb25..61dda81 100644
    --- a/packages/test-app/package.json
    +++ b/packages/test-app/package.json
    @@ -21,7 +21,7 @@
         "start": "react-native start --projectRoot src"
       },
       "dependencies": {
    -    "react": "17.0.1",
    +    "react": "18.0.1",
         "react-native": "^0.64.2",
         "react-native-windows": "^0.64.0"
       },
    ```
2. Run `yarn rnx-dep-check`
3. It should output the following at the end:
    ```
    error Changes are needed to satisfy all requirements. Re-run with `--write` to have dep-check apply them.
    info Visit https://aka.ms/dep-check for more information about dep-check.
    ```