### PR TITLE
fix(metro-config): Add react peer dependencies

### DIFF
--- a/change/@rnx-kit-metro-config-3c28c6a6-f6f6-44c0-8984-09d3bfb9403a.json
+++ b/change/@rnx-kit-metro-config-3c28c6a6-f6f6-44c0-8984-09d3bfb9403a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add react peer dependencies",
+  "packageName": "@rnx-kit/metro-config",
+  "email": "asgramme@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -25,7 +25,9 @@
     "workspace-tools": "^0.16.2"
   },
   "peerDependencies": {
-    "metro-config": ">=0.58.0"
+    "metro-config": ">=0.58.0",
+    "react": "*",
+    "react-native": "*"
   },
   "devDependencies": {
     "@types/babel__core": "^7.0.0",


### PR DESCRIPTION
### Description

In order to avoid bundling duplicates, metro-config walks up the
dependency tree, looking for react and react native. This means that
metro-config dependants need to depend on react and react-native.
