### PR TITLE
fix(dep-check): fix error messages accumulating when gathering requirements

### DIFF
--- a/change/@rnx-kit-dep-check-8db71726-c18c-4bdf-a5ca-f2c173a3c3ff.json
+++ b/change/@rnx-kit-dep-check-8db71726-c18c-4bdf-a5ca-f2c173a3c3ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix error messages accumulating when gathering requirements",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Description

Error messages are being accumulated and printed with every dependency that cannot be satisfied with current set of profiles. Moving the print/throw outside the loop fixes the issue.

### Test plan

Tests should pass.