### PR TITLE
ci: fix publishing pipeline

### DIFF
--- a/change/@rnx-kit-cli-76e161f1-2474-4cbf-9156-9ddd44d42f68.json
+++ b/change/@rnx-kit-cli-76e161f1-2474-4cbf-9156-9ddd44d42f68.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump @rnx-kit/console to 1.0.2",
+  "packageName": "@rnx-kit/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@react-native-community/cli-server-api": "^5.0.1",
     "@rnx-kit/config": "^0.4.0",
-    "@rnx-kit/console": "^1.0.1",
+    "@rnx-kit/console": "^1.0.2",
     "@rnx-kit/dep-check": "^1.5.21",
     "@rnx-kit/metro-plugin-cyclic-dependencies-detector": "^1.0.5",
     "@rnx-kit/metro-plugin-duplicates-checker": "^1.1.5",


### PR DESCRIPTION
### Description

Beachball is trying to bump @rnx-kit/cli to a version that already exists. cli depends on console@^1.0.1 but latest is 1.0.2.

### Test plan

Beachball doesn't have a dry-run flag but you can run `yarn publish:beachball` without a token and it would do most of the work up until the actual push to npm.