### PR TITLE
feat(dep-check): allow looser requirements checks

### DIFF
--- a/change/@rnx-kit-cli-cb66ae4a-3761-4f96-93a5-0fbc3dc318bd.json
+++ b/change/@rnx-kit-cli-cb66ae4a-3761-4f96-93a5-0fbc3dc318bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow apps to depend on a newer version of React Native than their dependencies declare support for via the `--loose` flag.",
+  "packageName": "@rnx-kit/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-dep-check-e7596695-0308-4076-b057-6774cc4eea66.json
+++ b/change/@rnx-kit-dep-check-e7596695-0308-4076-b057-6774cc4eea66.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow apps to depend on a newer version of React Native than their dependencies declare support for via the `--loose` flag.",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/dep-check.ts
+++ b/packages/cli/src/dep-check.ts
@@ -23,6 +23,7 @@ export function rnxDepCheck(
     ...pickValue<Args>("init", "init", args),
     ...pickValue<Args>("set-version", "setVersion", args),
     ...pickValue<Args>("vigilant", "vigilant", args),
+    loose: Boolean(args.loose),
     write: Boolean(args.write),
     "package-json": argv[0],
   });
@@ -46,6 +47,11 @@ export const rnxDepCheckCommand = {
     {
       name: "--init [app|library]",
       description: "Writes an initial kit config",
+    },
+    {
+      name: "--loose",
+      description:
+        "Determines how strict the React Native version requirement should be. Useful for apps that depend on a newer React Native version than their dependencies declare support for.",
     },
     {
       name: "--set-version [versions]",

--- a/packages/dep-check/src/check.ts
+++ b/packages/dep-check/src/check.ts
@@ -9,7 +9,7 @@ import { findBadPackages } from "./findBadPackages";
 import { readJsonFile } from "./json";
 import { updatePackageManifest } from "./manifest";
 import { getProfilesFor } from "./profiles";
-import type { Options, PackageManifest } from "./types";
+import type { CheckOptions, Command, PackageManifest } from "./types";
 
 export function isManifest(manifest: unknown): manifest is PackageManifest {
   return (
@@ -22,7 +22,7 @@ export function isManifest(manifest: unknown): manifest is PackageManifest {
 
 export function checkPackageManifest(
   manifestPath: string,
-  { uncheckedReturnCode = 0, write }: Options = {}
+  { loose, uncheckedReturnCode = 0, write }: CheckOptions
 ): number {
   const manifest = readJsonFile(manifestPath);
   if (!isManifest(manifest)) {
@@ -60,7 +60,8 @@ export function checkPackageManifest(
       kitType,
       manifest,
       projectRoot,
-      customProfiles
+      customProfiles,
+      { loose }
     );
   requiredCapabilities.push(...targetCapabilities);
 
@@ -108,4 +109,10 @@ export function checkPackageManifest(
   }
 
   return 0;
+}
+
+export function makeCheckCommand(options: CheckOptions): Command {
+  return (manifest: string) => {
+    return checkPackageManifest(manifest, options);
+  };
 }

--- a/packages/dep-check/src/dependencies.ts
+++ b/packages/dep-check/src/dependencies.ts
@@ -16,10 +16,11 @@ import {
   profilesSatisfying,
 } from "./profiles";
 import type {
+  CheckOptions,
   PackageManifest,
   Profile,
   ProfileVersion,
-  ResolverOptions,
+  TestOverrides,
 } from "./types";
 
 type Requirements = Required<
@@ -83,7 +84,8 @@ export function getRequirements(
   targetManifest: PackageManifest,
   projectRoot: string,
   customProfiles: string | undefined,
-  options?: ResolverOptions
+  { loose }: Pick<CheckOptions, "loose">,
+  testOverrides?: TestOverrides
 ): Requirements {
   let profileVersions = getProfileVersionsFor(targetReactNativeVersion);
   if (profileVersions.length === 0) {
@@ -104,39 +106,53 @@ export function getRequirements(
 
     visitDependencies(targetManifest, projectRoot, (module, modulePath) => {
       const kitConfig = getKitConfig({ cwd: modulePath });
-      if (kitConfig) {
-        const { reactNativeVersion, capabilities } =
-          getKitCapabilities(kitConfig);
+      if (!kitConfig) {
+        return;
+      }
 
-        profileVersions = profilesSatisfying(
-          profileVersions,
-          reactNativeVersion
-        );
-        if (profileVersions.length != trace[trace.length - 1].profiles.length) {
-          trace.push({ module, reactNativeVersion, profiles: profileVersions });
-        }
+      const { reactNativeVersion, capabilities } =
+        getKitCapabilities(kitConfig);
 
-        if (profileVersions.length === 0) {
-          const message =
-            "No React Native profile could satisfy all dependencies";
-          const fullTrace = [
-            message,
-            ...trace.map(({ module, reactNativeVersion, profiles }) => {
-              const satisfiedVersions = profiles.join(", ");
-              return `    [${satisfiedVersions}] satisfies '${module}' because it supports '${reactNativeVersion}'`;
-            }),
-          ].join("\n");
-          error(fullTrace);
+      const validVersions = profilesSatisfying(
+        profileVersions,
+        reactNativeVersion
+      );
+      if (validVersions.length != profileVersions.length) {
+        trace.push({
+          module,
+          reactNativeVersion,
+          profiles: validVersions,
+        });
+      }
+
+      if (Array.isArray(capabilities)) {
+        capabilities.forEach((capability) => allCapabilities.add(capability));
+      }
+
+      if (validVersions.length === 0) {
+        const message =
+          "No React Native profile could satisfy all dependencies";
+        const fullTrace = [
+          message,
+          ...trace.map(({ module, reactNativeVersion, profiles }) => {
+            const satisfiedVersions = profiles.join(", ");
+            return `    [${satisfiedVersions}] satisfies '${module}' because it supports '${reactNativeVersion}'`;
+          }),
+        ].join("\n");
+        error(fullTrace);
+        if (!loose) {
           throw new Error(message);
         }
-
-        if (Array.isArray(capabilities)) {
-          capabilities.forEach((capability) => allCapabilities.add(capability));
-        }
+      } else {
+        profileVersions = validVersions;
       }
     });
 
-    const profiles = getProfilesFor(profileVersions, customProfiles, options);
+    const profiles = getProfilesFor(
+      profileVersions,
+      customProfiles,
+      testOverrides
+    );
     allCapabilities.forEach((capability) => {
       /**
        * Core capabilities are capabilities that must always be declared by the

--- a/packages/dep-check/src/dependencies.ts
+++ b/packages/dep-check/src/dependencies.ts
@@ -139,8 +139,10 @@ export function getRequirements(
             return `    [${satisfiedVersions}] satisfies '${module}' because it supports '${reactNativeVersion}'`;
           }),
         ].join("\n");
-        error(fullTrace);
-        if (!loose) {
+        if (loose) {
+          warn(fullTrace);
+        } else {
+          error(fullTrace);
           throw new Error(message);
         }
       } else {

--- a/packages/dep-check/src/profiles.ts
+++ b/packages/dep-check/src/profiles.ts
@@ -6,7 +6,7 @@ import profile_0_63 from "./profiles/profile-0.63";
 import profile_0_64 from "./profiles/profile-0.64";
 import profile_0_65 from "./profiles/profile-0.65";
 import { isString, keysOf } from "./helpers";
-import type { Profile, ProfileVersion, ResolverOptions } from "./types";
+import type { Profile, ProfileVersion, TestOverrides } from "./types";
 
 type ProfileMap = Record<ProfileVersion, Profile>;
 
@@ -63,7 +63,7 @@ function tryInvoke<T>(fn: () => T): [T, undefined] | [undefined, Error] {
 
 function loadCustomProfiles(
   customProfilesPath: string | undefined,
-  { moduleResolver = require.resolve }: ResolverOptions = {}
+  { moduleResolver = require.resolve }: TestOverrides = {}
 ): Partial<ProfileMap> {
   if (customProfilesPath) {
     const [resolvedPath, moduleNotFoundError] = tryInvoke(() =>
@@ -129,9 +129,9 @@ export function getProfileVersionsFor(
 export function getProfilesFor(
   reactVersionRange: string | ProfileVersion[],
   customProfilesPath: string | undefined,
-  options?: ResolverOptions
+  testOverrides?: TestOverrides
 ): Profile[] {
-  const customProfiles = loadCustomProfiles(customProfilesPath, options);
+  const customProfiles = loadCustomProfiles(customProfilesPath, testOverrides);
   const profiles = getProfileVersionsFor(reactVersionRange).map((version) => ({
     ...defaultProfiles[version],
     ...customProfiles[version],
@@ -148,7 +148,7 @@ export function getProfilesFor(
 export function parseProfilesString(
   versions: string | number,
   customProfilesPath?: string | number,
-  options?: ResolverOptions
+  testOverrides?: TestOverrides
 ): ProfilesInfo {
   const profileVersions = versions
     .toString()
@@ -163,13 +163,13 @@ export function parseProfilesString(
     supportedProfiles: getProfilesFor(
       supportedVersions,
       customProfilesPath?.toString(),
-      options
+      testOverrides
     ),
     supportedVersions,
     targetProfile: getProfilesFor(
       targetVersion,
       customProfilesPath?.toString(),
-      options
+      testOverrides
     ),
     targetVersion,
   };

--- a/packages/dep-check/src/setVersion.ts
+++ b/packages/dep-check/src/setVersion.ts
@@ -60,8 +60,11 @@ export async function makeSetVersionCommand(
     return undefined;
   }
 
+  const checkOnly = { loose: false, write: false };
+  const write = { loose: false, write: true };
+
   return (manifestPath: string) => {
-    const checkReturnCode = checkPackageManifest(manifestPath);
+    const checkReturnCode = checkPackageManifest(manifestPath, checkOnly);
     if (checkReturnCode !== 0) {
       return checkReturnCode;
     }
@@ -76,6 +79,6 @@ export async function makeSetVersionCommand(
     rnxKitConfig.reactNativeDevVersion = targetVersion;
 
     writeJsonFile(manifestPath, manifest);
-    return checkPackageManifest(manifestPath, { write: true });
+    return checkPackageManifest(manifestPath, write);
   };
 }

--- a/packages/dep-check/src/types.ts
+++ b/packages/dep-check/src/types.ts
@@ -1,13 +1,27 @@
 import type { Capability, KitType } from "@rnx-kit/config";
 
-export type Args = {
+type Options = {
+  customProfiles?: string;
+  excludePackages?: string;
+  loose: boolean;
+  write: boolean;
+};
+
+export type Args = Options & {
   "custom-profiles"?: string | number;
   "exclude-packages"?: string | number;
   "package-json"?: string | number;
   "set-version"?: string | number;
   init?: string;
   vigilant?: string | number;
-  write: boolean;
+};
+
+export type CheckOptions = Options & {
+  uncheckedReturnCode?: number;
+};
+
+export type VigilantOptions = Options & {
+  versions: string;
 };
 
 export type CapabilitiesOptions = {
@@ -18,12 +32,6 @@ export type CapabilitiesOptions = {
 export type Command = (manifest: string) => number;
 
 export type DependencyType = "direct" | "development" | "peer";
-
-export type Options = {
-  customProfiles?: string;
-  uncheckedReturnCode?: number;
-  write?: boolean;
-};
 
 export type Package = {
   name: string;
@@ -43,7 +51,9 @@ export type Profile = Readonly<Record<Capability, Package>>;
 
 export type ProfileVersion = "0.61" | "0.62" | "0.63" | "0.64" | "0.65";
 
-export type ResolverOptions = { moduleResolver?: typeof require.resolve };
+export type TestOverrides = {
+  moduleResolver?: typeof require.resolve;
+};
 
 export type ExcludedPackage = Package & {
   reason: string;

--- a/packages/dep-check/test/__fixtures__/no-profile-satisfying-deps/node_modules/conan/package.json
+++ b/packages/dep-check/test/__fixtures__/no-profile-satisfying-deps/node_modules/conan/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "conan",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "react-native": "^0.63.2 || ^0.64.2"
+  },
+  "devDependencies": {
+    "react-native": "^0.63.2"
+  },
+  "rnx-kit": {
+    "reactNativeVersion": "^0.63 || ^0.64",
+    "capabilities": [
+      "core-android",
+      "core-ios"
+    ]
+  }
+}

--- a/packages/dep-check/test/__fixtures__/no-profile-satisfying-deps/node_modules/react-native/package.json
+++ b/packages/dep-check/test/__fixtures__/no-profile-satisfying-deps/node_modules/react-native/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "react-native",
+  "version": "0.64.2",
+  "dependencies": {
+    "react": "17.0.1"
+  }
+}

--- a/packages/dep-check/test/__fixtures__/no-profile-satisfying-deps/node_modules/react/package.json
+++ b/packages/dep-check/test/__fixtures__/no-profile-satisfying-deps/node_modules/react/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "react",
+  "version": "17.0.1"
+}

--- a/packages/dep-check/test/__fixtures__/no-profile-satisfying-deps/node_modules/t-800/package.json
+++ b/packages/dep-check/test/__fixtures__/no-profile-satisfying-deps/node_modules/t-800/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "t-800",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "react-native": "^0.63.2"
+  },
+  "devDependencies": {
+    "react-native": "^0.63.2"
+  },
+  "rnx-kit": {
+    "reactNativeVersion": "^0.63",
+    "capabilities": [
+      "core-android",
+      "core-ios"
+    ]
+  }
+}

--- a/packages/dep-check/test/__fixtures__/no-profile-satisfying-deps/package.json
+++ b/packages/dep-check/test/__fixtures__/no-profile-satisfying-deps/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "no-profile-satisfying-deps",
+  "version": "1.0.0",
+  "dependencies": {
+    "conan": "1.0.0",
+    "react": "17.0.1",
+    "react-native": "^0.64.2",
+    "t-800": "1.0.0"
+  },
+  "rnx-kit": {
+    "reactNativeVersion": "^0.64",
+    "kitType": "app",
+    "capabilities": [
+      "core-android",
+      "core-ios"
+    ]
+  }
+}

--- a/packages/dep-check/test/check.app.test.ts
+++ b/packages/dep-check/test/check.app.test.ts
@@ -30,7 +30,9 @@ describe("checkPackageManifest({ kitType: 'app' })", () => {
       updatedManifest = content;
     });
 
-    expect(checkPackageManifest(manifestPath, { write: true })).toBe(0);
+    expect(
+      checkPackageManifest(manifestPath, { loose: false, write: true })
+    ).toBe(0);
     expect(consoleWarnSpy).not.toBeCalled();
     expect(destination).toBe(manifestPath);
     expect(updatedManifest).toMatchSnapshot();

--- a/packages/dep-check/test/check.test.ts
+++ b/packages/dep-check/test/check.test.ts
@@ -29,6 +29,8 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
   const consoleLogSpy = jest.spyOn(global.console, "log");
   const consoleWarnSpy = jest.spyOn(global.console, "warn");
 
+  const defaultOptions = { loose: false, write: false };
+
   const mockManifest = {
     name: "@rnx-kit/dep-check",
     version: "0.0.1",
@@ -53,7 +55,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
   });
 
   test("returns error code when reading invalid manifests", () => {
-    expect(checkPackageManifest("package.json")).not.toBe(0);
+    expect(checkPackageManifest("package.json", defaultOptions)).not.toBe(0);
     expect(consoleErrorSpy).toBeCalledTimes(1);
   });
 
@@ -63,7 +65,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       dependencies: { "react-native-linear-gradient": "0.0.0" },
     });
 
-    const options = { uncheckedReturnCode: -1 };
+    const options = { ...defaultOptions, uncheckedReturnCode: -1 };
     expect(checkPackageManifest("package.json", options)).toBe(-1);
     expect(consoleWarnSpy).toBeCalled();
   });
@@ -81,7 +83,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     });
     rnxKitConfig.__setMockConfig({ reactNativeVersion: "0.64.0" });
 
-    expect(checkPackageManifest("package.json")).toBe(0);
+    expect(checkPackageManifest("package.json", defaultOptions)).toBe(0);
     expect(consoleErrorSpy).not.toBeCalled();
     expect(consoleWarnSpy.mock.calls).toMatchSnapshot();
   });
@@ -93,7 +95,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     });
     rnxKitConfig.__setMockConfig({ reactNativeVersion: "^0.63.0 || ^0.64.0" });
 
-    expect(checkPackageManifest("package.json")).toBe(0);
+    expect(checkPackageManifest("package.json", defaultOptions)).toBe(0);
     expect(consoleErrorSpy).not.toBeCalled();
     expect(consoleWarnSpy.mock.calls).toMatchSnapshot();
   });
@@ -102,7 +104,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     fs.__setMockContent(mockManifest);
     rnxKitConfig.__setMockConfig({ reactNativeVersion: "0.64.0" });
 
-    expect(checkPackageManifest("package.json")).toBe(0);
+    expect(checkPackageManifest("package.json", defaultOptions)).toBe(0);
     expect(consoleErrorSpy).not.toBeCalled();
     expect(consoleWarnSpy).not.toBeCalled();
   });
@@ -122,7 +124,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       capabilities: ["core-ios"],
     });
 
-    expect(checkPackageManifest("package.json")).toBe(0);
+    expect(checkPackageManifest("package.json", defaultOptions)).toBe(0);
     expect(consoleErrorSpy).not.toBeCalled();
     expect(consoleLogSpy).not.toBeCalled();
     expect(consoleWarnSpy).not.toBeCalled();
@@ -148,7 +150,9 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       capabilities: ["core-ios"],
     });
 
-    expect(checkPackageManifest("package.json", { write: true })).toBe(0);
+    expect(
+      checkPackageManifest("package.json", { loose: false, write: true })
+    ).toBe(0);
     expect(didWriteToPath).toBe(false);
     expect(consoleErrorSpy).not.toBeCalled();
     expect(consoleLogSpy).not.toBeCalled();
@@ -162,7 +166,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       capabilities: ["core-ios"],
     });
 
-    expect(checkPackageManifest("package.json")).not.toBe(0);
+    expect(checkPackageManifest("package.json", defaultOptions)).not.toBe(0);
     expect(consoleErrorSpy).toBeCalledTimes(1);
     expect(consoleWarnSpy).not.toBeCalled();
     expect(consoleLogSpy).toBeCalledTimes(2);
@@ -180,7 +184,9 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       capabilities: ["core-ios"],
     });
 
-    expect(checkPackageManifest("package.json", { write: true })).toBe(0);
+    expect(
+      checkPackageManifest("package.json", { loose: false, write: true })
+    ).toBe(0);
     expect(didWriteToPath).toBe("package.json");
     expect(consoleErrorSpy).not.toBeCalled();
     expect(consoleWarnSpy).not.toBeCalled();
@@ -202,7 +208,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       capabilities: ["core-ios"],
     });
 
-    expect(checkPackageManifest("package.json")).toBe(0);
+    expect(checkPackageManifest("package.json", defaultOptions)).toBe(0);
     expect(consoleErrorSpy).not.toBeCalled();
     expect(consoleLogSpy).not.toBeCalled();
     expect(consoleWarnSpy).not.toBeCalled();
@@ -224,7 +230,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       capabilities: ["core-ios"],
     });
 
-    expect(checkPackageManifest("package.json")).toBe(0);
+    expect(checkPackageManifest("package.json", defaultOptions)).toBe(0);
     expect(consoleErrorSpy).not.toBeCalled();
     expect(consoleLogSpy).not.toBeCalled();
     expect(consoleWarnSpy).not.toBeCalled();
@@ -246,7 +252,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       capabilities: ["core-ios"],
     });
 
-    expect(checkPackageManifest("package.json")).toBe(0);
+    expect(checkPackageManifest("package.json", defaultOptions)).toBe(0);
     expect(consoleErrorSpy).not.toBeCalled();
     expect(consoleLogSpy).not.toBeCalled();
     expect(consoleWarnSpy).not.toBeCalled();

--- a/packages/dep-check/test/dependencies.test.ts
+++ b/packages/dep-check/test/dependencies.test.ts
@@ -204,8 +204,6 @@ describe("getRequirements()", () => {
       getRequirements("^0.64", "app", manifest, fixture, undefined, {
         loose: true,
       })
-    ).not.toThrowError(
-      "No React Native profile could satisfy all dependencies"
-    );
+    ).not.toThrow();
   });
 });

--- a/packages/dep-check/test/dependencies.test.ts
+++ b/packages/dep-check/test/dependencies.test.ts
@@ -105,7 +105,14 @@ describe("visitDependencies()", () => {
 });
 
 describe("getRequirements()", () => {
+  const consoleErrorSpy = jest.spyOn(global.console, "error");
+  const consoleWarnSpy = jest.spyOn(global.console, "warn");
   const defaultOptions = { loose: false };
+
+  afterEach(() => {
+    consoleErrorSpy.mockReset();
+    consoleWarnSpy.mockReset();
+  });
 
   test("gets requirements from all dependencies", () => {
     const [fixture, manifest] = useFixture("awesome-repo");
@@ -126,6 +133,9 @@ describe("getRequirements()", () => {
       "storage",
       "webview",
     ]);
+
+    expect(consoleErrorSpy).not.toBeCalled();
+    expect(consoleWarnSpy).not.toBeCalled();
   });
 
   test("gets requirements from all dependencies with custom profiles", () => {
@@ -166,6 +176,9 @@ describe("getRequirements()", () => {
       "storage",
       "webview",
     ]);
+
+    expect(consoleErrorSpy).not.toBeCalled();
+    expect(consoleWarnSpy).not.toBeCalled();
   });
 
   test("throws if no profiles can satisfy required React Native version", () => {
@@ -182,6 +195,9 @@ describe("getRequirements()", () => {
         defaultOptions
       )
     ).toThrow();
+
+    expect(consoleErrorSpy).not.toBeCalled();
+    expect(consoleWarnSpy).not.toBeCalled();
   });
 
   test("throws if no profiles can satisfy requirement of dependencies", () => {
@@ -196,6 +212,14 @@ describe("getRequirements()", () => {
         defaultOptions
       )
     ).toThrowError("No React Native profile could satisfy all dependencies");
+
+    expect(consoleErrorSpy).toBeCalledWith(
+      "error",
+      expect.stringContaining(
+        "No React Native profile could satisfy all dependencies"
+      )
+    );
+    expect(consoleWarnSpy).not.toBeCalled();
   });
 
   test("does not throw if no profiles can satisfy requirement of dependencies in loose mode", () => {
@@ -205,5 +229,13 @@ describe("getRequirements()", () => {
         loose: true,
       })
     ).not.toThrow();
+
+    expect(consoleErrorSpy).not.toBeCalled();
+    expect(consoleWarnSpy).toBeCalledWith(
+      "warn",
+      expect.stringContaining(
+        "No React Native profile could satisfy all dependencies"
+      )
+    );
   });
 });

--- a/packages/dep-check/test/dependencies.test.ts
+++ b/packages/dep-check/test/dependencies.test.ts
@@ -1,12 +1,17 @@
-import fs from "fs";
 import path from "path";
 import { getRequirements, visitDependencies } from "../src/dependencies";
 import { readJsonFile } from "../src/json";
+import type { PackageManifest } from "../src/types";
 
 jest.unmock("@rnx-kit/config");
 
 function fixturePath(name: string) {
   return path.join(process.cwd(), "test", "__fixtures__", name);
+}
+
+function useFixture(name: string): [string, PackageManifest] {
+  const fixture = fixturePath(name);
+  return [fixture, readJsonFile(path.join(fixture, "package.json"))];
 }
 
 describe("visitDependencies()", () => {
@@ -100,15 +105,17 @@ describe("visitDependencies()", () => {
 });
 
 describe("getRequirements()", () => {
+  const defaultOptions = { loose: false };
+
   test("gets requirements from all dependencies", () => {
-    const fixture = fixturePath("awesome-repo");
-    const manifest = readJsonFile(path.join(fixture, "package.json"));
+    const [fixture, manifest] = useFixture("awesome-repo");
     const { reactNativeVersion, capabilities } = getRequirements(
       "^0.63 || ^0.64",
       "app",
       manifest,
       fixture,
-      undefined
+      undefined,
+      defaultOptions
     );
 
     expect(reactNativeVersion).toBe("^0.63 || ^0.64");
@@ -139,14 +146,14 @@ describe("getRequirements()", () => {
       { virtual: true }
     );
 
-    const fixture = fixturePath("awesome-repo-extended");
-    const manifest = readJsonFile(path.join(fixture, "package.json"));
+    const [fixture, manifest] = useFixture("awesome-repo-extended");
     const { reactNativeVersion, capabilities } = getRequirements(
       "^0.63 || ^0.64",
       "app",
       manifest,
       fixture,
       "awesome-dep-check-profiles",
+      defaultOptions,
       { moduleResolver: (() => "awesome-dep-check-profiles") as any }
     );
 
@@ -171,8 +178,34 @@ describe("getRequirements()", () => {
           version: "1.0.0",
         },
         "",
-        undefined
+        undefined,
+        defaultOptions
       )
     ).toThrow();
+  });
+
+  test("throws if no profiles can satisfy requirement of dependencies", () => {
+    const [fixture, manifest] = useFixture("no-profile-satisfying-deps");
+    expect(() =>
+      getRequirements(
+        "^0.64",
+        "app",
+        manifest,
+        fixture,
+        undefined,
+        defaultOptions
+      )
+    ).toThrowError("No React Native profile could satisfy all dependencies");
+  });
+
+  test("does not throw if no profiles can satisfy requirement of dependencies in loose mode", () => {
+    const [fixture, manifest] = useFixture("no-profile-satisfying-deps");
+    expect(() =>
+      getRequirements("^0.64", "app", manifest, fixture, undefined, {
+        loose: true,
+      })
+    ).not.toThrowError(
+      "No React Native profile could satisfy all dependencies"
+    );
   });
 });

--- a/packages/dep-check/test/vigilant.test.ts
+++ b/packages/dep-check/test/vigilant.test.ts
@@ -184,7 +184,9 @@ describe("makeVigilantCommand()", () => {
   });
 
   test("returns no command if no versions are specified", () => {
-    expect(makeVigilantCommand({ versions: "", write: false })).toBeUndefined();
+    expect(
+      makeVigilantCommand({ versions: "", loose: false, write: false })
+    ).toBeUndefined();
   });
 
   test("returns exit code 0 when there are no violations", () => {
@@ -201,9 +203,11 @@ describe("makeVigilantCommand()", () => {
       didWrite = true;
     });
 
-    const result = makeVigilantCommand({ versions: "0.63", write: false })(
-      "package.json"
-    );
+    const result = makeVigilantCommand({
+      versions: "0.63",
+      loose: false,
+      write: false,
+    })("package.json");
     expect(result).toBe(0);
     expect(didWrite).toBe(false);
     expect(consoleErrorSpy).not.toBeCalled();
@@ -223,9 +227,11 @@ describe("makeVigilantCommand()", () => {
       didWrite = true;
     });
 
-    const result = makeVigilantCommand({ versions: "0.63", write: false })(
-      "package.json"
-    );
+    const result = makeVigilantCommand({
+      versions: "0.63",
+      loose: false,
+      write: false,
+    })("package.json");
     expect(result).not.toBe(0);
     expect(didWrite).toBe(false);
     expect(consoleErrorSpy).toBeCalledTimes(1);
@@ -245,9 +251,11 @@ describe("makeVigilantCommand()", () => {
       didWrite = true;
     });
 
-    const result = makeVigilantCommand({ versions: "0.63", write: true })(
-      "package.json"
-    );
+    const result = makeVigilantCommand({
+      versions: "0.63",
+      loose: false,
+      write: true,
+    })("package.json");
     expect(result).toBe(0);
     expect(didWrite).toBe(true);
     expect(consoleErrorSpy).not.toBeCalled();
@@ -271,6 +279,7 @@ describe("makeVigilantCommand()", () => {
       versions: "0.63",
       write: false,
       excludePackages: "@rnx-kit/dep-check",
+      loose: false,
     })("package.json");
     expect(result).toBe(0);
     expect(didWrite).toBe(false);


### PR DESCRIPTION
### Description

Allow apps to depend on a newer version of React Native than their dependencies declare support for via the `--loose` flag.

Resolves #491.

### Test plan

Tests were added.