### PR TITLE
fix(test-app): fix test app not starting on Windows

### DIFF
--- a/packages/test-app/metro.config.js
+++ b/packages/test-app/metro.config.js
@@ -4,7 +4,7 @@ const { exclusionList, makeMetroConfig } = require("@rnx-kit/metro-config");
 const blockList = exclusionList([/.*__fixtures__.*/]);
 
 module.exports = makeMetroConfig({
-  projectRoot: __dirname,
+  projectRoot: __dirname + "/src",
   resolver: {
     blacklistRE: blockList,
     blockList,

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -64,7 +64,7 @@
     "reactNativeVersion": "^0.65",
     "kitType": "app",
     "bundle": {
-      "entryPath": "src/index.ts",
+      "entryPath": "index.ts",
       "distPath": "dist",
       "assetsPath": "dist",
       "bundlePrefix": "main",


### PR DESCRIPTION
### Description

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/4123478/130934024-3b875dd8-1c72-4675-9955-adc6d6e48641.png) | ![image](https://user-images.githubusercontent.com/4123478/130933642-1a8c1de6-24b7-4e5c-9b69-3ec255eda3e3.png) |

Resolves #529.

### Test plan

1. Test the Windows test app:
   ```
   yarn
   cd packages/test-app
   yarn build --dependencies
   yarn install-windows-test-app --use-nuget
   yarn windows
   ```
2. Also make sure that the other test apps still work:
   ```
   # Android
   yarn android

   # iOS
   pod install --project-directory=ios
   yarn ios
   ```

### Known Issues

The background image is missing, same as on Android. This was reported here in #528.