### PR TITLE
chore: bump react-native to 0.66

### DIFF
--- a/change/@rnx-kit-metro-serializer-38c03324-a80a-4a9e-96a9-2af6cc29a069.json
+++ b/change/@rnx-kit-metro-serializer-38c03324-a80a-4a9e-96a9-2af6cc29a069.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump react-native to 0.66",
+  "packageName": "@rnx-kit/metro-serializer",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-serializer-esbuild-dc825d9b-b375-42d2-b43e-0e183c793442.json
+++ b/change/@rnx-kit-metro-serializer-esbuild-dc825d9b-b375-42d2-b43e-0e183c793442.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump react-native to 0.66",
+  "packageName": "@rnx-kit/metro-serializer-esbuild",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-service-0a05bada-b35d-4724-b371-c0c0cfd3713e.json
+++ b/change/@rnx-kit-metro-service-0a05bada-b35d-4724-b371-c0c0cfd3713e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump react-native to 0.66",
+  "packageName": "@rnx-kit/metro-service",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -33,7 +33,7 @@
     "@types/metro-config": "*",
     "@types/metro-transform-worker": "*",
     "@types/semver": "^7.0.0",
-    "metro": "^0.66.1",
+    "metro": "^0.66.2",
     "rnx-kit-scripts": "*"
   },
   "depcheck": {

--- a/packages/metro-serializer/package.json
+++ b/packages/metro-serializer/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@types/metro": "*",
     "@types/semver": "^7.0.0",
-    "metro": "^0.66.1",
+    "metro": "^0.66.2",
     "rnx-kit-scripts": "*"
   },
   "depcheck": {

--- a/packages/metro-service/package.json
+++ b/packages/metro-service/package.json
@@ -44,12 +44,12 @@
     "@types/metro-config": "*",
     "@types/metro-resolver": "*",
     "@types/node": "^14.15.0",
-    "metro": "^0.66.1",
-    "metro-config": "^0.66.1",
-    "metro-core": "^0.66.1",
-    "metro-react-native-babel-transformer": "^0.66.1",
-    "metro-resolver": "^0.66.1",
-    "metro-runtime": "^0.66.1",
+    "metro": "^0.66.2",
+    "metro-config": "^0.66.2",
+    "metro-core": "^0.66.2",
+    "metro-react-native-babel-transformer": "^0.66.2",
+    "metro-resolver": "^0.66.2",
+    "metro-runtime": "^0.66.2",
     "rnx-kit-scripts": "*"
   },
   "depcheck": {

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -22,8 +22,8 @@
   },
   "dependencies": {
     "react": "17.0.2",
-    "react-native": "^0.65.0-0",
-    "react-native-windows": "^0.65.0-0"
+    "react-native": "^0.66.0-0",
+    "react-native-windows": "^0.66.0-0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
@@ -57,7 +57,7 @@
     "preset": "rnx-kit-scripts"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.65",
+    "reactNativeVersion": "^0.66",
     "kitType": "app",
     "bundle": {
       "entryPath": "index.ts",

--- a/scripts/rnx-dep-check.js
+++ b/scripts/rnx-dep-check.js
@@ -61,6 +61,7 @@ module.exports = {
   0.63: common,
   0.64: common,
   0.65: common,
+  0.66: common,
 };
 
 if (require.main === module) {
@@ -68,7 +69,7 @@ if (require.main === module) {
     "custom-profiles": __filename,
     // the following packages support multiple versions of react-native
     "exclude-packages": "@rnx-kit/jest-preset,@rnx-kit/metro-config",
-    vigilant: "0.65",
+    vigilant: "0.66",
     write: process.argv.includes("--write"),
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1729,19 +1729,20 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
-"@react-native-windows/cli@0.65.1":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@react-native-windows/cli/-/cli-0.65.1.tgz#0f987f22063a6d18bf0bbbf398495b687d64d083"
-  integrity sha512-IqReN23gOZWfy6Q70HHY/guPFeKdb6XvyqWR5qVh4LvS/S/csZ2cajsZd48A+aKBaW5buAPrcAtQAB/Lo4JsSg==
+"@react-native-windows/cli@0.66.0":
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/@react-native-windows/cli/-/cli-0.66.0.tgz#68c6919cf9546478ff36a38d9c89bf118f480e5e"
+  integrity sha512-+mzm3k+X1AXQe+OqYZxPPeoY4r/plaPKXe+P7y3tjWZN77ia+pdrKShJuQaAYRG3MhkEtNQpXRoJqb35AM7xrA==
   dependencies:
-    "@react-native-windows/package-utils" "0.65.0"
-    "@react-native-windows/telemetry" "0.65.0"
+    "@react-native-windows/package-utils" "0.66.0"
+    "@react-native-windows/telemetry" "0.66.0"
     "@xmldom/xmldom" "^0.7.5"
     chalk "^4.1.0"
     cli-spinners "^2.2.0"
     envinfo "^7.5.0"
     find-up "^4.1.0"
     glob "^7.1.1"
+    lodash "^4.17.15"
     mustache "^4.0.1"
     ora "^3.4.0"
     prompts "^2.4.1"
@@ -1753,28 +1754,35 @@
     xml-parser "^1.2.1"
     xpath "^0.0.27"
 
-"@react-native-windows/find-repo-root@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@react-native-windows/find-repo-root/-/find-repo-root-0.65.0.tgz#e542a39cb322ba338bae3151220b743db92ed13b"
-  integrity sha512-79CmialL2ee6nD+k1/AtpSYwAxCDBEn7zfJb0KU5Hjk/SXaKdPJF6kRRG0T+A3OaP6PVofDUSkQ0yhfEgQ1AxA==
+"@react-native-windows/find-repo-root@0.66.0":
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/@react-native-windows/find-repo-root/-/find-repo-root-0.66.0.tgz#b837e8e92d8edef37fd336c8a1676a19509e985a"
+  integrity sha512-VJj/VvbPZ361Y0D9k53eyRo8ESDKaBaSkO3OHdV7yPr9W9UDHpQyw92fQ4EUz/4z91exyb0BceUS+5cDw8usPw==
   dependencies:
     find-up "^4.1.0"
 
-"@react-native-windows/package-utils@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@react-native-windows/package-utils/-/package-utils-0.65.0.tgz#48c7aaddc350d05a7bbcde242e6940d20221b238"
-  integrity sha512-sRKdB73NzjDTFkrfE1IH91zsbwYlzn9SDY6u4KC5Q+aaBLam5WPlbtm2+HukNvY+0PFhaTni6c6FxEI6m5JXRA==
+"@react-native-windows/package-utils@0.66.0":
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/@react-native-windows/package-utils/-/package-utils-0.66.0.tgz#9d273a838001929d566010175ff691b974669671"
+  integrity sha512-hh+WuSZEsni3KTxi7SAMYJY/xZx55XmBV3/LI8t87WlfEs1jsFDEkDgJ8RZa5z1CKv+OGTVoMprYUzk0xqz1aA==
   dependencies:
-    "@react-native-windows/find-repo-root" "0.65.0"
+    "@react-native-windows/find-repo-root" "0.66.0"
     get-monorepo-packages "^1.2.0"
     lodash "^4.17.15"
 
-"@react-native-windows/telemetry@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@react-native-windows/telemetry/-/telemetry-0.65.0.tgz#821ae46697d64848282a46db9c9c2f99f8c9638a"
-  integrity sha512-tS0JfRinTvx3B/2CxgzO2zgcjTrGIfj6cFiwwOD28tzJGr0FWOUYvgtfxdcnXRSabJ4NTbpBxdo0oP9TvvSSmw==
+"@react-native-windows/telemetry@0.66.0":
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/@react-native-windows/telemetry/-/telemetry-0.66.0.tgz#968a7ba443cd5393d9b1040700f59b1dd564668b"
+  integrity sha512-SxN0o1GkqT5Vpw+3GlFXpiKXgaOhDetqtqf6pbxfiykKPODKduOO8qneS6zzW7Mbw30yXtNOrKBM0CxNRQQeOg==
   dependencies:
     applicationinsights "^1.8.8"
+
+"@react-native-windows/virtualized-list@0.66.0":
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/@react-native-windows/virtualized-list/-/virtualized-list-0.66.0.tgz#6d8d1a9fc75360e47e2bd8223e58f10f5fd620ac"
+  integrity sha512-DXve8EACESyBbTykaJykvvgptaXaosBJVgkyHOzn4xOr/aywmn9TU92OPyn7D9Ya2+axK/ZOwyl70ZHjlqpHNA==
+  dependencies:
+    invariant "^2.2.4"
 
 "@react-native/assets@1.0.0":
   version "1.0.0"
@@ -1786,10 +1794,10 @@
   resolved "https://registry.yarnpkg.com/@react-native/normalize-color/-/normalize-color-1.0.0.tgz#c52a99d4fe01049102d47dc45d40cbde4f720ab6"
   integrity sha512-xUNRvNmCl3UGCPbbHvfyFMnpvLPoOjDCcp5bT9m2k+TF/ZBklEQwhPZlkrxRx2NhgFh1X3a5uL7mJ7ZR+8G7Qg==
 
-"@react-native/polyfills@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-1.0.0.tgz#05bb0031533598f9458cf65a502b8df0eecae780"
-  integrity sha512-0jbp4RxjYopTsIdLl+/Fy2TiwVYHy4mgeu07DG4b/LyM0OS/+lPP5c9sbnt/AMlnF6qz2JRZpPpGw1eMNS6A4w==
+"@react-native/polyfills@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-2.0.0.tgz#4c40b74655c83982c8cf47530ee7dc13d957b6aa"
+  integrity sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==
 
 "@rushstack/node-core-library@3.35.2":
   version "3.35.2"
@@ -4919,10 +4927,10 @@ hash-sum@^2.0.0:
   resolved "https://registry.yarnpkg.com/hash-sum/-/hash-sum-2.0.0.tgz#81d01bb5de8ea4a214ad5d6ead1b523460b0b45a"
   integrity sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==
 
-hermes-engine@~0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.8.1.tgz#b6d0d70508ac5add2d198304502fb968cdecb8b2"
-  integrity sha512-as9Iccj/qrqqtDmfYUHbOIjt5xsQbUB6pjNIW3i1+RVr+pCAdz5S8/Jry778mz3rJWplYzHWdR1u1xQSYfBRYw==
+hermes-engine@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.9.0.tgz#84d9cfe84e8f6b1b2020d6e71b350cec84ed982f"
+  integrity sha512-r7U+Y4P2Qg/igFVZN+DpT7JFfXUn1MM4dFne8aW+cCrF6RRymof+VqrUHs1kl07j8h8V2CNesU19RKgWbr3qPw==
 
 hermes-parser@0.4.7:
   version "0.4.7"
@@ -7847,10 +7855,10 @@ range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-react-devtools-core@^4.6.0:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.10.1.tgz#6d57db291aeac9cc45ef9fb4636dd2ab97490daf"
-  integrity sha512-sXbBjGAWcf9HAblTP/zMtFhGHqxAfIR+GPxONZsSGN9FHnF4635dx1s2LdQWG9rJ+Ehr3nWg+BUAB6P78my5PA==
+react-devtools-core@^4.13.0:
+  version "4.19.2"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.19.2.tgz#57f5d19b67e8658323474ab51c6c1292bf8243c9"
+  integrity sha512-Z9K+h9gjEwimZtZB1NsWm5hQsxAcElW0GI2KXLQDpk2o1YIZQ+lOSesUr0npUyLeb37k2hTtyxp8wumeRJpG5Q==
   dependencies:
     shell-quote "^1.6.1"
     ws "^7"
@@ -7885,25 +7893,26 @@ react-native-test-app@^0.7.6:
     semver "^7.3.5"
     yargs "^16.0.0"
 
-react-native-windows@^0.65.0-0:
-  version "0.65.4"
-  resolved "https://registry.yarnpkg.com/react-native-windows/-/react-native-windows-0.65.4.tgz#706cf8fc5fe94405e0081d52f656f8bdf564049e"
-  integrity sha512-qKTeZ68pQn35LI+dPdHGvgn/jJc0x2xbWT2wTfWbrk9XatNq1qXeAxAeD/7iYxsLSdCnOpbrfLbZ5M4nHM70jQ==
+react-native-windows@^0.66.0-0:
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/react-native-windows/-/react-native-windows-0.66.0.tgz#f937de6a48a86b4c2541782be0ce2d60523d8df4"
+  integrity sha512-3b8YPZs7G8hBN4T/qiwP7wLBZyzx7zXti0lZWlg9iV6auszR5mI7PoL/j1aOzO0JJY22QyJ+ALxFQc/xacoNfw==
   dependencies:
     "@babel/runtime" "^7.0.0"
     "@jest/create-cache-key-function" "^27.0.1"
     "@react-native-community/cli" "^6.0.0"
     "@react-native-community/cli-platform-android" "^6.0.0"
     "@react-native-community/cli-platform-ios" "^6.0.0"
-    "@react-native-windows/cli" "0.65.1"
+    "@react-native-windows/cli" "0.66.0"
+    "@react-native-windows/virtualized-list" "0.66.0"
     "@react-native/assets" "1.0.0"
     "@react-native/normalize-color" "1.0.0"
-    "@react-native/polyfills" "1.0.0"
+    "@react-native/polyfills" "2.0.0"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     base64-js "^1.1.2"
     event-target-shim "^5.0.1"
-    hermes-engine "~0.8.1"
+    hermes-engine "~0.9.0"
     invariant "^2.2.4"
     jsc-android "^250230.2.1"
     metro-babel-register "0.66.2"
@@ -7914,20 +7923,21 @@ react-native-windows@^0.65.0-0:
     pretty-format "^26.5.2"
     promise "^8.0.3"
     prop-types "^15.7.2"
-    react-devtools-core "^4.6.0"
+    react-devtools-core "^4.13.0"
+    react-native-codegen "^0.0.7"
     react-refresh "^0.4.0"
     regenerator-runtime "^0.13.2"
-    scheduler "^0.20.1"
+    scheduler "^0.20.2"
     source-map-support "^0.5.19"
     stacktrace-parser "^0.1.3"
     use-subscription "^1.0.0"
     whatwg-fetch "^3.0.0"
     ws "^6.1.4"
 
-react-native@^0.65.0-0:
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.65.1.tgz#bd8cd313e0eb8ddcf08e61e3f8b54b7fc31a418c"
-  integrity sha512-0UOVSnlssweQZjuaUtzViCifE/4tXm8oRbxwakopc8GavPu9vLulde145GOw6QVYiOy4iL50f+2XXRdX9NmMeQ==
+react-native@^0.66.0-0:
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.66.0.tgz#99bdd83a9a612a71b94242767989d666d445b007"
+  integrity sha512-m26TKwzsfHVdZ1hDG+7mZ4M4ftxFFZrhtiT0OXuwfBzmNtB3xhsJtYszPeizw33c9YNp8rvehKT3c4ldDCW6kA==
   dependencies:
     "@jest/create-cache-key-function" "^27.0.1"
     "@react-native-community/cli" "^6.0.0"
@@ -7935,12 +7945,12 @@ react-native@^0.65.0-0:
     "@react-native-community/cli-platform-ios" "^6.0.0"
     "@react-native/assets" "1.0.0"
     "@react-native/normalize-color" "1.0.0"
-    "@react-native/polyfills" "1.0.0"
+    "@react-native/polyfills" "2.0.0"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     base64-js "^1.1.2"
     event-target-shim "^5.0.1"
-    hermes-engine "~0.8.1"
+    hermes-engine "~0.9.0"
     invariant "^2.2.4"
     jsc-android "^250230.2.1"
     metro-babel-register "0.66.2"
@@ -7951,7 +7961,8 @@ react-native@^0.65.0-0:
     pretty-format "^26.5.2"
     promise "^8.0.3"
     prop-types "^15.7.2"
-    react-devtools-core "^4.6.0"
+    react-devtools-core "^4.13.0"
+    react-native-codegen "^0.0.7"
     react-refresh "^0.4.0"
     regenerator-runtime "^0.13.2"
     scheduler "^0.20.2"
@@ -8340,7 +8351,7 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.20.1, scheduler@^0.20.2:
+scheduler@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
   integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==


### PR DESCRIPTION
### Description

Bumps react-native and react-native-windows to 0.66.

This also fixes all dep-check warnings.

### Test plan

CI should pass.