### PR TITLE
fix(config): `projectRoot` default value overrides the value from Metro config

### DIFF
--- a/change/@rnx-kit-cli-d03d7e0b-daca-4343-ad38-53fe5c88851c.json
+++ b/change/@rnx-kit-cli-d03d7e0b-daca-4343-ad38-53fe5c88851c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Default value for `projectRoot` overrides value in Metro config",
+  "packageName": "@rnx-kit/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-config-fa9c8389-7dff-455f-9324-4782d9897632.json
+++ b/change/@rnx-kit-config-fa9c8389-7dff-455f-9324-4782d9897632.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Default value for `projectRoot` overrides value in Metro config",
+  "packageName": "@rnx-kit/config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -104,16 +104,20 @@ export async function rnxStart(
   // load Metro configuration, applying overrides from the command line
   const metroConfig = await loadMetroConfig(cliConfig, {
     ...cliOptions,
-    projectRoot: path.resolve(serverConfig.projectRoot),
+    ...(serverConfig.projectRoot
+      ? { projectRoot: path.resolve(serverConfig.projectRoot) }
+      : undefined),
     reporter,
-    ...(serverConfig.sourceExts ? { sourceExts: serverConfig.sourceExts } : {}),
+    ...(serverConfig.sourceExts
+      ? { sourceExts: serverConfig.sourceExts }
+      : undefined),
     ...(serverConfig.assetPlugins
       ? {
           assetPlugins: serverConfig.assetPlugins.map((p) =>
             require.resolve(p)
           ),
         }
-      : {}),
+      : undefined),
   });
 
   // prepare for typescript validation, if requested

--- a/packages/config/src/bundleConfig.ts
+++ b/packages/config/src/bundleConfig.ts
@@ -8,17 +8,6 @@ import type { OutputOptions } from "metro";
  */
 export type BundlerRuntimeParameters = {
   /**
-   * Path to the root of your react-native experience project. The bundle server uses
-   * this root path to resolve all web requests. Either absolute, or relative to the
-   * package.
-   *
-   * Note that `projectRoot` should also contain your Babel config, otherwise
-   * Metro won't be able to find it. For details, see
-   * https://github.com/microsoft/rnx-kit/issues/706.
-   */
-  projectRoot?: string;
-
-  /**
    * Choose whether to detect cycles in the dependency graph. If true, then a default set
    * of options will be used. Otherwise the object allows for fine-grained control over
    * the detection process.

--- a/packages/config/src/bundleConfig.ts
+++ b/packages/config/src/bundleConfig.ts
@@ -8,6 +8,17 @@ import type { OutputOptions } from "metro";
  */
 export type BundlerRuntimeParameters = {
   /**
+   * Path to the root of your react-native experience project. The bundle server uses
+   * this root path to resolve all web requests. Either absolute, or relative to the
+   * package.
+   *
+   * Note that `projectRoot` should also contain your Babel config, otherwise
+   * Metro won't be able to find it. For details, see
+   * https://github.com/microsoft/rnx-kit/issues/706.
+   */
+  projectRoot?: string;
+
+  /**
    * Choose whether to detect cycles in the dependency graph. If true, then a default set
    * of options will be used. Otherwise the object allows for fine-grained control over
    * the detection process.

--- a/packages/config/src/getServerConfig.ts
+++ b/packages/config/src/getServerConfig.ts
@@ -14,7 +14,6 @@ export function getServerConfig(
   config: KitConfig
 ): ServerWithRequiredParameters {
   const defaultConfig: ServerWithRequiredParameters = {
-    projectRoot: process.cwd(),
     detectCyclicDependencies: true,
     detectDuplicateDependencies: true,
     typescriptValidation: true,

--- a/packages/config/src/getServerConfig.ts
+++ b/packages/config/src/getServerConfig.ts
@@ -14,7 +14,7 @@ export function getServerConfig(
   config: KitConfig
 ): ServerWithRequiredParameters {
   const defaultConfig: ServerWithRequiredParameters = {
-    projectRoot: "src",
+    projectRoot: process.cwd(),
     detectCyclicDependencies: true,
     detectDuplicateDependencies: true,
     typescriptValidation: true,

--- a/packages/config/src/serverConfig.ts
+++ b/packages/config/src/serverConfig.ts
@@ -6,7 +6,11 @@ export type ServerRequiredParameters = BundlerRuntimeParameters & {
    * this root path to resolve all web requests. Either absolute, or relative to the
    * package.
    *
-   * @default "src"
+   * Note that `projectRoot` should also contain your Babel config, otherwise
+   * Metro won't be able to find it. For details, see
+   * https://github.com/microsoft/rnx-kit/issues/706.
+   *
+   * @default `process.cwd()`
    */
   projectRoot: string;
 };

--- a/packages/config/src/serverConfig.ts
+++ b/packages/config/src/serverConfig.ts
@@ -1,12 +1,18 @@
 import type { BundlerRuntimeParameters } from "./bundleConfig";
 
-export type ServerRequiredParameters = Omit<
-  BundlerRuntimeParameters,
-  "projectRoot"
->;
+export type ServerRequiredParameters = BundlerRuntimeParameters;
 
 export type ServerParameters = Partial<ServerRequiredParameters> & {
-  projectRoot?: BundlerRuntimeParameters["projectRoot"];
+  /**
+   * Path to the root of your react-native experience project. The bundle server uses
+   * this root path to resolve all web requests. Either absolute, or relative to the
+   * package.
+   *
+   * Note that `projectRoot` should also contain your Babel config, otherwise
+   * Metro won't be able to find it. For details, see
+   * https://github.com/microsoft/rnx-kit/issues/706.
+   */
+  projectRoot?: string;
 
   /**
    * Additional asset plugins to be used by the Metro Babel transformer. Comma-separated

--- a/packages/config/src/serverConfig.ts
+++ b/packages/config/src/serverConfig.ts
@@ -1,21 +1,13 @@
 import type { BundlerRuntimeParameters } from "./bundleConfig";
 
-export type ServerRequiredParameters = BundlerRuntimeParameters & {
-  /**
-   * Path to the root of your react-native experience project. The bundle server uses
-   * this root path to resolve all web requests. Either absolute, or relative to the
-   * package.
-   *
-   * Note that `projectRoot` should also contain your Babel config, otherwise
-   * Metro won't be able to find it. For details, see
-   * https://github.com/microsoft/rnx-kit/issues/706.
-   *
-   * @default `process.cwd()`
-   */
-  projectRoot: string;
-};
+export type ServerRequiredParameters = Omit<
+  BundlerRuntimeParameters,
+  "projectRoot"
+>;
 
 export type ServerParameters = Partial<ServerRequiredParameters> & {
+  projectRoot?: BundlerRuntimeParameters["projectRoot"];
+
   /**
    * Additional asset plugins to be used by the Metro Babel transformer. Comma-separated
    * list containing plugin modules and/or absolute paths to plugin packages.

--- a/packages/config/test/getServerConfig.test.ts
+++ b/packages/config/test/getServerConfig.test.ts
@@ -29,7 +29,7 @@ function validateDefaultConfig(c: ServerConfig) {
     "typescriptValidation",
     "experimental_treeShake",
   ]);
-  expect(c.projectRoot).toEqual("src");
+  expect(c.projectRoot).toEqual(process.cwd());
   expect(c.detectCyclicDependencies).toBeTrue();
   expect(c.detectDuplicateDependencies).toBeTrue();
   expect(c.typescriptValidation).toBeTrue();

--- a/packages/config/test/getServerConfig.test.ts
+++ b/packages/config/test/getServerConfig.test.ts
@@ -23,13 +23,12 @@ const kitConfigWithServer: KitConfig = {
 
 function validateDefaultConfig(c: ServerConfig) {
   expect(c).toContainAllKeys([
-    "projectRoot",
     "detectCyclicDependencies",
     "detectDuplicateDependencies",
     "typescriptValidation",
     "experimental_treeShake",
   ]);
-  expect(c.projectRoot).toEqual(process.cwd());
+  expect(c.projectRoot).toBeUndefined();
   expect(c.detectCyclicDependencies).toBeTrue();
   expect(c.detectDuplicateDependencies).toBeTrue();
   expect(c.typescriptValidation).toBeTrue();

--- a/packages/test-app/metro.config.js
+++ b/packages/test-app/metro.config.js
@@ -5,7 +5,6 @@ const MetroSymlinksResolver = require("@rnx-kit/metro-resolver-symlinks");
 const blockList = exclusionList([/.*__fixtures__.*/]);
 
 module.exports = makeMetroConfig({
-  projectRoot: __dirname + "/src",
   resolver: {
     blacklistRE: blockList,
     blockList,

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -18,7 +18,7 @@
     "ios": "react-native run-ios",
     "macos": "react-native run-macos --scheme ReactTestApp",
     "windows": "react-native run-windows --sln windows\\SampleCrossApp.sln",
-    "start": "react-native rnx-start --project-root src"
+    "start": "react-native rnx-start"
   },
   "dependencies": {
     "react": "17.0.2",
@@ -86,6 +86,7 @@
       }
     },
     "server": {
+      "projectRoot": "src",
       "detectDuplicateDependencies": {
         "ignoredModules": [
           "react-is"

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -62,7 +62,7 @@
     "reactNativeVersion": "^0.66",
     "kitType": "app",
     "bundle": {
-      "entryPath": "index.ts",
+      "entryPath": "src/index.ts",
       "distPath": "dist",
       "assetsPath": "dist",
       "bundlePrefix": "main",


### PR DESCRIPTION
### Description

We don't actually need a default value for `projectRoot`, and it currently overrides the value in `metro.config.js`.

Resolves #631.

### Test plan

1. Build test app's dependencies:
   ```
   yarn
   cd packages/test-app
   yarn build --dependencies
   ```
2. Make sure bundle works: `yarn bundle`
3. Make sure dev server works: `yarn start`