### PR TITLE
fix(metro-config): handle workspace dependencies in exclusions

### DIFF
--- a/change/@rnx-kit-metro-config-b17b7d9b-b77c-436c-80b0-e37d28b95662.json
+++ b/change/@rnx-kit-metro-config-b17b7d9b-b77c-436c-80b0-e37d28b95662.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(metro-config): handle workspace dependencies in exclusions",
+  "packageName": "@rnx-kit/metro-config",
+  "email": "arabisho@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/metro-config/test/__fixtures__/awesome-repo/node_modules/@commando/matrix/package.json
+++ b/packages/metro-config/test/__fixtures__/awesome-repo/node_modules/@commando/matrix/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@commando/matrix",
+  "version": "0.0.1"
+}

--- a/packages/metro-config/test/__fixtures__/awesome-repo/packages/john/node_modules/@commando/matrix/package.json
+++ b/packages/metro-config/test/__fixtures__/awesome-repo/packages/john/node_modules/@commando/matrix/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@commando/matrix",
+  "version": "0.0.1"
+}

--- a/packages/metro-config/test/index.test.js
+++ b/packages/metro-config/test/index.test.js
@@ -91,6 +91,51 @@ describe("@rnx-kit/metro-config", () => {
     expect(exclude.test(projectCopy)).toBeFalsy();
   });
 
+  test("excludeExtraCopiesOf() handles nested dependencies", () => {
+    const repo = fixturePath("awesome-repo");
+    const packageRnCopy = path.join(
+      repo,
+      "packages",
+      "john",
+      "node_modules",
+      "react-native",
+      "package.json"
+    );
+    const projectRnCopy = path.join(
+      repo,
+      "node_modules",
+      "react-native",
+      "package.json"
+    );
+
+    const packageMatrixCopy = path.join(
+      repo,
+      "packages",
+      "john",
+      "node_modules",
+      "@commando",
+      "matrix",
+      "package.json"
+    );
+    const projectMatrixCopy = path.join(
+      repo,
+      "node_modules",
+      "@commando",
+      "matrix",
+      "package.json"
+    );
+
+    setFixture("awesome-repo/packages/john");
+
+    const excludeReactNative = excludeExtraCopiesOf("react-native");
+    expect(excludeReactNative.test(packageRnCopy)).toBeFalsy();
+    expect(excludeReactNative.test(projectRnCopy)).toBeTruthy();
+
+    const excludeMatrix = excludeExtraCopiesOf("@commando/matrix");
+    expect(excludeMatrix.test(packageMatrixCopy)).toBeFalsy();
+    expect(excludeMatrix.test(projectMatrixCopy)).toBeTruthy();
+  });
+
   test("excludeExtraCopiesOf() throws if a package is not found", () => {
     expect(excludeExtraCopiesOf("jest", process.cwd())).toBeDefined();
 


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

Fixes the bug where `excludeExtraCopiesOf` gets confused by dependencies that are nested under workspace folders in `node_modules`. For example: `path/to/proj/node_modules/@babel/runtime`. 

Fix: do not assume that all dependencies are nested directly within `node_modules`. Use `findUp` to resolve the `node_modules` folder first and then use the parent directory as the project directory.

### Test plan

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->

Automated tests.
