### PR TITLE
[chore] Add reference to the RNEU talk in the readme

### DIFF
--- a/change/@rnx-kit-dep-check-6313c1f5-3ea0-4770-9ec5-f5adc5c2651b.json
+++ b/change/@rnx-kit-dep-check-6313c1f5-3ea0-4770-9ec5-f5adc5c2651b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add rneu mention",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "lsciandra@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/dep-check/README.md
+++ b/packages/dep-check/README.md
@@ -8,7 +8,7 @@ its needs and requirements.
 
 If you want to learn how dep-check is used at Microsoft, and see a demo of how
 it works in a monorepo - you can watch the
-["Improve all the repos – exploring Microsoft’s DevExp"](https://www.youtube.com/watch?v=DAEnPV78rQc)
+["Improve all the repos – exploring Microsoft’s DevExp"](https://youtu.be/DAEnPV78rQc?t=1085)
 talk by @kelset and @tido64 from React Native Europe 2021.
 
 ## Installation

--- a/packages/dep-check/README.md
+++ b/packages/dep-check/README.md
@@ -6,6 +6,11 @@
 `@rnx-kit/dep-check` manages React Native dependencies for a package, based on
 its needs and requirements.
 
+If you want to learn how dep-check is used at Microsoft, and see a demo of how
+it works in a monorepo - you can watch the
+["Improve all the repos – exploring Microsoft’s DevExp"](https://www.youtube.com/watch?v=DAEnPV78rQc)
+talk by @kelset and @tido64 from React Native Europe 2021.
+
 ## Installation
 
 ```sh


### PR DESCRIPTION
Similar to https://github.com/microsoft/react-native-test-app/pull/588, small PR to add a direct reference to the YT video in the readme: it should help provide some context and insights in how dep-check is and can be used.