### PR TITLE
CLI refactoring for testability - part 6

### DIFF
--- a/change/@rnx-kit-cli-7389a7d3-f229-4fd4-ac91-44fbb1573db8.json
+++ b/change/@rnx-kit-cli-7389a7d3-f229-4fd4-ac91-44fbb1573db8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Create a new type to encapsulate everything needed for bundling. Use this as the main type for driving metro bundle runs in the rnxBundle loop.",
+  "packageName": "@rnx-kit/cli",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-tools-language-c04915c0-999e-4199-81b3-8e1b31eac479.json
+++ b/change/@rnx-kit-tools-language-c04915c0-999e-4199-81b3-8e1b31eac479.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add two new functions for extended objects and their types.",
+  "packageName": "@rnx-kit/tools-language",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/bundle.ts
+++ b/packages/cli/src/bundle.ts
@@ -1,7 +1,7 @@
 import type { Config as CLIConfig } from "@react-native-community/cli-types";
 import { info, warn } from "@rnx-kit/console";
 import { bundle, BundleArgs, loadMetroConfig } from "@rnx-kit/metro-service";
-import { extendObjectArray } from "@rnx-kit/tools-node/properties";
+import { extendObjectArray } from "@rnx-kit/tools-language/properties";
 import type { AllPlatforms } from "@rnx-kit/tools-react-native/platform";
 import { Service } from "@rnx-kit/typescript-service";
 import chalk from "chalk";

--- a/packages/cli/src/bundle.ts
+++ b/packages/cli/src/bundle.ts
@@ -1,6 +1,7 @@
 import type { Config as CLIConfig } from "@react-native-community/cli-types";
 import { info, warn } from "@rnx-kit/console";
 import { bundle, BundleArgs, loadMetroConfig } from "@rnx-kit/metro-service";
+import { extendObjectArray } from "@rnx-kit/tools-node/properties";
 import type { AllPlatforms } from "@rnx-kit/tools-react-native/platform";
 import { Service } from "@rnx-kit/typescript-service";
 import chalk from "chalk";
@@ -8,6 +9,7 @@ import fs from "fs";
 import path from "path";
 import { getKitBundleConfigs } from "./bundle/kit-config";
 import { applyKitBundleConfigOverrides } from "./bundle/overrides";
+import type { BundleConfig, KitBundleConfig } from "./bundle/types";
 import { customizeMetroConfig } from "./metro-config";
 import type { TSProjectInfo } from "./types";
 
@@ -46,10 +48,18 @@ export async function rnxBundle(
 
   applyKitBundleConfigOverrides(cliOptions, kitBundleConfigs);
 
+  const bundleConfigs = extendObjectArray<KitBundleConfig, BundleConfig>(
+    kitBundleConfigs,
+    {
+      dev: cliOptions.dev,
+      minify: cliOptions.minify,
+    }
+  );
+
   const tsservice = new Service();
 
-  for (const kitBundleConfig of kitBundleConfigs) {
-    const targetPlatform = kitBundleConfig.platform;
+  for (const bundleConfig of bundleConfigs) {
+    const targetPlatform = bundleConfig.platform;
 
     info(`Bundling ${targetPlatform}...`);
 
@@ -64,7 +74,7 @@ export async function rnxBundle(
       detectDuplicateDependencies,
       typescriptValidation,
       experimental_treeShake,
-    } = kitBundleConfig;
+    } = bundleConfig;
 
     //  assemble the full path to the bundle file
     const bundleExtension =
@@ -74,10 +84,10 @@ export async function rnxBundle(
     const bundleFile = `${bundlePrefix}.${targetPlatform}.${bundleExtension}`;
     const bundlePath = path.join(distPath, bundleFile);
 
-    let { sourceMapPath } = kitBundleConfig;
+    let { sourceMapPath } = bundleConfig;
 
     //  always create a source-map in dev mode
-    if (cliOptions.dev) {
+    if (bundleConfig.dev) {
       sourceMapPath = sourceMapPath ?? bundleFile + ".map";
     }
 
@@ -128,9 +138,9 @@ export async function rnxBundle(
       {
         assetsDest: assetsPath,
         entryFile: entryPath,
-        minify: cliOptions.minify,
+        minify: bundleConfig.minify,
         platform: targetPlatform,
-        dev: cliOptions.dev,
+        dev: bundleConfig.dev,
         bundleOutput: bundlePath,
         bundleEncoding,
         sourcemapOutput: sourceMapPath,

--- a/packages/cli/src/bundle/types.ts
+++ b/packages/cli/src/bundle/types.ts
@@ -6,5 +6,23 @@ import type { AllPlatforms } from "@rnx-kit/tools-react-native/platform";
 
 export type KitBundleConfig = BundleParameters &
   BundleRequiredParameters & {
+    /**
+     * Target platform for the bundle
+     */
     platform: AllPlatforms;
   };
+
+export type BundleConfig = KitBundleConfig & {
+  /**
+   * Choose whether or not this will be a "developer" bundle. The alternative is a "production" bundle.
+   *
+   * When `true`, warnings are enabled, and the bundle is not minified by default.
+   * When `false`, Warnings are disabled and the bundle is minified by default.
+   */
+  dev: boolean;
+
+  /**
+   * Optionally choose whether or not the bundle is minified. When not set, minification is controlled by the `dev` property.
+   */
+  minify?: boolean;
+};

--- a/packages/cli/src/bundle/types.ts
+++ b/packages/cli/src/bundle/types.ts
@@ -17,7 +17,9 @@ export type BundleConfig = KitBundleConfig & {
    * Choose whether or not this will be a "developer" bundle. The alternative is a "production" bundle.
    *
    * When `true`, warnings are enabled, and the bundle is not minified by default.
-   * When `false`, Warnings are disabled and the bundle is minified by default.
+   * Further, optimizations like constant folding are disabled.
+   *
+   * When `false`, warnings are disabled and the bundle is minified by default.
    */
   dev: boolean;
 

--- a/packages/tools-language/src/properties.ts
+++ b/packages/tools-language/src/properties.ts
@@ -48,3 +48,36 @@ export function pickValues<T>(
 
   return pickedValue ? results : undefined;
 }
+
+/**
+ * Add properties to an object, changing it from its current type to an extended type.
+ *
+ * Properties are added in-place, and the original object reference is returned as the extended type.
+ *
+ * @param obj Object to extend
+ * @param extendedProps Properties to add to the object, extending it
+ * @returns The original object reference as the extended type
+ */
+export function extendObject<T, TExtended extends T>(
+  obj: T,
+  extendedProps: Omit<TExtended, keyof T>
+): TExtended {
+  return Object.assign(obj, extendedProps) as TExtended;
+}
+
+/**
+ * Add properties to each object in an array, changing the object from its current type to an extended type.
+ *
+ * Properties are added in-place, and the original object array reference is returned as the extended array type.
+ *
+ * @param arr Array of objects to extend
+ * @param extendedProps Properties to add to each object in the array, extending it
+ * @returns The original object array reference as the extended array type
+ */
+export function extendObjectArray<T, TExtended extends T>(
+  arr: T[],
+  extendedProps: Omit<TExtended, keyof T>
+): TExtended[] {
+  arr.map((obj) => Object.assign(obj, extendedProps));
+  return arr as TExtended[];
+}

--- a/packages/tools-language/test/properties.test.ts
+++ b/packages/tools-language/test/properties.test.ts
@@ -100,6 +100,7 @@ describe("Language > Props", () => {
   type ExtendedType = BaseType & { extended?: number };
 
   const baseObj: BaseType = { base: "base object" };
+  const baseObj2: BaseType = { base: "another base object" };
   const extendedProps: Omit<ExtendedType, keyof BaseType> = { extended: 12345 };
 
   test("extendObject adds the extended props", () => {
@@ -122,14 +123,14 @@ describe("Language > Props", () => {
     expect(extendObject<BaseType, ExtendedType>(copy, {})).toEqual(baseObj);
   });
 
-  test("extendObjectArray adds the extended props to each object in the array", () => {
+  test("extendObjectArray adds the extended props to each object in the 1-element array", () => {
     const copy = [{ ...baseObj }];
     const extended = extendObjectArray<BaseType, ExtendedType>(
       copy,
       extendedProps
     );
     expect(extended).toBeArrayOfSize(1);
-    expect(extended).toIncludeSameMembers([
+    expect(extended).toEqual([
       {
         ...baseObj,
         ...extendedProps,
@@ -137,8 +138,27 @@ describe("Language > Props", () => {
     ]);
   });
 
+  test("extendObjectArray adds the extended props to each object in the 2-element array", () => {
+    const copy = [{ ...baseObj }, { ...baseObj2 }];
+    const extended = extendObjectArray<BaseType, ExtendedType>(
+      copy,
+      extendedProps
+    );
+    expect(extended).toBeArrayOfSize(2);
+    expect(extended).toEqual([
+      {
+        ...baseObj,
+        ...extendedProps,
+      },
+      {
+        ...baseObj2,
+        ...extendedProps,
+      },
+    ]);
+  });
+
   test("extendObjectArray returns the original object array reference", () => {
-    const copy = [{ ...baseObj }];
+    const copy = [{ ...baseObj }, { ...baseObj2 }];
     const extended = extendObjectArray<BaseType, ExtendedType>(
       copy,
       extendedProps
@@ -147,9 +167,9 @@ describe("Language > Props", () => {
   });
 
   test("extendObjectArray makes no changes when extended props are optional and are not given", () => {
-    const copy = [{ ...baseObj }];
+    const copy = [{ ...baseObj }, { ...baseObj2 }];
     const extended = extendObjectArray<BaseType, ExtendedType>(copy, {});
-    expect(extended).toBeArrayOfSize(1);
-    expect(extended).toIncludeSameMembers([baseObj]);
+    expect(extended).toBeArrayOfSize(2);
+    expect(extended).toEqual([baseObj, baseObj2]);
   });
 });

--- a/packages/tools-language/test/properties.test.ts
+++ b/packages/tools-language/test/properties.test.ts
@@ -1,5 +1,10 @@
 import "jest-extended";
-import { pickValue, pickValues } from "../src/properties";
+import {
+  pickValue,
+  pickValues,
+  extendObject,
+  extendObjectArray,
+} from "../src/properties";
 
 describe("Language > Props", () => {
   test("pickValue returns undefined when the key is not found", () => {
@@ -89,5 +94,62 @@ describe("Language > Props", () => {
         ["x", "y", "foo"]
       )
     ).toEqual({ x: 123, y: "test" });
+  });
+
+  type BaseType = { base: string };
+  type ExtendedType = BaseType & { extended?: number };
+
+  const baseObj: BaseType = { base: "base object" };
+  const extendedProps: Omit<ExtendedType, keyof BaseType> = { extended: 12345 };
+
+  test("extendObject adds the extended props", () => {
+    const copy = { ...baseObj };
+    expect(extendObject<BaseType, ExtendedType>(copy, extendedProps)).toEqual({
+      ...baseObj,
+      ...extendedProps,
+    });
+  });
+
+  test("extendObject returns the original object reference", () => {
+    const copy = { ...baseObj };
+    expect(extendObject<BaseType, ExtendedType>(copy, extendedProps)).toBe(
+      copy
+    );
+  });
+
+  test("extendObject makes no changes when extended props are optional and are not given", () => {
+    const copy = { ...baseObj };
+    expect(extendObject<BaseType, ExtendedType>(copy, {})).toEqual(baseObj);
+  });
+
+  test("extendObjectArray adds the extended props to each object in the array", () => {
+    const copy = [{ ...baseObj }];
+    const extended = extendObjectArray<BaseType, ExtendedType>(
+      copy,
+      extendedProps
+    );
+    expect(extended).toBeArrayOfSize(1);
+    expect(extended).toIncludeSameMembers([
+      {
+        ...baseObj,
+        ...extendedProps,
+      },
+    ]);
+  });
+
+  test("extendObjectArray returns the original object array reference", () => {
+    const copy = [{ ...baseObj }];
+    const extended = extendObjectArray<BaseType, ExtendedType>(
+      copy,
+      extendedProps
+    );
+    expect(extended).toBe(copy);
+  });
+
+  test("extendObjectArray makes no changes when extended props are optional and are not given", () => {
+    const copy = [{ ...baseObj }];
+    const extended = extendObjectArray<BaseType, ExtendedType>(copy, {});
+    expect(extended).toBeArrayOfSize(1);
+    expect(extended).toIncludeSameMembers([baseObj]);
   });
 });


### PR DESCRIPTION
### Description

In part 6, I've combined kit bundle configuration with command-line-only params (dev, minify) to produce a final bundle config. This is what will drive each bundling operation.

To support this new type, I've added utility functions which "extend" an object from type `T` to type `TExtended extends T`.

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

Add new tests to cover the "extend" functions.

Run existing tests and bundling to ensure things continue working as expected.

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
