### PR TITLE
chore(security): scope internal scripts package to prevent hijacking

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,9 @@ jobs:
           fetch-depth: 0
       - name: Ensure rnx-kit packages come from our repository
         run: |
-          grep rnx-kit yarn.lock 1> /dev/null && exit 1
+          if grep rnx-kit yarn.lock; then
+            exit 1
+          fi
       - name: Deduplicate packages
         run: |
           npx yarn-deduplicate --list --fail

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,9 @@ jobs:
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      - name: Ensure rnx-kit packages come from our repository
+        run: |
+          grep rnx-kit yarn.lock 1> /dev/null && exit 1
       - name: Deduplicate packages
         run: |
           npx yarn-deduplicate --list --fail

--- a/change/@rnx-kit-babel-plugin-import-path-remapper-f1f7461e-56fd-4b31-bfb3-06ac263a3d7e.json
+++ b/change/@rnx-kit-babel-plugin-import-path-remapper-f1f7461e-56fd-4b31-bfb3-06ac263a3d7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/babel-plugin-import-path-remapper",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-babel-preset-metro-react-native-7f19519b-7b20-4478-897d-afeafabe10f2.json
+++ b/change/@rnx-kit-babel-preset-metro-react-native-7f19519b-7b20-4478-897d-afeafabe10f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/babel-preset-metro-react-native",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-bundle-diff-55776a2c-cf9b-4242-9772-d22b3e1c410a.json
+++ b/change/@rnx-kit-bundle-diff-55776a2c-cf9b-4242-9772-d22b3e1c410a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/bundle-diff",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-cli-8c616e65-2b06-4b33-a56c-c310f70149ce.json
+++ b/change/@rnx-kit-cli-8c616e65-2b06-4b33-a56c-c310f70149ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-config-e8a650ff-fec7-46c8-aec8-c917747d4fe3.json
+++ b/change/@rnx-kit-config-e8a650ff-fec7-46c8-aec8-c917747d4fe3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-console-e6f51c23-ed8c-4203-a3c0-21e8ae6409a8.json
+++ b/change/@rnx-kit-console-e6f51c23-ed8c-4203-a3c0-21e8ae6409a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/console",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-dep-check-27fbbb48-e387-4ffb-911d-e7ad2f389f6a.json
+++ b/change/@rnx-kit-dep-check-27fbbb48-e387-4ffb-911d-e7ad2f389f6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-esbuild-plugin-import-path-remapper-83ed00cd-3f75-4f94-bc5d-c02169310d0d.json
+++ b/change/@rnx-kit-esbuild-plugin-import-path-remapper-83ed00cd-3f75-4f94-bc5d-c02169310d0d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/esbuild-plugin-import-path-remapper",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-eslint-plugin-bb884841-becc-4011-9b43-5be5690b099d.json
+++ b/change/@rnx-kit-eslint-plugin-bb884841-becc-4011-9b43-5be5690b099d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/eslint-plugin",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-golang-b2fa31d6-527f-47ba-b3c1-8aebfb5da7d9.json
+++ b/change/@rnx-kit-golang-b2fa31d6-527f-47ba-b3c1-8aebfb5da7d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/golang",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-jest-preset-fd260fb6-8efb-4aa4-a544-c2ecf04b5758.json
+++ b/change/@rnx-kit-jest-preset-fd260fb6-8efb-4aa4-a544-c2ecf04b5758.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/jest-preset",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-config-d076a325-93b3-4e9c-9a89-59c83d53c01b.json
+++ b/change/@rnx-kit-metro-config-d076a325-93b3-4e9c-9a89-59c83d53c01b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/metro-config",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-plugin-cyclic-dependencies-detector-ee788607-2b14-4c0b-af46-d04c68a0a3e4.json
+++ b/change/@rnx-kit-metro-plugin-cyclic-dependencies-detector-ee788607-2b14-4c0b-af46-d04c68a0a3e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-plugin-duplicates-checker-96a8d225-bb54-4514-9dd7-74579e775938.json
+++ b/change/@rnx-kit-metro-plugin-duplicates-checker-96a8d225-bb54-4514-9dd7-74579e775938.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/metro-plugin-duplicates-checker",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-plugin-typescript-validation-f6035c58-cbf7-4caa-9753-c0c5ae4ce2d5.json
+++ b/change/@rnx-kit-metro-plugin-typescript-validation-f6035c58-cbf7-4caa-9753-c0c5ae4ce2d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/metro-plugin-typescript-validation",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-resolver-symlinks-5a5d1fa1-3564-443f-98eb-d81b0ae90675.json
+++ b/change/@rnx-kit-metro-resolver-symlinks-5a5d1fa1-3564-443f-98eb-d81b0ae90675.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/metro-resolver-symlinks",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-serializer-esbuild-98138402-0633-408d-a983-098e8083843c.json
+++ b/change/@rnx-kit-metro-serializer-esbuild-98138402-0633-408d-a983-098e8083843c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/metro-serializer-esbuild",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-serializer-f113da02-5fd8-48c1-98dd-56f58ea81d29.json
+++ b/change/@rnx-kit-metro-serializer-f113da02-5fd8-48c1-98dd-56f58ea81d29.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/metro-serializer",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-service-b3953195-41ef-498e-a01d-a458e8063a2a.json
+++ b/change/@rnx-kit-metro-service-b3953195-41ef-498e-a01d-a458e8063a2a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/metro-service",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-metro-swc-worker-5525f02f-d9ae-430e-a68b-c4ea88e78042.json
+++ b/change/@rnx-kit-metro-swc-worker-5525f02f-d9ae-430e-a68b-c4ea88e78042.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/metro-swc-worker",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-third-party-notices-304f4f83-86cd-4fd2-940d-6b993cc2e19b.json
+++ b/change/@rnx-kit-third-party-notices-304f4f83-86cd-4fd2-940d-6b993cc2e19b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/third-party-notices",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-tools-language-5c17b0fc-7b8a-4e77-8d5b-5bdd13c731e2.json
+++ b/change/@rnx-kit-tools-language-5c17b0fc-7b8a-4e77-8d5b-5bdd13c731e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/tools-language",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-tools-node-234b1c17-2c75-4664-8f2e-ddf49dd5d49b.json
+++ b/change/@rnx-kit-tools-node-234b1c17-2c75-4664-8f2e-ddf49dd5d49b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/tools-node",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-tools-react-native-caa7c7b0-e71b-4208-905d-cc0256f97216.json
+++ b/change/@rnx-kit-tools-react-native-caa7c7b0-e71b-4208-905d-cc0256f97216.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/tools-react-native",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-typescript-react-native-compiler-990e5448-9398-4db3-bace-a945f5f9fae9.json
+++ b/change/@rnx-kit-typescript-react-native-compiler-990e5448-9398-4db3-bace-a945f5f9fae9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/typescript-react-native-compiler",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-typescript-react-native-resolver-8d1b1b69-55d7-4377-accc-f8f17cbbed90.json
+++ b/change/@rnx-kit-typescript-react-native-resolver-8d1b1b69-55d7-4377-accc-f8f17cbbed90.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/typescript-react-native-resolver",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@rnx-kit-typescript-service-d234d097-e184-4086-8a26-52ee71472887.json
+++ b/change/@rnx-kit-typescript-service-d234d097-e184-4086-8a26-52ee71472887.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed rnx-kit-scripts package to @rnx-kit/scripts to prevent hijacking",
+  "packageName": "@rnx-kit/typescript-service",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/babel-plugin-import-path-remapper/just.config.js
+++ b/packages/babel-plugin-import-path-remapper/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/babel-plugin-import-path-remapper/package.json
+++ b/packages/babel-plugin-import-path-remapper/package.json
@@ -25,11 +25,11 @@
     "@rnx-kit/tools-node": "^1.2.4"
   },
   "devDependencies": {
+    "@rnx-kit/scripts": "*",
     "@types/babel__core": "^7.0.0",
     "@types/babel__helper-plugin-utils": "^7.0.0",
     "@types/jest": "^27.0.0",
     "prettier": "^2.0.0",
-    "rnx-kit-scripts": "*",
     "typescript": "^4.0.0"
   },
   "eslintConfig": {

--- a/packages/babel-plugin-import-path-remapper/tsconfig.json
+++ b/packages/babel-plugin-import-path-remapper/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "compilerOptions": {
     "noEmit": true
   },

--- a/packages/babel-preset-metro-react-native/just.config.js
+++ b/packages/babel-preset-metro-react-native/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/babel-preset-metro-react-native/package.json
+++ b/packages/babel-preset-metro-react-native/package.json
@@ -34,10 +34,10 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@rnx-kit/babel-plugin-import-path-remapper": "*",
+    "@rnx-kit/scripts": "*",
     "@types/babel__core": "^7.0.0",
     "@types/jest": "^27.0.0",
     "prettier": "^2.0.0",
-    "rnx-kit-scripts": "*",
     "typescript": "^4.0.0"
   },
   "depcheck": {

--- a/packages/babel-preset-metro-react-native/tsconfig.json
+++ b/packages/babel-preset-metro-react-native/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "compilerOptions": {
     "noEmit": true
   },

--- a/packages/bundle-diff/just.config.js
+++ b/packages/bundle-diff/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/bundle-diff/package.json
+++ b/packages/bundle-diff/package.json
@@ -24,15 +24,15 @@
     "test": "rnx-kit-scripts test"
   },
   "devDependencies": {
+    "@rnx-kit/scripts": "*",
     "@types/jest": "^27.0.0",
     "prettier": "^2.0.0",
-    "rnx-kit-scripts": "*",
     "typescript": "^4.0.0"
   },
   "eslintConfig": {
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   }
 }

--- a/packages/bundle-diff/tsconfig.json
+++ b/packages/bundle-diff/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"]
 }

--- a/packages/cli/just.config.js
+++ b/packages/cli/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,10 +46,10 @@
   },
   "devDependencies": {
     "@react-native-community/cli-types": "^6.0.0",
+    "@rnx-kit/scripts": "*",
     "@types/metro": "^0.66.0",
     "@types/metro-config": "^0.66.0",
     "jest-extended": "^0.11.5",
-    "rnx-kit-scripts": "*",
     "typescript": "^4.0.0"
   },
   "depcheck": {
@@ -63,7 +63,7 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts",
+    "preset": "@rnx-kit/scripts",
     "setupFilesAfterEnv": [
       "jest-extended"
     ]

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"]
 }

--- a/packages/config/just.config.js
+++ b/packages/config/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -26,13 +26,13 @@
   "devDependencies": {
     "@rnx-kit/metro-plugin-cyclic-dependencies-detector": "*",
     "@rnx-kit/metro-plugin-duplicates-checker": "*",
+    "@rnx-kit/scripts": "*",
     "@rnx-kit/tools-react-native": "*",
     "@types/lodash": "^4.14.172",
     "@types/metro": "^0.66.0",
     "@types/node": "^14.15.0",
     "@types/semver": "^7.0.0",
-    "jest-extended": "^0.11.5",
-    "rnx-kit-scripts": "0.1.1"
+    "jest-extended": "^0.11.5"
   },
   "depcheck": {
     "ignoreMatches": [
@@ -43,7 +43,7 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts",
+    "preset": "@rnx-kit/scripts",
     "setupFilesAfterEnv": [
       "jest-extended"
     ]

--- a/packages/config/test/__fixtures__/in-config-js/package.json
+++ b/packages/config/test/__fixtures__/in-config-js/package.json
@@ -3,14 +3,6 @@
   "version": "0.0.1",
   "description": "Package with kit options defined in config js file",
   "private": true,
-  "scripts": {},
-  "dependencies": {
-    "path": "^0.12.7"
-  },
-  "devDependencies": {
-    "@types/node": "^14.14.20",
-    "rnx-kit-scripts": "0.1.1"
-  },
   "author": "",
   "license": "MIT"
 }

--- a/packages/config/test/__fixtures__/in-package/package.json
+++ b/packages/config/test/__fixtures__/in-package/package.json
@@ -3,14 +3,6 @@
   "version": "0.0.1",
   "description": "Package with kit behavior defined in package json",
   "private": true,
-  "scripts": {},
-  "dependencies": {
-    "path": "^0.12.7"
-  },
-  "devDependencies": {
-    "@types/node": "^14.14.20",
-    "rnx-kit-scripts": "0.1.1"
-  },
   "author": "",
   "license": "MIT",
   "rnx-kit": {

--- a/packages/config/test/__fixtures__/not-present/package.json
+++ b/packages/config/test/__fixtures__/not-present/package.json
@@ -3,14 +3,6 @@
   "version": "0.0.1",
   "description": "Package with no kit behavior defined",
   "private": true,
-  "scripts": {},
-  "dependencies": {
-    "path": "^0.12.7"
-  },
-  "devDependencies": {
-    "@types/node": "^14.14.20",
-    "rnx-kit-scripts": "0.1.1"
-  },
   "author": "",
   "license": "MIT"
 }

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"],
   "exclude": ["src/__fixtures__/**/*", "src/__snapshots__/**/*"]
 }

--- a/packages/console/just.config.js
+++ b/packages/console/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -24,14 +24,14 @@
     "chalk": "^4.1.0"
   },
   "devDependencies": {
+    "@rnx-kit/scripts": "*",
     "@types/jest": "^27.0.0",
-    "@types/node": "^14.15.0",
-    "rnx-kit-scripts": "*"
+    "@types/node": "^14.15.0"
   },
   "eslintConfig": {
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   }
 }

--- a/packages/console/tsconfig.json
+++ b/packages/console/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"]
 }

--- a/packages/dep-check/just.config.js
+++ b/packages/dep-check/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/dep-check/package.json
+++ b/packages/dep-check/package.json
@@ -39,19 +39,19 @@
     "yargs": "^16.0.0"
   },
   "devDependencies": {
+    "@rnx-kit/scripts": "*",
     "@types/jest": "^27.0.0",
     "@types/lodash": "^4.14.172",
     "@types/prompts": "^2.0.0",
     "@types/semver": "^7.0.0",
     "@types/yargs": "^16.0.0",
     "markdown-table": "^2.0.0",
-    "rnx-kit-scripts": "*",
     "typescript": "^4.0.0"
   },
   "eslintConfig": {
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   }
 }

--- a/packages/dep-check/tsconfig.json
+++ b/packages/dep-check/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "compilerOptions": {
     "lib": ["ES2019.Object"]
   },

--- a/packages/esbuild-plugin-import-path-remapper/just.config.js
+++ b/packages/esbuild-plugin-import-path-remapper/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/esbuild-plugin-import-path-remapper/package.json
+++ b/packages/esbuild-plugin-import-path-remapper/package.json
@@ -21,9 +21,9 @@
     "test": "rnx-kit-scripts test"
   },
   "devDependencies": {
+    "@rnx-kit/scripts": "*",
     "prettier": "^2.0.0",
-    "esbuild": "^0.13.4",
-    "rnx-kit-scripts": "*"
+    "esbuild": "^0.13.4"
   },
   "depcheck": {
     "ignorePatterns": [
@@ -34,6 +34,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   }
 }

--- a/packages/esbuild-plugin-import-path-remapper/tsconfig.json
+++ b/packages/esbuild-plugin-import-path-remapper/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"],
   "compilerOptions": {
     "outDir": "lib"

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -27,7 +27,7 @@ index d9daf8f..9ca1826 100644
    "dependencies": {
      "chalk": "^4.1.0",
 @@ -37,6 +39,9 @@
-     "rnx-kit-scripts": "*",
+     "@rnx-kit/scripts": "*",
      "typescript": "^4.0.0"
    },
 +  "eslintConfig": {

--- a/packages/eslint-config/just.config.js
+++ b/packages/eslint-config/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/eslint-plugin/just.config.js
+++ b/packages/eslint-plugin/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -53,6 +53,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   }
 }

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "compilerOptions": {
     "noEmit": true
   },

--- a/packages/golang/tsconfig.json
+++ b/packages/golang/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "compilerOptions": {
     "noEmit": true
   },

--- a/packages/jest-preset/just.config.js
+++ b/packages/jest-preset/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -41,8 +41,8 @@
   "devDependencies": {
     "@jest/types": "^27.0.0",
     "@rnx-kit/eslint-config": "*",
-    "@types/node": "^14.15.0",
-    "rnx-kit-scripts": "*"
+    "@rnx-kit/scripts": "*",
+    "@types/node": "^14.15.0"
   },
   "depcheck": {
     "ignoreMatches": [
@@ -54,6 +54,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   }
 }

--- a/packages/jest-preset/tsconfig.json
+++ b/packages/jest-preset/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "compilerOptions": {
     "noEmit": true,
     "sourceMap": false

--- a/packages/metro-config/just.config.js
+++ b/packages/metro-config/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -30,13 +30,13 @@
     "react-native": "*"
   },
   "devDependencies": {
+    "@rnx-kit/scripts": "*",
     "@types/babel__core": "^7.0.0",
     "@types/jest": "^27.0.0",
     "@types/metro": "^0.66.0",
     "@types/metro-config": "^0.66.0",
     "metro-config": "^0.66.2",
     "prettier": "^2.0.0",
-    "rnx-kit-scripts": "*",
     "type-fest": "^2.1.0",
     "typescript": "^4.0.0"
   },
@@ -50,6 +50,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   }
 }

--- a/packages/metro-config/tsconfig.json
+++ b/packages/metro-config/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "compilerOptions": {
     "noEmit": true
   },

--- a/packages/metro-plugin-cyclic-dependencies-detector/just.config.js
+++ b/packages/metro-plugin-cyclic-dependencies-detector/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/metro-plugin-cyclic-dependencies-detector/package.json
+++ b/packages/metro-plugin-cyclic-dependencies-detector/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@rnx-kit/metro-serializer": "*",
+    "@rnx-kit/scripts": "*",
     "@types/jest": "^27.0.0",
     "@types/metro": "^0.66.0",
     "@types/node": "^14.15.0",
     "prettier": "^2.0.0",
-    "rnx-kit-scripts": "*",
     "typescript": "^4.0.0"
   },
   "depcheck": {
@@ -42,6 +42,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   }
 }

--- a/packages/metro-plugin-cyclic-dependencies-detector/tsconfig.json
+++ b/packages/metro-plugin-cyclic-dependencies-detector/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"]
 }

--- a/packages/metro-plugin-duplicates-checker/just.config.js
+++ b/packages/metro-plugin-duplicates-checker/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/metro-plugin-duplicates-checker/package.json
+++ b/packages/metro-plugin-duplicates-checker/package.json
@@ -29,12 +29,12 @@
   },
   "devDependencies": {
     "@rnx-kit/metro-serializer": "*",
+    "@rnx-kit/scripts": "*",
     "@types/jest": "^27.0.0",
     "@types/metro": "^0.66.0",
     "@types/metro-source-map": "^0.66.0",
     "@types/node": "^14.15.0",
     "prettier": "^2.0.0",
-    "rnx-kit-scripts": "*",
     "typescript": "^4.0.0"
   },
   "depcheck": {
@@ -47,6 +47,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   }
 }

--- a/packages/metro-plugin-duplicates-checker/tsconfig.json
+++ b/packages/metro-plugin-duplicates-checker/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"]
 }

--- a/packages/metro-plugin-typescript-validation/just.config.js
+++ b/packages/metro-plugin-typescript-validation/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/metro-plugin-typescript-validation/package.json
+++ b/packages/metro-plugin-typescript-validation/package.json
@@ -27,10 +27,10 @@
   },
   "devDependencies": {
     "@rnx-kit/metro-serializer": "*",
+    "@rnx-kit/scripts": "*",
     "@types/metro": "^0.66.0",
     "@types/node": "^14.15.0",
-    "@types/yargs": "^16.0.0",
-    "rnx-kit-scripts": "*"
+    "@types/yargs": "^16.0.0"
   },
   "depcheck": {
     "ignoreMatches": [
@@ -42,6 +42,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   }
 }

--- a/packages/metro-plugin-typescript-validation/tsconfig.json
+++ b/packages/metro-plugin-typescript-validation/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"]
 }

--- a/packages/metro-resolver-symlinks/just.config.js
+++ b/packages/metro-resolver-symlinks/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/metro-resolver-symlinks/package.json
+++ b/packages/metro-resolver-symlinks/package.json
@@ -26,15 +26,15 @@
   },
   "devDependencies": {
     "@rnx-kit/eslint-config": "*",
+    "@rnx-kit/scripts": "*",
     "@types/metro-resolver": "^0.66.0",
     "@types/node": "^14.15.0",
-    "metro-resolver": "^0.66.2",
-    "rnx-kit-scripts": "*"
+    "metro-resolver": "^0.66.2"
   },
   "eslintConfig": {
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   }
 }

--- a/packages/metro-resolver-symlinks/tsconfig.json
+++ b/packages/metro-resolver-symlinks/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src/*.ts"]
 }

--- a/packages/metro-serializer-esbuild/just.config.js
+++ b/packages/metro-serializer-esbuild/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -30,12 +30,12 @@
   },
   "devDependencies": {
     "@rnx-kit/metro-serializer": "*",
+    "@rnx-kit/scripts": "*",
     "@types/metro": "^0.66.0",
     "@types/metro-config": "^0.66.0",
     "@types/metro-transform-worker": "^0.66.0",
     "@types/semver": "^7.0.0",
-    "metro": "^0.66.2",
-    "rnx-kit-scripts": "*"
+    "metro": "^0.66.2"
   },
   "depcheck": {
     "ignoreMatches": [
@@ -47,6 +47,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   }
 }

--- a/packages/metro-serializer-esbuild/tsconfig.json
+++ b/packages/metro-serializer-esbuild/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "compilerOptions": {
     "target": "ES2017"
   },

--- a/packages/metro-serializer/just.config.js
+++ b/packages/metro-serializer/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/metro-serializer/package.json
+++ b/packages/metro-serializer/package.json
@@ -27,10 +27,10 @@
     "metro": ">=0.58.0"
   },
   "devDependencies": {
+    "@rnx-kit/scripts": "*",
     "@types/metro": "^0.66.0",
     "@types/semver": "^7.0.0",
-    "metro": "^0.66.2",
-    "rnx-kit-scripts": "*"
+    "metro": "^0.66.2"
   },
   "depcheck": {
     "ignoreMatches": []
@@ -39,6 +39,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   }
 }

--- a/packages/metro-serializer/tsconfig.json
+++ b/packages/metro-serializer/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"]
 }

--- a/packages/metro-service/just.config.js
+++ b/packages/metro-service/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/metro-service/package.json
+++ b/packages/metro-service/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@react-native-community/cli-types": "^6.0.0",
+    "@rnx-kit/scripts": "*",
     "@types/metro": "^0.66.0",
     "@types/metro-babel-transformer": "^0.66.0",
     "@types/metro-core": "^0.66.0",
@@ -50,8 +51,7 @@
     "metro-core": "^0.66.2",
     "metro-react-native-babel-transformer": "^0.66.2",
     "metro-resolver": "^0.66.2",
-    "metro-runtime": "^0.66.2",
-    "rnx-kit-scripts": "*"
+    "metro-runtime": "^0.66.2"
   },
   "depcheck": {
     "ignoreMatches": [
@@ -62,6 +62,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   }
 }

--- a/packages/metro-service/tsconfig.json
+++ b/packages/metro-service/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"]
 }

--- a/packages/metro-swc-worker/just.config.js
+++ b/packages/metro-swc-worker/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/metro-swc-worker/package.json
+++ b/packages/metro-swc-worker/package.json
@@ -28,9 +28,9 @@
   },
   "devDependencies": {
     "@rnx-kit/eslint-config": "*",
+    "@rnx-kit/scripts": "*",
     "@types/metro": "^0.66.0",
-    "@types/metro-transform-worker": "^0.66.0",
-    "rnx-kit-scripts": "*"
+    "@types/metro-transform-worker": "^0.66.0"
   },
   "depcheck": {
     "ignoreMatches": [
@@ -41,6 +41,6 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   }
 }

--- a/packages/metro-swc-worker/tsconfig.json
+++ b/packages/metro-swc-worker/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src/*.ts"]
 }

--- a/packages/test-app/just.config.js
+++ b/packages/test-app/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -43,20 +43,20 @@
     "@rnx-kit/metro-serializer-esbuild": "*",
     "@rnx-kit/metro-swc-worker": "*",
     "@rnx-kit/react-native-test-app-msal": "*",
+    "@rnx-kit/scripts": "*",
     "@types/react": "^17.0.2",
     "@types/react-native": "^0.64.0",
     "metro-react-native-babel-preset": "^0.66.2",
     "react-native-codegen": "^0.0.7",
     "react-native-test-app": "^0.9.0",
     "react-test-renderer": "^17.0.2",
-    "rnx-kit-scripts": "*",
     "typescript": "^4.0.0"
   },
   "eslintConfig": {
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   },
   "rnx-kit": {
     "reactNativeVersion": "^0.66",

--- a/packages/test-app/tsconfig.json
+++ b/packages/test-app/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "compilerOptions": {
     "checkJs": false
   },

--- a/packages/third-party-notices/just.config.js
+++ b/packages/third-party-notices/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/third-party-notices/package.json
+++ b/packages/third-party-notices/package.json
@@ -32,15 +32,15 @@
   },
   "devDependencies": {
     "@rnx-kit/eslint-config": "*",
+    "@rnx-kit/scripts": "*",
     "@types/jest": "^27.0.0",
     "@types/yargs": "^16.0.0",
-    "rnx-kit-scripts": "*",
     "typescript": "^4.0.0"
   },
   "eslintConfig": {
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts"
+    "preset": "@rnx-kit/scripts"
   }
 }

--- a/packages/third-party-notices/tsconfig.json
+++ b/packages/third-party-notices/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"]
 }

--- a/packages/tools-language/just.config.js
+++ b/packages/tools-language/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/tools-language/package.json
+++ b/packages/tools-language/package.json
@@ -27,17 +27,16 @@
     "test": "rnx-kit-scripts test",
     "update-readme": "rnx-kit-scripts update-api-readme"
   },
-  "dependencies": {},
   "devDependencies": {
+    "@rnx-kit/scripts": "*",
     "@types/node": "^14.15.0",
-    "jest-extended": "^0.11.5",
-    "rnx-kit-scripts": "*"
+    "jest-extended": "^0.11.5"
   },
   "eslintConfig": {
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts",
+    "preset": "@rnx-kit/scripts",
     "setupFilesAfterEnv": [
       "jest-extended"
     ]

--- a/packages/tools-language/tsconfig.json
+++ b/packages/tools-language/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"]
 }

--- a/packages/tools-node/just.config.js
+++ b/packages/tools-node/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/tools-node/package.json
+++ b/packages/tools-node/package.json
@@ -36,16 +36,16 @@
     "pkg-up": "^3.1.0"
   },
   "devDependencies": {
+    "@rnx-kit/scripts": "*",
     "@types/node": "^14.15.0",
     "jest-extended": "^0.11.5",
-    "rnx-kit-scripts": "*",
     "temp-dir": "^2.0.0"
   },
   "eslintConfig": {
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts",
+    "preset": "@rnx-kit/scripts",
     "setupFilesAfterEnv": [
       "jest-extended"
     ]

--- a/packages/tools-node/tsconfig.json
+++ b/packages/tools-node/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"]
 }

--- a/packages/tools-react-native/just.config.js
+++ b/packages/tools-react-native/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/tools-react-native/package.json
+++ b/packages/tools-react-native/package.json
@@ -25,15 +25,15 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@rnx-kit/scripts": "*",
     "@types/node": "^14.15.0",
-    "jest-extended": "^0.11.5",
-    "rnx-kit-scripts": "*"
+    "jest-extended": "^0.11.5"
   },
   "eslintConfig": {
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts",
+    "preset": "@rnx-kit/scripts",
     "setupFilesAfterEnv": [
       "jest-extended"
     ]

--- a/packages/tools-react-native/tsconfig.json
+++ b/packages/tools-react-native/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"]
 }

--- a/packages/typescript-react-native-compiler/just.config.js
+++ b/packages/typescript-react-native-compiler/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/typescript-react-native-compiler/package.json
+++ b/packages/typescript-react-native-compiler/package.json
@@ -31,9 +31,9 @@
     "chalk": "^4.1.0"
   },
   "devDependencies": {
+    "@rnx-kit/scripts": "*",
     "@types/node": "^14.15.0",
     "jest-extended": "^0.11.5",
-    "rnx-kit-scripts": "*",
     "temp-dir": "^2.0.0",
     "typescript": "^4.0.0"
   },
@@ -44,7 +44,7 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts",
+    "preset": "@rnx-kit/scripts",
     "setupFilesAfterEnv": [
       "jest-extended"
     ]

--- a/packages/typescript-react-native-compiler/tsconfig.json
+++ b/packages/typescript-react-native-compiler/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"]
 }

--- a/packages/typescript-react-native-resolver/just.config.js
+++ b/packages/typescript-react-native-resolver/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/typescript-react-native-resolver/package.json
+++ b/packages/typescript-react-native-resolver/package.json
@@ -24,9 +24,9 @@
     "@rnx-kit/tools-node": "^1.2.4"
   },
   "devDependencies": {
+    "@rnx-kit/scripts": "*",
     "@types/node": "^14.15.0",
     "jest-extended": "^0.11.5",
-    "rnx-kit-scripts": "*",
     "typescript": "^4.0.0"
   },
   "peerDependencies": {
@@ -36,7 +36,7 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts",
+    "preset": "@rnx-kit/scripts",
     "setupFilesAfterEnv": [
       "jest-extended"
     ]

--- a/packages/typescript-react-native-resolver/tsconfig.json
+++ b/packages/typescript-react-native-resolver/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"]
 }

--- a/packages/typescript-service/just.config.js
+++ b/packages/typescript-service/just.config.js
@@ -1,2 +1,2 @@
-const { configureJust } = require("rnx-kit-scripts");
+const { configureJust } = require("@rnx-kit/scripts");
 configureJust();

--- a/packages/typescript-service/package.json
+++ b/packages/typescript-service/package.json
@@ -24,9 +24,9 @@
     "@rnx-kit/tools-node": "^1.2.4"
   },
   "devDependencies": {
+    "@rnx-kit/scripts": "*",
     "@types/node": "^14.15.0",
     "jest-extended": "^0.11.5",
-    "rnx-kit-scripts": "*",
     "temp-dir": "^2.0.0",
     "typescript": "^4.0.0"
   },
@@ -37,7 +37,7 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "rnx-kit-scripts",
+    "preset": "@rnx-kit/scripts",
     "setupFilesAfterEnv": [
       "jest-extended"
     ]

--- a/packages/typescript-service/tsconfig.json
+++ b/packages/typescript-service/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"]
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rnx-kit-scripts",
-  "version": "0.1.1",
+  "name": "@rnx-kit/scripts",
+  "version": "1.0.0",
   "private": true,
   "main": "./lib/index.js",
   "bin": {

--- a/scripts/src/tasks/depcheck.js
+++ b/scripts/src/tasks/depcheck.js
@@ -26,7 +26,7 @@ function depcheckTask() {
     const options = mergeOneLevel(
       {
         ignorePatterns: ["/lib/*", "/lib-commonjs/*"],
-        ignoreMatches: ["@rnx-kit/eslint-config", "rnx-kit-scripts"],
+        ignoreMatches: ["@rnx-kit/eslint-config", "@rnx-kit/scripts"],
         specials: [
           depcheck.special.babel,
           depcheck.special.eslint,

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "rnx-kit-scripts/tsconfig-shared.json",
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "include": ["src"]
 }


### PR DESCRIPTION
### Description

We don't publish `rnx-kit-scripts` and are using Yarn workspaces to consume the package internally within the repository. Since we are using Yarn Classic, it does not understand `workspace:*` version syntax, which would've ensured that we will always resolve to a package within the workspace, but have to rely on `*` or matching exact version number. We are only using exact version number in one package, but that would've been enough to trigger an exploit if the version number of `rnx-kit-scripts` changed for any reason.

To mitigate this, the package has been moved under the `@rnx-kit` scope to prevent us from consuming malware. I've also made sure that we are using `*` everywhere, and added a CI step to scan `yarn.lock` for packages that should've come from the repository. In the future, when we migrate to npm or some later version of Yarn, we should start using `workspace:*` instead.

### Test plan

CI should pass.