### PR TITLE
fix(metro-resolver-symlinks): type info is empty

### DIFF
--- a/change/@rnx-kit-metro-resolver-symlinks-20b3abcb-3c1a-4437-9774-1560f69b2ac5.json
+++ b/change/@rnx-kit-metro-resolver-symlinks-20b3abcb-3c1a-4437-9774-1560f69b2ac5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix type information not being generated correctly",
+  "packageName": "@rnx-kit/metro-resolver-symlinks",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/metro-resolver-symlinks/src/index.ts
+++ b/packages/metro-resolver-symlinks/src/index.ts
@@ -1,12 +1,11 @@
-import {
-  isFileModuleRef,
-  normalizePath,
-  parseModuleRef,
-} from "@rnx-kit/tools-node";
+import { normalizePath } from "@rnx-kit/tools-node";
 import type { ResolutionContext } from "metro-resolver";
-import path from "path";
-
-type MetroResolver = typeof import("metro-resolver").resolve;
+import type { MetroResolver } from "./resolver";
+import {
+  getMetroResolver,
+  remapReactNativeModule,
+  resolveModulePath,
+} from "./resolver";
 
 type Options = {
   remapModule?: (
@@ -15,68 +14,6 @@ type Options = {
     platform: string
   ) => string;
 };
-
-function resolveFrom(moduleName: string, startDir: string): string {
-  return require.resolve(moduleName, { paths: [startDir] });
-}
-
-/**
- * Get `metro-resolver` from the cli to avoid adding another dependency that
- * needs to be kept in sync.
- */
-function getMetroResolver(fromDir = process.cwd()): MetroResolver {
-  try {
-    const rnPath = path.dirname(
-      resolveFrom("react-native/package.json", fromDir)
-    );
-    const rncliPath = path.dirname(
-      resolveFrom("@react-native-community/cli/package.json", rnPath)
-    );
-    const metroResolverPath = resolveFrom("metro-resolver", rncliPath);
-    return require(metroResolverPath).resolve;
-  } catch (_) {
-    throw new Error(
-      "Cannot find module 'metro-resolver'. This probably means that '@rnx-kit/metro-resolver-symlinks' is not compatible with the version of 'metro' that you are currently using. Please update to the latest version and try again. If the issue still persists after the update, please file a bug at https://github.com/microsoft/rnx-kit/issues."
-    );
-  }
-}
-
-function remapReactNativeModule(
-  moduleName: string,
-  platform: string,
-  platformImplementations: Record<string, string>
-): string {
-  const platformImpl = platformImplementations[platform];
-  if (platformImpl) {
-    if (moduleName === "react-native") {
-      return platformImpl;
-    } else if (moduleName.startsWith("react-native/")) {
-      return `${platformImpl}/${moduleName.slice("react-native/".length)}`;
-    }
-  }
-  return moduleName;
-}
-
-function resolveModulePath(
-  moduleName: string,
-  originModulePath: string
-): string {
-  // Performance: Assume relative links are not going to hit symlinks
-  const ref = parseModuleRef(moduleName);
-  if (isFileModuleRef(ref)) {
-    return moduleName;
-  }
-
-  const pkgName = ref.scope ? `${ref.scope}/${ref.name}` : ref.name;
-  const pkgRoot = path.dirname(
-    resolveFrom(`${pkgName}/package.json`, originModulePath)
-  );
-  const replaced = moduleName.replace(pkgName, pkgRoot);
-  const relativePath = path.relative(path.dirname(originModulePath), replaced);
-  return relativePath.startsWith(".")
-    ? relativePath
-    : `.${path.sep}${relativePath}`;
-}
 
 function makeResolver({
   remapModule = (_, moduleName, __) => moduleName,
@@ -119,7 +56,4 @@ function makeResolver({
   };
 }
 
-module.exports = makeResolver;
-module.exports.getMetroResolver = getMetroResolver;
-module.exports.remapReactNativeModule = remapReactNativeModule;
-module.exports.resolveModulePath = resolveModulePath;
+export = makeResolver;

--- a/packages/metro-resolver-symlinks/src/resolver.ts
+++ b/packages/metro-resolver-symlinks/src/resolver.ts
@@ -1,0 +1,66 @@
+import { isFileModuleRef, parseModuleRef } from "@rnx-kit/tools-node";
+import path from "path";
+
+export type MetroResolver = typeof import("metro-resolver").resolve;
+
+function resolveFrom(moduleName: string, startDir: string): string {
+  return require.resolve(moduleName, { paths: [startDir] });
+}
+
+/**
+ * Get `metro-resolver` from the cli to avoid adding another dependency that
+ * needs to be kept in sync.
+ */
+export function getMetroResolver(fromDir = process.cwd()): MetroResolver {
+  try {
+    const rnPath = path.dirname(
+      resolveFrom("react-native/package.json", fromDir)
+    );
+    const rncliPath = path.dirname(
+      resolveFrom("@react-native-community/cli/package.json", rnPath)
+    );
+    const metroResolverPath = resolveFrom("metro-resolver", rncliPath);
+    return require(metroResolverPath).resolve;
+  } catch (_) {
+    throw new Error(
+      "Cannot find module 'metro-resolver'. This probably means that '@rnx-kit/metro-resolver-symlinks' is not compatible with the version of 'metro' that you are currently using. Please update to the latest version and try again. If the issue still persists after the update, please file a bug at https://github.com/microsoft/rnx-kit/issues."
+    );
+  }
+}
+
+export function remapReactNativeModule(
+  moduleName: string,
+  platform: string,
+  platformImplementations: Record<string, string>
+): string {
+  const platformImpl = platformImplementations[platform];
+  if (platformImpl) {
+    if (moduleName === "react-native") {
+      return platformImpl;
+    } else if (moduleName.startsWith("react-native/")) {
+      return `${platformImpl}/${moduleName.slice("react-native/".length)}`;
+    }
+  }
+  return moduleName;
+}
+
+export function resolveModulePath(
+  moduleName: string,
+  originModulePath: string
+): string {
+  // Performance: Assume relative links are not going to hit symlinks
+  const ref = parseModuleRef(moduleName);
+  if (isFileModuleRef(ref)) {
+    return moduleName;
+  }
+
+  const pkgName = ref.scope ? `${ref.scope}/${ref.name}` : ref.name;
+  const pkgRoot = path.dirname(
+    resolveFrom(`${pkgName}/package.json`, originModulePath)
+  );
+  const replaced = moduleName.replace(pkgName, pkgRoot);
+  const relativePath = path.relative(path.dirname(originModulePath), replaced);
+  return relativePath.startsWith(".")
+    ? relativePath
+    : `.${path.sep}${relativePath}`;
+}

--- a/packages/metro-resolver-symlinks/test/index.test.ts
+++ b/packages/metro-resolver-symlinks/test/index.test.ts
@@ -1,11 +1,9 @@
 import path from "path";
 import {
   getMetroResolver,
-  getPackageName,
-  isRelativeModule,
   remapReactNativeModule,
   resolveModulePath,
-} from "../src/index";
+} from "../src/resolver";
 
 function useFixture(name: string): string {
   return path.join(__dirname, "__fixtures__", name);

--- a/packages/test-app/metro.config.js
+++ b/packages/test-app/metro.config.js
@@ -1,4 +1,5 @@
 const { exclusionList, makeMetroConfig } = require("@rnx-kit/metro-config");
+const MetroSymlinksResolver = require("@rnx-kit/metro-resolver-symlinks");
 
 // Metro will pick up react-native-macos/-windows mocks if we don't exclude them
 const blockList = exclusionList([/.*__fixtures__.*/]);
@@ -8,5 +9,6 @@ module.exports = makeMetroConfig({
   resolver: {
     blacklistRE: blockList,
     blockList,
+    resolveRequest: MetroSymlinksResolver(),
   },
 });

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -38,6 +38,7 @@
     "@rnx-kit/metro-plugin-cyclic-dependencies-detector": "*",
     "@rnx-kit/metro-plugin-duplicates-checker": "*",
     "@rnx-kit/metro-plugin-typescript-validation": "*",
+    "@rnx-kit/metro-resolver-symlinks": "*",
     "@rnx-kit/metro-serializer": "*",
     "@rnx-kit/metro-serializer-esbuild": "*",
     "@types/react": "^17.0.2",


### PR DESCRIPTION
### Description

Type information for `metro-resolver-symlinks` is empty. Regressed in #587.

Resolves #643.

### Test plan

```
yarn
cd packages/metro-resolver-symlinks
build --dependencies
cat lib/index.d.ts
```

`lib/index.d.ts` should not be empty.