### PR TITLE
CLI refactoring for testability - part 4

### DIFF
--- a/change/@rnx-kit-cli-61894ff0-35fa-4ab8-9c5f-bab96b87fd4d.json
+++ b/change/@rnx-kit-cli-61894ff0-35fa-4ab8-9c5f-bab96b87fd4d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Create type KitBundleConfig which combines a platform and its bundle configuration. Update rnxBundle to build a set of these, and apply command-line overrides to each one. Add/update related tests.",
+  "packageName": "@rnx-kit/cli",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/bundle/kit-config.ts
+++ b/packages/cli/src/bundle/kit-config.ts
@@ -1,7 +1,13 @@
 import type { BundleDefinitionWithRequiredParameters } from "@rnx-kit/config";
-import { getBundleDefinition, getKitConfig } from "@rnx-kit/config";
+import {
+  getBundleDefinition,
+  getBundlePlatformDefinition,
+  getKitConfig,
+} from "@rnx-kit/config";
 import { warn } from "@rnx-kit/console";
+import type { AllPlatforms } from "@rnx-kit/tools-react-native/platform";
 import chalk from "chalk";
+import type { KitBundleConfig } from "./types";
 
 /**
  * Get a bundle definition from the kit configuration.
@@ -37,4 +43,25 @@ export function getKitBundleDefinition(
 
   // get the bundle definition
   return getBundleDefinition(kitConfig.bundle, id);
+}
+
+/**
+ * Create a set of kit bundle configurations, one per platform. Each kit bundle
+ * config is built using the bundle definition and includes any platform-specific
+ * overrides from the definition.
+ *
+ * @param bundleDefinition Bundle definition
+ * @param platforms Platform list
+ * @returns Arrary of kit bundle configurations, one per platform
+ */
+export function getKitBundleConfigs(
+  bundleDefinition: BundleDefinitionWithRequiredParameters,
+  platforms: AllPlatforms[]
+): KitBundleConfig[] {
+  return platforms.map<KitBundleConfig>((platform) => {
+    return {
+      ...getBundlePlatformDefinition(bundleDefinition, platform),
+      platform,
+    };
+  });
 }

--- a/packages/cli/src/bundle/overrides.ts
+++ b/packages/cli/src/bundle/overrides.ts
@@ -1,8 +1,8 @@
-import type { BundleDefinitionWithRequiredParameters } from "@rnx-kit/config";
 import type { BundleArgs } from "@rnx-kit/metro-service";
 import { pickValues } from "@rnx-kit/tools-language/properties";
+import type { KitBundleConfig } from "../bundle/types";
 
-export type BundleDefinitionOverrides = {
+export type KitBundleConfigOverrides = {
   entryPath?: string;
   distPath?: string;
   assetsPath?: string;
@@ -14,14 +14,14 @@ export type BundleDefinitionOverrides = {
 };
 
 /**
- * Apply overrides, if any, to a bundle definition. Overrides are applied in-place.
+ * Apply overrides, if any, to a kit bundle config. Overrides are applied in-place.
  *
  * @param overrides Optional overrides to apply
- * @param bundleDefinition Bundle definition to override. This is modified if any overrides are applied.
+ * @param config Kit bundle config to override. This is modified if any overrides are applied.
  */
-export function applyBundleDefinitionOverrides(
-  overrides: BundleDefinitionOverrides,
-  bundleDefinition: BundleDefinitionWithRequiredParameters
+export function applyKitBundleConfigOverrides(
+  overrides: KitBundleConfigOverrides,
+  config: KitBundleConfig
 ): void {
   const overridesToApply = pickValues(
     overrides,
@@ -47,6 +47,6 @@ export function applyBundleDefinitionOverrides(
     ]
   );
   if (overridesToApply) {
-    Object.assign(bundleDefinition, overridesToApply);
+    Object.assign(config, overridesToApply);
   }
 }

--- a/packages/cli/src/bundle/types.ts
+++ b/packages/cli/src/bundle/types.ts
@@ -1,0 +1,10 @@
+import type {
+  BundleParameters,
+  BundleRequiredParameters,
+} from "@rnx-kit/config";
+import type { AllPlatforms } from "@rnx-kit/tools-react-native/platform";
+
+export type KitBundleConfig = BundleParameters &
+  BundleRequiredParameters & {
+    platform: AllPlatforms;
+  };

--- a/packages/cli/test/bundle/kit-config.test.ts
+++ b/packages/cli/test/bundle/kit-config.test.ts
@@ -1,5 +1,10 @@
 import "jest-extended";
-import { getKitBundleDefinition } from "../../src/bundle/kit-config";
+import type { BundleDefinitionWithRequiredParameters } from "@rnx-kit/config";
+import {
+  getKitBundleConfigs,
+  getKitBundleDefinition,
+} from "../../src/bundle/kit-config";
+import { KitBundleConfig } from "../../src/bundle/types";
 
 describe("CLI > Bundle > Kit Config > getKitBundleDefinition", () => {
   const rnxKitConfig = require("@rnx-kit/config");
@@ -41,5 +46,52 @@ describe("CLI > Bundle > Kit Config > getKitBundleDefinition", () => {
     expect(definition).toBeObject();
     expect(definition.entryPath).toBeString();
     expect(definition.entryPath.length).toBeGreaterThan(0);
+  });
+});
+
+describe("CLI > Bundle > Kit Config > getKitBundleConfigs", () => {
+  const definition: BundleDefinitionWithRequiredParameters = {
+    entryPath: "start.js",
+    distPath: "out",
+    assetsPath: "out/assets",
+    bundlePrefix: "fabrikam",
+    detectCyclicDependencies: true,
+    detectDuplicateDependencies: true,
+    typescriptValidation: true,
+    experimental_treeShake: true,
+    platforms: {
+      ios: {
+        entryPath: "entry.ios.js",
+      },
+    },
+  };
+
+  test("returns no kit bundle configs when no platforms are given", () => {
+    const kitBundleConfigs = getKitBundleConfigs(definition, []);
+    expect(kitBundleConfigs).toBeArrayOfSize(0);
+  });
+
+  test("returns one kit bundle config when one platform is given", () => {
+    const kitBundleConfigs = getKitBundleConfigs(definition, ["ios"]);
+    expect(kitBundleConfigs).toBeArrayOfSize(1);
+  });
+
+  test("sets the platform property", () => {
+    const kitBundleConfigs = getKitBundleConfigs(definition, [
+      "ios",
+      "android",
+    ]);
+    expect(kitBundleConfigs).toBeArrayOfSize(2);
+    expect(kitBundleConfigs[0].platform).toEqual("ios");
+    expect(kitBundleConfigs[1].platform).toEqual("android");
+  });
+
+  test("sets all bundle definition properties", () => {
+    const kitBundleConfigs = getKitBundleConfigs(definition, ["android"]);
+    expect(kitBundleConfigs).toBeArrayOfSize(1);
+    expect(kitBundleConfigs[0]).toEqual({
+      ...definition,
+      platform: "android",
+    });
   });
 });

--- a/packages/cli/test/bundle/overrides.test.ts
+++ b/packages/cli/test/bundle/overrides.test.ts
@@ -1,9 +1,9 @@
 import "jest-extended";
-import type { BundleDefinitionWithRequiredParameters } from "@rnx-kit/config";
-import { applyBundleDefinitionOverrides } from "../../src/bundle/overrides";
+import { applyKitBundleConfigOverrides } from "../../src/bundle/overrides";
+import type { KitBundleConfig } from "../../src/bundle/types";
 
-describe("CLI > Bundle > Overrides > applyBundleDefinitionOverrides", () => {
-  const definition: BundleDefinitionWithRequiredParameters = {
+describe("CLI > Bundle > Overrides > applyKitBundleConfigOverrides", () => {
+  const config: KitBundleConfig = {
     detectCyclicDependencies: true,
     detectDuplicateDependencies: true,
     typescriptValidation: true,
@@ -12,24 +12,25 @@ describe("CLI > Bundle > Overrides > applyBundleDefinitionOverrides", () => {
     distPath: "dist",
     assetsPath: "dist",
     bundlePrefix: "main",
+    platform: "ios",
   };
 
   test("returns bundle definition without any changes", () => {
-    const copy = { ...definition };
-    applyBundleDefinitionOverrides({}, copy);
-    expect(copy).toEqual(definition);
+    const copy = { ...config };
+    applyKitBundleConfigOverrides({}, copy);
+    expect(copy).toEqual(config);
   });
 
   function testOverride(name: string, value: unknown) {
-    const copy = { ...definition };
-    applyBundleDefinitionOverrides(
+    const copy = { ...config };
+    applyKitBundleConfigOverrides(
       {
         [name]: value,
       },
       copy
     );
     expect(copy).toEqual({
-      ...definition,
+      ...config,
       [name]: value,
     });
   }
@@ -63,15 +64,15 @@ describe("CLI > Bundle > Overrides > applyBundleDefinitionOverrides", () => {
   });
 
   test("returns bundle definition with experimentalTreeShake override", () => {
-    const copy = { ...definition };
-    applyBundleDefinitionOverrides(
+    const copy = { ...config };
+    applyKitBundleConfigOverrides(
       {
         experimentalTreeShake: true,
       },
       copy
     );
     expect(copy).toEqual({
-      ...definition,
+      ...config,
       experimental_treeShake: true,
     });
   });


### PR DESCRIPTION
### Description

Part 4 is all about moving to a `KitBundleConfig` object which is a combination of a platform field and the platform-overridden kit bundle definition. I've made a function which creates an array of `KitBundleConfig` objects. They are used in the main bundle code as the basis for generating each bundle. I added a set of tests to protect the new function.

As part of this change, I had to rename the "apply overrides" method and arg type in code and tests.

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

New tests pass.

CI passes, and bundling continues to work without issue.

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
