### PR TITLE
Fix type-checking in Metro for windows dev machines

### DIFF
--- a/change/@rnx-kit-cli-3e870134-72cb-450a-8fd7-be3dcb158025.json
+++ b/change/@rnx-kit-cli-3e870134-72cb-450a-8fd7-be3dcb158025.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix type-checking on windows",
+  "packageName": "@rnx-kit/cli",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/metro-ts-resolver.ts
+++ b/packages/cli/src/metro-ts-resolver.ts
@@ -6,6 +6,7 @@ import {
   getMangledPackageName,
   isFileModuleRef,
   isPackageModuleRef,
+  normalizePath,
   PackageModuleRef,
   parseModuleRef,
   readPackage,
@@ -312,21 +313,25 @@ export class SourceFiles {
   }
 
   public get(fileName: string): ModuleMap | undefined {
-    return this.files[fileName];
+    const normalized = normalizePath(fileName);
+    return this.files[normalized];
   }
 
   public set(fileName: string, metroModules: Map<string, Dependency>): void {
+    const normalized = normalizePath(fileName);
+
     // extract each Metro dependency
     const modules: ModuleMap = {};
     metroModules.forEach((value: Dependency, key: string) => {
-      modules[key] = value.absolutePath;
+      modules[key] = normalizePath(value.absolutePath);
     });
 
-    this.files[fileName] = modules;
+    this.files[normalized] = modules;
   }
 
   public remove(fileName: string): void {
-    delete this.files[fileName];
+    const normalized = normalizePath(fileName);
+    delete this.files[normalized];
   }
 }
 
@@ -363,7 +368,7 @@ export class MetroTypeScriptResolverHost {
     }
 
     if (resolved) {
-      return resolved.map((r) => {
+      return resolved.map((r, i) => {
         if (r) {
           return {
             resolvedFileName: r,

--- a/packages/cli/src/metro-ts-resolver.ts
+++ b/packages/cli/src/metro-ts-resolver.ts
@@ -368,7 +368,7 @@ export class MetroTypeScriptResolverHost {
     }
 
     if (resolved) {
-      return resolved.map((r, i) => {
+      return resolved.map((r) => {
         if (r) {
           return {
             resolvedFileName: r,


### PR DESCRIPTION
### Description

There were a few spots where path-normalization was missing in the Metro+TS code. This led to failures resolving modules, and incorrect error-reporting.

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

Manual inspection in the debugger and running bundling on all platforms.

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
