### PR TITLE
Minor fixes to TypeScript utility packages

### DIFF
--- a/change/@rnx-kit-typescript-react-native-resolver-c20ca636-2896-415e-b7a8-983df9bc24c4.json
+++ b/change/@rnx-kit-typescript-react-native-resolver-c20ca636-2896-415e-b7a8-983df9bc24c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "When modifying a TypeScript host, only change trace() when logging is enabled. Also, when changing file/directory APIs, bind the original calls to the host so that the 'this' reference is set properly.",
+  "packageName": "@rnx-kit/typescript-react-native-resolver",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-typescript-service-dc656710-e2b1-484f-8862-8a417a9841d2.json
+++ b/change/@rnx-kit-typescript-service-dc656710-e2b1-484f-8862-8a417a9841d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Don't format/print \"suggestion\" diagnostics. Doing so hits an internal debug assert in TypeScript.",
+  "packageName": "@rnx-kit/typescript-service",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/typescript-react-native-resolver/README.md
+++ b/packages/typescript-react-native-resolver/README.md
@@ -13,7 +13,5 @@ react-native resolution.
 The resolver uses the target platform to find platform-override files such as
 `foo.ios.ts` and `foo.native.ts`. It also maps `react-native` module references
 to out-of-tree platforms such as `react-native-windows` and
-`react-native-macos`.
-
-The resolver loads react-native configuration, including out-of-tree platforms,
-using `@react-native-community/cli`.
+`react-native-macos`. For performance reasons, these mappings are built into the
+resolver, rather than loaded dynamically using `@react-native-community/cli`.

--- a/packages/typescript-react-native-resolver/src/log.ts
+++ b/packages/typescript-react-native-resolver/src/log.ts
@@ -89,11 +89,11 @@ export class ResolverLog {
 export function changeModuleResolutionHostToLogFileSystemReads(
   host: ModuleResolutionHostLike
 ): void {
-  const originalFileExists = host.fileExists;
-  const originalReadFile = host.readFile;
-  const originalDirectoryExists = host.directoryExists;
-  const originalRealpath = host.realpath;
-  const originalGetDirectories = host.getDirectories;
+  const originalFileExists = host.fileExists.bind(host);
+  const originalReadFile = host.readFile.bind(host);
+  const originalDirectoryExists = host.directoryExists.bind(host);
+  const originalRealpath = host.realpath ? host.realpath.bind(host) : undefined;
+  const originalGetDirectories = host.getDirectories.bind(host);
 
   host.fileExists = (fileName: string): boolean => {
     const result = originalFileExists(fileName);

--- a/packages/typescript-react-native-resolver/src/log.ts
+++ b/packages/typescript-react-native-resolver/src/log.ts
@@ -89,11 +89,11 @@ export class ResolverLog {
 export function changeModuleResolutionHostToLogFileSystemReads(
   host: ModuleResolutionHostLike
 ): void {
-  const originalFileExists = host.fileExists.bind(host);
-  const originalReadFile = host.readFile.bind(host);
-  const originalDirectoryExists = host.directoryExists.bind(host);
-  const originalRealpath = host.realpath ? host.realpath.bind(host) : undefined;
-  const originalGetDirectories = host.getDirectories.bind(host);
+  const originalFileExists = () => host.fileExists();
+  const originalReadFile = () => host.readFile();
+  const originalDirectoryExists = () => host.directoryExists();
+  const originalRealpath = host.realpath ? () => host.realpath() : undefined;
+  const originalGetDirectories = () => host.getDirectories();
 
   host.fileExists = (fileName: string): boolean => {
     const result = originalFileExists(fileName);

--- a/packages/typescript-react-native-resolver/src/log.ts
+++ b/packages/typescript-react-native-resolver/src/log.ts
@@ -89,11 +89,11 @@ export class ResolverLog {
 export function changeModuleResolutionHostToLogFileSystemReads(
   host: ModuleResolutionHostLike
 ): void {
-  const originalFileExists = () => host.fileExists();
-  const originalReadFile = () => host.readFile();
-  const originalDirectoryExists = () => host.directoryExists();
-  const originalRealpath = host.realpath ? () => host.realpath() : undefined;
-  const originalGetDirectories = () => host.getDirectories();
+  const originalFileExists = host.fileExists.bind(host);
+  const originalReadFile = host.readFile.bind(host);
+  const originalDirectoryExists = host.directoryExists.bind(host);
+  const originalRealpath = host.realpath ? host.realpath.bind(host) : undefined;
+  const originalGetDirectories = host.getDirectories.bind(host);
 
   host.fileExists = (fileName: string): boolean => {
     const result = originalFileExists(fileName);

--- a/packages/typescript-react-native-resolver/test/host.test.ts
+++ b/packages/typescript-react-native-resolver/test/host.test.ts
@@ -14,93 +14,87 @@ import type { ModuleResolutionHostLike, ResolverContext } from "../src/types";
 import { ResolverLog, ResolverLogMode } from "../src/log";
 
 describe("Host > changeHostToUseReactNativeResolver", () => {
-  function testChangeHost(host: ts.CompilerHost): void {
+  const mockFileExists = jest.fn();
+  const mockReadFile = jest.fn();
+  const mockDirectoryExists = jest.fn();
+  const mockRealpath = jest.fn();
+  const mockGetDirectories = jest.fn();
+  const host = {
+    fileExists: mockFileExists,
+    readFile: mockReadFile,
+    directoryExists: mockDirectoryExists,
+    realpath: mockRealpath,
+    getDirectories: mockGetDirectories,
+  } as unknown as ts.CompilerHost;
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  function testChangeHost(): void {
     changeHostToUseReactNativeResolver({
       host,
       options: {},
       platform: "ios",
       platformExtensionNames: ["native"],
       disableReactNativePackageSubstitution: false,
-      traceReactNativeModuleResolutionErrors: false,
+      traceReactNativeModuleResolutionErrors: true,
       traceResolutionLog: undefined,
     });
   }
 
   test("sets the trace function to ensure trace logging is possible", () => {
-    const host = {} as unknown as ts.CompilerHost;
-    testChangeHost(host);
+    testChangeHost();
     expect(host.trace).toBeFunction();
   });
 
   test("hooks fileExists with a function that calls the original function", () => {
-    const mock = jest.fn();
-    const host = {
-      fileExists: mock,
-    } as unknown as ts.CompilerHost;
-    testChangeHost(host);
+    testChangeHost();
     expect(host.fileExists).toBeFunction();
-    expect(host.fileExists).not.toBe(mock);
+    expect(host.fileExists).not.toBe(mockFileExists);
     host.fileExists("alpha");
-    expect(mock).toBeCalledWith("alpha");
+    expect(mockFileExists).toBeCalledWith("alpha");
   });
 
   test("hooks readFile with a function that calls the original function", () => {
-    const mock = jest.fn();
-    const host = {
-      readFile: mock,
-    } as unknown as ts.CompilerHost;
-    testChangeHost(host);
+    testChangeHost();
     expect(host.readFile).toBeFunction();
-    expect(host.readFile).not.toBe(mock);
+    expect(host.readFile).not.toBe(mockReadFile);
     host.readFile("beta");
-    expect(mock).toBeCalledWith("beta");
+    expect(mockReadFile).toBeCalledWith("beta");
   });
 
   test("hooks directoryExists with a function that calls the original function", () => {
-    const mock = jest.fn();
-    const host = {
-      directoryExists: mock,
-    } as unknown as ts.CompilerHost;
-    testChangeHost(host);
+    testChangeHost();
     expect(host.directoryExists).toBeFunction();
-    expect(host.directoryExists).not.toBe(mock);
+    expect(host.directoryExists).not.toBe(mockDirectoryExists);
     host.directoryExists("gamma");
-    expect(mock).toBeCalledWith("gamma");
+    expect(mockDirectoryExists).toBeCalledWith("gamma");
   });
 
   test("hooks realpath with a function that calls the original function", () => {
-    const mock = jest.fn();
-    const host = {
-      realpath: mock,
-    } as unknown as ts.CompilerHost;
-    testChangeHost(host);
+    testChangeHost();
     expect(host.realpath).toBeFunction();
-    expect(host.realpath).not.toBe(mock);
+    expect(host.realpath).not.toBe(mockRealpath);
     host.realpath("delta");
-    expect(mock).toBeCalledWith("delta");
+    expect(mockRealpath).toBeCalledWith("delta");
   });
 
   test("hooks getDirectories with a function that calls the original function", () => {
-    const mock = jest.fn();
-    const host = {
-      getDirectories: mock,
-    } as unknown as ts.CompilerHost;
-    testChangeHost(host);
+    testChangeHost();
     expect(host.getDirectories).toBeFunction();
-    expect(host.getDirectories).not.toBe(mock);
+    expect(host.getDirectories).not.toBe(mockGetDirectories);
     host.getDirectories("epsilon");
-    expect(mock).toBeCalledWith("epsilon");
+    expect(mockGetDirectories).toBeCalledWith("epsilon");
   });
 
   test("sets resolveModuleNames", () => {
-    const host = {} as unknown as ts.CompilerHost;
-    testChangeHost(host);
+    testChangeHost();
     expect(host.resolveModuleNames).toBeFunction();
   });
 
   test("sets resolveTypeReferenceDirectives", () => {
-    const host = {} as unknown as ts.CompilerHost;
-    testChangeHost(host);
+    testChangeHost();
     expect(host.resolveTypeReferenceDirectives).toBeFunction();
   });
 });

--- a/packages/typescript-service/src/project.ts
+++ b/packages/typescript-service/src/project.ts
@@ -124,7 +124,9 @@ export class Project {
   }
 
   validateFile(fileName: string): boolean {
-    const diagnostics = this.getFileDiagnostics(fileName);
+    const diagnostics = this.getFileDiagnostics(fileName).filter(
+      (d) => d.category !== ts.DiagnosticCategory.Suggestion
+    );
     if (isNonEmptyArray(diagnostics)) {
       diagnostics.forEach((d) => this.diagnosticWriter.print(d));
       return false;


### PR DESCRIPTION
### Description

Make minor fixes to TypeScript utility packages.

`@rnx-kit/typescript-react-native-resolver`
When modifying a TypeScript host, only change trace() when logging is enabled. Also, when changing file/directory APIs, bind the original calls to the host so that the 'this' reference is set properly.

`@rnx-kit/typescript-service`
Don't format/print "suggestion" diagnostics. Doing so hits an internal debug assert in TypeScript.

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

CI tests pass. Manual validation in a private repo. 
<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
