### PR TITLE
fix(metro-service): support Metro <0.63

### DIFF
--- a/change/@rnx-kit-metro-service-07d44a96-bde3-4f8b-89cc-4beb2ec4adbf.json
+++ b/change/@rnx-kit-metro-service-07d44a96-bde3-4f8b-89cc-4beb2ec4adbf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Support Metro <0.63",
+  "packageName": "@rnx-kit/metro-service",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/metro-service/src/config.ts
+++ b/packages/metro-service/src/config.ts
@@ -48,6 +48,15 @@ function reactNativePlatformResolver(platformImplementations: {
   };
 }
 
+function getAsyncRequireModulePath(): string | undefined {
+  try {
+    // `metro-runtime` was introduced in 0.63
+    return require.resolve("metro-runtime/src/modules/asyncRequire");
+  } catch (_) {
+    return require.resolve("metro/src/lib/bundle-modules/asyncRequire");
+  }
+}
+
 function getDefaultConfig(cliConfig: CLIConfig): InputConfigT {
   const outOfTreePlatforms = Object.keys(cliConfig.platforms).filter(
     (platform) => cliConfig.platforms[platform].npmPackageName
@@ -111,9 +120,7 @@ function getDefaultConfig(cliConfig: CLIConfig): InputConfigT {
         "metro-react-native-babel-transformer"
       ),
       assetRegistryPath: "react-native/Libraries/Image/AssetRegistry",
-      asyncRequireModulePath: require.resolve(
-        "metro-runtime/src/modules/asyncRequire"
-      ),
+      asyncRequireModulePath: getAsyncRequireModulePath(),
     },
     watchFolders: [],
   };


### PR DESCRIPTION
### Description

This enables `metro-service` to work in FluentUI React Native (FURN), where Metro is still at 0.59.

### Test plan

1. Build `metro-service` locally
2. Clone FURN: `yarn clone https://github.com/microsoft/fluentui-react-native.git`
3. Bump `@rnx-kit/cli` to 0.5.36 in FURN
4. Replace `FURN/node_modules/@rnx-kit/metro-service` with `rnx-kit/packages/metro-service`
5. Build FURN: `yarn build`
6. Bundle: `yarn bundle`