### PR TITLE
fix(metro-resolver-symlinks): fails when path is child of origin path

### DIFF
--- a/change/@rnx-kit-metro-resolver-symlinks-63a399a7-93d8-4425-94af-bdab500a153a.json
+++ b/change/@rnx-kit-metro-resolver-symlinks-63a399a7-93d8-4425-94af-bdab500a153a.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix wrong resolved path when module is relative to current working directory",
+  "comment": "Fixed wrong resolved path when module is in a path within origin module path",
   "packageName": "@rnx-kit/metro-resolver-symlinks",
   "email": "4123478+tido64@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@rnx-kit-metro-resolver-symlinks-63a399a7-93d8-4425-94af-bdab500a153a.json
+++ b/change/@rnx-kit-metro-resolver-symlinks-63a399a7-93d8-4425-94af-bdab500a153a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix wrong resolved path when module is relative to current working directory",
+  "packageName": "@rnx-kit/metro-resolver-symlinks",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/metro-resolver-symlinks/src/index.ts
+++ b/packages/metro-resolver-symlinks/src/index.ts
@@ -24,7 +24,7 @@ function resolveFrom(moduleName: string, startDir: string): string {
  * Get `metro-resolver` from the cli to avoid adding another dependency that
  * needs to be kept in sync.
  */
-export function getMetroResolver(fromDir = process.cwd()): MetroResolver {
+function getMetroResolver(fromDir = process.cwd()): MetroResolver {
   try {
     const rnPath = path.dirname(
       resolveFrom("react-native/package.json", fromDir)
@@ -41,7 +41,7 @@ export function getMetroResolver(fromDir = process.cwd()): MetroResolver {
   }
 }
 
-export function remapReactNativeModule(
+function remapReactNativeModule(
   moduleName: string,
   platform: string,
   platformImplementations: Record<string, string>
@@ -57,7 +57,7 @@ export function remapReactNativeModule(
   return moduleName;
 }
 
-export function resolveModulePath(
+function resolveModulePath(
   moduleName: string,
   originModulePath: string
 ): string {
@@ -72,10 +72,13 @@ export function resolveModulePath(
     resolveFrom(`${pkgName}/package.json`, originModulePath)
   );
   const replaced = moduleName.replace(pkgName, pkgRoot);
-  return path.relative(path.dirname(originModulePath), replaced);
+  const relativePath = path.relative(path.dirname(originModulePath), replaced);
+  return relativePath.startsWith(".")
+    ? relativePath
+    : `.${path.sep}${relativePath}`;
 }
 
-export default function makeResolver({
+function makeResolver({
   remapModule = (_, moduleName, __) => moduleName,
 }: Options = {}): MetroResolver {
   const resolve = getMetroResolver();
@@ -115,3 +118,8 @@ export default function makeResolver({
     return resolution;
   };
 }
+
+module.exports = makeResolver;
+module.exports.getMetroResolver = getMetroResolver;
+module.exports.remapReactNativeModule = remapReactNativeModule;
+module.exports.resolveModulePath = resolveModulePath;

--- a/packages/metro-resolver-symlinks/test/index.test.ts
+++ b/packages/metro-resolver-symlinks/test/index.test.ts
@@ -84,13 +84,15 @@ describe("resolveModulePath", () => {
   test("resolves module path relative to requester", () => {
     const p = useFixture("duplicates");
     expect(resolveModulePath("react-native", p)).toBe(
-      path.join("duplicates", "node_modules", "react-native")
+      `.${path.sep}${path.join("duplicates", "node_modules", "react-native")}`
     );
     expect(
       resolveModulePath(
         "react-native",
         path.join(p, "node_modules", "terminator")
       )
-    ).toBe(path.join("terminator", "node_modules", "react-native"));
+    ).toBe(
+      `.${path.sep}${path.join("terminator", "node_modules", "react-native")}`
+    );
   });
 });


### PR DESCRIPTION
### Description

`metro-resolver-symlinks` returns the correct path, but in the wrong format, when a path is a child of origin module path.

Resolves #585.

### Test plan

Check out the repro in #585. You may have to apply #586 first before reproing this:

```
git clone https://github.com/icesuicune/rnxSymlinkErrorRepro.git
cd rnxSymlinkErrorRepro/MyApp
pnpm install
pnpm react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist
```