### PR TITLE
chore(dep-check): bump a couple of RN versions to latest patch

### DIFF
--- a/change/@rnx-kit-dep-check-39294211-aab9-4818-ad3d-59d04391c2c2.json
+++ b/change/@rnx-kit-dep-check-39294211-aab9-4818-ad3d-59d04391c2c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bump patch versions of certain versions to latest available",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "lsciandra@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dep-check/src/profiles/profile-0.63.ts
+++ b/packages/dep-check/src/profiles/profile-0.63.ts
@@ -3,7 +3,7 @@ import profile62 from "./profile-0.62";
 
 const reactNative: Package = {
   name: "react-native",
-  version: "^0.63.2",
+  version: "^0.63.4",
   capabilities: ["react"],
 };
 

--- a/packages/dep-check/src/profiles/profile-0.65.ts
+++ b/packages/dep-check/src/profiles/profile-0.65.ts
@@ -3,7 +3,7 @@ import profile_0_64 from "./profile-0.64";
 
 const reactNative: Package = {
   name: "react-native",
-  version: "^0.65.0-0",
+  version: "^0.65.1",
   capabilities: ["react"],
 };
 

--- a/packages/dep-check/test/__snapshots__/vigilant.test.ts.snap
+++ b/packages/dep-check/test/__snapshots__/vigilant.test.ts.snap
@@ -102,7 +102,7 @@ Object {
     "hermes-engine": "~0.5.0 || ~0.7.0",
     "react": "16.13.1 || 17.0.1",
     "react-dom": "16.13.1 || 17.0.1",
-    "react-native": "^0.63.2 || ^0.64.2",
+    "react-native": "^0.63.4 || ^0.64.2",
     "react-native-base64": "^0.2.1",
     "react-native-floating-action": "^1.21.0",
     "react-native-fs": "^2.16.6 || ^2.17.0",

--- a/packages/dep-check/test/setVersion.test.ts
+++ b/packages/dep-check/test/setVersion.test.ts
@@ -34,7 +34,7 @@ describe("makeSetVersionCommand()", () => {
     version: "1.0.0-test",
     dependencies: {
       react: "16.13.1",
-      "react-native": "^0.63.2",
+      "react-native": "^0.63.4",
     },
     devDependencies: {},
     "rnx-kit": {
@@ -82,7 +82,7 @@ describe("makeSetVersionCommand()", () => {
       },
       peerDependencies: {
         react: "16.13.1 || 17.0.1",
-        "react-native": "^0.63.2 || ^0.64.2",
+        "react-native": "^0.63.4 || ^0.64.2",
       },
       "rnx-kit": {
         ...mockManifest["rnx-kit"],

--- a/packages/dep-check/test/vigilant.test.ts
+++ b/packages/dep-check/test/vigilant.test.ts
@@ -195,7 +195,7 @@ describe("makeVigilantCommand()", () => {
       name: "@rnx-kit/dep-check",
       version: "1.0.0",
       dependencies: {
-        "react-native": "^0.63.2",
+        "react-native": "^0.63.4",
       },
     });
 


### PR DESCRIPTION
### Description

A couple of RN versions were not pointing to latest available, which in some scenarios might lead to baad behaviours when ex. the native side pick sup the version from the package.json but doesn't understand semver so it complains (ex. 0.63.2 v 0.63.4 that we are hitting in a project right now).

For some reason once again I can't seem to get the update-script to update the README, so @tido64 do you think you'd be able to do it? 😓
