### PR TITLE
fix(eslint-plugin): no-export-all fails to parse files outside project

### DIFF
--- a/change/@rnx-kit-eslint-plugin-c299df5c-2e1a-43ef-ac82-5c637225d92b.json
+++ b/change/@rnx-kit-eslint-plugin-c299df5c-2e1a-43ef-ac82-5c637225d92b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix no-export-all failing to parse files that are outside the TypeScript project",
+  "packageName": "@rnx-kit/eslint-plugin",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/test/no-export-all.test.ts
+++ b/packages/eslint-plugin/test/no-export-all.test.ts
@@ -59,6 +59,10 @@ describe("disallows `export *`", () => {
       "export default 'Arnold';",
       "const name = 'Arnold'; export { name as default };",
       "export { escape } from 'chopper';",
+      {
+        code: "export * from './internal';",
+        options: [{ expand: "external-only" }],
+      },
     ],
     invalid: [
       {
@@ -88,6 +92,13 @@ describe("disallows `export *`", () => {
         code: "export * from 'types';",
         errors: 1,
         output: "export type { IChopper, Predator } from 'types';",
+      },
+      {
+        code: "export * from './internal'; export * from 'types';",
+        errors: 1,
+        output:
+          "export * from './internal'; export type { IChopper, Predator } from 'types';",
+        options: [{ expand: "external-only" }],
       },
     ],
   });


### PR DESCRIPTION
### Description

Fix no-export-all failing to parse files that are outside the TypeScript project. Also adds an option for ignoring `export *` from internal files.

### Test plan

CI should pass. @dzearing should validate :)