### PR TITLE
fix(cli): cannot disable plugins when bundling/serving

### DIFF
--- a/change/@rnx-kit-cli-ee96f13f-0047-4cf8-8618-fb3f866285e9.json
+++ b/change/@rnx-kit-cli-ee96f13f-0047-4cf8-8618-fb3f866285e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix plugins cannot be disabled when bundling/serving",
+  "packageName": "@rnx-kit/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/metro-config.ts
+++ b/packages/cli/src/metro-config.ts
@@ -102,15 +102,15 @@ export function customizeMetroConfig(
   const metroConfig = metroConfigReadonly as InputConfigT;
 
   const plugins: MetroPlugin[] = [];
-  if (typeof detectDuplicateDependencies === "boolean") {
-    plugins.push(DuplicateDependencies());
-  } else if (typeof detectDuplicateDependencies === "object") {
+  if (typeof detectDuplicateDependencies === "object") {
     plugins.push(DuplicateDependencies(detectDuplicateDependencies));
+  } else if (detectDuplicateDependencies !== false) {
+    plugins.push(DuplicateDependencies());
   }
-  if (typeof detectCyclicDependencies === "boolean") {
-    plugins.push(CyclicDependencies());
-  } else if (typeof detectCyclicDependencies === "object") {
+  if (typeof detectCyclicDependencies === "object") {
     plugins.push(CyclicDependencies(detectCyclicDependencies));
+  } else if (detectCyclicDependencies !== false) {
+    plugins.push(CyclicDependencies());
   }
 
   if (experimental_treeShake) {

--- a/packages/cli/test/metro-config.test.ts
+++ b/packages/cli/test/metro-config.test.ts
@@ -1,0 +1,181 @@
+import { CyclicDependencies } from "@rnx-kit/metro-plugin-cyclic-dependencies-detector";
+import { DuplicateDependencies } from "@rnx-kit/metro-plugin-duplicates-checker";
+import { customizeMetroConfig } from "../src/metro-config";
+
+jest.mock("@rnx-kit/metro-plugin-cyclic-dependencies-detector", () => {
+  return {
+    CyclicDependencies: jest.fn(),
+  };
+});
+
+jest.mock("@rnx-kit/metro-plugin-duplicates-checker", () => {
+  return {
+    DuplicateDependencies: jest.fn(),
+  };
+});
+
+describe("cli/metro-config/customizeMetroConfig", () => {
+  const mockConfig = {
+    serializer: {
+      customSerializer: false,
+      experimentalSerializerHook: false,
+    },
+    transformer: {},
+  };
+
+  afterEach(() => {
+    (CyclicDependencies as any).mockClear();
+    (DuplicateDependencies as any).mockClear();
+  });
+
+  test("returns a config with plugins by default", () => {
+    const inputConfig = { ...mockConfig };
+    customizeMetroConfig(
+      inputConfig as any,
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    );
+
+    expect(inputConfig).toEqual({
+      serializer: {
+        customSerializer: expect.anything(),
+        experimentalSerializerHook: expect.anything(),
+      },
+      transformer: {},
+    });
+    expect(typeof inputConfig.serializer.customSerializer).toBe("function");
+    expect(typeof inputConfig.serializer.experimentalSerializerHook).toBe(
+      "function"
+    );
+    expect(CyclicDependencies).toHaveBeenCalledWith();
+    expect(DuplicateDependencies).toHaveBeenCalledWith();
+  });
+
+  test("returns a config without a custom serializer when there are no plugins", () => {
+    const inputConfig = { ...mockConfig };
+    customizeMetroConfig(
+      inputConfig as any,
+      false,
+      false,
+      undefined,
+      undefined
+    );
+
+    expect(inputConfig).toEqual({
+      serializer: {
+        experimentalSerializerHook: expect.anything(),
+      },
+      transformer: {},
+    });
+    expect(inputConfig.serializer.customSerializer).toBeUndefined();
+    expect(typeof inputConfig.serializer.experimentalSerializerHook).toBe(
+      "function"
+    );
+    expect(CyclicDependencies).not.toHaveBeenCalled();
+    expect(DuplicateDependencies).not.toHaveBeenCalled();
+  });
+
+  test("returns a config with only duplicates plugin", () => {
+    const inputConfig = { ...mockConfig };
+    customizeMetroConfig(
+      inputConfig as any,
+      false,
+      undefined,
+      undefined,
+      undefined
+    );
+
+    expect(inputConfig).toEqual({
+      serializer: {
+        customSerializer: expect.anything(),
+        experimentalSerializerHook: expect.anything(),
+      },
+      transformer: {},
+    });
+    expect(typeof inputConfig.serializer.customSerializer).toBe("function");
+    expect(typeof inputConfig.serializer.experimentalSerializerHook).toBe(
+      "function"
+    );
+    expect(CyclicDependencies).not.toHaveBeenCalled();
+    expect(DuplicateDependencies).toHaveBeenCalledWith();
+  });
+
+  test("returns a config with only cyclic dependencies plugin", () => {
+    const inputConfig = { ...mockConfig };
+    customizeMetroConfig(
+      inputConfig as any,
+      undefined,
+      false,
+      undefined,
+      undefined
+    );
+
+    expect(inputConfig).toEqual({
+      serializer: {
+        customSerializer: expect.anything(),
+        experimentalSerializerHook: expect.anything(),
+      },
+      transformer: {},
+    });
+    expect(typeof inputConfig.serializer.customSerializer).toBe("function");
+    expect(typeof inputConfig.serializer.experimentalSerializerHook).toBe(
+      "function"
+    );
+    expect(CyclicDependencies).toHaveBeenCalledWith();
+    expect(DuplicateDependencies).not.toHaveBeenCalled();
+  });
+
+  test("forwards plugin options", () => {
+    const inputConfig = { ...mockConfig };
+    const cyclicDependenciesOptions = { cyclicDependencies: true } as any;
+    const duplicateDependencesOptions = { duplicateDependencies: true } as any;
+    customizeMetroConfig(
+      inputConfig as any,
+      cyclicDependenciesOptions,
+      duplicateDependencesOptions,
+      undefined,
+      undefined
+    );
+
+    expect(inputConfig).toEqual({
+      serializer: {
+        customSerializer: expect.anything(),
+        experimentalSerializerHook: expect.anything(),
+      },
+      transformer: {},
+    });
+    expect(typeof inputConfig.serializer.customSerializer).toBe("function");
+    expect(typeof inputConfig.serializer.experimentalSerializerHook).toBe(
+      "function"
+    );
+    expect(CyclicDependencies).toHaveBeenCalledWith(cyclicDependenciesOptions);
+    expect(DuplicateDependencies).toHaveBeenCalledWith(
+      duplicateDependencesOptions
+    );
+  });
+
+  test("returns a config with a custom serializer when tree shaking is enabled", () => {
+    const inputConfig = { ...mockConfig };
+    customizeMetroConfig(inputConfig as any, false, false, undefined, true);
+
+    expect(inputConfig).toEqual({
+      serializer: {
+        customSerializer: expect.anything(),
+        experimentalSerializerHook: expect.anything(),
+      },
+      transformer: expect.objectContaining({
+        minifierPath: expect.stringContaining(
+          "@rnx-kit/metro-serializer-esbuild"
+        ),
+      }),
+    });
+    expect(typeof inputConfig.serializer.customSerializer).toBe("function");
+    expect(typeof inputConfig.serializer.experimentalSerializerHook).toBe(
+      "function"
+    );
+    expect(CyclicDependencies).not.toHaveBeenCalled();
+    expect(DuplicateDependencies).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Description

Plugins cannot be disabled because we only check whether `detectCyclicDependencies` and `detectDuplicateDependencies` are booleans.

Resolves #605.

### Test plan

Tests were added.