### PR TITLE
fix(cli): jest-cli allows passing argv directly to run()

### DIFF
--- a/change/@rnx-kit-cli-b1334c61-8350-45d0-9e54-85fd51983527.json
+++ b/change/@rnx-kit-cli-b1334c61-8350-45d0-9e54-85fd51983527.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "jest-cli allows passing argv directly to run()",
+  "packageName": "@rnx-kit/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/dep-check.ts
+++ b/packages/cli/src/dep-check.ts
@@ -1,6 +1,5 @@
+import type { Config as CLIConfig } from "@react-native-community/cli-types";
 import { Args, cli } from "@rnx-kit/dep-check";
-
-type ConfigT = Record<string, unknown>;
 
 // TypeScript loses the type of `key` when return type is `T`.
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -10,7 +9,7 @@ function pickValue<T>(key: keyof T, obj: T): {} | undefined {
 
 export function rnxDepCheck(
   argv: string[],
-  _config: ConfigT,
+  _config: CLIConfig,
   args: Args
 ): void {
   cli({

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -1,4 +1,5 @@
 import type { Config as CLIConfig } from "@react-native-community/cli-types";
+import { run as runJest } from "jest-cli";
 import { parsePlatform } from "./parsers";
 
 type Args = {
@@ -16,37 +17,29 @@ type Options = {
     | ((config: CLIConfig) => string | boolean | number);
 };
 
-const COMMAND_NAME = "rnx-test";
-
 export function rnxTest(
   _argv: string[],
   _config: CLIConfig,
   { platform }: Args
 ): void {
-  const platformIndex = process.argv.indexOf("--platform");
+  // Copy and remove the first three arguments from
+  // `node react-native rnx-test ...`
+  const argv = process.argv.slice(3);
+
+  const platformIndex = argv.indexOf("--platform");
   if (platformIndex < 0) {
     throw new Error("A target platform must be specified");
   }
 
-  const originalArgv = process.argv.slice();
-
   // Remove `--platform` otherwise Jest will complain about an unrecognized
-  // option.
-  process.argv.splice(platformIndex, 2);
-
-  // Remove `rnx-test` otherwise Jest will think it's a regex for test files.
-  process.argv.splice(process.argv.indexOf(COMMAND_NAME), 1);
+  // option. We can pass the rest of the arguments to Jest as they are.
+  argv.splice(platformIndex, 2);
 
   process.env["RN_TARGET_PLATFORM"] = platform;
-  require("jest-cli/bin/jest");
-
-  // Restore `argv` otherwise `@react-native-community/cli` will think we tried
-  // to show help message.
-  process.argv.length = 0;
-  process.argv.push(...originalArgv);
+  runJest(argv);
 }
 
-export function jestOptions(): Options[] {
+function jestOptions(): Options[] {
   const { options } = require("jest-cli/build/cli/args");
   return Object.keys(options).map((option) => {
     const { default: defaultValue, description, type } = options[option];
@@ -59,7 +52,7 @@ export function jestOptions(): Options[] {
 }
 
 export const rnxTestCommand = {
-  name: COMMAND_NAME,
+  name: "rnx-test",
   description: "Test runner for React Native apps",
   func: rnxTest,
   options: [

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -17,14 +17,20 @@ type Options = {
     | ((config: CLIConfig) => string | boolean | number);
 };
 
+const COMMAND_NAME = "rnx-test";
+
 export function rnxTest(
   _argv: string[],
   _config: CLIConfig,
   { platform }: Args
 ): void {
-  // Copy and remove the first three arguments from
-  // `node react-native rnx-test ...`
-  const argv = process.argv.slice(3);
+  const commandIndex = process.argv.indexOf(COMMAND_NAME);
+  if (commandIndex < 0) {
+    throw new Error("Failed to parse command arguments");
+  }
+
+  // Copy and remove the first arguments from `node react-native rnx-test ...`
+  const argv = process.argv.slice(commandIndex + 1);
 
   const platformIndex = argv.indexOf("--platform");
   if (platformIndex < 0) {
@@ -52,7 +58,7 @@ function jestOptions(): Options[] {
 }
 
 export const rnxTestCommand = {
-  name: "rnx-test",
+  name: COMMAND_NAME,
   description: "Test runner for React Native apps",
   func: rnxTest,
   options: [


### PR DESCRIPTION
### Description

Invoke `run()` directly rather than manipulating command line arguments to get the desired outcome.

### Test plan

```
$ react-native rnx-test --platform ios
 PASS  test/App.test.tsx
  ✓ renders correctly (433 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        1.821 s, estimated 2 s
Ran all test suites.
✨  Done in 3.45s.
```

```
$ react-native rnx-test --platform ios --coverage
 PASS  test/App.test.tsx
  ✓ renders correctly (431 ms)

----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------|---------|----------|---------|---------|-------------------
All files |     100 |       50 |     100 |     100 |
 App.tsx  |     100 |       50 |     100 |     100 | 40
----------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        1.889 s, estimated 2 s
Ran all test suites.
✨  Done in 3.51s.
```

```
$ react-native rnx-test
error A target platform must be specified.
Error: A target platform must be specified
    at ...
info Run CLI with --verbose flag for more details.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```