### PR TITLE
fix(eslint/no-export-all): fix dupes sometimes showing up

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,6 +3,8 @@
   - packages/config/**/*
 'feature: dep-check':
   - packages/dep-check/**/*
+'feature: eslint':
+  - packages/eslint-*/**/*
 'feature: jest':
   - packages/jest-*/**/*
 'feature: metro':

--- a/change/@rnx-kit-eslint-plugin-e0243bf2-724f-47a5-a039-d474cfe6ff53.json
+++ b/change/@rnx-kit-eslint-plugin-e0243bf2-724f-47a5-a039-d474cfe6ff53.json
@@ -3,5 +3,5 @@
   "comment": "no-export-all: Fix dupes sometimes showing up in fixed code",
   "packageName": "@rnx-kit/eslint-plugin",
   "email": "4123478+tido64@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@rnx-kit-eslint-plugin-e0243bf2-724f-47a5-a039-d474cfe6ff53.json
+++ b/change/@rnx-kit-eslint-plugin-e0243bf2-724f-47a5-a039-d474cfe6ff53.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "no-export-all: Fix dupes sometimes showing up in fixed code",
+  "packageName": "@rnx-kit/eslint-plugin",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Description

ESLint sometimes revisits the same nodes in a single traversal. If there are exported names, they can show up multiple times in the fixed code.

Resolves #870.

### Test plan

See repro in ##870. Existing tests should pass.