### PR TITLE
fix(template): add author field used by Podspecs

### DIFF
--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -5,6 +5,10 @@
   "description": "Template folder to use as baseline for new packages in rnx-kit",
   "homepage": "https://github.com/microsoft/rnx-kit/tree/main/packages/template#readme",
   "license": "MIT",
+  "author": {
+    "name": "Microsoft Open Source",
+    "email": "microsoftopensource@users.noreply.github.com"
+  },
   "files": [
     "lib/*"
   ],


### PR DESCRIPTION
### Description

Add `author` field to `package.json`. It is often used in Podspecs: https://github.com/microsoft/rnx-kit/blob/8caf9131a12d26137fedf7ca9b2dfc2ae1342742/packages/react-native-test-app-msal/ReactTestApp-MSAL.podspec#L9

### Test plan

n/a