### PR TITLE
fix(metro-serializer-esbuild): enable esbuild sourcemap

### DIFF
--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -40,7 +40,7 @@ function fixSourceMap(outputPath: string, text: string): string {
     path.resolve(sourceRoot, file)
   );
 
-  return JSON.stringify({ ...sourcemap, sources }, undefined, 2);
+  return JSON.stringify({ ...sourcemap, sources });
 }
 
 function isRedundantPolyfill(modulePath: string): boolean {


### PR DESCRIPTION
### Description

esbuild's sourcemap will be mapped to the transformed JS. Ideally, it should map to the original source code, but since Metro currently handles the transformation, we cannot do that. At least now, it won't be pointing at wrong lines.

### Test plan

1. Build everything up to, and including, `@rnx-kit/test-app`:
    ```
    yarn
    yarn build-scope @rnx-kit/test-app
    ```
2. Enable `experimental_treeShake`:
    ```diff
    diff --git a/packages/test-app/package.json b/packages/test-app/package.json
    index a870cbb..7a3438b 100644
    --- a/packages/test-app/package.json
    +++ b/packages/test-app/package.json
    @@ -68,7 +68,7 @@
             ]
           },
           "typescriptValidation": true,
    -      "experimental_treeShake": false,
    +      "experimental_treeShake": true,
           "targets": [
             "android",
             "ios",
    ```
3. Run `yarn bundle+esbuild`
4. Examine `dist/main+esbuild.*.jsbundle.map`