### PR TITLE
Normalize package.json properties - main, types

### DIFF
--- a/change/@rnx-kit-bundle-diff-2f5d5205-2db7-421f-a988-6fb714c02a52.json
+++ b/change/@rnx-kit-bundle-diff-2f5d5205-2db7-421f-a988-6fb714c02a52.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/bundle-diff",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-cli-a365cd92-d1bf-4dc3-a864-f60be5ed727a.json
+++ b/change/@rnx-kit-cli-a365cd92-d1bf-4dc3-a864-f60be5ed727a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/cli",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-config-75f841ac-4ad9-4352-ad32-cf308063feac.json
+++ b/change/@rnx-kit-config-75f841ac-4ad9-4352-ad32-cf308063feac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/config",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-console-2e3de950-0e9c-4b73-a4e2-0b3f729155b4.json
+++ b/change/@rnx-kit-console-2e3de950-0e9c-4b73-a4e2-0b3f729155b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/console",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-esbuild-plugin-import-path-remapper-3a42a308-cf78-446e-bb55-9882299d21ae.json
+++ b/change/@rnx-kit-esbuild-plugin-import-path-remapper-3a42a308-cf78-446e-bb55-9882299d21ae.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/esbuild-plugin-import-path-remapper",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-metro-plugin-cyclic-dependencies-detector-4c77c378-5ba3-46a9-b2c1-0f9226811602.json
+++ b/change/@rnx-kit-metro-plugin-cyclic-dependencies-detector-4c77c378-5ba3-46a9-b2c1-0f9226811602.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-metro-plugin-duplicates-checker-4ba9b71e-8a0b-437c-bad2-e278b6f36fdd.json
+++ b/change/@rnx-kit-metro-plugin-duplicates-checker-4ba9b71e-8a0b-437c-bad2-e278b6f36fdd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/metro-plugin-duplicates-checker",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-metro-plugin-typescript-validation-59cdd394-5e69-44d7-9b15-75a1968c2bbd.json
+++ b/change/@rnx-kit-metro-plugin-typescript-validation-59cdd394-5e69-44d7-9b15-75a1968c2bbd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/metro-plugin-typescript-validation",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-metro-resolver-symlinks-e2ee751d-4905-4e5f-ad9b-b29e0f95bd22.json
+++ b/change/@rnx-kit-metro-resolver-symlinks-e2ee751d-4905-4e5f-ad9b-b29e0f95bd22.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/metro-resolver-symlinks",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-metro-serializer-b807efb4-7f2e-4f16-b8b1-fe3c7a7c148b.json
+++ b/change/@rnx-kit-metro-serializer-b807efb4-7f2e-4f16-b8b1-fe3c7a7c148b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/metro-serializer",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-metro-serializer-esbuild-0d5ded0c-6541-4f8d-8e1a-8df6bac5374d.json
+++ b/change/@rnx-kit-metro-serializer-esbuild-0d5ded0c-6541-4f8d-8e1a-8df6bac5374d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/metro-serializer-esbuild",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-metro-service-493fd946-6a90-4d5b-88f0-94118ca27176.json
+++ b/change/@rnx-kit-metro-service-493fd946-6a90-4d5b-88f0-94118ca27176.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/metro-service",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-third-party-notices-10a5e556-9a07-4c9f-8c2b-f0c0a7150b56.json
+++ b/change/@rnx-kit-third-party-notices-10a5e556-9a07-4c9f-8c2b-f0c0a7150b56.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/third-party-notices",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-tools-language-ead613c5-22dc-49c7-87d5-9bbc0e20a1aa.json
+++ b/change/@rnx-kit-tools-language-ead613c5-22dc-49c7-87d5-9bbc0e20a1aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/tools-language",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-tools-node-93518f6b-4fd0-42ed-9456-3cc87904396e.json
+++ b/change/@rnx-kit-tools-node-93518f6b-4fd0-42ed-9456-3cc87904396e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/tools-node",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-tools-react-native-578a5806-d65e-480d-80dd-dddf61ae3ced.json
+++ b/change/@rnx-kit-tools-react-native-578a5806-d65e-480d-80dd-dddf61ae3ced.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/tools-react-native",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-typescript-service-95b7a8e5-fbe7-4248-a7f5-f31d31056e90.json
+++ b/change/@rnx-kit-typescript-service-95b7a8e5-fbe7-4248-a7f5-f31d31056e90.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Normalize main and types fields across all packages which use them.",
+  "packageName": "@rnx-kit/typescript-service",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/bundle-diff/package.json
+++ b/packages/bundle-diff/package.json
@@ -8,6 +8,7 @@
     "lib/*"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "bin": {
     "rnx-bundle-diff": "lib/cli.js"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,8 +4,8 @@
   "description": "Command-line interface for working with kit packages in your repo",
   "homepage": "https://github.com/microsoft/rnx-kit/tree/main/packages/cli",
   "license": "MIT",
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -3,8 +3,8 @@
   "version": "0.4.13",
   "description": "Define and query information about a kit package",
   "license": "MIT",
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "build": "rnx-kit-scripts build",
     "depcheck": "rnx-kit-scripts depcheck",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -8,6 +8,7 @@
     "lib/*"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/esbuild-plugin-import-path-remapper/package.json
+++ b/packages/esbuild-plugin-import-path-remapper/package.json
@@ -8,6 +8,7 @@
     "lib/*"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/metro-plugin-cyclic-dependencies-detector/package.json
+++ b/packages/metro-plugin-cyclic-dependencies-detector/package.json
@@ -8,6 +8,7 @@
     "lib/*"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/metro-plugin-duplicates-checker/package.json
+++ b/packages/metro-plugin-duplicates-checker/package.json
@@ -8,6 +8,7 @@
     "lib/*"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "bin": {
     "check-duplicates": "lib/index.js"
   },

--- a/packages/metro-plugin-typescript-validation/package.json
+++ b/packages/metro-plugin-typescript-validation/package.json
@@ -8,6 +8,7 @@
     "lib/*"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/metro-resolver-symlinks/package.json
+++ b/packages/metro-resolver-symlinks/package.json
@@ -9,6 +9,7 @@
     "lib/*.js"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -8,6 +8,7 @@
     "lib/*"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/metro-serializer/package.json
+++ b/packages/metro-serializer/package.json
@@ -8,6 +8,7 @@
     "lib/*"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/metro-service/package.json
+++ b/packages/metro-service/package.json
@@ -8,6 +8,7 @@
     "lib/*"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/third-party-notices/package.json
+++ b/packages/third-party-notices/package.json
@@ -9,6 +9,7 @@
     "lib"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "bin": {
     "build-tpn": "./lib/build-tpn.js"
   },

--- a/packages/tools-language/package.json
+++ b/packages/tools-language/package.json
@@ -14,6 +14,7 @@
     "properties.d.ts"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/tools-node/package.json
+++ b/packages/tools-node/package.json
@@ -16,6 +16,7 @@
     "path.d.ts"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/tools-react-native/package.json
+++ b/packages/tools-react-native/package.json
@@ -10,6 +10,7 @@
     "platform.d.ts"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/typescript-service/package.json
+++ b/packages/typescript-service/package.json
@@ -8,6 +8,7 @@
     "lib/*"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",


### PR DESCRIPTION
### Description

Normalize the use of `main` and `types` across all packages in the repo. Make sure they are specified, when applicable, and that they all follow the same pattern.

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

CI tests pass.

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
