### PR TITLE
fix(dep-check): init broke when loose was introduced

### DIFF
--- a/change/@rnx-kit-dep-check-583d042d-31ec-404c-be33-0abcfc7ac42c.json
+++ b/change/@rnx-kit-dep-check-583d042d-31ec-404c-be33-0abcfc7ac42c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix broken `--init` due to loose and init being mutually exclusive, but `--loose` has a default value.",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dep-check/src/cli.ts
+++ b/packages/dep-check/src/cli.ts
@@ -193,7 +193,6 @@ if (require.main === module) {
         description:
           "Determines how strict the React Native version requirement should be. Useful for apps that depend on a newer React Native version than their dependencies declare support for.",
         type: "boolean",
-        conflicts: ["init"],
       },
       "set-version": {
         description:


### PR DESCRIPTION
### Description

```
% yarn rnx-dep-check --init
rnx-dep-check [package-json]

Dependency checker for React Native apps

Options:
  <...>

Arguments loose and init are mutually exclusive
error Command failed with exit code 1.
```

### Test plan

`rnx-dep-check --init` should not fail.