### PR TITLE
fix(babel-plugin-import-path-remapper): only the first `lib` folder should be replaced

### DIFF
--- a/change/@rnx-kit-babel-plugin-import-path-remapper-567a26da-8961-4521-a950-a57d060e1380.json
+++ b/change/@rnx-kit-babel-plugin-import-path-remapper-567a26da-8961-4521-a950-a57d060e1380.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed all `lib` components in a path being incorrectly replaced",
+  "packageName": "@rnx-kit/babel-plugin-import-path-remapper",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-plugin-import-path-remapper/package.json
+++ b/packages/babel-plugin-import-path-remapper/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "@babel/core": "^7.0.0",
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.0.0",
+    "@rnx-kit/tools-node": "^1.1.3"
   },
   "devDependencies": {
     "@types/babel__core": "^7.0.0",

--- a/packages/babel-plugin-import-path-remapper/test/babel-plugin-import-path-remapper.test.js
+++ b/packages/babel-plugin-import-path-remapper/test/babel-plugin-import-path-remapper.test.js
@@ -82,4 +82,10 @@ describe("@rnx-kit/babel-plugin-import-path-remapper", () => {
       transform(`export { a, b } from "@rnx-kit/example/lib/index";`)
     ).toBe(`export { a, b } from "@rnx-kit/example/src/index";`);
   });
+
+  test("ignores subsequent lib folders", () => {
+    expect(
+      transform(`import A from "@rnx-kit/example/lib/index/lib/index";`)
+    ).toBe(`import A from "@rnx-kit/example/src/index/lib/index";`);
+  });
 });


### PR DESCRIPTION
### Description

Fixed all `lib` components in a path being incorrectly replaced.

### Test plan

A test was added to capture this issue. It should pass.