### PR TITLE
fix(eslint-plugin): prefer parsing `.d.ts` over `.js`

### DIFF
--- a/change/@rnx-kit-eslint-plugin-ae9acd7d-6ab1-46dc-984d-7d010616e4bc.json
+++ b/change/@rnx-kit-eslint-plugin-ae9acd7d-6ab1-46dc-984d-7d010616e4bc.json
@@ -3,5 +3,5 @@
   "comment": "Prefer parsing `.d.ts` over `.js` so we don't lose type information",
   "packageName": "@rnx-kit/eslint-plugin",
   "email": "4123478+tido64@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@rnx-kit-eslint-plugin-ae9acd7d-6ab1-46dc-984d-7d010616e4bc.json
+++ b/change/@rnx-kit-eslint-plugin-ae9acd7d-6ab1-46dc-984d-7d010616e4bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Prefer parsing `.d.ts` over `.js` so we don't lose type information",
+  "packageName": "@rnx-kit/eslint-plugin",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/rules/no-export-all.js
+++ b/packages/eslint-plugin/src/rules/no-export-all.js
@@ -331,10 +331,15 @@ module.exports = {
                   lines.push(`export { ${names} } from ${node.source.raw};`);
                 }
                 if (result.types.length > 0) {
-                  const types = result.types.sort().join(", ");
-                  lines.push(
-                    `export type { ${types} } from ${node.source.raw};`
+                  const uniqueTypes = result.types.filter(
+                    (type) => !result.exports.includes(type)
                   );
+                  if (uniqueTypes.length > 0) {
+                    const types = uniqueTypes.sort().join(", ");
+                    lines.push(
+                      `export type { ${types} } from ${node.source.raw};`
+                    );
+                  }
                 }
                 return fixer.replaceText(node, lines.join("\n"));
               },

--- a/packages/eslint-plugin/src/rules/no-export-all.js
+++ b/packages/eslint-plugin/src/rules/no-export-all.js
@@ -77,7 +77,8 @@ function makeTraverser() {
 }
 
 /**
- * Resolves specified `moduleId` starting from `fromDir`.
+ * Resolves specified `moduleId` starting from `fromDir`. When possible, prefers
+ * `.d.ts` over `.js` as the latter does not contain type information.
  */
 const resolveFrom =
   /** @type {() => (fromDir: string, moduleId: string) => string} */
@@ -98,6 +99,14 @@ const resolveFrom =
           throw new Error(
             `Module not found: ${moduleId} (start path: ${fromDir})`
           );
+        }
+        if (m.endsWith(".js")) {
+          // `.js` files don't contain type information. If we find a `.d.ts`
+          // next to it, we should use that instead.
+          const typedef = m.replace(/\.js$/, ".d.ts");
+          if (fs.existsSync(typedef)) {
+            return typedef;
+          }
         }
         return m;
       };
@@ -206,7 +215,9 @@ function extractExports(context, moduleId, depth) {
               switch (node.declaration.type) {
                 case "ClassDeclaration":
                 // fallthrough
-                case "FunctionDeclaration": {
+                case "FunctionDeclaration":
+                // fallthrough
+                case "TSDeclareFunction": {
                   const name = node.declaration.id?.name;
                   if (name) {
                     result.exports.push(name);

--- a/packages/eslint-plugin/test/no-export-all.test.ts
+++ b/packages/eslint-plugin/test/no-export-all.test.ts
@@ -34,6 +34,15 @@ export interface IChopper {
 
 export declare function escape(): void;
 `,
+  "@fluentui/react-focus": `
+export declare const FocusZoneTabbableElements: {
+  none: 0;
+  all: 1;
+  inputOnly: 2;
+};
+
+export declare type FocusZoneTabbableElements = typeof FocusZoneTabbableElements[keyof typeof FocusZoneTabbableElements];
+`,
 });
 
 const config = {
@@ -111,6 +120,12 @@ describe("disallows `export *`", () => {
           "export type { IChopper, Predator } from 'types';"
         ),
         options: [{ expand: "external-only" }],
+      },
+      {
+        code: "export * from '@fluentui/react-focus';",
+        errors: 1,
+        output:
+          "export { FocusZoneTabbableElements } from '@fluentui/react-focus';",
       },
     ],
   });

--- a/packages/eslint-plugin/test/no-export-all.test.ts
+++ b/packages/eslint-plugin/test/no-export-all.test.ts
@@ -31,6 +31,8 @@ export type Predator = { kind: "$predator" };
 export interface IChopper {
   kind: "$helicopter"
 };
+
+export declare function escape(): void;
 `,
 });
 
@@ -48,6 +50,10 @@ const config = {
     sourceType: "module",
   },
 };
+
+function lines(...strings: string[]): string {
+  return strings.join("\n");
+}
 
 describe("disallows `export *`", () => {
   const ruleTester = new RuleTester(config);
@@ -68,10 +74,10 @@ describe("disallows `export *`", () => {
       {
         code: "export * from 'chopper';",
         errors: 1,
-        output: [
+        output: lines(
           "export { Chopper, escape, escapeRe, name, nameRe } from 'chopper';",
-          "export type { IChopper, IChopperRe, Predator, PredatorRe } from 'chopper';",
-        ].join("\n"),
+          "export type { IChopper, IChopperRe, Predator, PredatorRe } from 'chopper';"
+        ),
       },
       {
         code: "export * from 'conquerer';",
@@ -91,13 +97,19 @@ describe("disallows `export *`", () => {
       {
         code: "export * from 'types';",
         errors: 1,
-        output: "export type { IChopper, Predator } from 'types';",
+        output: lines(
+          "export { escape } from 'types';",
+          "export type { IChopper, Predator } from 'types';"
+        ),
       },
       {
-        code: "export * from './internal'; export * from 'types';",
+        code: lines("export * from './internal';", "export * from 'types';"),
         errors: 1,
-        output:
-          "export * from './internal'; export type { IChopper, Predator } from 'types';",
+        output: lines(
+          "export * from './internal';",
+          "export { escape } from 'types';",
+          "export type { IChopper, Predator } from 'types';"
+        ),
         options: [{ expand: "external-only" }],
       },
     ],


### PR DESCRIPTION
### Description

Prefer parsing `.d.ts` over `.js` so we don't lose type information.

### Test plan

CI should pass. @dzearing to verify his use cases.