### PR TITLE
chore: fix publishing

### DIFF
--- a/change/@rnx-kit-third-party-notices-be194906-4245-4d18-8946-9d3f6ec71b83.json
+++ b/change/@rnx-kit-third-party-notices-be194906-4245-4d18-8946-9d3f6ec71b83.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump @rnx-kit/console to 1.0.1 so Beachball doesn't get confused during publishing",
+  "packageName": "@rnx-kit/third-party-notices",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/third-party-notices/package.json
+++ b/packages/third-party-notices/package.json
@@ -24,7 +24,7 @@
     "test": "rnx-kit-scripts test"
   },
   "dependencies": {
-    "@rnx-kit/console": "^1.0.0",
+    "@rnx-kit/console": "^1.0.1",
     "spdx-expression-parse": "^3.0.1",
     "yargs": "^16.0.0"
   },


### PR DESCRIPTION
### Description

Beachball gets confused when a package depends on another workspace package using a version that is different from latest.

### Test plan

Publish should succeed.