### PR TITLE
ci: [skip ci] is now supported by GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '***NO_CI***')"
     steps:
       - name: Set up Git
         run: |

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint": "lage lint --verbose --grouped --no-cache",
     "preinstall": "node ./scripts/preinstall.js",
     "postinstall": "yarn build-tools",
-    "publish:beachball": "beachball publish --verbose --bump-deps -m\"📦 applying package updates ***NO_CI***\"",
+    "publish:beachball": "beachball publish --verbose --bump-deps -m\"📦 applying package updates [skip ci]\"",
     "rnx-dep-check": "yarn build-scope @rnx-kit/dep-check && scripts/rnx-dep-check.js",
     "test": "lage test --verbose --grouped",
     "update-readme": "yarn update-readme:main && lage update-readme",


### PR DESCRIPTION
### Description

See [GitHub Actions: Skip pull request and push workflows with [skip ci]](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/).

### Test plan

n/a