### PR TITLE
fix(cli): add flag for enabling experimental tree shake

### DIFF
--- a/change/@rnx-kit-cli-71288069-205c-440e-80bc-726a97ebdab8.json
+++ b/change/@rnx-kit-cli-71288069-205c-440e-80bc-726a97ebdab8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added flag for enabling experimental tree shake",
+  "packageName": "@rnx-kit/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-config-eab16f8e-2b8a-44a9-ba75-c585788e2620.json
+++ b/change/@rnx-kit-config-eab16f8e-2b8a-44a9-ba75-c585788e2620.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added flag for enabling experimental tree shake",
+  "packageName": "@rnx-kit/config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-metro-serializer-esbuild-5f5c9feb-d674-409e-ae16-331d129cc46c.json
+++ b/change/@rnx-kit-metro-serializer-esbuild-5f5c9feb-d674-409e-ae16-331d129cc46c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Correct metro version in peer dependencies",
+  "packageName": "@rnx-kit/metro-serializer-esbuild",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
     "@rnx-kit/metro-plugin-cyclic-dependencies-detector": "1.0.3",
     "@rnx-kit/metro-plugin-duplicates-checker": "1.1.3",
     "@rnx-kit/metro-serializer": "1.0.0",
+    "@rnx-kit/metro-serializer-esbuild": "^0.0.8",
     "@rnx-kit/metro-service": "1.0.2",
     "@rnx-kit/third-party-notices": "1.0.1",
     "chalk": "^4.1.0"

--- a/packages/cli/src/bundle.ts
+++ b/packages/cli/src/bundle.ts
@@ -137,8 +137,12 @@ export async function rnxBundle(
       sourceMapSourceRootPath,
       sourceMapUseAbsolutePaths,
     } = platformDefinition;
-    const { detectCyclicDependencies, detectDuplicateDependencies } =
-      platformDefinition;
+
+    const {
+      detectCyclicDependencies,
+      detectDuplicateDependencies,
+      experimental_treeShake,
+    } = platformDefinition;
 
     //  apply command-line overrides to the platform-specific bundle definition
     entryPath = cliBundleOptions.entryPath ?? entryPath;
@@ -173,7 +177,8 @@ export async function rnxBundle(
     customizeMetroConfig(
       metroConfig,
       detectCyclicDependencies,
-      detectDuplicateDependencies
+      detectDuplicateDependencies,
+      experimental_treeShake
     );
 
     //  ensure all output directories exist

--- a/packages/cli/src/metro-config.ts
+++ b/packages/cli/src/metro-config.ts
@@ -1,4 +1,3 @@
-import type { ConfigT, InputConfigT, SerializerConfigT } from "metro-config";
 import {
   CyclicDependencies,
   PluginOptions as CyclicDetectorOptions,
@@ -8,6 +7,8 @@ import {
   Options as DuplicateDetectorOptions,
 } from "@rnx-kit/metro-plugin-duplicates-checker";
 import { MetroSerializer, MetroPlugin } from "@rnx-kit/metro-serializer";
+import { MetroSerializer as MetroSerializerEsbuild } from "@rnx-kit/metro-serializer-esbuild";
+import type { ConfigT, InputConfigT, SerializerConfigT } from "metro-config";
 
 function reportError(prop: string) {
   console.error(
@@ -32,7 +33,8 @@ export function validateMetroConfig(metroConfig: ConfigT): boolean {
 export function customizeMetroConfig(
   metroConfigReadonly: InputConfigT,
   detectCyclicDependencies: boolean | CyclicDetectorOptions,
-  detectDuplicateDependencies: boolean | DuplicateDetectorOptions
+  detectDuplicateDependencies: boolean | DuplicateDetectorOptions,
+  experimental_treeShake: boolean
 ): void {
   //  We will be making changes to the Metro configuration. Coerce from a
   //  type with readonly props to a type where the props are writeable.
@@ -61,9 +63,9 @@ export function customizeMetroConfig(
     //
     //  Since it can handle either scenario, just coerce it to whatever
     //  the current version of Metro expects.
-    const serializer = MetroSerializer(
-      plugins
-    ) as SerializerConfigT["customSerializer"];
+    const serializer = experimental_treeShake
+      ? MetroSerializerEsbuild(plugins)
+      : (MetroSerializer(plugins) as SerializerConfigT["customSerializer"]);
 
     metroConfig.serializer.customSerializer = serializer;
   } else {

--- a/packages/config/src/bundleConfig.ts
+++ b/packages/config/src/bundleConfig.ts
@@ -72,6 +72,15 @@ export type BundleRequiredParameters = {
    * @default true
    */
   typescriptValidation: boolean;
+
+  /**
+   * Choose whether to enable tree shaking.
+
+   * ⚠️ **THIS FEATURE IS HIGHLY EXPERIMENTAL** ⚠️
+   *
+   * @default false
+   */
+  experimental_treeShake: boolean;
 };
 
 export type BundleParameters = Partial<BundleRequiredParameters> & {

--- a/packages/config/src/getBundleDefinition.ts
+++ b/packages/config/src/getBundleDefinition.ts
@@ -34,6 +34,7 @@ export function getBundleDefinition(
     detectCyclicDependencies: true,
     detectDuplicateDependencies: true,
     typescriptValidation: true,
+    experimental_treeShake: false,
   };
   if (typeof config === "boolean") {
     return defaultDefinition;

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -25,7 +25,7 @@
     "semver": "^7.0.0"
   },
   "peerDependencies": {
-    "metro": ">=0.67.0"
+    "metro": ">=0.66.1"
   },
   "devDependencies": {
     "@rnx-kit/babel-preset-jest-typescript": "*",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -68,6 +68,7 @@
         ]
       },
       "typescriptValidation": true,
+      "experimental_treeShake": false,
       "targets": [
         "android",
         "ios",


### PR DESCRIPTION
### Description

Adds `experimental_treeShake` to CLI to enable `metro-serializer-esbuild`.

### Test plan

1. Build everything up to, and including, `@rnx-kit/test-app`:
    ```
    yarn
    yarn build-scope @rnx-kit/test-app
    ```
2. Enable `experimental_treeShake`:
    ```diff
    diff --git a/packages/test-app/package.json b/packages/test-app/package.json
    index a870cbb..7a3438b 100644
    --- a/packages/test-app/package.json
    +++ b/packages/test-app/package.json
    @@ -68,7 +68,7 @@
             ]
           },
           "typescriptValidation": true,
    -      "experimental_treeShake": false,
    +      "experimental_treeShake": true,
           "targets": [
             "android",
             "ios",
    ```
3. Run `yarn bundle+esbuild`