### PR TITLE
fix(eslint-plugin): re-enable no-unused-vars

### DIFF
--- a/change/@rnx-kit-eslint-plugin-f6bccbd6-3946-41a9-a198-b81f634b122c.json
+++ b/change/@rnx-kit-eslint-plugin-f6bccbd6-3946-41a9-a198-b81f634b122c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Re-enable no-unused-vars. It looks like optional chaining is no longer causing false positives.",
+  "packageName": "@rnx-kit/eslint-plugin",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/configs/recommended.js
+++ b/packages/eslint-plugin/src/configs/recommended.js
@@ -22,7 +22,7 @@ module.exports = {
   plugins: ["@rnx-kit", "@typescript-eslint"],
   rules: {
     "@rnx-kit/no-export-all": "warn",
-    "@typescript-eslint/no-unused-vars": "off", // too many false-positives with optional chaining
+    "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
     "@typescript-eslint/no-var-requires": "off",
     "react/prop-types": "off",
   },


### PR DESCRIPTION
### Description

It looks like optional chaining is no longer causing false positives.

### Test plan

CI should pass.