### PR TITLE
fix(eslint-plugin/no-export-all): handle non-string project field

### DIFF
--- a/change/@rnx-kit-eslint-plugin-6ae78891-af37-4832-ac76-9f22afe937c5.json
+++ b/change/@rnx-kit-eslint-plugin-6ae78891-af37-4832-ac76-9f22afe937c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Handle `project` field sometimes returning an array of strings, and add support for enums.",
+  "packageName": "@rnx-kit/eslint-plugin",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/eslint-plugin/src/rules/no-export-all.js
+++ b/packages/eslint-plugin/src/rules/no-export-all.js
@@ -51,15 +51,20 @@ function isEmpty(namedExports) {
 
 /**
  * Returns whether a module likely belongs to a project.
- * @param {string?} project
+ * @param {(string | string[])?} project
  * @param {string} modulePath
+ * @returns {boolean}
  */
 function isLikelyInProject(project, modulePath) {
-  return (
-    project &&
-    (modulePath.endsWith(".ts") || modulePath.endsWith(".tsx")) &&
-    !path.relative(path.dirname(project), modulePath).startsWith("..")
-  );
+  if (
+    !project ||
+    (!modulePath.endsWith(".ts") && !modulePath.endsWith(".tsx"))
+  ) {
+    return false;
+  }
+
+  const tsconfig = typeof project === "string" ? project : project[0];
+  return !path.relative(path.dirname(tsconfig), modulePath).startsWith("..");
 }
 
 /**
@@ -217,7 +222,9 @@ function extractExports(context, moduleId, depth) {
                 // fallthrough
                 case "FunctionDeclaration":
                 // fallthrough
-                case "TSDeclareFunction": {
+                case "TSDeclareFunction":
+                // fallthrough
+                case "TSEnumDeclaration": {
                   const name = node.declaration.id?.name;
                   if (name) {
                     result.exports.push(name);

--- a/packages/eslint-plugin/test/no-export-all.test.ts
+++ b/packages/eslint-plugin/test/no-export-all.test.ts
@@ -6,10 +6,15 @@ jest.mock("fs");
 require("fs").__setMocks({
   barbarian: "export const name = 'Conan';",
   chopper: `
-export type Predator = { kind: "$predator" };
+export enum Kind {
+  Predator = 0,
+  Helicopter,
+}
+
+export type Predator = { kind: Kind.Predator };
 
 export interface IChopper {
-  kind: "$helicopter"
+  kind: Kind.Helicopter
 };
 
 export class Chopper implements IChopper {};
@@ -84,7 +89,7 @@ describe("disallows `export *`", () => {
         code: "export * from 'chopper';",
         errors: 1,
         output: lines(
-          "export { Chopper, escape, escapeRe, name, nameRe } from 'chopper';",
+          "export { Chopper, Kind, escape, escapeRe, name, nameRe } from 'chopper';",
           "export type { IChopper, IChopperRe, Predator, PredatorRe } from 'chopper';"
         ),
       },


### PR DESCRIPTION
### Description

Handle `project` field sometimes returning an array of strings, and add support for enums.

### Test plan

CI should pass.