### PR TITLE
docs(dep-check): improve usage documentation

### DIFF
--- a/change/@rnx-kit-dep-check-e9842ae4-355a-490d-a83a-e1f913519214.json
+++ b/change/@rnx-kit-dep-check-e9842ae4-355a-490d-a83a-e1f913519214.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Improve usage documentation.",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/dep-check/README.md
+++ b/packages/dep-check/README.md
@@ -33,15 +33,17 @@ Examples:
   ```sh
   yarn rnx-dep-check --vigilant 0.64
   ```
-- Initialize a config for current library package:
+- Initialize a config for your app (or library):
   ```sh
-  yarn rnx-dep-check --init library
+  yarn rnx-dep-check --init app
+  # or specify `library` for a library
   ```
 - Apply changes suggested by dep-check:
   ```sh
   yarn rnx-dep-check --write
   ```
-- Update supported react-native versions or bump version used for development:
+- Interactively update supported react-native versions (or bump version used for
+  development):
   ```sh
   yarn rnx-dep-check --set-version
   ```

--- a/packages/dep-check/README.md
+++ b/packages/dep-check/README.md
@@ -6,14 +6,45 @@
 `@rnx-kit/dep-check` manages React Native dependencies for a package, based on
 its needs and requirements.
 
+## Installation
+
+```sh
+yarn add @rnx-kit/dep-check --dev
+```
+
+or if you're using npm
+
+```sh
+npm add --save-dev @rnx-kit/dep-check
+```
+
 ## Usage
 
 ```sh
-rnx-dep-check [options] [/path/to/package.json]
+yarn rnx-dep-check [options] [/path/to/package.json]
 ```
 
 Providing a path to `package.json` is optional. If omitted, it will look for one
 using Node module resolution.
+
+Examples:
+
+- Ensure dependencies are compatible with react-native 0.64 without a config:
+  ```sh
+  yarn rnx-dep-check --vigilant 0.64
+  ```
+- Initialize a config for current library package:
+  ```sh
+  yarn rnx-dep-check --init library
+  ```
+- Apply changes suggested by dep-check:
+  ```sh
+  yarn rnx-dep-check --write
+  ```
+- Update supported react-native versions or bump version used for development:
+  ```sh
+  yarn rnx-dep-check --set-version
+  ```
 
 ### `--custom-profiles <module>`
 


### PR DESCRIPTION
### Description

Make it clearer that `@rnx-kit/dep-check` should be installed, and provide some usage examples.

### Test plan

n/a