### PR TITLE
fix(metro-config): fix assets not resolving correctly in monorepos

### DIFF
--- a/change/@rnx-kit-metro-config-cbfc2e82-2458-4043-b087-773881b1fa37.json
+++ b/change/@rnx-kit-metro-config-cbfc2e82-2458-4043-b087-773881b1fa37.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix assets not resolving correctly in monorepos",
+  "packageName": "@rnx-kit/metro-config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-third-party-notices-3f529249-8ae6-4f51-9fb5-d1b8989c57e2.json
+++ b/change/@rnx-kit-third-party-notices-3f529249-8ae6-4f51-9fb5-d1b8989c57e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Formatted test code",
+  "packageName": "@rnx-kit/third-party-notices",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -32,6 +32,8 @@
   "devDependencies": {
     "@types/babel__core": "^7.0.0",
     "@types/jest": "^26.0.0",
+    "@types/metro": "*",
+    "@types/metro-config": "*",
     "metro-config": "^0.66.1",
     "prettier": "^2.0.0",
     "rnx-kit-scripts": "*",

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -37,6 +37,7 @@
     "metro-config": "^0.66.1",
     "prettier": "^2.0.0",
     "rnx-kit-scripts": "*",
+    "type-fest": "^2.1.0",
     "typescript": "^4.0.0"
   },
   "depcheck": {

--- a/packages/metro-config/src/assetPluginForMonorepos.js
+++ b/packages/metro-config/src/assetPluginForMonorepos.js
@@ -1,0 +1,20 @@
+/**
+ * Metro doesn't support assets in a monorepo setup. When the app requests
+ * assets at URLs such as `/assets/../../../node_modules/react-native/<...>`,
+ * the URL will be resolved to `/node_modules/react-native/<...>` and Metro will
+ * fail to resolve them. The workaround is to replace `..` with something else
+ * so the URL doesn't collapse when resolved, then restore them in
+ * `server.enhanceMiddleware`.
+ *
+ * For more details, see https://github.com/facebook/metro/issues/290.
+ *
+ * @typedef {Record<string, unknown> & { httpServerLocation: string }} AssetData
+ * @type {(assetData: AssetData) => AssetData}
+ */
+module.exports = (assetData) => {
+  assetData.httpServerLocation = assetData.httpServerLocation.replace(
+    /\.\.\//g,
+    "@@/"
+  );
+  return assetData;
+};

--- a/packages/metro-config/src/assetPluginForMonorepos.js
+++ b/packages/metro-config/src/assetPluginForMonorepos.js
@@ -7,9 +7,16 @@
  * `server.enhanceMiddleware`.
  *
  * For more details, see https://github.com/facebook/metro/issues/290.
- *
- * @typedef {Record<string, unknown> & { httpServerLocation: string }} AssetData
- * @type {(assetData: AssetData) => AssetData}
+ */
+
+/**
+ * @template T
+ * @typedef {{-readonly [P in keyof T]: T[P]}} Mutable;
+ */
+
+/**
+ * @typedef {import("metro").AssetData} AssetData;
+ * @type {(assetData: Mutable<AssetData>) => AssetData};
  */
 module.exports = (assetData) => {
   assetData.httpServerLocation = assetData.httpServerLocation.replace(

--- a/packages/metro-config/src/assetPluginForMonorepos.js
+++ b/packages/metro-config/src/assetPluginForMonorepos.js
@@ -1,4 +1,9 @@
 /**
+ * @typedef {import("metro").AssetData} AssetData;
+ * @typedef {import("metro-config").Middleware} Middleware;
+ */
+
+/**
  * Metro doesn't support assets in a monorepo setup. When the app requests
  * assets at URLs such as `/assets/../../../node_modules/react-native/<...>`,
  * the URL will be resolved to `/node_modules/react-native/<...>` and Metro will
@@ -8,13 +13,32 @@
  *
  * For more details, see https://github.com/facebook/metro/issues/290.
  *
- * @typedef {import("metro").AssetData} AssetData;
- * @type {(assetData: import("type-fest").Mutable<AssetData>) => AssetData};
+ * @param {import("type-fest").Mutable<AssetData>} assetData
+ * @returns {AssetData}
  */
-module.exports = (assetData) => {
+function assetPlugin(assetData) {
   assetData.httpServerLocation = assetData.httpServerLocation.replace(
     /\.\.\//g,
     "@@/"
   );
   return assetData;
-};
+}
+
+/**
+ * This middleware restores `..` in asset URLs.
+ *
+ * @param {Middleware} middleware
+ * @returns {Middleware}
+ */
+function enhanceMiddleware(middleware) {
+  return (req, res, next) => {
+    const { url } = req;
+    if (url && url.startsWith("/assets/")) {
+      req.url = url.replace(/@@\//g, "../");
+    }
+    return middleware(req, res, next);
+  };
+}
+
+module.exports = assetPlugin;
+module.exports.enhanceMiddleware = enhanceMiddleware;

--- a/packages/metro-config/src/assetPluginForMonorepos.js
+++ b/packages/metro-config/src/assetPluginForMonorepos.js
@@ -7,16 +7,9 @@
  * `server.enhanceMiddleware`.
  *
  * For more details, see https://github.com/facebook/metro/issues/290.
- */
-
-/**
- * @template T
- * @typedef {{-readonly [P in keyof T]: T[P]}} Mutable;
- */
-
-/**
+ *
  * @typedef {import("metro").AssetData} AssetData;
- * @type {(assetData: Mutable<AssetData>) => AssetData};
+ * @type {(assetData: import("type-fest").Mutable<AssetData>) => AssetData};
  */
 module.exports = (assetData) => {
   assetData.httpServerLocation = assetData.httpServerLocation.replace(

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -3,27 +3,9 @@
 
 /**
  * @typedef {import("metro-config").ExtraTransformOptions} ExtraTransformOptions;
+ * @typedef {import("metro-config").InputConfigT} InputConfigT;
  * @typedef {import("metro-config").Middleware} Middleware;
- *
- * @typedef {{
- *   projectRoot?: string;
- *   resetCache?: boolean;
- *   resolver?: {
- *     extraNodeModules?: Record<string, string>;
- *     blacklistRE?: RegExp;
- *     blockList?: RegExp;
- *     [key: string]: unknown;
- *   };
- *   server?: {
- *     enhanceMiddleware?: (middleware: Middleware) => Middleware;
- *   };
- *   transformer?: {
- *     getTransformOptions: () => Promise<ExtraTransformOptions>;
- *     [key: string]: unknown;
- *   };
- *   watchFolders?: string[];
- *   [key: string]: unknown;
- * }} MetroConfig;
+ * @typedef {import("type-fest").PartialDeep<InputConfigT>} MetroConfig;
  */
 
 /** Packages that must be resolved to one specific copy. */

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -4,7 +4,6 @@
 /**
  * @typedef {import("metro-config").ExtraTransformOptions} ExtraTransformOptions;
  * @typedef {import("metro-config").InputConfigT} InputConfigT;
- * @typedef {import("metro-config").Middleware} Middleware;
  * @typedef {import("type-fest").PartialDeep<InputConfigT>} MetroConfig;
  */
 
@@ -176,6 +175,7 @@ module.exports = {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore There are no type definition files for `metro-config`
     const { mergeConfig } = require("metro-config");
+    const { enhanceMiddleware } = require("./assetPluginForMonorepos");
 
     const projectRoot = customConfig.projectRoot || process.cwd();
     const blockList = exclusionList([], projectRoot);
@@ -186,21 +186,7 @@ module.exports = {
           blockList, // For Metro >= 0.60
         },
         server: {
-          /**
-           * This middleware restores `..` in asset URLs. See
-           * `assetPluginForMonorepos.js` for more details.
-           *
-           * @type {(middleware: Middleware) => Middleware}
-           */
-          enhanceMiddleware: (middleware) => {
-            return (req, res, next) => {
-              const { url } = req;
-              if (url && url.startsWith("/assets/@")) {
-                req.url = url.replace(/@@\//g, "../");
-              }
-              return middleware(req, res, next);
-            };
-          },
+          enhanceMiddleware,
         },
         transformer: {
           assetPlugins: [require.resolve("./assetPluginForMonorepos")],

--- a/packages/metro-config/test/assetPluginForMonorepos.test.js
+++ b/packages/metro-config/test/assetPluginForMonorepos.test.js
@@ -6,7 +6,8 @@ describe("@rnx-kit/metro-config/assetPluginForMonorepos", () => {
     "/assets/./node_modules": "/assets/./node_modules",
     "/assets/../node_modules": "/assets/@@/node_modules",
     "/assets/../../node_modules": "/assets/@@/@@/node_modules",
-    "/assets/node_modules/../../react-native": "/assets/node_modules/@@/@@/react-native",
+    "/assets/node_modules/../../react-native":
+      "/assets/node_modules/@@/@@/react-native",
   };
 
   test("escapes `..` in URLs", () => {

--- a/packages/metro-config/test/assetPluginForMonorepos.test.js
+++ b/packages/metro-config/test/assetPluginForMonorepos.test.js
@@ -1,0 +1,39 @@
+describe("@rnx-kit/metro-config/assetPluginForMonorepos", () => {
+  const assetPlugin = require("../src/assetPluginForMonorepos");
+  const { enhanceMiddleware } = assetPlugin;
+
+  const cases = {
+    "/assets/./node_modules": "/assets/./node_modules",
+    "/assets/../node_modules": "/assets/@@/node_modules",
+    "/assets/../../node_modules": "/assets/@@/@@/node_modules",
+    "/assets/node_modules/../../react-native": "/assets/node_modules/@@/@@/react-native",
+  };
+
+  test("escapes `..` in URLs", () => {
+    Object.entries(cases).forEach(([input, output]) => {
+      const assetData = /** @type {import("metro").AssetData} */ ({
+        httpServerLocation: input,
+      });
+      expect(assetPlugin(assetData)).toEqual(
+        expect.objectContaining({
+          httpServerLocation: output,
+        })
+      );
+    });
+  });
+
+  test("unescapes `..` in URLs", () => {
+    Object.entries(cases).forEach(([output, input]) => {
+      /** @type {import("metro-config").Middleware} */
+      const middleware = (req) => {
+        expect(req).toEqual(expect.objectContaining({ url: output }));
+        return middleware;
+      };
+      const incoming = /** @type {import("http").IncomingMessage} */ ({
+        url: input,
+      });
+      const response = /** @type {import("http").ServerResponse} */ ({});
+      enhanceMiddleware(middleware)(incoming, response, () => undefined);
+    });
+  });
+});

--- a/packages/metro-config/test/index.test.js
+++ b/packages/metro-config/test/index.test.js
@@ -236,6 +236,8 @@ describe("@rnx-kit/metro-config", () => {
       fail("Expected `config.resolver.blockList` to be a RegExp");
     } else if (!config.transformer) {
       fail("Expected `config.transformer` to be defined");
+    } else if (!config.transformer.getTransformOptions) {
+      fail("Expected `config.transformer.getTransformOptions` to be defined");
     } else if (!Array.isArray(config.watchFolders)) {
       fail("Expected `config.watchFolders` to be an array");
     }
@@ -249,7 +251,7 @@ describe("@rnx-kit/metro-config", () => {
     expect(config.resolver.blockList.source).toBe(blockList);
 
     const opts = { dev: false, hot: false };
-    const transformerOptions = await config.transformer?.getTransformOptions?.(
+    const transformerOptions = await config.transformer.getTransformOptions(
       [],
       opts,
       () => Promise.resolve([])
@@ -285,6 +287,8 @@ describe("@rnx-kit/metro-config", () => {
       fail("Expected `config.resolver.blockList` to be a RegExp");
     } else if (!config.transformer) {
       fail("Expected `config.transformer` to be defined");
+    } else if (!config.transformer.getTransformOptions) {
+      fail("Expected `config.transformer.getTransformOptions` to be defined");
     } else if (!Array.isArray(config.watchFolders)) {
       fail("Expected `config.watchFolders` to be an array");
     }
@@ -298,7 +302,7 @@ describe("@rnx-kit/metro-config", () => {
     expect(config.resolver.blockList.source).toBe(blockList);
 
     const opts = { dev: false, hot: false };
-    const transformerOptions = await config.transformer?.getTransformOptions?.(
+    const transformerOptions = await config.transformer.getTransformOptions(
       [],
       opts,
       () => Promise.resolve([])

--- a/packages/metro-config/test/index.test.js
+++ b/packages/metro-config/test/index.test.js
@@ -248,8 +248,13 @@ describe("@rnx-kit/metro-config", () => {
     expect(config.resolver.blacklistRE.source).toBe(blockList);
     expect(config.resolver.blockList.source).toBe(blockList);
 
-    const transformerOptions = await config.transformer.getTransformOptions();
-    expect(transformerOptions.transform).toEqual({
+    const opts = { dev: false, hot: false };
+    const transformerOptions = await config.transformer?.getTransformOptions?.(
+      [],
+      opts,
+      () => Promise.resolve([])
+    );
+    expect(transformerOptions?.transform).toEqual({
       experimentalImportSupport: false,
       inlineRequires: false,
     });
@@ -292,8 +297,13 @@ describe("@rnx-kit/metro-config", () => {
     expect(config.resolver.blacklistRE.source).toBe(blockList);
     expect(config.resolver.blockList.source).toBe(blockList);
 
-    const transformerOptions = await config.transformer.getTransformOptions();
-    expect(transformerOptions.transform).toEqual({
+    const opts = { dev: false, hot: false };
+    const transformerOptions = await config.transformer?.getTransformOptions?.(
+      [],
+      opts,
+      () => Promise.resolve([])
+    );
+    expect(transformerOptions?.transform).toEqual({
       experimentalImportSupport: false,
       inlineRequires: false,
     });

--- a/packages/third-party-notices/test/normalizePaths.test.ts
+++ b/packages/third-party-notices/test/normalizePaths.test.ts
@@ -37,7 +37,9 @@ describe("normalizePath", () => {
   });
 
   test("webPackScopedPackage", () => {
-    expect(normalizePath("webpack://@scope/myPkg/path", "@scope/myPkg")).toBe("path");
+    expect(normalizePath("webpack://@scope/myPkg/path", "@scope/myPkg")).toBe(
+      "path"
+    );
   });
 
   // Paths

--- a/yarn.lock
+++ b/yarn.lock
@@ -9251,6 +9251,11 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-fest@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.1.0.tgz#1f8b20ff51519f3b01b3188d50dea9f9ebfbf1b8"
+  integrity sha512-2wHUmKDy5wNLmebekbHx/zE9ElYAKOmz34psTLG7OwyEJHaIUr6jnaCd55EvgrawAvliwbwgbyH1LkxIfWFyNg==
+
 type@^1.0.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"


### PR DESCRIPTION
### Description

Metro doesn't support loading assets in a monorepo. This implements a workaround found in an old issue in `react-native`.

Resolves #528.

### Test plan

```
yarn
cd packages/test-app
yarn build --dependencies
yarn android
yarn start --reset-cache # Cache must be reset otherwise assets will come from cache
```

| Before | After |
| - | - |
| ![Screenshot_1629977984](https://user-images.githubusercontent.com/4123478/130956639-cff7bd52-1fb1-474e-ba24-61c90b645f44.png) | ![Screenshot_1629978022](https://user-images.githubusercontent.com/4123478/130956649-a55d96e9-04cc-4e87-baeb-814f8d5f682f.png) |
