### PR TITLE
chore: enable `--isolatedModules` by default

### DIFF
--- a/change/@rnx-kit-babel-preset-metro-react-native-8ecf8ba6-719e-445c-90bb-58e22980a9f8.json
+++ b/change/@rnx-kit-babel-preset-metro-react-native-8ecf8ba6-719e-445c-90bb-58e22980a9f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Enable `--isolatedModules` to ensure compatibility with transpilers that only operate on a single file at a time, e.g. Babel or esbuild.",
+  "packageName": "@rnx-kit/babel-preset-metro-react-native",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-config-190d7185-0ce2-4d46-88fd-60d8abf9e2fc.json
+++ b/change/@rnx-kit-metro-config-190d7185-0ce2-4d46-88fd-60d8abf9e2fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Enable `--isolatedModules` to ensure compatibility with transpilers that only operate on a single file at a time, e.g. Babel or esbuild.",
+  "packageName": "@rnx-kit/metro-config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-third-party-notices-41c567e5-b56b-4970-8fed-066c7f9d7552.json
+++ b/change/@rnx-kit-third-party-notices-41c567e5-b56b-4970-8fed-066c7f9d7552.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Enable `--isolatedModules` to ensure compatibility with transpilers that only operate on a single file at a time, e.g. Babel or esbuild.",
+  "packageName": "@rnx-kit/third-party-notices",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/babel-preset-metro-react-native/test/__fixtures__/App.ts
+++ b/packages/babel-preset-metro-react-native/test/__fixtures__/App.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 require("typescript/lib/remap-test/lib/lib");
 
 const enum Direction {

--- a/packages/metro-config/test/index.test.ts
+++ b/packages/metro-config/test/index.test.ts
@@ -1,6 +1,7 @@
+import * as fs from "fs";
+import * as path from "path";
+
 describe("@rnx-kit/metro-config", () => {
-  const fs = require("fs");
-  const path = require("path");
   const {
     UNIQUE_PACKAGES,
     defaultWatchFolders,

--- a/packages/third-party-notices/src/index.ts
+++ b/packages/third-party-notices/src/index.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   WriteThirdPartyNoticesOptions as IWriteThirdPartyNoticesOptions,
   WriteThirdPartyNoticesOptions,
 } from "./types";

--- a/scripts/tsconfig-shared.json
+++ b/scripts/tsconfig-shared.json
@@ -16,6 +16,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "esModuleInterop": true,
+    "isolatedModules": true,
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
### Description

Enable isolated modules to ensure compatibility with transpilers that only operate on a single file at a time, e.g. Babel or esbuild.

See also https://www.typescriptlang.org/tsconfig#isolatedModules.

### Test plan

n/a