### PR TITLE
docs(metro-serializer-esbuild): add known limitations

### DIFF
--- a/change/@rnx-kit-metro-serializer-esbuild-27397be9-9b6f-4131-9d0c-fdbe0351f95f.json
+++ b/change/@rnx-kit-metro-serializer-esbuild-27397be9-9b6f-4131-9d0c-fdbe0351f95f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add known limitations",
+  "packageName": "@rnx-kit/metro-serializer-esbuild",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/metro-serializer-esbuild/README.md
+++ b/packages/metro-serializer-esbuild/README.md
@@ -76,3 +76,12 @@ We can now create a bundle as usual, e.g.:
 ```sh
 react-native bundle --entry-file index.js --platform ios --dev false ...
 ```
+
+## Known Limitations
+
+- Dev server may not work with this serializer. To work around this limitation,
+  you can save the esbuild specific Metro config to a separate file and only
+  specify it when needed, e.g.:
+  ```sh
+  react-native bundle ... --config metro+esbuild.config.js
+  ```


### PR DESCRIPTION
### Description

Adds a section about known limitations.

### Test plan

There's nothing to test.