### PR TITLE
fix(metro-config): wrong module resolved due to ignoring symlinks

### DIFF
--- a/change/@rnx-kit-metro-config-3bd652a3-40fa-4006-9aa5-607ca55eee3b.json
+++ b/change/@rnx-kit-metro-config-3bd652a3-40fa-4006-9aa5-607ca55eee3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Wrong module may be resolved because we're ignoring symlinks",
+  "packageName": "@rnx-kit/metro-config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -62,10 +62,11 @@ function defaultWatchFolders(projectRoot) {
  */
 function resolveModule(name, projectRoot) {
   const { findPackageDependencyDir } = require("@rnx-kit/tools-node/package");
-  return findPackageDependencyDir(
+  const result = findPackageDependencyDir(
     { name },
-    { startDir: projectRoot, allowSymlinks: false }
+    { startDir: projectRoot, allowSymlinks: true }
   );
+  return result && require("fs").realpathSync(result);
 }
 
 /**

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -52,9 +52,8 @@ function defaultWatchFolders(projectRoot) {
 /**
  * Returns the path to specified module; `undefined` if not found.
  *
- * Note that this function ignores symlinks. When creating rules to
- * exclude extra copies, Metro will be unable to resolve packages
- * because it doesn't resolve symlinks and all real paths are excluded.
+ * Note that this function resolves symlinks. This is necessary for setups that
+ * only have symlinks under `node_modules` (e.g. with pnpm).
  *
  * @param {string} name
  * @param {string=} projectRoot


### PR DESCRIPTION
### Description

In a pnpm-managed repository, we cannot ignore symlinks. This change will allow symlinks, and resolve them to a real path.

Resolves #585.

### Test plan

Check out the repro in #585:

```
git clone https://github.com/icesuicune/rnxSymlinkErrorRepro.git
cd rnxSymlinkErrorRepro/MyApp
pnpm install
pnpm react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist
```