### PR TITLE
fix(config): warn when `reactNativeDevVersion` is set and `kitType` is `app`

### DIFF
--- a/change/@rnx-kit-config-e9e5faea-722c-453f-86ed-7990e30b601a.json
+++ b/change/@rnx-kit-config-e9e5faea-722c-453f-86ed-7990e30b601a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Warn when `reactNativeDevVersion` is set and `kitType` is `app`",
+  "packageName": "@rnx-kit/config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -13,6 +13,7 @@
     "test": "rnx-kit-scripts test"
   },
   "dependencies": {
+    "@rnx-kit/console": "^1.0.2",
     "cosmiconfig": "^7.0.0",
     "lodash": "^4.17.21",
     "semver": "^7.0.0"

--- a/packages/config/src/getKitCapabilities.ts
+++ b/packages/config/src/getKitCapabilities.ts
@@ -1,3 +1,4 @@
+import { warn } from "@rnx-kit/console";
 import semver from "semver";
 import type { KitConfig } from "./kitConfig";
 
@@ -25,6 +26,10 @@ export function getKitCapabilities({
       !semver.validRange(reactNativeVersion))
   ) {
     throw new Error(`'${reactNativeVersion}' is not a valid version range`);
+  }
+
+  if (kitType === "app" && rawDevVersion) {
+    warn("'reactNativeDevVersion' is not used when 'kitType' is 'app'");
   }
 
   const reactNativeDevVersion =

--- a/packages/config/test/getKitCapabilities.test.ts
+++ b/packages/config/test/getKitCapabilities.test.ts
@@ -1,6 +1,12 @@
 import { getKitCapabilities } from "../src/getKitCapabilities";
 
 describe("getKitCapabilities()", () => {
+  const consoleWarnSpy = jest.spyOn(global.console, "warn");
+
+  afterEach(() => {
+    consoleWarnSpy.mockReset();
+  });
+
   test("throws when supported React Native versions is invalid", () => {
     expect(() => getKitCapabilities({})).toThrow();
     expect(() => getKitCapabilities({ reactNativeVersion: "" })).toThrow();
@@ -12,6 +18,7 @@ describe("getKitCapabilities()", () => {
     expect(() =>
       getKitCapabilities({ reactNativeVersion: "0.64.0" })
     ).not.toThrow();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
   test("throws when React Native dev version does not satisfy supported versions", () => {
@@ -49,6 +56,8 @@ describe("getKitCapabilities()", () => {
         reactNativeDevVersion: "0.64.0",
       }).reactNativeVersion
     ).toBe("^0.63 || ^0.64");
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
   test("returns declared React Native dev version", () => {
@@ -64,6 +73,7 @@ describe("getKitCapabilities()", () => {
         reactNativeDevVersion: "^0.64.0",
       }).reactNativeDevVersion
     ).toBe("^0.64.0");
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
   test("returns minimum supported React Native version as dev version when unspecified", () => {
@@ -84,6 +94,8 @@ describe("getKitCapabilities()", () => {
         reactNativeVersion: "^0.63.4 || ^0.64.0",
       }).reactNativeDevVersion
     ).toBe("0.63.4");
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
   test("returns 'library' when 'kitType' is undefined", () => {
@@ -100,6 +112,8 @@ describe("getKitCapabilities()", () => {
       getKitCapabilities({ reactNativeVersion: "0.64.0", kitType: "app" })
         .kitType
     ).toBe("app");
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
   test("returns empty array when 'capabilities' is undefined", () => {
@@ -113,5 +127,20 @@ describe("getKitCapabilities()", () => {
         capabilities: ["core-ios"],
       }).capabilities
     ).toEqual(["core-ios"]);
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  test("warns when 'reactNativeDevVersion' is set and 'kitType' is 'app'", () => {
+    getKitCapabilities({
+      reactNativeVersion: "^0.64",
+      reactNativeDevVersion: "0.64.2",
+      kitType: "app",
+      capabilities: ["core-ios"],
+    });
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("warn"),
+      "'reactNativeDevVersion' is not used when 'kitType' is 'app'"
+    );
   });
 });


### PR DESCRIPTION
### Description

Notify the user that `reactNativeDevVersion` is unused when `kitType` is `app` to avoid confusion.

Resolves #542.

### Test plan

Tests were added.