### PR TITLE
fix(jest-preset): fix incorrect peer dependencies

### DIFF
--- a/change/@rnx-kit-jest-preset-b0c884bf-6f3f-442e-81fb-351968c499d3.json
+++ b/change/@rnx-kit-jest-preset-b0c884bf-6f3f-442e-81fb-351968c499d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix incorrect peer dependencies: added `@babel/core` and made the others optional since this package can be used without react-native.",
+  "packageName": "@rnx-kit/jest-preset",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -25,8 +25,17 @@
     "find-up": "^5.0.0"
   },
   "peerDependencies": {
+    "@babel/core": "^7.0.0-0",
     "@react-native-community/cli": ">=4.10",
     "react-native": "^0.0.0-0 || >=0.63"
+  },
+  "peerDependenciesMeta": {
+    "@react-native-community/cli": {
+      "optional": true
+    },
+    "react-native": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@jest/types": "^27.0.0",


### PR DESCRIPTION
### Description

These warnings show up using Yarn 3:

```
➤ YN0002: │ @rnx-kit/jest-preset@npm:0.1.0 [ea016] doesn't provide @babel/core (p091ea), requested by @babel/preset-env
➤ YN0002: │ @rnx-kit/jest-preset@npm:0.1.0 [ea016] doesn't provide @babel/core (pdef5a), requested by @babel/preset-typescript
➤ YN0002: │ react-native-lazy-index@workspace:. doesn't provide @react-native-community/cli (pe5104), requested by @rnx-kit/jest-preset
```

We need to add `@babel/core` to `peerDependencies` to fix the first two. `@react-native-community/cli` and `react-native` are not required and should be optional.

### Test plan

1. Build `jest-preset`
   ```sh
   cd packages/jest-preset
   yarn build --dependencies
   ```
2. Build npm package: `npm pack`
3. Consume the package in a different project (e.g. `react-native-lazy-index`):
   ```diff
   diff --git a/package.json b/package.json
   index b555a1b..da6b6c6 100644
   --- a/package.json
   +++ b/package.json
   @@ -45,7 +45,7 @@
      },
      "devDependencies": {
        "@babel/cli": "^7.0.0",
   -    "@rnx-kit/jest-preset": "^0.1.0",
   +    "@rnx-kit/jest-preset": "../rnx-kit/packages/jest-preset/rnx-kit-jest-preset-0.1.0.tgz",
        "@types/jest": "^26.0.0",
        "@types/node": "^14.0.0",
        "@typescript-eslint/parser": "^4.0.0",
   ```

Yarn should no longer output any warnings.