### PR TITLE
chore: @rnx-kit/metro-config supports multiple versions of react-native

### DIFF
--- a/scripts/rnx-dep-check.js
+++ b/scripts/rnx-dep-check.js
@@ -54,7 +54,8 @@ module.exports = {
 if (require.main === module) {
   require("@rnx-kit/dep-check").cli({
     "custom-profiles": __filename,
-    "exclude-packages": "@rnx-kit/jest-preset,@rnx-kit/jest-resolver", // jest-resolver supports multiple versions of react-native
+    // the following packages support multiple versions of react-native
+    "exclude-packages": "@rnx-kit/jest-preset,@rnx-kit/metro-config",
     vigilant: "0.64",
     write: process.argv.includes("--write"),
   });


### PR DESCRIPTION
### Description

Adds `@rnx-kit/metro-config` to exclusion list so `dep-check` doesn't complain about its `peerDependencies`.

### Test plan

CI should no longer complain about `@rnx-kit/metro-config` not having declared correct versions of `react` and `react-native`.