### PR TITLE
fix(babel-plugin-import-path-remapper): Preserve comments within require/import

### DIFF
--- a/change/@rnx-kit-babel-plugin-import-path-remapper-f2e4a3f3-2281-4a59-b23c-c39cff5e3b82.json
+++ b/change/@rnx-kit-babel-plugin-import-path-remapper-f2e4a3f3-2281-4a59-b23c-c39cff5e3b82.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Preserve Comments within require and import",
+  "packageName": "@rnx-kit/babel-plugin-import-path-remapper",
+  "email": "sverre.johansen@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-plugin-import-path-remapper/src/index.js
+++ b/packages/babel-plugin-import-path-remapper/src/index.js
@@ -54,12 +54,15 @@ function findMainSourceFile(sourcePath) {
  * @param {string} source
  */
 function updateCallWith(path, source) {
-  path.node.arguments[0].value = source;
+  const firstArgument = path.node.arguments[0];
+  if (types.isStringLiteral(firstArgument)) {
+    firstArgument.value = source;
+  }
 }
 
 /**
  * Replaces the source string in specified import/export declaration.
- * @param {NodePath<Node>} path
+ * @param {NodePath<ImportExportDeclarationNodePath>} path
  * @param {string} source
  */
 function updateDeclarationWith(path, source) {

--- a/packages/babel-plugin-import-path-remapper/test/babel-plugin-import-path-remapper.test.js
+++ b/packages/babel-plugin-import-path-remapper/test/babel-plugin-import-path-remapper.test.js
@@ -94,4 +94,15 @@ describe("@rnx-kit/babel-plugin-import-path-remapper", () => {
       transform(`import A from "@rnx-kit/example/lib/index/lib/index";`)
     ).toBe(`import A from "@rnx-kit/example/src/index/lib/index";`);
   });
+
+  test("Preserves magic comments", () => {
+    expect(
+      transform(`import(/* webpackChunkName: "example" */ "@rnx-kit/example/lib/index");
+`)
+    ).toBe(
+      `import(
+/* webpackChunkName: "example" */
+"@rnx-kit/example/src/index");`
+    );
+  });
 });


### PR DESCRIPTION
### Description

This fixes comments being stripped from within import() calls. This is for example used as "magic comments" in webpack to pass arguments to the code splitter.

This fix changes the approach to mutating rather than replacing the nodes. This is to guarantee that everything attached is carried over in the transform.
    
