### PR TITLE
fix(dep-check): also check workspace root package

### DIFF
--- a/change/@rnx-kit-dep-check-305db3fd-112a-4c4b-bf54-fc55f3dafac4.json
+++ b/change/@rnx-kit-dep-check-305db3fd-112a-4c4b-bf54-fc55f3dafac4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Also check workspace root package",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dep-check/src/cli.ts
+++ b/packages/dep-check/src/cli.ts
@@ -48,7 +48,9 @@ function getManifests(
   }
 
   try {
-    return getAllPackageJsonFiles(packageDir);
+    const allPackages = getAllPackageJsonFiles(packageDir) ?? [];
+    allPackages.push(currentPackageJson);
+    return allPackages;
   } catch (e) {
     if (hasProperty(e, "message")) {
       error(e.message);


### PR DESCRIPTION
### Description

When in a workspace, dep-check does not check the root package.

### Test plan

1. Make a change that will trigger dep-check in the root package, e.g.:
   ```diff
   diff --git a/package.json b/package.json
   index 888a95e..afd4e62 100644
   --- a/package.json
   +++ b/package.json
   @@ -47,6 +47,7 @@
        "metro-react-native-babel-transformer": "^0.66.2",
        "metro-resolver": "^0.66.2",
        "metro-runtime": "^0.66.2",
   +    "react-native": "^0.63.2",
        "prettier": "^2.3.0",
        "suggestion-bot": "^1.2.2"
      },
   ```
2. Run `yarn rnx-dep-check`

Prior to this change, step 2 would exit successfully. Now we will now see an error:

```
error Found 1 violation(s) in rnx-kit:
    react-native "^0.63.2" -> "^0.65.0-0" (devDependencies)
```