### PR TITLE
fix: drop `const-enum` plugin on newer @babel/plugin-transform-typescript

### DIFF
--- a/change/@rnx-kit-babel-preset-metro-react-native-330e6254-3b90-4d54-8817-412b2fb566aa.json
+++ b/change/@rnx-kit-babel-preset-metro-react-native-330e6254-3b90-4d54-8817-412b2fb566aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add support for @babel/plugin-transform-typescript 7.15",
+  "packageName": "@rnx-kit/babel-preset-metro-react-native",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-preset-metro-react-native/package.json
+++ b/packages/babel-preset-metro-react-native/package.json
@@ -22,7 +22,13 @@
     "babel-plugin-const-enum": "^1.0.0"
   },
   "peerDependencies": {
+    "@babel/plugin-transform-typescript": "^7.0.0",
     "metro-react-native-babel-preset": "*"
+  },
+  "peerDependenciesMeta": {
+    "@babel/plugin-transform-typescript": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/babel-preset-metro-react-native/src/index.js
+++ b/packages/babel-preset-metro-react-native/src/index.js
@@ -20,6 +20,28 @@
  * @typedef {MetroPresetOptions & { additionalPlugins?: PluginItem[]; }} PresetOptions
  */
 
+/**
+ * Returns plugin for transforming `const enum` if necessary.
+ *
+ * @babel/plugin-transform-typescript doesn't support `const enum`s until 7.15.
+ * See https://github.com/babel/babel/pull/13324.
+ */
+function constEnumPlugin() {
+  try {
+    const {
+      version,
+    } = require("@babel/plugin-transform-typescript/package.json");
+    const { [0]: major, [1]: minor } = version.split(".");
+    if (Number(major) * 1000 + Number(minor) >= 7015) {
+      return [];
+    }
+  } catch (_) {
+    // assume we need `const-enum`
+  }
+
+  return ["const-enum"];
+}
+
 /** @type {(api?: ConfigAPI, opts?: PresetOptions) => TransformOptions} */
 module.exports = (_, { additionalPlugins, ...options } = {}) => {
   return {
@@ -28,11 +50,7 @@ module.exports = (_, { additionalPlugins, ...options } = {}) => {
       {
         test: /\.tsx?$/,
         plugins: [
-          // @babel/plugin-transform-typescript doesn't support `const enum`s.
-          // See https://babeljs.io/docs/en/babel-plugin-transform-typescript#caveats
-          // for more details.
-          "const-enum",
-
+          ...constEnumPlugin(),
           ...(Array.isArray(additionalPlugins) ? additionalPlugins : []),
         ],
       },

--- a/packages/babel-preset-metro-react-native/test/__snapshots__/index.test.js.snap
+++ b/packages/babel-preset-metro-react-native/test/__snapshots__/index.test.js.snap
@@ -1,30 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`@rnx-kit/babel-preset-metro-react-native applies \`babel-plugin-const-enum\` 1`] = `
-"require(\\"./lib/remap-test\\");
-var Direction;
-(function (Direction) {
-  Direction[(Direction[\\"Up\\"] = 0)] = \\"Up\\";
-  Direction[(Direction[\\"Down\\"] = 1)] = \\"Down\\";
-  Direction[(Direction[\\"Left\\"] = 2)] = \\"Left\\";
-  Direction[(Direction[\\"Right\\"] = 3)] = \\"Right\\";
-})(Direction || (Direction = {}));
-function takeDirection(direction) {
-  switch (direction) {
-    case Direction.Up:
-      return \\"up\\";
-    case Direction.Down:
-      return \\"down\\";
-    case Direction.Left:
-      return \\"left\\";
-    case Direction.Right:
-      return \\"right\\";
-  }
-}
-console.log(takeDirection(Direction.Up));
-"
-`;
-
 exports[`@rnx-kit/babel-preset-metro-react-native applies additional plugins 1`] = `
 "require(\\"./src/remap-test\\");
 var Direction;
@@ -52,6 +27,31 @@ console.log(takeDirection(Direction.Up));
 
 exports[`@rnx-kit/babel-preset-metro-react-native can be further extended 1`] = `
 "require(\\"./src/remap-test\\");
+var Direction;
+(function (Direction) {
+  Direction[(Direction[\\"Up\\"] = 0)] = \\"Up\\";
+  Direction[(Direction[\\"Down\\"] = 1)] = \\"Down\\";
+  Direction[(Direction[\\"Left\\"] = 2)] = \\"Left\\";
+  Direction[(Direction[\\"Right\\"] = 3)] = \\"Right\\";
+})(Direction || (Direction = {}));
+function takeDirection(direction) {
+  switch (direction) {
+    case Direction.Up:
+      return \\"up\\";
+    case Direction.Down:
+      return \\"down\\";
+    case Direction.Left:
+      return \\"left\\";
+    case Direction.Right:
+      return \\"right\\";
+  }
+}
+console.log(takeDirection(Direction.Up));
+"
+`;
+
+exports[`@rnx-kit/babel-preset-metro-react-native transforms \`const enum\`s 1`] = `
+"require(\\"./lib/remap-test\\");
 var Direction;
 (function (Direction) {
   Direction[(Direction[\\"Up\\"] = 0)] = \\"Up\\";

--- a/yarn.lock
+++ b/yarn.lock
@@ -175,16 +175,16 @@
     browserslist "^4.16.6"
     semver "^6.3.0"
 
-"@babel/helper-create-class-features-plugin@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.5.tgz#8842ec495516dd1ed8f6c572be92ba78b1e9beef"
-  integrity sha512-Uq9z2e7ZtcnDMirRqAGLRaLwJn+Lrh388v5ETrR3pALJnElVh2zqQmdbz4W2RUJYohAPh2mtyPUgyMHMzXMncQ==
+"@babel/helper-create-class-features-plugin@^7.14.5", "@babel/helper-create-class-features-plugin@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.0.tgz#c9a137a4d137b2d0e2c649acf536d7ba1a76c0f7"
+  integrity sha512-MdmDXgvTIi4heDVX/e9EFfeGpugqm9fobBVg/iioE8kueXrOHdRDe36FAY7SnE9xXLVeYCoJR/gdrBEIHRC83Q==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.14.5"
     "@babel/helper-function-name" "^7.14.5"
-    "@babel/helper-member-expression-to-functions" "^7.14.5"
+    "@babel/helper-member-expression-to-functions" "^7.15.0"
     "@babel/helper-optimise-call-expression" "^7.14.5"
-    "@babel/helper-replace-supers" "^7.14.5"
+    "@babel/helper-replace-supers" "^7.15.0"
     "@babel/helper-split-export-declaration" "^7.14.5"
 
 "@babel/helper-create-regexp-features-plugin@^7.14.5":
@@ -253,7 +253,7 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
-"@babel/helper-member-expression-to-functions@^7.14.5", "@babel/helper-member-expression-to-functions@^7.15.0":
+"@babel/helper-member-expression-to-functions@^7.15.0":
   version "7.15.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz#0ddaf5299c8179f27f37327936553e9bba60990b"
   integrity sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==
@@ -953,12 +953,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-transform-typescript@^7.14.5", "@babel/plugin-transform-typescript@^7.5.0":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.14.5.tgz#5b41b59072f765bd1ec1d0b694e08c7df0f6f8a0"
-  integrity sha512-cFD5PKp4b8/KkwQ7h71FdPXFvz1RgwTFF9akRZwFldb9G0AHf7CgoPx96c4Q/ZVjh6V81tqQwW5YiHws16OzPg==
+"@babel/plugin-transform-typescript@^7.15.0", "@babel/plugin-transform-typescript@^7.5.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.15.0.tgz#553f230b9d5385018716586fc48db10dd228eb7e"
+  integrity sha512-WIIEazmngMEEHDaPTx0IZY48SaAmjVWe3TRSX7cmJXn0bEv9midFzAjxiruOWYIVf5iQ10vFx7ASDpgEO08L5w==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.14.5"
+    "@babel/helper-create-class-features-plugin" "^7.15.0"
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-typescript" "^7.14.5"
 
@@ -1077,13 +1077,13 @@
     esutils "^2.0.2"
 
 "@babel/preset-typescript@^7.0.0", "@babel/preset-typescript@^7.1.0":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.14.5.tgz#aa98de119cf9852b79511f19e7f44a2d379bcce0"
-  integrity sha512-u4zO6CdbRKbS9TypMqrlGH7sd2TAJppZwn3c/ZRLeO/wGsbddxgbPDUZVNrie3JWYLQ9vpineKlsrWFvO6Pwkw==
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.15.0.tgz#e8fca638a1a0f64f14e1119f7fe4500277840945"
+  integrity sha512-lt0Y/8V3y06Wq/8H/u0WakrqciZ7Fz7mwPDHWUJAXlABL5hiUG42BNlRXiELNjeWjO5rWmnNKlx+yzJvxezHow==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/helper-validator-option" "^7.14.5"
-    "@babel/plugin-transform-typescript" "^7.14.5"
+    "@babel/plugin-transform-typescript" "^7.15.0"
 
 "@babel/register@^7.0.0":
   version "7.13.14"


### PR DESCRIPTION
### Description

Support for `const enum` was added to `@babel/plugin-transform-typescript` in 7.15 (see https://github.com/microsoft/rnx-kit/pull/464#issuecomment-893614218).

### Test plan

Tests should pass.