### PR TITLE
fix(cli): fix `rnx-test` failing under Jest 27

### DIFF
--- a/change/@rnx-kit-cli-8eb8a913-8e62-4b7b-afb6-daf7d3d78581.json
+++ b/change/@rnx-kit-cli-8eb8a913-8e62-4b7b-afb6-daf7d3d78581.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix `rnx-test` failing under Jest 27",
+  "packageName": "@rnx-kit/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -1,5 +1,6 @@
 import type { Config as CLIConfig } from "@react-native-community/cli-types";
 import { run as runJest } from "jest-cli";
+import path from "path";
 import { parsePlatform } from "./parsers";
 
 type Args = {
@@ -46,7 +47,16 @@ export function rnxTest(
 }
 
 function jestOptions(): Options[] {
-  const { options } = require("jest-cli/build/cli/args");
+  // Starting with Jest 27, we are getting this error:
+  //
+  // Package subpath './build/cli/args' is not defined by "exports" in
+  // /~/node_modules/jest-cli/package.json
+  //
+  // To work around this, resolve `jest-cli` first, then use the resolved path
+  // to import `./build/cli/args`.
+  const jestPath = require.resolve("jest-cli/package.json");
+  const { options } = require(`${path.dirname(jestPath)}/build/cli/args`);
+
   return Object.keys(options).map((option) => {
     const { default: defaultValue, description, type } = options[option];
     return {


### PR DESCRIPTION
### Description

Starting with Jest 27, we are getting this error:

```
Package subpath './build/cli/args' is not defined by "exports" in /~/node_modules/jest-cli/package.json
```

### Test plan

1. Bump `jest` to 27.0.6:
   ```diff
   diff --git a/scripts/package.json b/scripts/package.json
   index c816a68..8518e16 100644
   --- a/scripts/package.json
   +++ b/scripts/package.json
   @@ -15,13 +15,11 @@
      "dependencies": {
        "@babel/core": "^7.0.0",
        "@types/jest": "^26.0.0",
   -    "babel-jest": "^26.6.3",
        "chalk": "^4.1.0",
        "depcheck": "^1.0.0",
   -    "jest": "^26.0.0",
   +    "jest": "^27.0.0",
        "just-scripts": "^1.4.1",
        "midgard-yarn": "^1.23.24",
   -    "ts-jest": "^26.4.4",
        "typescript": "^4.0.0",
        "workspace-tools": "^0.16.2"
      }
   ```
2. Install: `yarn`
3. Build test app:
   ```sh
   cd packages/test-app
   yarn build --dependencies
   ```
4. Test: `yarn react-native rnx-test --help`

You should see a big list of flags originating from Jest.

> **Note**
> Tests fail with Jest 27 due to mocks not being correctly configured. Fortunately, running `rnx-test --help` is enough to trigger the bug.