### PR TITLE
chore: add repo jest-preset

### DIFF
--- a/change/@rnx-kit-bundle-diff-1cb4832f-2a7a-4acf-bd57-e1df16bb3af2.json
+++ b/change/@rnx-kit-bundle-diff-1cb4832f-2a7a-4acf-bd57-e1df16bb3af2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/bundle-diff",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-cli-4706a5c7-1833-43db-9444-e76e83c9fcb7.json
+++ b/change/@rnx-kit-cli-4706a5c7-1833-43db-9444-e76e83c9fcb7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-config-035a359e-61c2-4270-88e7-3cc092c7e449.json
+++ b/change/@rnx-kit-config-035a359e-61c2-4270-88e7-3cc092c7e449.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-console-d0ebf6de-93ef-452a-9079-ab049e21115b.json
+++ b/change/@rnx-kit-console-d0ebf6de-93ef-452a-9079-ab049e21115b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/console",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-dep-check-0bce1dcd-33a0-44d3-83cf-58c00d6d5ad8.json
+++ b/change/@rnx-kit-dep-check-0bce1dcd-33a0-44d3-83cf-58c00d6d5ad8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-esbuild-plugin-import-path-remapper-10becb8f-5e31-4d24-b2a3-c7e13df42631.json
+++ b/change/@rnx-kit-esbuild-plugin-import-path-remapper-10becb8f-5e31-4d24-b2a3-c7e13df42631.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/esbuild-plugin-import-path-remapper",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-jest-preset-c7d11c57-c31b-4367-bc29-d8fd6e388650.json
+++ b/change/@rnx-kit-jest-preset-c7d11c57-c31b-4367-bc29-d8fd6e388650.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/jest-preset",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-config-95ad7210-3027-4dac-ae1d-9b7055a14950.json
+++ b/change/@rnx-kit-metro-config-95ad7210-3027-4dac-ae1d-9b7055a14950.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/metro-config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-plugin-cyclic-dependencies-detector-bbdfb26d-017a-488a-a25c-57b4d0334295.json
+++ b/change/@rnx-kit-metro-plugin-cyclic-dependencies-detector-bbdfb26d-017a-488a-a25c-57b4d0334295.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-plugin-duplicates-checker-9de080ae-d85c-4067-ae39-a2c6c2017e5a.json
+++ b/change/@rnx-kit-metro-plugin-duplicates-checker-9de080ae-d85c-4067-ae39-a2c6c2017e5a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/metro-plugin-duplicates-checker",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-plugin-typescript-validation-b6c82e30-ee13-47e4-899a-e32ae6080b09.json
+++ b/change/@rnx-kit-metro-plugin-typescript-validation-b6c82e30-ee13-47e4-899a-e32ae6080b09.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/metro-plugin-typescript-validation",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-resolver-symlinks-888bbf18-12bc-4535-b9c3-af22239dbefc.json
+++ b/change/@rnx-kit-metro-resolver-symlinks-888bbf18-12bc-4535-b9c3-af22239dbefc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/metro-resolver-symlinks",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-serializer-5b400827-8c16-4ef9-a8bc-bd9b03ae4f50.json
+++ b/change/@rnx-kit-metro-serializer-5b400827-8c16-4ef9-a8bc-bd9b03ae4f50.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/metro-serializer",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-serializer-esbuild-edfe0456-6a07-4264-ae0e-fb0a2c3f0400.json
+++ b/change/@rnx-kit-metro-serializer-esbuild-edfe0456-6a07-4264-ae0e-fb0a2c3f0400.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/metro-serializer-esbuild",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-service-552fc909-4601-413e-a012-0831458808d2.json
+++ b/change/@rnx-kit-metro-service-552fc909-4601-413e-a012-0831458808d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/metro-service",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-third-party-notices-2356ac4d-5b0f-461c-9b18-e7f5af6da04a.json
+++ b/change/@rnx-kit-third-party-notices-2356ac4d-5b0f-461c-9b18-e7f5af6da04a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/third-party-notices",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-tools-language-2d7eed24-2439-455b-80d7-608862717814.json
+++ b/change/@rnx-kit-tools-language-2d7eed24-2439-455b-80d7-608862717814.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/tools-language",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-tools-node-ca46c8eb-49cb-4b3c-af85-3915262c25a2.json
+++ b/change/@rnx-kit-tools-node-ca46c8eb-49cb-4b3c-af85-3915262c25a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/tools-node",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-tools-react-native-70cb7927-d281-4a91-9f7d-3184b8547fd4.json
+++ b/change/@rnx-kit-tools-react-native-70cb7927-d281-4a91-9f7d-3184b8547fd4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/tools-react-native",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-typescript-service-d3bec8b3-b129-4ea2-9542-9336e1f7a08d.json
+++ b/change/@rnx-kit-typescript-service-d3bec8b3-b129-4ea2-9542-9336e1f7a08d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use repo Jest preset",
+  "packageName": "@rnx-kit/typescript-service",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/bundle-diff/package.json
+++ b/packages/bundle-diff/package.json
@@ -23,7 +23,6 @@
     "test": "rnx-kit-scripts test"
   },
   "devDependencies": {
-    "@rnx-kit/jest-preset": "*",
     "@types/jest": "^26.0.0",
     "prettier": "^2.0.0",
     "rnx-kit-scripts": "*",
@@ -33,10 +32,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    "preset": "rnx-kit-scripts"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,6 @@
   },
   "devDependencies": {
     "@react-native-community/cli-types": "^6.0.0",
-    "@rnx-kit/jest-preset": "*",
     "@types/metro": "*",
     "@types/metro-config": "*",
     "jest-extended": "^0.11.5",
@@ -64,13 +63,9 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
+    "preset": "rnx-kit-scripts",
     "setupFilesAfterEnv": [
       "jest-extended"
-    ],
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    ]
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -19,7 +19,6 @@
     "semver": "^7.0.0"
   },
   "devDependencies": {
-    "@rnx-kit/jest-preset": "*",
     "@rnx-kit/metro-plugin-cyclic-dependencies-detector": "*",
     "@rnx-kit/metro-plugin-duplicates-checker": "*",
     "@rnx-kit/tools-react-native": "*",
@@ -39,13 +38,9 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
+    "preset": "rnx-kit-scripts",
     "setupFilesAfterEnv": [
       "jest-extended"
-    ],
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    ]
   }
 }

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -23,7 +23,6 @@
     "chalk": "^4.1.0"
   },
   "devDependencies": {
-    "@rnx-kit/jest-preset": "*",
     "@types/jest": "^26.0.0",
     "@types/node": "^14.15.0",
     "rnx-kit-scripts": "*"
@@ -32,10 +31,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    "preset": "rnx-kit-scripts"
   }
 }

--- a/packages/dep-check/package.json
+++ b/packages/dep-check/package.json
@@ -39,7 +39,6 @@
     "yargs": "^16.0.0"
   },
   "devDependencies": {
-    "@rnx-kit/jest-preset": "*",
     "@types/jest": "^26.0.0",
     "@types/lodash": "^4.14.172",
     "@types/prompts": "^2.0.0",
@@ -53,13 +52,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
-    "collectCoverageFrom": [
-      "src/**"
-    ],
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    "preset": "rnx-kit-scripts"
   }
 }

--- a/packages/esbuild-plugin-import-path-remapper/package.json
+++ b/packages/esbuild-plugin-import-path-remapper/package.json
@@ -32,10 +32,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.js$"
+    "preset": "rnx-kit-scripts"
   }
 }

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -53,13 +53,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
-    "collectCoverageFrom": [
-      "src/*.js"
-    ],
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    "preset": "rnx-kit-scripts"
   }
 }

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -30,7 +30,6 @@
     "react-native": "*"
   },
   "devDependencies": {
-    "@rnx-kit/jest-preset": "*",
     "@types/babel__core": "^7.0.0",
     "@types/jest": "^26.0.0",
     "@types/metro": "*",
@@ -51,10 +50,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    "preset": "rnx-kit-scripts"
   }
 }

--- a/packages/metro-plugin-cyclic-dependencies-detector/package.json
+++ b/packages/metro-plugin-cyclic-dependencies-detector/package.json
@@ -24,7 +24,6 @@
     "@rnx-kit/tools-node": "^1.1.3"
   },
   "devDependencies": {
-    "@rnx-kit/jest-preset": "*",
     "@rnx-kit/metro-serializer": "*",
     "@types/jest": "^26.0.0",
     "@types/metro": "*",
@@ -42,10 +41,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    "preset": "rnx-kit-scripts"
   }
 }

--- a/packages/metro-plugin-duplicates-checker/package.json
+++ b/packages/metro-plugin-duplicates-checker/package.json
@@ -27,7 +27,6 @@
     "@rnx-kit/tools-node": "^1.1.3"
   },
   "devDependencies": {
-    "@rnx-kit/jest-preset": "*",
     "@rnx-kit/metro-serializer": "*",
     "@types/jest": "^26.0.0",
     "@types/metro": "*",
@@ -47,10 +46,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    "preset": "rnx-kit-scripts"
   }
 }

--- a/packages/metro-plugin-typescript-validation/package.json
+++ b/packages/metro-plugin-typescript-validation/package.json
@@ -25,7 +25,6 @@
     "yargs": "^16.0.0"
   },
   "devDependencies": {
-    "@rnx-kit/jest-preset": "*",
     "@rnx-kit/metro-serializer": "*",
     "@types/metro": "*",
     "@types/node": "^14.15.0",
@@ -42,10 +41,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    "preset": "rnx-kit-scripts"
   }
 }

--- a/packages/metro-resolver-symlinks/package.json
+++ b/packages/metro-resolver-symlinks/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "@rnx-kit/eslint-config": "*",
-    "@rnx-kit/jest-preset": "*",
     "@types/metro-resolver": "*",
     "@types/node": "^14.15.0",
     "metro-resolver": "^0.66.2",
@@ -34,10 +33,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    "preset": "rnx-kit-scripts"
   }
 }

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -46,9 +46,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    "preset": "rnx-kit-scripts"
   }
 }

--- a/packages/metro-serializer/package.json
+++ b/packages/metro-serializer/package.json
@@ -26,7 +26,6 @@
     "metro": ">=0.58.0"
   },
   "devDependencies": {
-    "@rnx-kit/jest-preset": "*",
     "@types/metro": "*",
     "@types/semver": "^7.0.0",
     "metro": "^0.66.1",
@@ -39,10 +38,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    "preset": "rnx-kit-scripts"
   }
 }

--- a/packages/metro-service/package.json
+++ b/packages/metro-service/package.json
@@ -37,7 +37,6 @@
   },
   "devDependencies": {
     "@react-native-community/cli-types": "^6.0.0",
-    "@rnx-kit/jest-preset": "*",
     "@types/metro": "*",
     "@types/metro-babel-transformer": "*",
     "@types/metro-core": "*",
@@ -61,10 +60,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    "preset": "rnx-kit-scripts"
   }
 }

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -34,7 +34,6 @@
     "@react-native-community/cli-platform-ios": "^6.0.0-0",
     "@rnx-kit/babel-preset-metro-react-native": "*",
     "@rnx-kit/cli": "*",
-    "@rnx-kit/jest-preset": "*",
     "@rnx-kit/metro-config": "*",
     "@rnx-kit/metro-plugin-cyclic-dependencies-detector": "*",
     "@rnx-kit/metro-plugin-duplicates-checker": "*",
@@ -54,11 +53,7 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.tsx?$"
+    "preset": "rnx-kit-scripts"
   },
   "rnx-kit": {
     "reactNativeVersion": "^0.65",

--- a/packages/third-party-notices/package.json
+++ b/packages/third-party-notices/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "@rnx-kit/eslint-config": "*",
-    "@rnx-kit/jest-preset": "*",
     "@types/jest": "^26.0.0",
     "@types/yargs": "^16.0.0",
     "rnx-kit-scripts": "*",
@@ -41,10 +40,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    "preset": "rnx-kit-scripts"
   }
 }

--- a/packages/tools-language/package.json
+++ b/packages/tools-language/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@rnx-kit/jest-preset": "*",
     "@types/node": "^14.15.0",
     "jest-extended": "^0.11.5",
     "rnx-kit-scripts": "*"
@@ -37,13 +36,9 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
+    "preset": "rnx-kit-scripts",
     "setupFilesAfterEnv": [
       "jest-extended"
-    ],
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    ]
   }
 }

--- a/packages/tools-node/package.json
+++ b/packages/tools-node/package.json
@@ -35,7 +35,6 @@
     "pkg-up": "^3.1.0"
   },
   "devDependencies": {
-    "@rnx-kit/jest-preset": "*",
     "@types/node": "^14.15.0",
     "jest-extended": "^0.11.5",
     "rnx-kit-scripts": "*",
@@ -45,13 +44,9 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
+    "preset": "rnx-kit-scripts",
     "setupFilesAfterEnv": [
       "jest-extended"
-    ],
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    ]
   }
 }

--- a/packages/tools-react-native/package.json
+++ b/packages/tools-react-native/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@rnx-kit/jest-preset": "*",
     "@types/node": "^14.15.0",
     "jest-extended": "^0.11.5",
     "rnx-kit-scripts": "*"
@@ -33,13 +32,9 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
+    "preset": "rnx-kit-scripts",
     "setupFilesAfterEnv": [
       "jest-extended"
-    ],
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    ]
   }
 }

--- a/packages/typescript-service/package.json
+++ b/packages/typescript-service/package.json
@@ -24,28 +24,18 @@
     "typescript": "^4.0.0"
   },
   "devDependencies": {
-    "@rnx-kit/jest-preset": "*",
     "@types/node": "^14.15.0",
     "jest-extended": "^0.11.5",
     "rnx-kit-scripts": "*",
     "temp-dir": "^2.0.0"
   },
-  "depcheck": {
-    "ignoreMatches": [
-      "@rnx-kit/jest-preset"
-    ]
-  },
   "eslintConfig": {
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/jest-preset",
+    "preset": "rnx-kit-scripts",
     "setupFilesAfterEnv": [
       "jest-extended"
-    ],
-    "roots": [
-      "test"
-    ],
-    "testRegex": "/test/.*\\.test\\.ts$"
+    ]
   }
 }

--- a/scripts/jest-preset.js
+++ b/scripts/jest-preset.js
@@ -1,0 +1,9 @@
+module.exports = {
+  // Jest doesn't support nesting presets:
+  // https://github.com/facebook/jest/issues/8714
+  ...require("@rnx-kit/jest-preset/jest-preset"),
+  collectCoverage: true,
+  collectCoverageFrom: ["src/**"],
+  roots: ["test"],
+  testRegex: "/test/.*\\.test\\.[jt]sx?$",
+};


### PR DESCRIPTION
### Description

Adds a Jest preset for the repo, using `@rnx-kit/jest-preset` as baseline.

### Test plan

All tests should pass. Build output should also display code coverage.