### PR TITLE
chore(metro-swc-worker): bump @rnx-kit/metro-serializer-esbuild to avoid dupes

### DIFF
--- a/change/@rnx-kit-metro-swc-worker-b82ead06-11cd-4c53-a914-c35b64ff5cb2.json
+++ b/change/@rnx-kit-metro-swc-worker-b82ead06-11cd-4c53-a914-c35b64ff5cb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump @rnx-kit/metro-serializer-esbuild to avoid dupes in the repo",
+  "packageName": "@rnx-kit/metro-swc-worker",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/metro-swc-worker/package.json
+++ b/packages/metro-swc-worker/package.json
@@ -20,7 +20,7 @@
     "lint": "rnx-kit-scripts lint"
   },
   "dependencies": {
-    "@rnx-kit/metro-serializer-esbuild": "^0.0.14",
+    "@rnx-kit/metro-serializer-esbuild": "^0.0.17",
     "@swc/core": "^1.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description

Bump `@rnx-kit/metro-serializer-esbuild` to avoid dupes in the repo.

### Test plan

CI should pass.