### PR TITLE
feat(dep-check): add command for setting react-native version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,9 @@ jobs:
       - name: Align dependencies
         run: yarn rnx-dep-check --write
       - name: Report changes
-        run: git diff | GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} yarn suggestion-bot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: git diff | yarn suggestion-bot
   build:
     name: "Build"
     strategy:
@@ -58,9 +60,11 @@ jobs:
         run: yarn build:ci
       - name: Ensure READMEs are up-to-date
         if: ${{ matrix.node-version == 14 && matrix.os == 'ubuntu-latest' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           yarn update-readme
-          git diff | GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} yarn suggestion-bot
+          git diff | yarn suggestion-bot
       - name: Bundle packages
         run: yarn bundle:ci
       - name: Bundle test app with esbuild

--- a/change/@rnx-kit-cli-1712cb66-dab7-46a0-93cd-6715820f985d.json
+++ b/change/@rnx-kit-cli-1712cb66-dab7-46a0-93cd-6715820f985d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix arguments not being properly forwarded to dep-check",
+  "packageName": "@rnx-kit/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-dep-check-0148d857-b99f-4666-83d2-b33ff70947fa.json
+++ b/change/@rnx-kit-dep-check-0148d857-b99f-4666-83d2-b33ff70947fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add command for setting react-native version",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/react-native.config.js
+++ b/packages/cli/react-native.config.js
@@ -5,7 +5,7 @@ const {
   parseBoolean,
   rnxBundle,
   rnxStart,
-  rnxDepCheck,
+  rnxDepCheckCommand,
   rnxTestCommand,
   rnxWriteThirdPartyNotices,
 } = require("./lib/index");
@@ -181,36 +181,7 @@ module.exports = {
         },
       ],
     },
-    {
-      name: "rnx-dep-check",
-      description: "Dependency checker for React Native apps",
-      func: rnxDepCheck,
-      options: [
-        {
-          name: "--custom-profiles [module]",
-          description:
-            "Path to custom profiles. This can be a path to a JSON file, a `.js` file, or a module name.",
-        },
-        {
-          name: "--exclude-packages [packages]",
-          description:
-            "Comma-separated list of package names to exclude from inspection.",
-        },
-        {
-          name: "--init [app|library]",
-          description: "Writes an initial kit config",
-        },
-        {
-          name: "--vigilant [versions]",
-          description:
-            "Inspects packages regardless of whether they've been configured. Specify a comma-separated list of profile versions to compare against, e.g. `0.63,0.64`. The first number specifies the target version.",
-        },
-        {
-          name: "--write",
-          description: "Writes all changes to the specified `package.json`",
-        },
-      ],
-    },
+    rnxDepCheckCommand,
     rnxTestCommand,
     {
       name: "rnx-write-third-party-notices",

--- a/packages/cli/src/dep-check.ts
+++ b/packages/cli/src/dep-check.ts
@@ -1,23 +1,65 @@
 import type { Config as CLIConfig } from "@react-native-community/cli-types";
 import { Args, cli } from "@rnx-kit/dep-check";
 
-// TypeScript loses the type of `key` when return type is `T`.
-// eslint-disable-next-line @typescript-eslint/ban-types
-function pickValue<T>(key: keyof T, obj: T): {} | undefined {
-  return typeof obj[key] !== "undefined" ? { [key]: obj[key] } : undefined;
+type CLIArgs = Record<string, string | number | boolean | undefined>;
+
+function pickValue<T extends CLIArgs>(
+  name: keyof T,
+  key: string,
+  obj: CLIArgs
+): T | undefined {
+  const value = obj[key];
+  return typeof value !== "undefined" ? ({ [name]: value } as T) : undefined;
 }
 
 export function rnxDepCheck(
   argv: string[],
   _config: CLIConfig,
-  args: Args
+  args: CLIArgs
 ): void {
   cli({
-    ...pickValue("custom-profiles", args),
-    ...pickValue("exclude-packages", args),
-    ...pickValue("init", args),
-    ...pickValue("vigilant", args),
+    ...pickValue<Args>("custom-profiles", "customProfiles", args),
+    ...pickValue<Args>("exclude-packages", "excludePackages", args),
+    ...pickValue<Args>("init", "init", args),
+    ...pickValue<Args>("set-version", "setVersion", args),
+    ...pickValue<Args>("vigilant", "vigilant", args),
     write: Boolean(args.write),
     "package-json": argv[0],
   });
 }
+
+export const rnxDepCheckCommand = {
+  name: "rnx-dep-check",
+  description: "Dependency checker for React Native apps",
+  func: rnxDepCheck,
+  options: [
+    {
+      name: "--custom-profiles [module]",
+      description:
+        "Path to custom profiles. This can be a path to a JSON file, a `.js` file, or a module name.",
+    },
+    {
+      name: "--exclude-packages [packages]",
+      description:
+        "Comma-separated list of package names to exclude from inspection.",
+    },
+    {
+      name: "--init [app|library]",
+      description: "Writes an initial kit config",
+    },
+    {
+      name: "--set-version [versions]",
+      description:
+        "Sets `reactNativeVersion` and `reactNativeDevVersion` for any configured package. The value should be a comma-separated list of `react-native` versions to set. The first number specifies the development version. Example: `0.64,0.63`",
+    },
+    {
+      name: "--vigilant [versions]",
+      description:
+        "Inspects packages regardless of whether they've been configured. Specify a comma-separated list of profile versions to compare against, e.g. `0.63,0.64`. The first number specifies the target version.",
+    },
+    {
+      name: "--write",
+      description: "Writes all changes to the specified `package.json`",
+    },
+  ],
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,5 @@
 export { rnxBundle } from "./bundle";
-export { rnxDepCheck } from "./dep-check";
+export { rnxDepCheck, rnxDepCheckCommand } from "./dep-check";
 export { rnxStart } from "./start";
 export { rnxTest, rnxTestCommand } from "./test";
 export { rnxWriteThirdPartyNotices } from "./write-third-party-notices";

--- a/packages/dep-check/README.md
+++ b/packages/dep-check/README.md
@@ -6,6 +6,162 @@
 `@rnx-kit/dep-check` manages React Native dependencies for a package, based on
 its needs and requirements.
 
+## Usage
+
+```sh
+rnx-dep-check [options] [/path/to/package.json]
+```
+
+Providing a path to `package.json` is optional. If omitted, it will look for one
+using Node module resolution.
+
+### `--custom-profiles <module>`
+
+Path to custom profiles. This can be a path to a JSON file, a `.js` file, or a
+module name. The module must default export an object similar to the one below:
+
+```js
+module.exports = {
+  0.63: {
+    "my-capability": {
+      name: "my-module",
+      version: "1.0.0",
+    },
+  },
+  0.64: {
+    "my-capability": {
+      name: "my-module",
+      version: "1.1.0",
+    },
+  },
+};
+```
+
+For a more complete example, have a look at the
+[default profiles](https://github.com/microsoft/rnx-kit/blob/769e9fa290929effd5111884f1637c21326b5a95/packages/dep-check/src/profiles.ts#L11).
+
+> #### Note
+>
+> This specific flag may only be used with `--vigilant`. You can specify custom
+> profiles in normal mode by adding `customProfiles` to your package
+> [configuration](#configure).
+
+### `--exclude-packages`
+
+Comma-separated list of package names to exclude from inspection.
+
+> #### Note
+>
+> `--exclude-packages` will only exclude packages that do not have a
+> configuration. Packages that have a configuration, will still be checked. This
+> flag may only be used with `--vigilant`.
+
+### `--init <app | library>`
+
+When integrating `@rnx-kit/dep-check` for the first time, it may be a cumbersome
+to manually add all capabilities yourself. You can run this tool with `--init`,
+and it will try to add a sensible configuration based on what is currently
+defined in the specified `package.json`.
+
+### `--set-version`
+
+Sets `reactNativeVersion` and `reactNativeDevVersion` for any configured
+package. The value should be a comma-separated list of `react-native` versions
+to set. The first number specifies the development version. For example,
+`0.64,0.63` will set the following values:
+
+```json
+{
+  "rnx-kit": {
+    "reactNativeVersion": "^0.63.0 || ^0.64.0",
+    "reactNativeDevVersion": "^0.64.0"
+  }
+}
+```
+
+If the version numbers are omitted, an _interactive prompt_ will appear.
+
+> #### Note
+>
+> A `rnx-dep-check --write` run will be invoked right after changes have been
+> made. As such, this flag will fail if changes are needed before making any
+> modifications.
+
+### `--vigilant`
+
+Also inspect packages that are not configured. Specify a comma-separated list of
+profile versions to compare against, e.g. `0.63,0.64`. The first number
+specifies the target version.
+
+### `--write`
+
+Writes all proposed changes to the specified `package.json`.
+
+## Configure
+
+`@rnx-kit/dep-check` must first be configured before it can be used. It uses
+`@rnx-kit/config` to retrieve your kit configuration. Your configuration can be
+specified either in a file, `rnx-kit.config.js`, or in an `"rnx-kit"` section of
+your `package.json`.
+
+| Option                  | Type                   | Default               | Description                                                                                                 |
+| :---------------------- | :--------------------- | :-------------------- | :---------------------------------------------------------------------------------------------------------- |
+| `kitType`               | `"app"` \| `"library"` | `"library"`           | Whether this kit is an "app" or a "library". Determines how dependencies are declared.                      |
+| `reactNativeVersion`    | string                 | (required)            | Supported versions of React Native. The value can be a specific version or a range.                         |
+| `reactNativeDevVersion` | string                 | `minVersion(version)` | The version of React Native to use for development. If omitted, the minimum supported version will be used. |
+| `capabilities`          | Capabilities[]         | `[]`                  | List of used/provided capabilities. A full list can be found below.                                         |
+| `customProfiles`        | string                 | `undefined`           | Path to custom profiles. This can be a path to a JSON file, a `.js` file, or a module name.                 |
+
+## Capabilities
+
+<!-- The following table can be updated by running `yarn update-readme` -->
+<!-- @rnx-kit/dep-check/capabilities start -->
+
+| Capability        | 0.65                                              | 0.64                                              | 0.63                                          | 0.62                                          | 0.61                                          |
+| ----------------- | ------------------------------------------------- | ------------------------------------------------- | --------------------------------------------- | --------------------------------------------- | --------------------------------------------- |
+| core              | react-native@^0.65.0-0                            | react-native@^0.64.2                              | react-native@^0.63.2                          | react-native@^0.62.3                          | react-native@^0.61.5                          |
+| core-android      | react-native@^0.65.0-0                            | react-native@^0.64.2                              | react-native@^0.63.2                          | react-native@^0.62.3                          | react-native@^0.61.5                          |
+| core-ios          | react-native@^0.65.0-0                            | react-native@^0.64.2                              | react-native@^0.63.2                          | react-native@^0.62.3                          | react-native@^0.61.5                          |
+| core-macos        | react-native-macos@^0.65.0-0                      | react-native-macos@^0.64.0                        | react-native-macos@^0.63.0                    | react-native-macos@^0.62.0                    | react-native-macos@^0.61.0                    |
+| core-windows      | react-native-windows@^0.65.0-0                    | react-native-windows@^0.64.0                      | react-native-windows@^0.63.0                  | react-native-windows@^0.62.0                  | react-native-windows@^0.61.0                  |
+| animation         | react-native-reanimated@^2.1.0                    | react-native-reanimated@^2.1.0                    | react-native-reanimated@^1.13.3               | react-native-reanimated@^1.13.3               | react-native-reanimated@^1.13.3               |
+| base64            | react-native-base64@^0.2.1                        | react-native-base64@^0.2.1                        | react-native-base64@^0.2.1                    | react-native-base64@^0.2.1                    | react-native-base64@^0.2.1                    |
+| checkbox          | @react-native-community/checkbox@^0.5.8           | @react-native-community/checkbox@^0.5.8           | @react-native-community/checkbox@^0.5.7       | @react-native-community/checkbox@^0.5.7       | @react-native-community/checkbox@^0.5.7       |
+| clipboard         | @react-native-clipboard/clipboard@^1.7.3          | @react-native-clipboard/clipboard@^1.7.3          | @react-native-community/clipboard@^1.5.1      | @react-native-community/clipboard@^1.5.1      | @react-native-community/clipboard@^1.5.1      |
+| datetime-picker   | @react-native-community/datetimepicker@^3.4.6     | @react-native-community/datetimepicker@^3.4.6     | @react-native-community/datetimepicker@^3.0.9 | @react-native-community/datetimepicker@^3.0.9 | @react-native-community/datetimepicker@^3.0.9 |
+| filesystem        | react-native-fs@^2.17.0                           | react-native-fs@^2.17.0                           | react-native-fs@^2.16.6                       | react-native-fs@^2.16.6                       | react-native-fs@^2.16.6                       |
+| floating-action   | react-native-floating-action@^1.21.0              | react-native-floating-action@^1.21.0              | react-native-floating-action@^1.21.0          | react-native-floating-action@^1.18.0          | react-native-floating-action@^1.18.0          |
+| gestures          | react-native-gesture-handler@^1.10.3              | react-native-gesture-handler@^1.10.3              | react-native-gesture-handler@^1.10.3          | react-native-gesture-handler@^1.9.0           | react-native-gesture-handler@^1.9.0           |
+| hermes            | hermes-engine@~0.8.1                              | hermes-engine@~0.7.0                              | hermes-engine@~0.5.0                          | hermes-engine@~0.4.0                          | hermes-engine@^0.2.1                          |
+| hooks             | @react-native-community/hooks@^2.6.0              | @react-native-community/hooks@^2.6.0              | @react-native-community/hooks@^2.6.0          | @react-native-community/hooks@^2.6.0          | @react-native-community/hooks@^2.6.0          |
+| html              | react-native-render-html@^5.1.0                   | react-native-render-html@^5.1.0                   | react-native-render-html@^5.1.0               | react-native-render-html@^5.1.0               | react-native-render-html@^5.1.0               |
+| lazy-index        | react-native-lazy-index@^2.1.1                    | react-native-lazy-index@^2.1.1                    | react-native-lazy-index@^2.1.1                | react-native-lazy-index@^2.1.1                | react-native-lazy-index@^2.1.1                |
+| masked-view       | @react-native-masked-view/masked-view@^0.2.4      | @react-native-masked-view/masked-view@^0.2.4      | @react-native-masked-view/masked-view@^0.2.4  | @react-native-masked-view/masked-view@^0.2.4  | @react-native-masked-view/masked-view@^0.2.4  |
+| modal             | react-native-modal@^11.10.0                       | react-native-modal@^11.10.0                       | react-native-modal@^11.5.6                    | react-native-modal@^11.5.6                    | react-native-modal@^11.5.6                    |
+| navigation/native | @react-navigation/native@^5.9.4                   | @react-navigation/native@^5.9.4                   | @react-navigation/native@^5.9.4               | @react-navigation/native@^5.7.6               | @react-navigation/native@^5.7.6               |
+| navigation/stack  | @react-navigation/stack@^5.14.4                   | @react-navigation/stack@^5.14.4                   | @react-navigation/stack@^5.14.4               | @react-navigation/stack@^5.9.3                | @react-navigation/stack@^5.9.3                |
+| netinfo           | @react-native-community/netinfo@^6.0.0            | @react-native-community/netinfo@^6.0.0            | @react-native-community/netinfo@^5.9.10       | @react-native-community/netinfo@^5.9.10       | @react-native-community/netinfo@^5.7.1        |
+| popover           | react-native-popover-view@^4.0.0                  | react-native-popover-view@^4.0.0                  | react-native-popover-view@^3.1.1              | react-native-popover-view@^3.1.1              | react-native-popover-view@^3.1.1              |
+| react             | react@17.0.2                                      | react@17.0.1                                      | react@16.13.1                                 | react@16.11.0                                 | react@16.9.0                                  |
+| safe-area         | react-native-safe-area-context@^3.2.0             | react-native-safe-area-context@^3.2.0             | react-native-safe-area-context@^3.2.0         | react-native-safe-area-context@^3.1.9         | react-native-safe-area-context@^3.1.9         |
+| screens           | react-native-screens@^3.1.1                       | react-native-screens@^3.1.1                       | react-native-screens@^2.18.1                  | react-native-screens@^2.10.1                  | react-native-screens@^2.10.1                  |
+| shimmer           | react-native-shimmer@^0.5.0                       | react-native-shimmer@^0.5.0                       | react-native-shimmer@^0.5.0                   | react-native-shimmer@^0.5.0                   | react-native-shimmer@^0.5.0                   |
+| sqlite            | react-native-sqlite-storage@^5.0.0                | react-native-sqlite-storage@^5.0.0                | react-native-sqlite-storage@^3.3.11           | react-native-sqlite-storage@^3.3.11           | react-native-sqlite-storage@^3.3.11           |
+| storage           | @react-native-async-storage/async-storage@^1.15.5 | @react-native-async-storage/async-storage@^1.15.5 | @react-native-community/async-storage@^1.12.1 | @react-native-community/async-storage@^1.12.1 | @react-native-community/async-storage@^1.12.1 |
+| svg               | react-native-svg@^12.1.1                          | react-native-svg@^12.1.1                          | react-native-svg@^12.1.1                      | react-native-svg@^12.1.1                      | react-native-svg@^12.1.1                      |
+| test-app          | react-native-test-app@^0.7.0                      | react-native-test-app@^0.7.0                      | react-native-test-app@^0.7.0                  | react-native-test-app@^0.7.0                  | react-native-test-app@^0.7.0                  |
+| webview           | react-native-webview@^11.4.2                      | react-native-webview@^11.4.2                      | react-native-webview@^11.4.2                  | react-native-webview@^11.0.3                  | react-native-webview@^11.0.3                  |
+
+<!-- @rnx-kit/dep-check/capabilities end -->
+
+## Terminology
+
+| Terminology      | Definition (as used in `dep-check`'s context)                                                                                                                                     |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| capability       | A capability is in essence a feature that the kit uses. A capability is usually mapped to an npm package. Which versions of the package is determined by a profile (see below).   |
+| package manifest | This normally refers to a package's `package.json`.                                                                                                                               |
+| profile          | A profile is a mapping of capabilities to npm packages at a specific version or version range. Versions will vary depending on which React Native version a profile is meant for. |
+
 ## Motivation
 
 There is currently no centralised place where developers can go to and get a
@@ -104,135 +260,3 @@ example, because `awesome-library` needs the `netinfo` capability, it gets added
 to `awesome-app`.
 
 For a more detailed design document, see [`DESIGN.md`](./DESIGN.md).
-
-## Usage
-
-```sh
-rnx-dep-check [options] [/path/to/package.json]
-```
-
-Providing a path to `package.json` is optional. If omitted, it will look for one
-using Node module resolution.
-
-### `--custom-profiles <module>`
-
-Path to custom profiles. This can be a path to a JSON file, a `.js` file, or a
-module name. The module must default export an object similar to the one below:
-
-```js
-module.exports = {
-  0.63: {
-    "my-capability": {
-      name: "my-module",
-      version: "1.0.0",
-    },
-  },
-  0.64: {
-    "my-capability": {
-      name: "my-module",
-      version: "1.1.0",
-    },
-  },
-};
-```
-
-For a more complete example, have a look at the
-[default profiles](https://github.com/microsoft/rnx-kit/blob/769e9fa290929effd5111884f1637c21326b5a95/packages/dep-check/src/profiles.ts#L11).
-
-> #### Note
->
-> This specific flag may only be used with `--vigilant`. You can specify custom
-> profiles in normal mode by adding `customProfiles` to your package
-> [configuration](#configure).
-
-### `--exclude-packages`
-
-Comma-separated list of package names to exclude from inspection.
-
-> #### Note
->
-> `--exclude-packages` will only exclude packages that do not have a
-> configuration. Packages that have a configuration, will still be checked. This
-> flag may only be used with `--vigilant`.
-
-### `--init <app | library>`
-
-When integrating `@rnx-kit/dep-check` for the first time, it may be a cumbersome
-to manually add all capabilities yourself. You can run this tool with `--init`,
-and it will try to add a sensible configuration based on what is currently
-defined in the specified `package.json`.
-
-### `--vigilant`
-
-Also inspect packages that are not configured. Specify a comma-separated list of
-profile versions to compare against, e.g. `0.63,0.64`. The first number
-specifies the target version.
-
-### `--write`
-
-Writes all proposed changes to the specified `package.json`.
-
-## Configure
-
-`@rnx-kit/dep-check` must first be configured before it can be used. It uses
-`@rnx-kit/config` to retrieve your kit configuration. Your configuration can be
-specified either in a file, `rnx-kit.config.js`, or in an `"rnx-kit"` section of
-your `package.json`.
-
-| Option                  | Type                   | Default               | Description                                                                                                 |
-| :---------------------- | :--------------------- | :-------------------- | :---------------------------------------------------------------------------------------------------------- |
-| `kitType`               | `"app"` \| `"library"` | `"library"`           | Whether this kit is an "app" or a "library". Determines how dependencies are declared.                      |
-| `reactNativeVersion`    | string                 | (required)            | Supported versions of React Native. The value can be a specific version or a range.                         |
-| `reactNativeDevVersion` | string                 | `minVersion(version)` | The version of React Native to use for development. If omitted, the minimum supported version will be used. |
-| `capabilities`          | Capabilities[]         | `[]`                  | List of used/provided capabilities. A full list can be found below.                                         |
-| `customProfiles`        | string                 | `undefined`           | Path to custom profiles. This can be a path to a JSON file, a `.js` file, or a module name.                 |
-
-## Capabilities
-
-<!-- The following table can be updated by running `yarn update-readme` -->
-<!-- @rnx-kit/dep-check/capabilities start -->
-
-| Capability        | 0.65                                              | 0.64                                              | 0.63                                          | 0.62                                          | 0.61                                          |
-| ----------------- | ------------------------------------------------- | ------------------------------------------------- | --------------------------------------------- | --------------------------------------------- | --------------------------------------------- |
-| core              | react-native@^0.65.0-0                            | react-native@^0.64.2                              | react-native@^0.63.2                          | react-native@^0.62.3                          | react-native@^0.61.5                          |
-| core-android      | react-native@^0.65.0-0                            | react-native@^0.64.2                              | react-native@^0.63.2                          | react-native@^0.62.3                          | react-native@^0.61.5                          |
-| core-ios          | react-native@^0.65.0-0                            | react-native@^0.64.2                              | react-native@^0.63.2                          | react-native@^0.62.3                          | react-native@^0.61.5                          |
-| core-macos        | react-native-macos@^0.65.0-0                      | react-native-macos@^0.64.0                        | react-native-macos@^0.63.0                    | react-native-macos@^0.62.0                    | react-native-macos@^0.61.0                    |
-| core-windows      | react-native-windows@^0.65.0-0                    | react-native-windows@^0.64.0                      | react-native-windows@^0.63.0                  | react-native-windows@^0.62.0                  | react-native-windows@^0.61.0                  |
-| animation         | react-native-reanimated@^2.1.0                    | react-native-reanimated@^2.1.0                    | react-native-reanimated@^1.13.3               | react-native-reanimated@^1.13.3               | react-native-reanimated@^1.13.3               |
-| base64            | react-native-base64@^0.2.1                        | react-native-base64@^0.2.1                        | react-native-base64@^0.2.1                    | react-native-base64@^0.2.1                    | react-native-base64@^0.2.1                    |
-| checkbox          | @react-native-community/checkbox@^0.5.8           | @react-native-community/checkbox@^0.5.8           | @react-native-community/checkbox@^0.5.7       | @react-native-community/checkbox@^0.5.7       | @react-native-community/checkbox@^0.5.7       |
-| clipboard         | @react-native-clipboard/clipboard@^1.7.3          | @react-native-clipboard/clipboard@^1.7.3          | @react-native-community/clipboard@^1.5.1      | @react-native-community/clipboard@^1.5.1      | @react-native-community/clipboard@^1.5.1      |
-| datetime-picker   | @react-native-community/datetimepicker@^3.4.6     | @react-native-community/datetimepicker@^3.4.6     | @react-native-community/datetimepicker@^3.0.9 | @react-native-community/datetimepicker@^3.0.9 | @react-native-community/datetimepicker@^3.0.9 |
-| filesystem        | react-native-fs@^2.17.0                           | react-native-fs@^2.17.0                           | react-native-fs@^2.16.6                       | react-native-fs@^2.16.6                       | react-native-fs@^2.16.6                       |
-| floating-action   | react-native-floating-action@^1.21.0              | react-native-floating-action@^1.21.0              | react-native-floating-action@^1.21.0          | react-native-floating-action@^1.18.0          | react-native-floating-action@^1.18.0          |
-| gestures          | react-native-gesture-handler@^1.10.3              | react-native-gesture-handler@^1.10.3              | react-native-gesture-handler@^1.10.3          | react-native-gesture-handler@^1.9.0           | react-native-gesture-handler@^1.9.0           |
-| hermes            | hermes-engine@~0.8.1                              | hermes-engine@~0.7.0                              | hermes-engine@~0.5.0                          | hermes-engine@~0.4.0                          | hermes-engine@^0.2.1                          |
-| hooks             | @react-native-community/hooks@^2.6.0              | @react-native-community/hooks@^2.6.0              | @react-native-community/hooks@^2.6.0          | @react-native-community/hooks@^2.6.0          | @react-native-community/hooks@^2.6.0          |
-| html              | react-native-render-html@^5.1.0                   | react-native-render-html@^5.1.0                   | react-native-render-html@^5.1.0               | react-native-render-html@^5.1.0               | react-native-render-html@^5.1.0               |
-| lazy-index        | react-native-lazy-index@^2.1.1                    | react-native-lazy-index@^2.1.1                    | react-native-lazy-index@^2.1.1                | react-native-lazy-index@^2.1.1                | react-native-lazy-index@^2.1.1                |
-| masked-view       | @react-native-masked-view/masked-view@^0.2.4      | @react-native-masked-view/masked-view@^0.2.4      | @react-native-masked-view/masked-view@^0.2.4  | @react-native-masked-view/masked-view@^0.2.4  | @react-native-masked-view/masked-view@^0.2.4  |
-| modal             | react-native-modal@^11.10.0                       | react-native-modal@^11.10.0                       | react-native-modal@^11.5.6                    | react-native-modal@^11.5.6                    | react-native-modal@^11.5.6                    |
-| navigation/native | @react-navigation/native@^5.9.4                   | @react-navigation/native@^5.9.4                   | @react-navigation/native@^5.9.4               | @react-navigation/native@^5.7.6               | @react-navigation/native@^5.7.6               |
-| navigation/stack  | @react-navigation/stack@^5.14.4                   | @react-navigation/stack@^5.14.4                   | @react-navigation/stack@^5.14.4               | @react-navigation/stack@^5.9.3                | @react-navigation/stack@^5.9.3                |
-| netinfo           | @react-native-community/netinfo@^6.0.0            | @react-native-community/netinfo@^6.0.0            | @react-native-community/netinfo@^5.9.10       | @react-native-community/netinfo@^5.9.10       | @react-native-community/netinfo@^5.7.1        |
-| popover           | react-native-popover-view@^4.0.0                  | react-native-popover-view@^4.0.0                  | react-native-popover-view@^3.1.1              | react-native-popover-view@^3.1.1              | react-native-popover-view@^3.1.1              |
-| react             | react@17.0.2                                      | react@17.0.1                                      | react@16.13.1                                 | react@16.11.0                                 | react@16.9.0                                  |
-| safe-area         | react-native-safe-area-context@^3.2.0             | react-native-safe-area-context@^3.2.0             | react-native-safe-area-context@^3.2.0         | react-native-safe-area-context@^3.1.9         | react-native-safe-area-context@^3.1.9         |
-| screens           | react-native-screens@^3.1.1                       | react-native-screens@^3.1.1                       | react-native-screens@^2.18.1                  | react-native-screens@^2.10.1                  | react-native-screens@^2.10.1                  |
-| shimmer           | react-native-shimmer@^0.5.0                       | react-native-shimmer@^0.5.0                       | react-native-shimmer@^0.5.0                   | react-native-shimmer@^0.5.0                   | react-native-shimmer@^0.5.0                   |
-| sqlite            | react-native-sqlite-storage@^5.0.0                | react-native-sqlite-storage@^5.0.0                | react-native-sqlite-storage@^3.3.11           | react-native-sqlite-storage@^3.3.11           | react-native-sqlite-storage@^3.3.11           |
-| storage           | @react-native-async-storage/async-storage@^1.15.5 | @react-native-async-storage/async-storage@^1.15.5 | @react-native-community/async-storage@^1.12.1 | @react-native-community/async-storage@^1.12.1 | @react-native-community/async-storage@^1.12.1 |
-| svg               | react-native-svg@^12.1.1                          | react-native-svg@^12.1.1                          | react-native-svg@^12.1.1                      | react-native-svg@^12.1.1                      | react-native-svg@^12.1.1                      |
-| test-app          | react-native-test-app@^0.7.0                      | react-native-test-app@^0.7.0                      | react-native-test-app@^0.7.0                  | react-native-test-app@^0.7.0                  | react-native-test-app@^0.7.0                  |
-| webview           | react-native-webview@^11.4.2                      | react-native-webview@^11.4.2                      | react-native-webview@^11.4.2                  | react-native-webview@^11.0.3                  | react-native-webview@^11.0.3                  |
-
-<!-- @rnx-kit/dep-check/capabilities end -->
-
-## Terminology
-
-| Terminology      | Definition (as used in `dep-check`'s context)                                                                                                                                     |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| capability       | A capability is in essence a feature that the kit uses. A capability is usually mapped to an npm package. Which versions of the package is determined by a profile (see below).   |
-| package manifest | This normally refers to a package's `package.json`.                                                                                                                               |
-| profile          | A profile is a mapping of capabilities to npm packages at a specific version or version range. Versions will vary depending on which React Native version a profile is meant for. |

--- a/packages/dep-check/package.json
+++ b/packages/dep-check/package.json
@@ -31,6 +31,7 @@
     "find-up": "^5.0.0",
     "jest-diff": "^26.0.0",
     "pkg-dir": "^5.0.0",
+    "prompts": "^2.4.0",
     "semver": "^7.0.0",
     "workspace-tools": "^0.16.2",
     "yargs": "^16.0.0"
@@ -38,6 +39,7 @@
   "devDependencies": {
     "@rnx-kit/jest-preset": "*",
     "@types/jest": "^26.0.0",
+    "@types/prompts": "^2.0.0",
     "@types/semver": "^7.0.0",
     "@types/yargs": "^16.0.0",
     "markdown-table": "^2.0.0",

--- a/packages/dep-check/src/capabilities.ts
+++ b/packages/dep-check/src/capabilities.ts
@@ -1,6 +1,7 @@
 import type { Capability, KitCapabilities } from "@rnx-kit/config";
 import semver from "semver";
 import { getProfilesFor, getProfileVersionsFor } from "./profiles";
+import { concatVersionRanges, keysOf } from "./helpers";
 import type {
   CapabilitiesOptions,
   Package,
@@ -21,8 +22,7 @@ export function capabilitiesFor(
   const profiles = getProfilesFor(targetReactNativeVersion, customProfilesPath);
   const packageToCapabilityMap: Record<string, Capability[]> = {};
   profiles.forEach((profile) => {
-    const capabilityNames = Object.keys(profile) as Capability[];
-    capabilityNames.reduce((result, capability) => {
+    keysOf(profile).reduce((result, capability) => {
       const { name } = profile[capability];
       if (!result[name]) {
         result[name] = [capability];
@@ -33,8 +33,9 @@ export function capabilitiesFor(
     }, packageToCapabilityMap);
   });
 
-  const reactNativeVersion =
-    "^" + getProfileVersionsFor(targetReactNativeVersion).join(" || ^");
+  const reactNativeVersion = concatVersionRanges(
+    getProfileVersionsFor(targetReactNativeVersion)
+  );
 
   return {
     reactNativeVersion,
@@ -47,7 +48,7 @@ export function capabilitiesFor(
       : undefined),
     kitType,
     capabilities: Array.from(
-      Object.keys({
+      keysOf({
         ...dependencies,
         ...peerDependencies,
         ...devDependencies,

--- a/packages/dep-check/src/check.ts
+++ b/packages/dep-check/src/check.ts
@@ -6,6 +6,7 @@ import { diffLinesUnified } from "jest-diff";
 import path from "path";
 import { getRequirements } from "./dependencies";
 import { findBadPackages } from "./findBadPackages";
+import { readJsonFile } from "./json";
 import { updatePackageManifest } from "./manifest";
 import { getProfilesFor } from "./profiles";
 import type { Options, PackageManifest } from "./types";
@@ -23,8 +24,7 @@ export function checkPackageManifest(
   manifestPath: string,
   { uncheckedReturnCode = 0, write }: Options = {}
 ): number {
-  const manifestJson = fs.readFileSync(manifestPath, { encoding: "utf-8" });
-  const manifest = JSON.parse(manifestJson);
+  const manifest = readJsonFile(manifestPath);
   if (!isManifest(manifest)) {
     error(`'${manifestPath}' does not contain a valid package manifest`);
     return 1;

--- a/packages/dep-check/src/cli.ts
+++ b/packages/dep-check/src/cli.ts
@@ -107,9 +107,9 @@ async function makeCommand(args: Args): Promise<Command | undefined> {
     return makeInitializeCommand(init);
   }
 
-  // When `--set-version` is without a value, `versions` is an empty string if
+  // When `--set-version` is without a value, `setVersion` is an empty string if
   // invoked directly. When invoked via `@react-native-community/cli`,
-  // `versions` is `true` instead.
+  // `setVersion` is `true` instead.
   if (setVersion || isString(setVersion)) {
     return makeSetVersionCommand(setVersion);
   }
@@ -185,7 +185,7 @@ if (require.main === module) {
       },
       "set-version": {
         description:
-          "Sets `reactNativeVersion` and `reactNativeDevVersion` for any configured package. The value should be a comma-separated list of `react-native` versions to set. The first number specifies the development version. Example: `0.64,0.63`",
+          "Sets `reactNativeVersion` and `reactNativeDevVersion` for any configured package. There is an interactive prompt if no value is provided. The value should be a comma-separated list of `react-native` versions to set, where the first number specifies the development version. Example: `0.64,0.63`",
         type: "string",
         conflicts: ["init", "vigilant"],
       },

--- a/packages/dep-check/src/cli.ts
+++ b/packages/dep-check/src/cli.ts
@@ -7,7 +7,9 @@ import pkgDir from "pkg-dir";
 import { getAllPackageJsonFiles, getWorkspaceRoot } from "workspace-tools";
 import yargs from "yargs";
 import { checkPackageManifest } from "./check";
+import { isString } from "./helpers";
 import { initializeConfig } from "./initialize";
+import { makeSetVersionCommand } from "./setVersion";
 import type { Args, Command } from "./types";
 import { makeVigilantCommand } from "./vigilant";
 
@@ -24,7 +26,7 @@ function ensureKitType(type: string): KitType | undefined {
 function getManifests(
   packageJson: string | number | undefined
 ): string[] | undefined {
-  if (typeof packageJson === "string" && packageJson) {
+  if (isString(packageJson) && packageJson) {
     return [packageJson];
   }
 
@@ -50,10 +52,6 @@ function getManifests(
     error(e.message);
     return undefined;
   }
-}
-
-function isString(v: unknown): v is string {
-  return typeof v === "string";
 }
 
 function makeCheckCommand(write: boolean): Command {
@@ -86,10 +84,11 @@ function reportConflicts(conflicts: [string, string][], args: Args): boolean {
   }, false);
 }
 
-function makeCommand(args: Args): Command | undefined {
+async function makeCommand(args: Args): Promise<Command | undefined> {
   const conflicts: [string, string][] = [
     ["init", "vigilant"],
     ["init", args.write ? "write" : "no-write"],
+    ["set-version", args.write ? "write" : "no-write"],
   ];
   if (reportConflicts(conflicts, args)) {
     return undefined;
@@ -99,12 +98,20 @@ function makeCommand(args: Args): Command | undefined {
     "custom-profiles": customProfilesPath,
     "exclude-packages": excludePackages,
     init,
+    "set-version": setVersion,
     vigilant,
     write,
   } = args;
 
   if (isString(init)) {
     return makeInitializeCommand(init);
+  }
+
+  // When `--set-version` is without a value, `versions` is an empty string if
+  // invoked directly. When invoked via `@react-native-community/cli`,
+  // `versions` is `true` instead.
+  if (setVersion || isString(setVersion)) {
+    return makeSetVersionCommand(setVersion);
   }
 
   if (isString(vigilant)) {
@@ -119,8 +126,11 @@ function makeCommand(args: Args): Command | undefined {
   return makeCheckCommand(write);
 }
 
-export function cli({ "package-json": packageJson, ...args }: Args): void {
-  const command = makeCommand(args);
+export async function cli({
+  "package-json": packageJson,
+  ...args
+}: Args): Promise<void> {
+  const command = await makeCommand(args);
   if (!command) {
     process.exit(1);
   }
@@ -172,6 +182,12 @@ if (require.main === module) {
           "Writes an initial kit config to the specified 'package.json'.",
         choices: ["app", "library"],
         conflicts: ["vigilant"],
+      },
+      "set-version": {
+        description:
+          "Sets `reactNativeVersion` and `reactNativeDevVersion` for any configured package. The value should be a comma-separated list of `react-native` versions to set. The first number specifies the development version. Example: `0.64,0.63`",
+        type: "string",
+        conflicts: ["init", "vigilant"],
       },
       vigilant: {
         description:

--- a/packages/dep-check/src/dependencies.ts
+++ b/packages/dep-check/src/dependencies.ts
@@ -7,8 +7,9 @@ import {
 } from "@rnx-kit/config";
 import { error, warn } from "@rnx-kit/console";
 import findUp from "find-up";
-import fs from "fs";
 import path from "path";
+import { concatVersionRanges } from "./helpers";
+import { readJsonFile } from "./json";
 import {
   getProfilesFor,
   getProfileVersionsFor,
@@ -71,8 +72,7 @@ export function visitDependencies(
     const packageRoot = path.dirname(packageJson);
     visitor(dependency, packageRoot);
 
-    const content = fs.readFileSync(packageJson, { encoding: "utf-8" });
-    const manifest: PackageManifest = JSON.parse(content);
+    const manifest = readJsonFile(packageJson);
     visitDependencies(manifest, packageRoot, visitor, visited);
   });
 }
@@ -154,7 +154,7 @@ export function getRequirements(
   }
 
   return {
-    reactNativeVersion: "^" + profileVersions.join(" || ^"),
+    reactNativeVersion: concatVersionRanges(profileVersions),
     capabilities: Array.from(allCapabilities),
   };
 }

--- a/packages/dep-check/src/helpers.ts
+++ b/packages/dep-check/src/helpers.ts
@@ -1,0 +1,11 @@
+export function concatVersionRanges(versions: string[]): string {
+  return "^" + versions.join(" || ^");
+}
+
+export function isString(v: unknown): v is string {
+  return typeof v === "string";
+}
+
+export function keysOf<T extends Record<string, unknown>>(obj: T): (keyof T)[] {
+  return Object.keys(obj);
+}

--- a/packages/dep-check/src/initialize.ts
+++ b/packages/dep-check/src/initialize.ts
@@ -1,14 +1,12 @@
-import fs from "fs";
 import { capabilitiesFor } from "./capabilities";
+import { readJsonFile, writeJsonFile } from "./json";
 import type { CapabilitiesOptions } from "./types";
 
 export function initializeConfig(
   packageManifest: string,
   options: CapabilitiesOptions
 ): void {
-  const manifest = JSON.parse(
-    fs.readFileSync(packageManifest, { encoding: "utf-8" })
-  );
+  const manifest = readJsonFile(packageManifest);
   if (manifest["rnx-kit"]?.["capabilities"]) {
     return;
   }
@@ -25,8 +23,5 @@ export function initializeConfig(
       ...capabilities,
     },
   };
-  fs.writeFileSync(
-    packageManifest,
-    JSON.stringify(updatedManifest, undefined, 2) + "\n"
-  );
+  writeJsonFile(packageManifest, updatedManifest);
 }

--- a/packages/dep-check/src/json.ts
+++ b/packages/dep-check/src/json.ts
@@ -1,0 +1,28 @@
+import type { KitConfig } from "@rnx-kit/config";
+import fs from "fs";
+import type { PackageManifest } from "./types";
+
+type KitPackageManifest = PackageManifest & {
+  "rnx-kit"?: KitConfig;
+};
+
+type ReadFileOptions =
+  | { encoding: BufferEncoding; flag?: string }
+  | BufferEncoding;
+
+const defaultFileEncoding: ReadFileOptions = { encoding: "utf-8" };
+
+export function readJsonFile<T = KitPackageManifest>(
+  path: fs.PathLike,
+  options: ReadFileOptions = defaultFileEncoding
+): T {
+  return JSON.parse(fs.readFileSync(path, options));
+}
+
+export function writeJsonFile(
+  path: fs.PathLike,
+  object: Record<string, unknown>,
+  options: fs.WriteFileOptions = defaultFileEncoding
+): void {
+  fs.writeFileSync(path, JSON.stringify(object, undefined, 2) + "\n", options);
+}

--- a/packages/dep-check/src/setVersion.ts
+++ b/packages/dep-check/src/setVersion.ts
@@ -1,0 +1,81 @@
+import prompts from "prompts";
+import { checkPackageManifest } from "./check";
+import { readJsonFile, writeJsonFile } from "./json";
+import { defaultProfiles, parseProfilesString } from "./profiles";
+import { concatVersionRanges, isString, keysOf } from "./helpers";
+import type { Command, ProfileVersion } from "./types";
+
+function profileToChoice(version: ProfileVersion): prompts.Choice {
+  return { title: version, value: version };
+}
+
+async function parseInput(versions: string | number): Promise<{
+  supportedVersions?: string;
+  targetVersion?: string;
+}> {
+  // When `--set-version` is without a value, `versions` is an empty string if
+  // invoked directly. When invoked via `@react-native-community/cli`,
+  // `versions` is `true` instead.
+  if (isString(versions) && versions) {
+    return parseProfilesString(versions);
+  }
+
+  const { supportedVersions } = await prompts({
+    type: "multiselect",
+    name: "supportedVersions",
+    message: "Select all supported versions of `react-native`",
+    choices: keysOf(defaultProfiles).map(profileToChoice),
+    min: 1,
+  });
+  if (!Array.isArray(supportedVersions)) {
+    return {};
+  }
+
+  const targetVersion =
+    supportedVersions.length === 1
+      ? supportedVersions[0]
+      : (
+          await prompts({
+            type: "select",
+            name: "targetVersion",
+            message: "Select development version of `react-native`",
+            choices: supportedVersions.map(profileToChoice),
+          })
+        ).targetVersion;
+  if (!supportedVersions.includes(targetVersion)) {
+    return {};
+  }
+
+  return {
+    supportedVersions: concatVersionRanges(supportedVersions),
+    targetVersion,
+  };
+}
+
+export async function makeSetVersionCommand(
+  versions: string | number
+): Promise<Command | undefined> {
+  const { supportedVersions, targetVersion } = await parseInput(versions);
+  if (!supportedVersions) {
+    return undefined;
+  }
+
+  return (manifestPath: string) => {
+    const checkReturnCode = checkPackageManifest(manifestPath);
+    if (checkReturnCode !== 0) {
+      return checkReturnCode;
+    }
+
+    const manifest = readJsonFile(manifestPath);
+    const rnxKitConfig = manifest["rnx-kit"];
+    if (!rnxKitConfig) {
+      return 0;
+    }
+
+    rnxKitConfig.reactNativeVersion = supportedVersions;
+    rnxKitConfig.reactNativeDevVersion = targetVersion;
+
+    writeJsonFile(manifestPath, manifest);
+    return checkPackageManifest(manifestPath, { write: true });
+  };
+}

--- a/packages/dep-check/src/types.ts
+++ b/packages/dep-check/src/types.ts
@@ -4,6 +4,7 @@ export type Args = {
   "custom-profiles"?: string | number;
   "exclude-packages"?: string | number;
   "package-json"?: string | number;
+  "set-version"?: string | number;
   init?: string;
   vigilant?: string | number;
   write: boolean;

--- a/packages/dep-check/test/dependencies.test.ts
+++ b/packages/dep-check/test/dependencies.test.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { getRequirements, visitDependencies } from "../src/dependencies";
+import { readJsonFile } from "../src/json";
 
 jest.unmock("@rnx-kit/config");
 
@@ -101,10 +102,7 @@ describe("visitDependencies()", () => {
 describe("getRequirements()", () => {
   test("gets requirements from all dependencies", () => {
     const fixture = fixturePath("awesome-repo");
-    const manifestJson = fs.readFileSync(path.join(fixture, "package.json"), {
-      encoding: "utf-8",
-    });
-    const manifest = JSON.parse(manifestJson);
+    const manifest = readJsonFile(path.join(fixture, "package.json"));
     const { reactNativeVersion, capabilities } = getRequirements(
       "^0.63 || ^0.64",
       "app",
@@ -142,10 +140,7 @@ describe("getRequirements()", () => {
     );
 
     const fixture = fixturePath("awesome-repo-extended");
-    const manifestJson = fs.readFileSync(path.join(fixture, "package.json"), {
-      encoding: "utf-8",
-    });
-    const manifest = JSON.parse(manifestJson);
+    const manifest = readJsonFile(path.join(fixture, "package.json"));
     const { reactNativeVersion, capabilities } = getRequirements(
       "^0.63 || ^0.64",
       "app",

--- a/packages/dep-check/test/setVersion.test.ts
+++ b/packages/dep-check/test/setVersion.test.ts
@@ -1,0 +1,207 @@
+import prompts from "prompts";
+import { makeSetVersionCommand } from "../src/setVersion";
+
+jest.mock("fs");
+
+describe("makeSetVersionCommand()", () => {
+  const rnxKitConfig = require("@rnx-kit/config");
+  const fs = require("fs");
+
+  afterEach(() => {
+    fs.__setMockContent({});
+    rnxKitConfig.__setMockConfig();
+    jest.clearAllMocks();
+  });
+
+  test("rejects unsupported versions `react-native`", async () => {
+    expect(makeSetVersionCommand("0.59")).rejects.toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          "Unsupported 'react-native' version/range:"
+        ),
+      })
+    );
+  });
+
+  test("updates dependencies", async () => {
+    const mockManifest = {
+      name: "@rnx-kit/dep-check",
+      version: "1.0.0-test",
+      dependencies: {
+        "react-native": "^0.63.2",
+      },
+      "rnx-kit": {
+        reactNativeVersion: "^0.63",
+        kitType: "app",
+        capabilities: ["core"],
+      },
+    };
+    fs.__setMockContent(mockManifest);
+
+    let updatedManifest: Record<string, unknown>;
+    fs.__setMockFileWriter((_: string, content: string) => {
+      updatedManifest = JSON.parse(content);
+      fs.__setMockContent(updatedManifest);
+      rnxKitConfig.__setMockConfig(updatedManifest["rnx-kit"]);
+    });
+
+    const command = await makeSetVersionCommand("0.64,0.63");
+    expect(typeof command).toBe("function");
+    expect(command("package.json")).toBe(0);
+    expect(updatedManifest).toEqual({
+      ...mockManifest,
+      dependencies: {
+        "react-native": "^0.64.2",
+      },
+      devDependencies: {},
+      "rnx-kit": {
+        ...mockManifest["rnx-kit"],
+        reactNativeVersion: "^0.63.0 || ^0.64.0",
+        reactNativeDevVersion: "^0.64.0",
+      },
+    });
+  });
+
+  test("prompts the user if no version is specified", async () => {
+    const mockManifest = {
+      name: "@rnx-kit/dep-check",
+      version: "1.0.0-test",
+      dependencies: {
+        "react-native": "^0.63.2",
+      },
+      "rnx-kit": {
+        reactNativeVersion: "^0.63",
+        kitType: "app",
+        capabilities: ["core"],
+      },
+    };
+    fs.__setMockContent(mockManifest);
+
+    let updatedManifest: Record<string, unknown>;
+    fs.__setMockFileWriter((_: string, content: string) => {
+      updatedManifest = JSON.parse(content);
+      fs.__setMockContent(updatedManifest);
+      rnxKitConfig.__setMockConfig(updatedManifest["rnx-kit"]);
+    });
+
+    prompts.inject([["0.63", "0.64"], "0.64"]);
+
+    const command = await makeSetVersionCommand("");
+    expect(typeof command).toBe("function");
+    expect(command("package.json")).toBe(0);
+    expect(updatedManifest).toEqual({
+      ...mockManifest,
+      dependencies: {
+        "react-native": "^0.64.2",
+      },
+      devDependencies: {},
+      "rnx-kit": {
+        ...mockManifest["rnx-kit"],
+        reactNativeVersion: "^0.63 || ^0.64",
+        reactNativeDevVersion: "0.64",
+      },
+    });
+  });
+
+  test("skips the second prompt if only one version is supported", async () => {
+    const mockManifest = {
+      name: "@rnx-kit/dep-check",
+      version: "1.0.0-test",
+      dependencies: {
+        "react-native": "^0.63.2",
+      },
+      "rnx-kit": {
+        reactNativeVersion: "^0.63",
+        kitType: "app",
+        capabilities: ["core"],
+      },
+    };
+    fs.__setMockContent(mockManifest);
+
+    let updatedManifest: Record<string, unknown>;
+    fs.__setMockFileWriter((_: string, content: string) => {
+      updatedManifest = JSON.parse(content);
+      fs.__setMockContent(updatedManifest);
+      rnxKitConfig.__setMockConfig(updatedManifest["rnx-kit"]);
+    });
+
+    prompts.inject([["0.64"]]);
+
+    const command = await makeSetVersionCommand("");
+    expect(typeof command).toBe("function");
+    expect(command("package.json")).toBe(0);
+    expect(updatedManifest).toEqual({
+      ...mockManifest,
+      dependencies: {
+        "react-native": "^0.64.2",
+      },
+      devDependencies: {},
+      "rnx-kit": {
+        ...mockManifest["rnx-kit"],
+        reactNativeVersion: "^0.64",
+        reactNativeDevVersion: "0.64",
+      },
+    });
+  });
+
+  test('skips "dirty" packages', async () => {
+    const mockManifest = {
+      name: "@rnx-kit/dep-check",
+      version: "1.0.0-test",
+      dependencies: {
+        "react-native": "^0.62.3",
+      },
+      "rnx-kit": {
+        reactNativeVersion: "^0.63",
+        kitType: "app",
+        capabilities: ["core"],
+      },
+    };
+    fs.__setMockContent(mockManifest);
+    rnxKitConfig.__setMockConfig(mockManifest["rnx-kit"]);
+
+    let updatedManifest = false;
+    fs.__setMockFileWriter(() => {
+      updatedManifest = true;
+    });
+
+    prompts.inject([["0.64"]]);
+
+    const command = await makeSetVersionCommand("");
+    expect(typeof command).toBe("function");
+    expect(command("package.json")).not.toBe(0);
+    expect(updatedManifest).toBe(false);
+  });
+
+  test("skips unconfigured packages", async () => {
+    const mockManifest = {
+      name: "@rnx-kit/dep-check",
+      version: "1.0.0-test",
+      dependencies: {
+        "react-native": "^0.63.2",
+      },
+    };
+    fs.__setMockContent(mockManifest);
+    rnxKitConfig.__setMockConfig(mockManifest["rnx-kit"]);
+
+    let updatedManifest = false;
+    fs.__setMockFileWriter(() => {
+      updatedManifest = true;
+    });
+
+    prompts.inject([["0.64"]]);
+
+    const command = await makeSetVersionCommand("");
+    expect(typeof command).toBe("function");
+    expect(command("package.json")).toBe(0);
+    expect(updatedManifest).toBe(false);
+  });
+
+  test("exits if the user cancels during prompts", async () => {
+    prompts.inject([undefined]);
+    expect(await makeSetVersionCommand("")).toBeUndefined();
+
+    prompts.inject([["0.63", "0.64"], undefined]);
+    expect(await makeSetVersionCommand("")).toBeUndefined();
+  });
+});

--- a/packages/dep-check/test/setVersion.test.ts
+++ b/packages/dep-check/test/setVersion.test.ts
@@ -30,16 +30,16 @@ describe("makeSetVersionCommand()", () => {
   }
 
   const mockManifest = {
-      name: "@rnx-kit/dep-check",
-      version: "1.0.0-test",
-      dependencies: {
-        "react-native": "^0.63.2",
-      },
-      "rnx-kit": {
-        reactNativeVersion: "^0.63",
-        kitType: "app",
-        capabilities: ["core"],
-      },
+    name: "@rnx-kit/dep-check",
+    version: "1.0.0-test",
+    dependencies: {
+      "react-native": "^0.63.2",
+    },
+    "rnx-kit": {
+      reactNativeVersion: "^0.63",
+      kitType: "app",
+      capabilities: ["core"],
+    },
   };
 
   afterEach(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1955,6 +1955,13 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.3.tgz#ef65165aea2924c9359205bf748865b8881753c0"
   integrity sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==
 
+"@types/prompts@^2.0.0":
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/@types/prompts/-/prompts-2.0.14.tgz#10cb8899844bb0771cabe57c1becaaaca9a3b521"
+  integrity sha512-HZBd99fKxRWpYCErtm2/yxUZv6/PBI9J7N4TNFffl5JbrYMHBwF25DjQGTW3b3jmXq+9P6/8fCIb2ee57BFfYA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/prop-types@*":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"


### PR DESCRIPTION
### Description

Adds a command for easily setting `reactNativeVersion` and `reactNativeDevVersion` consistently across a repo.

### Test plan

1. Prepare: 
   ```sh
   yarn
   cd packages/test-app
   yarn build --dependencies

   # If you're not on Windows, you need to make the script executable:
   chmod +x ../dep-check/lib/cli.js
   ```
2. Test the prompt: `yarn rnx-dep-check --set-version`
   - On the first question, at least one version must be picked
   - When several versions are picked, the second prompt should only include the selection
   - If only one version was picked, there is no second prompt
3. Test providing values:
   - `yarn rnx-dep-check --set-version 0.63`: should set both `reactNativeVersion` and `reactNativeDevVersion` to 0.63, and also change the `react-native` version to `^0.63.2`
   - `yarn rnx-dep-check --set-version 0.64,0.63`: should set `reactNativeVersion: "^0.63 || ^0.64"` and `reactNativeDevVersion: ^0.64`
4. Repeat steps 2 and 3 using `yarn react-native rnx-dep-check` instead