### PR TITLE
fix(metro-serializer-esbuild): fix compatibility issues with Hermes

### DIFF
--- a/change/@rnx-kit-cli-10e488e5-469f-4ce9-abd3-d9aaad86a7f0.json
+++ b/change/@rnx-kit-cli-10e488e5-469f-4ce9-abd3-d9aaad86a7f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix `--experimental-tree-shake` not being applied correctly",
+  "packageName": "@rnx-kit/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-metro-serializer-esbuild-f4974997-f7bb-42b5-a751-246237c38606.json
+++ b/change/@rnx-kit-metro-serializer-esbuild-f4974997-f7bb-42b5-a751-246237c38606.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix compatibility issues with Hermes",
+  "packageName": "@rnx-kit/metro-serializer-esbuild",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/kit-config.ts
+++ b/packages/cli/src/kit-config.ts
@@ -89,7 +89,7 @@ export function getKitBundlePlatformDefinition(
       ? { sourceMapSourceRootPath: overrides.sourcemapSourcesRoot }
       : {}),
     ...(overrides.experimentalTreeShake
-      ? { experimentalTreeShake: overrides.experimentalTreeShake }
+      ? { experimental_treeShake: overrides.experimentalTreeShake }
       : {}),
   };
 }


### PR DESCRIPTION
### Description

Hermes doesn't like the bundles being produced by esbuild. This is mostly because it outputs `esnext` by default! Setting target to ES5 makes it a lot happier.

### Test plan

```
yarn
cd packages/test-app
yarn build --dependencies
yarn bundle+esbuild --platform android
mv dist/main+esbuild.android.bundle dist/main.android.jsbundle
yarn android
```