### PR TITLE
fix(cli): make 'cli-server-api' optional

### DIFF
--- a/change/@rnx-kit-cli-389ac13f-58f0-467b-bfc0-f6297ff9a0a4.json
+++ b/change/@rnx-kit-cli-389ac13f-58f0-467b-bfc0-f6297ff9a0a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make `@react-native-community/cli-server-api` optional. We want to prevent cli from installing an extra copy, and also not require the user to explicitly add it to their dependencies. Since we're running inside `@react-native-community/cli`, it is reasonable to assume that this package will be installed. And if it isn't, we need to update our code anyway.",
+  "packageName": "@rnx-kit/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,6 +39,11 @@
     "@react-native-community/cli-server-api": "^5.0.0-0 || ^6.0.0-0",
     "jest-cli": "^26.0 || ^27.0"
   },
+  "peerDependenciesMeta": {
+    "@react-native-community/cli-server-api": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@react-native-community/cli-types": "^6.0.0",
     "@rnx-kit/jest-preset": "*",

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -1,8 +1,5 @@
+import type CliServerApi from "@react-native-community/cli-server-api";
 import type { Config as CLIConfig } from "@react-native-community/cli-types";
-import {
-  createDevServerMiddleware,
-  indexPageMiddleware,
-} from "@react-native-community/cli-server-api";
 import {
   createTerminal,
   loadMetroConfig,
@@ -36,6 +33,16 @@ export type CLIStartOptions = {
   interactive: boolean;
 };
 
+function friendlyRequire<T>(module: string): T {
+  try {
+    return require(module) as T;
+  } catch (_) {
+    throw new Error(
+      `Cannot find module '${module}'. This probably means that '@rnx-kit/cli' is not compatible with the version of '@react-native-community/cli' that you are currently using. Please update to the latest version and try again. If the issue still persists after the update, please file a bug at https://github.com/microsoft/rnx-kit/issues.`
+    );
+  }
+}
+
 export async function rnxStart(
   _argv: Array<string>,
   cliConfig: CLIConfig,
@@ -45,6 +52,10 @@ export async function rnxStart(
   if (!serverConfig) {
     return Promise.resolve();
   }
+
+  const { createDevServerMiddleware, indexPageMiddleware } = friendlyRequire<
+    typeof CliServerApi
+  >("@react-native-community/cli-server-api");
 
   // interactive mode requires raw access to stdin
   let interactive = cliOptions.interactive;


### PR DESCRIPTION
### Description

Make `@react-native-community/cli-server-api` optional. We want to prevent cli from installing an extra copy, and also not require the user to explicitly add it to their dependencies. Since we're running inside `@react-native-community/cli`, it is reasonable to assume that this package will be installed. And if it isn't, we need to update our code anyway.

### Test plan

Existing tests should pass.