### PR TITLE
fix(dep-check): remove `reactNativeDevVersion` if `kitType` is `app`

### DIFF
--- a/change/@rnx-kit-dep-check-391fd315-d5d5-44f6-bd09-6721b995d659.json
+++ b/change/@rnx-kit-dep-check-391fd315-d5d5-44f6-bd09-6721b995d659.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "When upgrading profile version, also remove `reactNativeDevVersion` if `kitType` is `app`",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dep-check/src/setVersion.ts
+++ b/packages/dep-check/src/setVersion.ts
@@ -77,7 +77,11 @@ export async function makeSetVersionCommand(
     }
 
     rnxKitConfig.reactNativeVersion = supportedVersions;
-    rnxKitConfig.reactNativeDevVersion = targetVersion;
+    if (rnxKitConfig.kitType === "app") {
+      delete rnxKitConfig.reactNativeDevVersion;
+    } else {
+      rnxKitConfig.reactNativeDevVersion = targetVersion;
+    }
 
     modifyManifest(manifestPath, manifest);
     return checkPackageManifest(manifestPath, write);

--- a/packages/dep-check/test/setVersion.test.ts
+++ b/packages/dep-check/test/setVersion.test.ts
@@ -59,7 +59,44 @@ describe("makeSetVersionCommand()", () => {
   });
 
   test("updates dependencies", async () => {
-    const result = setupMocks(mockManifest);
+    const result = setupMocks({
+      ...mockManifest,
+      "rnx-kit": {
+        ...mockManifest["rnx-kit"],
+        kitType: "library",
+        reactNativeDevVersion: "^0.63.0",
+      },
+    });
+
+    const command = await makeSetVersionCommand("0.64,0.63");
+    expect(typeof command).toBe("function");
+    expect(command("package.json")).toBe(0);
+    expect(result.manifest).toEqual({
+      ...mockManifest,
+      dependencies: {},
+      devDependencies: {
+        "react-native": "^0.64.2",
+      },
+      peerDependencies: {
+        "react-native": "^0.63.2 || ^0.64.2",
+      },
+      "rnx-kit": {
+        ...mockManifest["rnx-kit"],
+        kitType: "library",
+        reactNativeVersion: "^0.63.0 || ^0.64.0",
+        reactNativeDevVersion: "^0.64.0",
+      },
+    });
+  });
+
+  test("removes `reactNativeDevVersion` if `kitType` is `app`", async () => {
+    const result = setupMocks({
+      ...mockManifest,
+      "rnx-kit": {
+        ...mockManifest["rnx-kit"],
+        reactNativeDevVersion: "^0.63.0",
+      },
+    });
 
     const command = await makeSetVersionCommand("0.64,0.63");
     expect(typeof command).toBe("function");
@@ -73,7 +110,6 @@ describe("makeSetVersionCommand()", () => {
       "rnx-kit": {
         ...mockManifest["rnx-kit"],
         reactNativeVersion: "^0.63.0 || ^0.64.0",
-        reactNativeDevVersion: "^0.64.0",
       },
     });
   });
@@ -95,7 +131,6 @@ describe("makeSetVersionCommand()", () => {
       "rnx-kit": {
         ...mockManifest["rnx-kit"],
         reactNativeVersion: "^0.63 || ^0.64",
-        reactNativeDevVersion: "0.64",
       },
     });
   });
@@ -117,7 +152,6 @@ describe("makeSetVersionCommand()", () => {
       "rnx-kit": {
         ...mockManifest["rnx-kit"],
         reactNativeVersion: "^0.64",
-        reactNativeDevVersion: "0.64",
       },
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -253,7 +253,7 @@
   dependencies:
     "@babel/types" "^7.15.4"
 
-"@babel/helper-member-expression-to-functions@^7.15.0", "@babel/helper-member-expression-to-functions@^7.15.4":
+"@babel/helper-member-expression-to-functions@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz#bfd34dc9bba9824a4658b0317ec2fd571a51e6ef"
   integrity sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==
@@ -281,7 +281,7 @@
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.4"
 
-"@babel/helper-optimise-call-expression@^7.14.5", "@babel/helper-optimise-call-expression@^7.15.4":
+"@babel/helper-optimise-call-expression@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz#f310a5121a3b9cc52d9ab19122bd729822dee171"
   integrity sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==
@@ -302,7 +302,7 @@
     "@babel/helper-wrap-function" "^7.15.4"
     "@babel/types" "^7.15.4"
 
-"@babel/helper-replace-supers@^7.14.5", "@babel/helper-replace-supers@^7.15.0", "@babel/helper-replace-supers@^7.15.4":
+"@babel/helper-replace-supers@^7.14.5", "@babel/helper-replace-supers@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz#52a8ab26ba918c7f6dee28628b07071ac7b7347a"
   integrity sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==
@@ -326,7 +326,7 @@
   dependencies:
     "@babel/types" "^7.15.4"
 
-"@babel/helper-split-export-declaration@^7.14.5", "@babel/helper-split-export-declaration@^7.15.4":
+"@babel/helper-split-export-declaration@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz#aecab92dcdbef6a10aa3b62ab204b085f776e257"
   integrity sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==
@@ -343,7 +343,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
   integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
 
-"@babel/helper-wrap-function@^7.14.5", "@babel/helper-wrap-function@^7.15.4":
+"@babel/helper-wrap-function@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.15.4.tgz#6f754b2446cfaf3d612523e6ab8d79c27c3a3de7"
   integrity sha512-Y2o+H/hRV5W8QhIfTpRIBwl57y8PrZt6JM3V8FOo5qarjshHItyH5lXlpMfBfmBefOqSCpKZs/6Dxqp0E/U+uw==
@@ -1103,7 +1103,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.0.0", "@babel/template@^7.14.5", "@babel/template@^7.15.4", "@babel/template@^7.3.3":
+"@babel/template@^7.0.0", "@babel/template@^7.15.4", "@babel/template@^7.3.3":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
   integrity sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==
@@ -1112,7 +1112,7 @@
     "@babel/parser" "^7.15.4"
     "@babel/types" "^7.15.4"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.12.5", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.0", "@babel/traverse@^7.14.5", "@babel/traverse@^7.15.4":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.12.5", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.0", "@babel/traverse@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.15.4.tgz#ff8510367a144bfbff552d9e18e28f3e2889c22d"
   integrity sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==


### PR DESCRIPTION
### Description

If `reactNativeDevVersion` is found during upgrading profile version, we should remove it to avoid confusion.

### Test plan

Tests were added.