### PR TITLE
fix(babel-preset-metro-react-native): add `esbuild` transform profile

### DIFF
--- a/change/@rnx-kit-babel-preset-metro-react-native-c872c54d-5a6d-425c-af3c-d6c5d68033a5.json
+++ b/change/@rnx-kit-babel-preset-metro-react-native-c872c54d-5a6d-425c-af3c-d6c5d68033a5.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Use `hermes-stable` transform profile for esbuild",
+  "comment": "Add `esbuild` transform profile for use with `metro-serializer-esbuild`",
   "packageName": "@rnx-kit/babel-preset-metro-react-native",
   "email": "4123478+tido64@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@rnx-kit-babel-preset-metro-react-native-c872c54d-5a6d-425c-af3c-d6c5d68033a5.json
+++ b/change/@rnx-kit-babel-preset-metro-react-native-c872c54d-5a6d-425c-af3c-d6c5d68033a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use `hermes-stable` transform profile for esbuild",
+  "packageName": "@rnx-kit/babel-preset-metro-react-native",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-metro-serializer-esbuild-96aa12e1-be14-4fd4-94e4-0fdefea2660e.json
+++ b/change/@rnx-kit-metro-serializer-esbuild-96aa12e1-be14-4fd4-94e4-0fdefea2660e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updated docs for users of `@rnx-kit/babel-preset-metro-react-native`",
+  "packageName": "@rnx-kit/metro-serializer-esbuild",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/babel-preset-metro-react-native/src/index.js
+++ b/packages/babel-preset-metro-react-native/src/index.js
@@ -52,15 +52,8 @@ function overridesFor(transformProfile) {
     case "esbuild":
       return {
         disableImportExportTransform: true,
-        /**
-         * We use the `hermes-stable` profile to exclude most Babel plugins.
-         * Like the Hermes compiler, esbuild is able to parse incoming JS
-         * without too much transpilation.
-         *
-         * See https://github.com/facebook/metro/blob/a75e292f57a51dad0e476bfe7009fcc1a32233d9/packages/metro-react-native-babel-preset/src/configs/main.js#L85.
-         */
-        unstable_transformProfile: "hermes-stable",
       };
+
     default:
       return transformProfile
         ? {

--- a/packages/metro-serializer-esbuild/README.md
+++ b/packages/metro-serializer-esbuild/README.md
@@ -52,6 +52,20 @@ in `babel.config.js`:
  };
 ```
 
+If you're using `@rnx-kit/babel-preset-metro-react-native`, you can instead set
+`esbuild` as transform profile:
+
+```diff
+ module.exports = {
+   presets: [
+     [
+       "@rnx-kit/babel-preset-metro-react-native",
++      { unstable_transformProfile: "esbuild" },
+     ],
+   ],
+ };
+```
+
 Next, configure Metro to use the esbuild serializer by making the following
 changes to `metro.config.js`:
 

--- a/packages/test-app/ios/Podfile
+++ b/packages/test-app/ios/Podfile
@@ -2,4 +2,5 @@ require_relative '../../../node_modules/react-native-test-app/test_app'
 
 workspace 'SampleCrossApp.xcworkspace'
 
+use_flipper! false
 use_test_app!

--- a/packages/test-app/ios/Podfile.lock
+++ b/packages/test-app/ios/Podfile.lock
@@ -1,6 +1,5 @@
 PODS:
   - boost-for-react-native (1.63.0)
-  - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.65.1)
   - FBReactNativeSpec (0.65.1):
@@ -10,70 +9,8 @@ PODS:
     - React-Core (= 0.65.1)
     - React-jsi (= 0.65.1)
     - ReactCommon/turbomodule/core (= 0.65.1)
-  - Flipper (0.93.0):
-    - Flipper-Folly (~> 2.6)
-    - Flipper-RSocket (~> 1.4)
-  - Flipper-Boost-iOSX (1.76.0.1.11)
-  - Flipper-DoubleConversion (3.1.7)
-  - Flipper-Fmt (7.1.7)
-  - Flipper-Folly (2.6.7):
-    - Flipper-Boost-iOSX
-    - Flipper-DoubleConversion
-    - Flipper-Fmt (= 7.1.7)
-    - Flipper-Glog
-    - libevent (~> 2.1.12)
-    - OpenSSL-Universal (= 1.1.180)
-  - Flipper-Glog (0.3.6)
-  - Flipper-PeerTalk (0.0.4)
-  - Flipper-RSocket (1.4.3):
-    - Flipper-Folly (~> 2.6)
-  - FlipperKit (0.93.0):
-    - FlipperKit/Core (= 0.93.0)
-  - FlipperKit/Core (0.93.0):
-    - Flipper (~> 0.93.0)
-    - FlipperKit/CppBridge
-    - FlipperKit/FBCxxFollyDynamicConvert
-    - FlipperKit/FBDefines
-    - FlipperKit/FKPortForwarding
-  - FlipperKit/CppBridge (0.93.0):
-    - Flipper (~> 0.93.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (0.93.0):
-    - Flipper-Folly (~> 2.6)
-  - FlipperKit/FBDefines (0.93.0)
-  - FlipperKit/FKPortForwarding (0.93.0):
-    - CocoaAsyncSocket (~> 7.6)
-    - Flipper-PeerTalk (~> 0.0.4)
-  - FlipperKit/FlipperKitHighlightOverlay (0.93.0)
-  - FlipperKit/FlipperKitLayoutHelpers (0.93.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutTextSearchable
-  - FlipperKit/FlipperKitLayoutIOSDescriptors (0.93.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutHelpers
-    - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutPlugin (0.93.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutHelpers
-    - FlipperKit/FlipperKitLayoutIOSDescriptors
-    - FlipperKit/FlipperKitLayoutTextSearchable
-    - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutTextSearchable (0.93.0)
-  - FlipperKit/FlipperKitNetworkPlugin (0.93.0):
-    - FlipperKit/Core
-  - FlipperKit/FlipperKitReactPlugin (0.93.0):
-    - FlipperKit/Core
-  - FlipperKit/FlipperKitUserDefaultsPlugin (0.93.0):
-    - FlipperKit/Core
-  - FlipperKit/SKIOSNetworkPlugin (0.93.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - libevent (2.1.12)
-  - OpenSSL-Universal (1.1.180)
   - QRCodeReader.swift (10.1.0)
   - RCT-Folly (2021.04.26.00):
     - boost-for-react-native
@@ -334,38 +271,15 @@ PODS:
     - React-cxxreact (= 0.65.1)
     - React-jsi (= 0.65.1)
     - React-perflogger (= 0.65.1)
-  - ReactTestApp-DevSupport (0.7.5)
+  - ReactTestApp-DevSupport (0.7.7)
   - ReactTestApp-Resources (1.0.0-dev)
-  - SwiftLint (0.43.1)
+  - SwiftLint (0.44.0)
   - Yoga (1.14.0)
-  - YogaKit (1.18.1):
-    - Yoga (~> 1.14)
 
 DEPENDENCIES:
   - DoubleConversion (from `../../../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../../../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../../../node_modules/react-native/React/FBReactNativeSpec`)
-  - Flipper (= 0.93.0)
-  - Flipper-Boost-iOSX (= 1.76.0.1.11)
-  - Flipper-DoubleConversion (= 3.1.7)
-  - Flipper-Fmt (= 7.1.7)
-  - Flipper-Folly (= 2.6.7)
-  - Flipper-Glog (= 0.3.6)
-  - Flipper-PeerTalk (= 0.0.4)
-  - Flipper-RSocket (= 1.4.3)
-  - FlipperKit (= 0.93.0)
-  - FlipperKit/Core (= 0.93.0)
-  - FlipperKit/CppBridge (= 0.93.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (= 0.93.0)
-  - FlipperKit/FBDefines (= 0.93.0)
-  - FlipperKit/FKPortForwarding (= 0.93.0)
-  - FlipperKit/FlipperKitHighlightOverlay (= 0.93.0)
-  - FlipperKit/FlipperKitLayoutPlugin (= 0.93.0)
-  - FlipperKit/FlipperKitLayoutTextSearchable (= 0.93.0)
-  - FlipperKit/FlipperKitNetworkPlugin (= 0.93.0)
-  - FlipperKit/FlipperKitReactPlugin (= 0.93.0)
-  - FlipperKit/FlipperKitUserDefaultsPlugin (= 0.93.0)
-  - FlipperKit/SKIOSNetworkPlugin (= 0.93.0)
   - glog (from `../../../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - QRCodeReader.swift
   - RCT-Folly (from `../../../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -401,22 +315,9 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - boost-for-react-native
-    - CocoaAsyncSocket
-    - Flipper
-    - Flipper-Boost-iOSX
-    - Flipper-DoubleConversion
-    - Flipper-Fmt
-    - Flipper-Folly
-    - Flipper-Glog
-    - Flipper-PeerTalk
-    - Flipper-RSocket
-    - FlipperKit
     - fmt
-    - libevent
-    - OpenSSL-Universal
     - QRCodeReader.swift
     - SwiftLint
-    - YogaKit
 
 EXTERNAL SOURCES:
   DoubleConversion:
@@ -482,23 +383,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: 33c82491102f20ecddb6c6a2c273696ace3191e0
   FBReactNativeSpec: df8f81d2a7541ee6755a047b398a5cb5a72acd0e
-  Flipper: b1fddf9a17c32097b2b4c806ad158b2f36bb2692
-  Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
-  Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
-  Flipper-Fmt: 60cbdd92fc254826e61d669a5d87ef7015396a9b
-  Flipper-Folly: 83af37379faa69497529e414bd43fbfc7cae259a
-  Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
-  Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
-  FlipperKit: aec2d931adeee48a07bab1ea8bcc8a6bb87dfce4
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 5337263514dd6f09803962437687240c5dc39aa4
-  libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   QRCodeReader.swift: 373a389fe9a22d513c879a32a6f647c58f4ef572
   RCT-Folly: 0dd9e1eb86348ecab5ba76f910b56f4b5fef3c46
   RCTRequired: 6cf071ab2adfd769014b3d94373744ee6e789530
@@ -523,12 +412,11 @@ SPEC CHECKSUMS:
   React-RCTVibration: 92d41c2442e5328cc4d342cd7f78e5876b68bae5
   React-runtimeexecutor: 85187f19dd9c47a7c102f9994f9d14e4dc2110de
   ReactCommon: eafed38eec7b591c31751bfa7494801618460459
-  ReactTestApp-DevSupport: 84ab1181efc86b93291e97746b58de70016c5340
+  ReactTestApp-DevSupport: 3e3e1b9dcf2a93da51b787771d42857d8bc1634b
   ReactTestApp-Resources: 15cdcdc66d0a6ef3e78dc2523a6bb6d0b88835ab
-  SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
+  SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
   Yoga: aa0cb45287ebe1004c02a13f279c55a95f1572f4
-  YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 65baeda55cf2acba5d4e93c37a7bf7df24c91fab
+PODFILE CHECKSUM: 71b08e582fb06a8ccbdbaed0cfe518f40b10bffc
 
-COCOAPODS: 1.10.2
+COCOAPODS: 1.11.2


### PR DESCRIPTION
### Description

~~Use the `hermes-stable` transform profile to reduce the number of Babel plugins used. In my entirely unscientific testing, I got a 5% reduction in bundle time.~~ Turns out setting `hermes-stable` breaks consuming TypeScript directly. For now, this PR will only add the `esbuild` transform profile.

### Test plan

```
yarn
cd packages/test-app
yarn build --dependencies
pod install --project-directory=ios
yarn ios
```