### PR TITLE
fix(eslint/no-export-all): add support for namespaces

### DIFF
--- a/change/@rnx-kit-eslint-plugin-4e1f10a5-0c1e-41e1-928a-d051ddb9eab2.json
+++ b/change/@rnx-kit-eslint-plugin-4e1f10a5-0c1e-41e1-928a-d051ddb9eab2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "no-export-all: add support for namespaces",
+  "packageName": "@rnx-kit/eslint-plugin",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -41,6 +41,9 @@
     "@types/jest": "^27.0.0",
     "eslint": "^8.0.0"
   },
+  "engines": {
+    "node": ">=14.15"
+  },
   "depcheck": {
     "ignoreMatches": [
       "@typescript-eslint/eslint-plugin",

--- a/packages/eslint-plugin/test/no-export-all.test.ts
+++ b/packages/eslint-plugin/test/no-export-all.test.ts
@@ -48,6 +48,12 @@ export declare const FocusZoneTabbableElements: {
 
 export declare type FocusZoneTabbableElements = typeof FocusZoneTabbableElements[keyof typeof FocusZoneTabbableElements];
 `,
+  "@fluentui/style-utilities": `
+export namespace ZIndexes {
+  export const Nav = 1;
+  export const ScrollablePane = 1;
+}
+`,
 });
 
 const config = {
@@ -131,6 +137,11 @@ describe("disallows `export *`", () => {
         errors: 1,
         output:
           "export { FocusZoneTabbableElements } from '@fluentui/react-focus';",
+      },
+      {
+        code: "export * from '@fluentui/style-utilities';",
+        errors: 1,
+        output: "export { ZIndexes } from '@fluentui/style-utilities';",
       },
     ],
   });


### PR DESCRIPTION
### Description

Auto-fix namespaces.

Resolves #871.

### Test plan

See repro in #871. Tests were added.

```diff
--- src/Styling.prev.ts	2021-11-19 10:00:15.000000000 +0100
+++ src/Styling.ts	2021-11-19 10:04:53.000000000 +0100
@@ -31,6 +31,7 @@
   ScreenWidthMinXXXLarge,
   Stylesheet,
   ThemeSettingName,
+  ZIndexes,
   buildClassMap,
   concatStyleSets,
   concatStyleSetsWithProps,
```