### PR TITLE
Updating minimum node requirement in eslint-plugin to 14.

### DIFF
--- a/change/@rnx-kit-eslint-plugin-de29dbec-1273-43f5-83ed-82593dc72035.json
+++ b/change/@rnx-kit-eslint-plugin-de29dbec-1273-43f5-83ed-82593dc72035.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated minimum node requirement in package.json.",
+  "packageName": "@rnx-kit/eslint-plugin",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -14,6 +14,9 @@
   "files": [
     "src/*"
   ],
+  "engines": {
+    "node": ">=14"
+  },
   "main": "src/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adding minimum node requirement (14) to `@rnx-kit/eslint-plugin` package.json definition (since optional chaining is not supported in 12.)