### PR TITLE
fix(cli): `--experimental-tree-shake` shouldn't need extra config

### DIFF
--- a/change/@rnx-kit-cli-a4516ce5-1fdd-43ff-bb0a-415a87a8a36f.json
+++ b/change/@rnx-kit-cli-a4516ce5-1fdd-43ff-bb0a-415a87a8a36f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "`--experimental-tree-shake` shouldn't need extra config",
+  "packageName": "@rnx-kit/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/metro-config.ts
+++ b/packages/cli/src/metro-config.ts
@@ -6,10 +6,13 @@ import {
   DuplicateDependencies,
   Options as DuplicateDetectorOptions,
 } from "@rnx-kit/metro-plugin-duplicates-checker";
-import type { Project } from "@rnx-kit/typescript-service";
 import { MetroPlugin, MetroSerializer } from "@rnx-kit/metro-serializer";
-import { MetroSerializer as MetroSerializerEsbuild } from "@rnx-kit/metro-serializer-esbuild";
+import {
+  esbuildTransformerConfig,
+  MetroSerializer as MetroSerializerEsbuild,
+} from "@rnx-kit/metro-serializer-esbuild";
 import type { AllPlatforms } from "@rnx-kit/tools-react-native/platform";
+import type { Project } from "@rnx-kit/typescript-service";
 import type { DeltaResult, Graph } from "metro";
 import type { InputConfigT, SerializerConfigT } from "metro-config";
 import type { TSProjectInfo } from "./types";
@@ -42,22 +45,23 @@ export function customizeMetroConfig(
     plugins.push(CyclicDependencies(detectCyclicDependencies));
   }
 
-  if (plugins.length > 0) {
-    //  MetroSerializer acts as a CustomSerializer, and it works with both
-    //  older and newer versions of Metro. Older versions expect a return
-    //  value, while newer versions expect a promise.
+  if (experimental_treeShake) {
+    metroConfig.serializer.customSerializer = MetroSerializerEsbuild(plugins);
+    Object.assign(metroConfig.transformer, esbuildTransformerConfig);
+  } else if (plugins.length > 0) {
+    // MetroSerializer acts as a CustomSerializer, and it works with both
+    // older and newer versions of Metro. Older versions expect a return
+    // value, while newer versions expect a promise.
     //
-    //  Its return type is the union of both the value and the promise.
-    //  This makes TypeScript upset because for any given version of Metro,
-    //  it's one or the other. Not both.
+    // Its return type is the union of both the value and the promise.
+    // This makes TypeScript upset because for any given version of Metro,
+    // it's one or the other. Not both.
     //
-    //  Since it can handle either scenario, just coerce it to whatever
-    //  the current version of Metro expects.
-    const serializer = experimental_treeShake
-      ? MetroSerializerEsbuild(plugins)
-      : (MetroSerializer(plugins) as SerializerConfigT["customSerializer"]);
-
-    metroConfig.serializer.customSerializer = serializer;
+    // Since it can handle either scenario, just coerce it to whatever
+    // the current version of Metro expects.
+    metroConfig.serializer.customSerializer = MetroSerializer(
+      plugins
+    ) as SerializerConfigT["customSerializer"];
   } else {
     delete metroConfig.serializer.customSerializer;
   }

--- a/packages/test-app/metro+esbuild.config.js
+++ b/packages/test-app/metro+esbuild.config.js
@@ -1,9 +1,0 @@
-const { makeMetroConfig } = require("@rnx-kit/metro-config");
-const {
-  esbuildTransformerConfig,
-} = require("@rnx-kit/metro-serializer-esbuild");
-
-module.exports = makeMetroConfig({
-  projectRoot: __dirname,
-  transformer: esbuildTransformerConfig,
-});

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -9,7 +9,7 @@
     "lint": "rnx-kit-scripts lint",
     "test": "react-native rnx-test --platform ios",
     "bundle": "react-native rnx-bundle",
-    "bundle+esbuild": "react-native rnx-bundle --bundle-prefix 'main+esbuild' --config metro+esbuild.config.js --experimental-tree-shake",
+    "bundle+esbuild": "react-native rnx-bundle --bundle-prefix 'main+esbuild' --experimental-tree-shake",
     "bundle:android": "react-native rnx-bundle --platform android",
     "bundle:ios": "react-native rnx-bundle --platform ios",
     "bundle:macos": "react-native rnx-bundle --platform macos",


### PR DESCRIPTION
### Description

Set `transformer` in code so cli users don't need to tweak their `metro.config.js`.

### Test plan

```
yarn
cd packages/test-app
yarn build --dependencies
yarn bundle+esbuild
```