### PR TITLE
chore(jest-preset): suppress TypeScript error with CLI 6.x

### DIFF
--- a/change/@rnx-kit-jest-preset-f6f5b9d5-7745-49f3-9436-57c1cfec6afb.json
+++ b/change/@rnx-kit-jest-preset-f6f5b9d5-7745-49f3-9436-57c1cfec6afb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Suppress TypeScript error with CLI 6.x",
+  "packageName": "@rnx-kit/jest-preset",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/jest-preset/src/index.js
+++ b/packages/jest-preset/src/index.js
@@ -5,6 +5,7 @@ const path = require("path");
  * @typedef {import("@jest/types").Config.HasteConfig} HasteConfig
  * @typedef {import("@jest/types").Config.InitialOptions} InitialOptions
  * @typedef {import("@jest/types").Config.TransformerConfig} TransformerConfig
+ * @typedef {import("@react-native-community/cli-types").Config} CLIConfig
  * @typedef {[string | undefined, string | undefined]} PlatformPath
  */
 
@@ -76,7 +77,10 @@ function getTargetPlatform(defaultPlatform) {
     return getReactNativePlatformPath();
   }
 
+  /** @type {() => CLIConfig} */
   const loadConfig =
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore could not find a declaration file
     require("@react-native-community/cli/build/tools/config").default;
 
   const { platforms } = loadConfig();


### PR DESCRIPTION
### Description

TypeScript fails building `jest-preset` when `@react-native-community/cli` 6.0 is installed. Long term, we want to make `loadConfig` public so we don't have to do this ugly workaround.

### Test plan

Apply these changes to #523 and build:

```
yarn
cd packages/jest-preset
yarn build
```