### PR TITLE
ci: test on two latest LTS versions of Node

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
     name: "Build"
     strategy:
       matrix:
-        node-version: [14, 15]
+        node-version: [14, 16]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -83,3 +83,4 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true
+        continue-on-error: true


### PR DESCRIPTION
### Description

Make sure we are compatible with the two latest LTS versions of Node.

Also, ignore if labeler fails. It won't label things correctly if PRs come from a forked repo.

### Test plan

CI should pass.