### PR TITLE
chore(config): add missing repo information

### DIFF
--- a/change/@rnx-kit-config-0632782a-c34b-409d-b5d6-3b5d6d106661.json
+++ b/change/@rnx-kit-config-0632782a-c34b-409d-b5d6-3b5d6d106661.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add missing repo information",
+  "packageName": "@rnx-kit/config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -5,6 +5,11 @@
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/rnx-kit",
+    "directory": "packages/config"
+  },
   "scripts": {
     "build": "rnx-kit-scripts build",
     "depcheck": "rnx-kit-scripts depcheck",


### PR DESCRIPTION
### Description

Adds missing repo information to the `config` package.

Supersedes #762.

### Test plan

n/a