### PR TITLE
fix(dep-check): fix dep-check not being executable

### DIFF
--- a/change/@rnx-kit-dep-check-6be639f6-f0c7-4faa-b126-20ad4ec8d6bd.json
+++ b/change/@rnx-kit-dep-check-6be639f6-f0c7-4faa-b126-20ad4ec8d6bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix dep-check not being executable",
+  "packageName": "@rnx-kit/dep-check",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/scripts/src/tasks/bundle.ts
+++ b/scripts/src/tasks/bundle.ts
@@ -8,6 +8,7 @@ export function bundle(): void {
   const manifest = fs.readFileSync("package.json", { encoding: "utf-8" });
   const { main, dependencies } = JSON.parse(manifest);
 
+  const targetPlatform = platform || "node";
   esbuild.build({
     bundle: true,
     entryPoints: ["src/index.ts"],
@@ -17,6 +18,8 @@ export function bundle(): void {
     ],
     minify,
     outfile: main,
-    platform: platform || "node",
+    platform: targetPlatform,
+    banner:
+      targetPlatform === "node" ? { js: "#!/usr/bin/env node" } : undefined,
   });
 }


### PR DESCRIPTION
### Description

dep-check 1.9.0 is missing the shebang.

### Test plan

Build dep-check and ensure that we have a shebang.

```
% yarn build
yarn run v1.22.17
$ rnx-kit-scripts build && rnx-kit-scripts bundle
[1:27:53 PM] ■ started 'build'
...
[1:27:57 PM] ■ finished 'build' in 3.74s
[1:27:57 PM] ■ started 'bundle'
[1:27:57 PM] ■ finished 'bundle' in 0.03s
✨  Done in 4.81s.

% head lib/index.js
#!/usr/bin/env node
var __create = Object.create;
var __defProp = Object.defineProperty;
var __defProps = Object.defineProperties;
var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
var __getOwnPropDescs = Object.getOwnPropertyDescriptors;
var __getOwnPropNames = Object.getOwnPropertyNames;
var __getOwnPropSymbols = Object.getOwnPropertySymbols;
var __getProtoOf = Object.getPrototypeOf;
var __hasOwnProp = Object.prototype.hasOwnProperty;
```