### PR TITLE
feat(dep-check): add support for meta packages

### DIFF
--- a/change/@rnx-kit-dep-check-2e1e099b-a744-4048-9859-eac1115188a9.json
+++ b/change/@rnx-kit-dep-check-2e1e099b-a744-4048-9859-eac1115188a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for dependencies and meta packages",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dep-check/README.md
+++ b/packages/dep-check/README.md
@@ -227,8 +227,8 @@ that `core-windows` depends on `core`:
 }
 ```
 
-You can also create "meta" capabilities that don't resolve to a package, but to
-a list of capabilities instead:
+You can also create capabilities that don't resolve to a package, but to a list
+of capabilities instead:
 
 ```js
 {

--- a/packages/dep-check/README.md
+++ b/packages/dep-check/README.md
@@ -213,7 +213,7 @@ is a capability that resolves to `react-native`:
 }
 ```
 
-A capability can depend on other capabilies. For example, we can ensure that
+A capability can depend on other capabilities. For example, we can ensure that
 `react-native` gets installed along with `react-native-windows` by declaring
 that `core-windows` depends on `core`:
 

--- a/packages/dep-check/README.md
+++ b/packages/dep-check/README.md
@@ -114,12 +114,11 @@ your `package.json`.
 
 ## Capabilities
 
-To add new capabilities, first add it to
-[`/packages/config/src/kitConfig.ts`](https://github.com/microsoft/rnx-kit/blob/62da26011c9ff86a24eed63356c68f6999034d34/packages/config/src/kitConfig.ts#L4),
-then update the
-[profiles](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check/src/profiles).
-For an example, have a look at how the
-[`hermes` capability was added](https://github.com/microsoft/rnx-kit/commit/c79828791a6ac5cf19b4abfff6347542af49eaec).
+The following table contains the currently supported capabilities and what they
+resolve to:
+
+<details>
+<summary>Capabilities Table</summary>
 
 <!-- The following table can be updated by running `yarn update-readme` -->
 <!-- @rnx-kit/dep-check/capabilities start -->
@@ -160,6 +159,90 @@ For an example, have a look at how the
 | webview           | react-native-webview@^11.4.2                      | react-native-webview@^11.4.2                      | react-native-webview@^11.4.2                  | react-native-webview@^11.0.3                  | react-native-webview@^11.0.3                  |
 
 <!-- @rnx-kit/dep-check/capabilities end -->
+
+</details>
+
+To add new capabilities, first add it to
+[`/packages/config/src/kitConfig.ts`](https://github.com/microsoft/rnx-kit/blob/62da26011c9ff86a24eed63356c68f6999034d34/packages/config/src/kitConfig.ts#L4),
+then update the
+[profiles](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check/src/profiles).
+For an example, have a look at how the
+[`hermes` capability was added](https://github.com/microsoft/rnx-kit/commit/c79828791a6ac5cf19b4abfff6347542af49eaec).
+
+## Custom Profiles
+
+A custom profile is a list of capabilities that map to specific versions of
+packages. It can be a JSON file, or a JS file wich default exports it. Custom
+profiles are consumed via the [`--custom-profiles`](#--custom-profiles-module)
+flag.
+
+For example, this a custom profile that adds `my-capability` to profile versions
+0.63 and 0.64:
+
+```js
+module.exports = {
+  0.63: {
+    "my-capability": {
+      name: "my-module",
+      version: "1.0.0",
+    },
+  },
+  0.64: {
+    "my-capability": {
+      name: "my-module",
+      version: "1.1.0",
+    },
+  },
+};
+```
+
+For a more complete example, have a look at the
+[default profiles](https://github.com/microsoft/rnx-kit/blob/769e9fa290929effd5111884f1637c21326b5a95/packages/dep-check/src/profiles.ts#L11).
+
+### Custom Capabilities
+
+Normally, a capability resolves to a version of a package. For instance, `core`
+is a capability that resolves to `react-native`:
+
+```js
+{
+  "core": {
+    name: "react-native",
+    version: "0.0.0",
+  },
+}
+```
+
+A capability can depend on other capabilies. For example, we can ensure that
+`react-native` gets installed along `react-native-windows` by declaring that
+`core-windows` depends on `core`:
+
+```js
+{
+  "core-windows": {
+    name: "react-native-windows",
+    version: "0.0.0",
+    capabilities: ["core"],
+  },
+}
+```
+
+You can also create "meta" capabilities that don't resolve to a package, but to
+a list of capabilities instead:
+
+```js
+{
+  "core/all": {
+    name: "#meta",
+    capabilities: [
+      "core-android",
+      "core-ios",
+      "core-macos",
+      "core-windows",
+    ],
+  },
+}
+```
 
 ## Terminology
 

--- a/packages/dep-check/README.md
+++ b/packages/dep-check/README.md
@@ -172,12 +172,12 @@ For an example, have a look at how the
 ## Custom Profiles
 
 A custom profile is a list of capabilities that map to specific versions of
-packages. It can be a JSON file, or a JS file wich default exports it. Custom
+packages. It can be a JSON file, or a JS file that default exports it. Custom
 profiles are consumed via the [`--custom-profiles`](#--custom-profiles-module)
 flag.
 
-For example, this a custom profile that adds `my-capability` to profile versions
-0.63 and 0.64:
+For example, this custom profile adds `my-capability` to profile versions 0.63
+and 0.64:
 
 ```js
 module.exports = {

--- a/packages/dep-check/README.md
+++ b/packages/dep-check/README.md
@@ -214,8 +214,8 @@ is a capability that resolves to `react-native`:
 ```
 
 A capability can depend on other capabilies. For example, we can ensure that
-`react-native` gets installed along `react-native-windows` by declaring that
-`core-windows` depends on `core`:
+`react-native` gets installed along with `react-native-windows` by declaring
+that `core-windows` depends on `core`:
 
 ```js
 {

--- a/packages/dep-check/src/profiles/profile-0.61.ts
+++ b/packages/dep-check/src/profiles/profile-0.61.ts
@@ -20,6 +20,7 @@ const profile: Profile = {
   "core-windows": {
     name: "react-native-windows",
     version: "^0.61.0",
+    capabilities: ["core"],
   },
 
   animation: {
@@ -85,6 +86,7 @@ const profile: Profile = {
   "navigation/stack": {
     name: "@react-navigation/stack",
     version: "^5.9.3",
+    capabilities: ["navigation/native"],
   },
   netinfo: {
     name: "@react-native-community/netinfo",

--- a/packages/dep-check/src/profiles/profile-0.62.ts
+++ b/packages/dep-check/src/profiles/profile-0.62.ts
@@ -22,6 +22,7 @@ const profile: Profile = {
   "core-windows": {
     name: "react-native-windows",
     version: "^0.62.0",
+    capabilities: ["core"],
   },
   hermes: {
     name: "hermes-engine",

--- a/packages/dep-check/src/profiles/profile-0.63.ts
+++ b/packages/dep-check/src/profiles/profile-0.63.ts
@@ -23,6 +23,7 @@ const profile: Profile = {
   "core-windows": {
     name: "react-native-windows",
     version: "^0.63.0",
+    capabilities: ["core"],
   },
 
   "floating-action": {
@@ -44,6 +45,7 @@ const profile: Profile = {
   "navigation/stack": {
     name: "@react-navigation/stack",
     version: "^5.14.4",
+    capabilities: ["navigation/native"],
   },
   "safe-area": {
     name: "react-native-safe-area-context",

--- a/packages/dep-check/src/profiles/profile-0.64.ts
+++ b/packages/dep-check/src/profiles/profile-0.64.ts
@@ -20,6 +20,7 @@ const profile: Profile = {
   "core-windows": {
     name: "react-native-windows",
     version: "^0.64.0",
+    capabilities: ["core"],
   },
 
   animation: {
@@ -85,6 +86,7 @@ const profile: Profile = {
   "navigation/stack": {
     name: "@react-navigation/stack",
     version: "^5.14.4",
+    capabilities: ["navigation/native"],
   },
   netinfo: {
     name: "@react-native-community/netinfo",

--- a/packages/dep-check/src/profiles/profile-0.65.ts
+++ b/packages/dep-check/src/profiles/profile-0.65.ts
@@ -18,6 +18,7 @@ const profile: Profile = {
   "core-windows": {
     name: "react-native-windows",
     version: "^0.65.0-0",
+    capabilities: ["core"],
   },
   hermes: {
     name: "hermes-engine",

--- a/packages/dep-check/src/types.ts
+++ b/packages/dep-check/src/types.ts
@@ -34,9 +34,16 @@ export type Command = (manifest: string) => number;
 
 export type DependencyType = "direct" | "development" | "peer";
 
+export type MetaPackage = {
+  name: "#meta";
+  capabilities: Capability[];
+  devOnly?: boolean;
+};
+
 export type Package = {
   name: string;
   version: string;
+  capabilities?: Capability[];
   devOnly?: boolean;
 };
 
@@ -46,7 +53,7 @@ export type ManifestProfile = PackageManifest & {
   devDependencies: Record<string, string>;
 };
 
-export type Profile = Readonly<Record<Capability, Package>>;
+export type Profile = Readonly<Record<Capability, MetaPackage | Package>>;
 
 export type ProfileVersion = "0.61" | "0.62" | "0.63" | "0.64" | "0.65";
 

--- a/packages/dep-check/test/capabilities.test.ts
+++ b/packages/dep-check/test/capabilities.test.ts
@@ -210,11 +210,11 @@ describe("resolveCapabilities()", () => {
       "mock-meta-package-loop",
       () => ({
         "0.64": {
-          "connor": {
+          connor: {
             name: "#meta",
             capabilities: ["core", "reese"],
           },
-          "reese": {
+          reese: {
             name: "#meta",
             capabilities: ["t-800"],
           },

--- a/packages/dep-check/test/helpers.ts
+++ b/packages/dep-check/test/helpers.ts
@@ -13,6 +13,8 @@ export function pickPackage(profile: Profile, capability: string): Package {
   const pkg = profile[capability];
   if (!pkg) {
     throw new Error(`Could not resolve '${capability}'`);
+  } else if (!("version" in pkg)) {
+    throw new Error(`'${capability}' is a meta package`);
   }
 
   return pkg;


### PR DESCRIPTION
### Description

Adds support for dependencies and meta packages:
- Dependencies: This allows us to declare that `core-windows` has a dependency on `core` as `react-native-windows` has a peer dependency on `react-native`.
- Meta packages: These are packages that don't provide anything by itself, but can reference other capabilities. For instance, you can define a capability, `core/all`, to pull in all platform capabilities, i.e. `[core-android, core-ios, core-macos, core-windows]`.

Resolves #256.

### Test plan

Tests were added.