### PR TITLE
feat(react-native-test-app-msal): add support for Android

### DIFF
--- a/.changeset/breezy-mugs-shake.md
+++ b/.changeset/breezy-mugs-shake.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-test-app-msal": minor
+---
+
+Added support for Android

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,6 +90,31 @@ jobs:
           yarn bundle+esbuild
         shell: bash
         working-directory: packages/test-app
+  build-android:
+    name: "Build Android"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Node 14
+        uses: actions/setup-node@v2.4.1
+        with:
+          node-version: 14
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
+      - name: Cache /.yarn-offline-mirror
+        uses: actions/cache@v2.1.7
+        with:
+          path: .yarn-offline-mirror
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-2
+      - name: Install npm dependencies
+        run: yarn ci
+        env:
+          CI_SKIP_GO: 1
+      - name: Build Android app
+        run: |
+          ./gradlew clean build
+        working-directory: packages/test-app/android
   build-ios:
     name: "Build iOS"
     runs-on: macos-11

--- a/change/@rnx-kit-react-native-test-app-msal-7b96fc17-5f2a-4ca3-b8d4-b04785e41e42.json
+++ b/change/@rnx-kit-react-native-test-app-msal-7b96fc17-5f2a-4ca3-b8d4-b04785e41e42.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adds support for Android",
+  "packageName": "@rnx-kit/react-native-test-app-msal",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnx-kit-react-native-test-app-msal-7b96fc17-5f2a-4ca3-b8d4-b04785e41e42.json
+++ b/change/@rnx-kit-react-native-test-app-msal-7b96fc17-5f2a-4ca3-b8d4-b04785e41e42.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Adds support for Android",
-  "packageName": "@rnx-kit/react-native-test-app-msal",
-  "email": "4123478+tido64@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/react-native-test-app-msal/README.md
+++ b/packages/react-native-test-app-msal/README.md
@@ -51,7 +51,12 @@ Add an entry for the account switcher in your `app.json`, e.g.:
        "appKey": "MyTestApp",
 +    },
 +    {
-+      "appKey": "MicrosoftAccounts"
++      "appKey": "com.microsoft.reacttestapp.msal.MicrosoftAccountsActivity",
++      "displayName": "MicrosoftAccounts (Android)"
++    },
++    {
++      "appKey": "MicrosoftAccounts",
++      "displayName": "MicrosoftAccounts (iOS/macOS)"
      }
    ],
    "resources": {
@@ -77,16 +82,28 @@ then fill out the following fields in `app.json`:
        "appKey": "MyTestApp",
      },
      {
-       "appKey": "MicrosoftAccounts"
+       "appKey": "com.microsoft.reacttestapp.msal.MicrosoftAccountsActivity",
+       "displayName": "MicrosoftAccounts (Android)"
+     },
+     {
+       "appKey": "MicrosoftAccounts",
+       "displayName": "MicrosoftAccounts (iOS/macOS)"
      }
    ],
++  "android": {
++    "package": "com.contoso.MyTestApp"
++  },
 +  "ios": {
 +    "bundleIdentifier": "com.contoso.MyTestApp"
 +  },
++  "macos": {
++    "bundleIdentifier": "com.contoso.MyTestApp"
++  },
 +  "react-native-test-app-msal": {
-+    "clientId": "00000000-0000-0000-0000-000000000000",
++    "clientId": "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
 +    "msaScopes": ["user.read"],
-+    "orgScopes": ["<Application ID URL>/scope"]
++    "orgScopes": ["user.read"],
++    "signatureHash": "1wIqXSqBj7w+h11ZifsnqwgyKrY="
 +  },
    "resources": {
      "android": ["dist/res", "dist/main.android.jsbundle"],

--- a/packages/react-native-test-app-msal/android/build.gradle
+++ b/packages/react-native-test-app-msal/android/build.gradle
@@ -38,8 +38,8 @@ buildscript {
 
     ext.getStringArray = { config, property ->
         return (!config.containsKey(property) || config[property].size() == 0)
-                ? ""
-                : "\"${config[property].join('", "')}\""
+            ? ""
+            : "\"${config[property].join('", "')}\""
     }
 
     ext.kotlinVersion = getExtProp('kotlinVersion', '1.5.31')
@@ -89,14 +89,14 @@ android {
         targetSdkVersion getExtProp('targetSdkVersion', 29)
 
         buildConfigField "String[]",
-                "ReactTestAppMSAL_msaScopes",
-                "new String[]{${getStringArray(config, "msaScopes")}}"
+            "ReactTestAppMSAL_msaScopes",
+            "new String[]{${getStringArray(config, "msaScopes")}}"
         buildConfigField "String[]",
-                "ReactTestAppMSAL_orgScopes",
-                "new String[]{${getStringArray(config, "orgScopes")}}"
+            "ReactTestAppMSAL_orgScopes",
+            "new String[]{${getStringArray(config, "orgScopes")}}"
 
         manifestPlaceholders = [
-                msalRedirectUriPath: "/$signatureHash"
+            msalRedirectUriPath: "/$signatureHash"
         ]
     }
     sourceSets {
@@ -116,25 +116,25 @@ android {
             def msalConfig = file("$temporaryDir/msal_config.json")
             msalConfig.withWriter {
                 it << JsonOutput.toJson([
-                        authorities                   : [
-                                [
-                                        type    : "AAD",
-                                        audience: [
-                                                type: "AzureADandPersonalMicrosoftAccount"
-                                        ],
-                                        default : true
-                                ],
-                                [
-                                        type    : "AAD",
-                                        audience: [
-                                                type: "PersonalMicrosoftAccount"
-                                        ],
-                                ],
+                    authorities: [
+                        [
+                            type: "AAD",
+                            audience: [
+                                type: "AzureADandPersonalMicrosoftAccount"
+                            ],
+                            default: true
                         ],
-                        client_id                     : clientId,
-                        redirect_uri                  : redirectUri,
-                        broker_redirect_uri_registered: true,
-                        account_mode                  : "MULTIPLE"
+                        [
+                            type: "AAD",
+                            audience: [
+                                type: "PersonalMicrosoftAccount"
+                            ],
+                        ],
+                    ],
+                    client_id: clientId,
+                    redirect_uri: redirectUri,
+                    broker_redirect_uri_registered: false,
+                    account_mode: "MULTIPLE"
                 ])
             }
 

--- a/packages/react-native-test-app-msal/android/build.gradle
+++ b/packages/react-native-test-app-msal/android/build.gradle
@@ -153,7 +153,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 
-    implementation 'androidx.fragment:fragment-ktx:1.4.0'
+    implementation 'androidx.activity:activity-ktx:1.4.0'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'com.microsoft.identity.client:msal:2.2.1'
 

--- a/packages/react-native-test-app-msal/android/build.gradle
+++ b/packages/react-native-test-app-msal/android/build.gradle
@@ -153,6 +153,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 
+    implementation 'androidx.fragment:fragment-ktx:1.4.0'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'com.microsoft.identity.client:msal:2.2.1'
 

--- a/packages/react-native-test-app-msal/android/build.gradle
+++ b/packages/react-native-test-app-msal/android/build.gradle
@@ -1,0 +1,161 @@
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+
+import java.nio.file.Paths
+
+buildscript {
+    ext.ensureProperty = { config, property ->
+        if (!config.containsKey(property)) {
+            throw new MissingPropertyException("Missing '$property' in 'react-native-test-app-msal' config")
+        }
+        return config[property]
+    }
+
+    ext.findFile = { fileName ->
+        def currentDirPath = rootDir == null ? null : rootDir.toString()
+
+        while (currentDirPath != null) {
+            def currentDir = file(currentDirPath);
+            def requestedFile = Paths.get(currentDirPath, fileName).toFile()
+
+            if (requestedFile.exists()) {
+                return requestedFile
+            }
+
+            currentDirPath = currentDir.getParent()
+        }
+
+        return null
+    }
+
+    ext.findNodeModulesPath = { packageName ->
+        return findFile(Paths.get('node_modules', packageName).toString())
+    }
+
+    ext.getExtProp = { prop, defaultValue ->
+        return rootProject.ext.has(prop) ? rootProject.ext.get(prop) : defaultValue
+    }
+
+    ext.getStringArray = { config, property ->
+        return (!config.containsKey(property) || config[property].size() == 0)
+                ? ""
+                : "\"${config[property].join('", "')}\""
+    }
+
+    ext.kotlinVersion = getExtProp('kotlinVersion', '1.5.31')
+
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath "com.android.tools.build:gradle:${getExtProp('androidPluginVersion', '4.2.2')}"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+    }
+}
+
+plugins {
+    id "com.android.library"
+    id "kotlin-android"
+}
+
+repositories {
+    maven {
+        url("${findNodeModulesPath('react-native')}/android")
+    }
+
+    google()
+    mavenCentral()
+
+    // https://github.com/AzureAD/microsoft-authentication-library-for-android#step-1-declare-dependency-on-msal
+    maven {
+        url 'https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed/maven/v1'
+    }
+}
+
+android {
+    def manifest = new JsonSlurper().parseText(findFile('app.json').text)
+    def config = manifest["react-native-test-app-msal"]
+    if (config == null) {
+        throw new MissingPropertyException("Missing 'react-native-test-app-msal' field in 'app.json'")
+    }
+
+    def signatureHash = ensureProperty(config, "signatureHash")
+
+    compileSdkVersion getExtProp('compileSdkVersion', 31)
+    defaultConfig {
+        minSdkVersion getExtProp('minSdkVersion', 21)
+        targetSdkVersion getExtProp('targetSdkVersion', 29)
+
+        buildConfigField "String[]",
+                "ReactTestAppMSAL_msaScopes",
+                "new String[]{${getStringArray(config, "msaScopes")}}"
+        buildConfigField "String[]",
+                "ReactTestAppMSAL_orgScopes",
+                "new String[]{${getStringArray(config, "orgScopes")}}"
+
+        manifestPlaceholders = [
+                msalRedirectUriPath: "/$signatureHash"
+        ]
+    }
+    sourceSets {
+        def clientId = ensureProperty(config, "clientId")
+
+        def appProject = rootProject.subprojects.find { it.name == "app" }
+        def applicationId = appProject.android.defaultConfig.applicationId
+        def redirectUri = "msauth://$applicationId/${URLEncoder.encode(signatureHash, "UTF-8")}"
+
+        def generatedResDir = file("$buildDir/generated/react-native-test-app-msal/src/main/res/")
+        generatedResDir.mkdirs()
+
+        task copyMsalConfig(type: Copy) {
+            def generatedRawDir = file("$generatedResDir/raw")
+            generatedRawDir.mkdirs()
+
+            def msalConfig = file("$temporaryDir/msal_config.json")
+            msalConfig.withWriter {
+                it << JsonOutput.toJson([
+                        authorities                   : [
+                                [
+                                        type    : "AAD",
+                                        audience: [
+                                                type: "AzureADandPersonalMicrosoftAccount"
+                                        ],
+                                        default : true
+                                ],
+                                [
+                                        type    : "AAD",
+                                        audience: [
+                                                type: "PersonalMicrosoftAccount"
+                                        ],
+                                ],
+                        ],
+                        client_id                     : clientId,
+                        redirect_uri                  : redirectUri,
+                        broker_redirect_uri_registered: true,
+                        account_mode                  : "MULTIPLE"
+                ])
+            }
+
+            from msalConfig
+            into generatedRawDir
+        }
+
+        preBuild.dependsOn(copyMsalConfig)
+
+        main.res.srcDirs += generatedResDir
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+
+    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'com.microsoft.identity.client:msal:2.2.1'
+
+    //noinspection GradleDynamicVersion
+    implementation 'com.facebook.react:react-native:+'
+}

--- a/packages/react-native-test-app-msal/android/build.gradle
+++ b/packages/react-native-test-app-msal/android/build.gradle
@@ -85,7 +85,7 @@ android {
 
     compileSdkVersion getExtProp('compileSdkVersion', 31)
     defaultConfig {
-        minSdkVersion getExtProp('minSdkVersion', 21)
+        minSdkVersion getExtProp('minSdkVersion', 23)
         targetSdkVersion getExtProp('targetSdkVersion', 29)
 
         buildConfigField "String[]",

--- a/packages/react-native-test-app-msal/android/gradle.properties
+++ b/packages/react-native-test-app-msal/android/gradle.properties
@@ -1,0 +1,3 @@
+# These properties are required to enable AndroidX for the test app.
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/react-native-test-app-msal/android/src/main/AndroidManifest.xml
+++ b/packages/react-native-test-app-msal/android/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.microsoft.reacttestapp.msal">
+
+    <application>
+        <activity android:name=".MicrosoftAccountsActivity" />
+        <activity
+            android:name="com.microsoft.identity.client.BrowserTabActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="${applicationId}"
+                    android:path="${msalRedirectUriPath}"
+                    android:scheme="msauth" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/Account.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/Account.kt
@@ -1,0 +1,18 @@
+package com.microsoft.reacttestapp.msal
+
+import com.microsoft.identity.client.IAccount
+
+data class Account(
+    val userPrincipalName: String,
+    val accountType: AccountType
+) {
+    override fun toString(): String {
+        return "$userPrincipalName (${accountType.description()})"
+    }
+}
+
+fun List<IAccount>.find(userPrincipalName: String, accountType: AccountType): IAccount? {
+    return find {
+        it.username == userPrincipalName && it.accountType() == accountType
+    }
+}

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/AccountType.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/AccountType.kt
@@ -1,0 +1,28 @@
+package com.microsoft.reacttestapp.msal
+
+import com.microsoft.identity.client.IAccount
+
+enum class AccountType(val type: String) {
+    MICROSOFT_ACCOUNT("MicrosoftAccount"),
+    ORGANIZATIONAL("Organizational");
+
+    companion object {
+        fun fromIssuer(issuer: String): AccountType {
+            return if (issuer.contains(TokenBroker.MSA_TENANT))
+                MICROSOFT_ACCOUNT
+            else
+                ORGANIZATIONAL
+        }
+    }
+
+    fun description(): String {
+        return when (this) {
+            MICROSOFT_ACCOUNT -> "personal"
+            ORGANIZATIONAL -> "work"
+        }
+    }
+}
+
+fun IAccount.accountType(): AccountType {
+    return AccountType.fromIssuer(claims?.get("iss").toString())
+}

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/AccountType.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/AccountType.kt
@@ -7,8 +7,11 @@ enum class AccountType(val type: String) {
     ORGANIZATIONAL("Organizational");
 
     companion object {
+        // Source: https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens
+        private const val MSA_TENANT = "9188040d-6c67-4c5b-b112-36a304b66dad"
+
         fun fromIssuer(issuer: String): AccountType {
-            return if (issuer.contains(TokenBroker.MSA_TENANT))
+            return if (issuer.contains(MSA_TENANT))
                 MICROSOFT_ACCOUNT
             else
                 ORGANIZATIONAL

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/AccountsAdapter.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/AccountsAdapter.kt
@@ -1,0 +1,31 @@
+package com.microsoft.reacttestapp.msal
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.TextView
+
+class AccountsAdapter(
+    context: Context,
+    private val accounts: MutableList<Account>
+) : ArrayAdapter<Account>(context, R.layout.account_item, accounts) {
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val layoutInflater = LayoutInflater.from(parent.context)
+        val view = convertView ?: layoutInflater.inflate(R.layout.account_item, parent, false)
+
+        val (userPrincipalName, accountType) = accounts[position]
+        view.findViewById<TextView>(R.id.username).text = userPrincipalName
+
+        val accountTypeText = parent.context.resources.getString(R.string.account_type)
+        view.findViewById<TextView>(R.id.account_type).text =
+            String.format(accountTypeText, accountType.description())
+
+        return view
+    }
+
+    override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
+        return getView(position, convertView, parent)
+    }
+}

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/AccountsViewModel.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/AccountsViewModel.kt
@@ -1,0 +1,22 @@
+package com.microsoft.reacttestapp.msal
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class AccountsViewModel : ViewModel() {
+    val accounts: MutableLiveData<List<Account>> by lazy {
+        MutableLiveData<List<Account>>()
+    }
+
+    val canAddAccount: MutableLiveData<Boolean> by lazy {
+        MutableLiveData<Boolean>(true)
+    }
+
+    val canSignOut: MutableLiveData<Boolean> by lazy {
+        MutableLiveData<Boolean>(false)
+    }
+
+    val selectedAccount: MutableLiveData<Account> by lazy {
+        MutableLiveData<Account>()
+    }
+}

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/AuthError.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/AuthError.kt
@@ -1,0 +1,15 @@
+package com.microsoft.reacttestapp.msal
+
+import com.microsoft.identity.common.exception.BaseException
+
+data class AuthError(
+    val type: AuthErrorType,
+    val correlationId: String,
+    val message: String?
+) {
+    constructor(exception: BaseException) : this(
+        AuthErrorType.fromMsalException(exception),
+        exception.correlationId ?: TokenBroker.EMPTY_GUID,
+        exception.message
+    )
+}

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/AuthErrorType.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/AuthErrorType.kt
@@ -1,0 +1,41 @@
+package com.microsoft.reacttestapp.msal
+
+import com.microsoft.identity.common.exception.BaseException
+import com.microsoft.identity.common.exception.DeviceRegistrationRequiredException
+import com.microsoft.identity.common.exception.IntuneAppProtectionPolicyRequiredException
+import com.microsoft.identity.common.exception.ServiceException
+import com.microsoft.identity.common.exception.UserCancelException
+
+enum class AuthErrorType(val type: String) {
+    UNKNOWN("Unknown"),
+    BAD_REFRESH_TOKEN("BadRefreshToken"),
+    CONDITIONAL_ACCESS_BLOCKED("ConditionalAccessBlocked"),
+    INTERACTION_REQUIRED("InteractionRequired"),
+    NO_RESPONSE("NoResponse"),
+    PRECONDITION_VIOLATED("PreconditionViolated"),
+    SERVER_DECLINED_SCOPES("ServerDeclinedScopes"),
+    SERVER_PROTECTION_POLICIES_REQUIRED("ServerProtectionPoliciesRequired"),
+    TIMEOUT("Timeout"),
+    USER_CANCELED("UserCanceled"),
+    WORKPLACE_JOIN_REQUIRED("WorkplaceJoinRequired");
+
+    companion object {
+        fun fromMsalException(exception: BaseException?): AuthErrorType {
+            // Try to map known exceptions found in
+            // https://github.com/AzureAD/microsoft-authentication-library-common-for-android/tree/dev/common4j/src/main/com/microsoft/identity/common/java/exception
+            return when (exception) {
+                is DeviceRegistrationRequiredException -> WORKPLACE_JOIN_REQUIRED
+                is IntuneAppProtectionPolicyRequiredException -> SERVER_PROTECTION_POLICIES_REQUIRED
+                is ServiceException -> when (exception.errorCode) {
+                    ServiceException.ACCESS_DENIED -> BAD_REFRESH_TOKEN
+                    ServiceException.INVALID_SCOPE -> SERVER_DECLINED_SCOPES
+                    ServiceException.REQUEST_TIMEOUT -> TIMEOUT
+                    ServiceException.SERVICE_NOT_AVAILABLE -> NO_RESPONSE
+                    else -> UNKNOWN
+                }
+                is UserCancelException -> USER_CANCELED
+                else -> UNKNOWN
+            }
+        }
+    }
+}

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/AuthResult.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/AuthResult.kt
@@ -1,0 +1,17 @@
+package com.microsoft.reacttestapp.msal
+
+import com.microsoft.identity.client.IAuthenticationResult
+
+data class AuthResult(
+    val accessToken: String,
+    val username: String,
+    val expirationTime: Int,
+    val redirectUri: String
+) {
+    constructor(result: IAuthenticationResult, redirectUri: String) : this(
+        result.accessToken,
+        result.account.username,
+        (result.expiresOn.time / 1000).toInt(),
+        redirectUri
+    )
+}

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/Config.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/Config.kt
@@ -7,6 +7,11 @@ class Config {
         val orgScopes: Array<String>
             get() = BuildConfig.ReactTestAppMSAL_orgScopes
 
+        fun authorityFor(accountType: AccountType): String = when (accountType) {
+            AccountType.MICROSOFT_ACCOUNT -> "https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize"
+            AccountType.ORGANIZATIONAL -> "https://login.microsoftonline.com/common/"
+        }
+
         fun scopesFor(accountType: AccountType): Array<String> = when (accountType) {
             AccountType.MICROSOFT_ACCOUNT -> msaScopes
             AccountType.ORGANIZATIONAL -> orgScopes

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/Config.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/Config.kt
@@ -1,0 +1,15 @@
+package com.microsoft.reacttestapp.msal
+
+class Config {
+    companion object {
+        val msaScopes: Array<String>
+            get() = BuildConfig.ReactTestAppMSAL_msaScopes
+        val orgScopes: Array<String>
+            get() = BuildConfig.ReactTestAppMSAL_orgScopes
+
+        fun scopesFor(accountType: AccountType): Array<String> = when (accountType) {
+            AccountType.MICROSOFT_ACCOUNT -> msaScopes
+            AccountType.ORGANIZATIONAL -> orgScopes
+        }
+    }
+}

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/IAccountsHandler.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/IAccountsHandler.kt
@@ -1,0 +1,8 @@
+package com.microsoft.reacttestapp.msal
+
+interface IAccountsHandler {
+    fun onAddAccount()
+    fun onSignOut()
+    fun onSignOutAllAccounts()
+    fun onSwitchAccount(index: Int)
+}

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/IAccountsHandler.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/IAccountsHandler.kt
@@ -1,8 +1,0 @@
-package com.microsoft.reacttestapp.msal
-
-interface IAccountsHandler {
-    fun onAddAccount()
-    fun onSignOut()
-    fun onSignOutAllAccounts()
-    fun onSwitchAccount(index: Int)
-}

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MicrosoftAccountsActivity.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MicrosoftAccountsActivity.kt
@@ -15,9 +15,7 @@ import java.util.concurrent.Executors
 
 @Suppress("unused")
 class MicrosoftAccountsActivity : AppCompatActivity() {
-    private val accounts: MutableList<Account> = mutableListOf(
-        Account("arnold@contoso.com", AccountType.MICROSOFT_ACCOUNT)
-    )
+    private val accounts: MutableList<Account> = mutableListOf()
 
     private val accountsAdapter: AccountsAdapter by lazy {
         AccountsAdapter(this, accounts)
@@ -60,6 +58,17 @@ class MicrosoftAccountsActivity : AppCompatActivity() {
         }
         signOutAllButton.setOnClickListener {
             onSignOutAllAccounts()
+        }
+
+        withTokenBroker { tokenBroker ->
+            val allAccounts = tokenBroker.allAccounts()
+            if (allAccounts.isNotEmpty()) {
+                accounts.addAll(allAccounts)
+                accountsAdapter.notifyDataSetChanged()
+                runOnUiThread {
+                    accountsDropdown.isEnabled = true
+                }
+            }
         }
     }
 

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MicrosoftAccountsActivity.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MicrosoftAccountsActivity.kt
@@ -25,6 +25,10 @@ class MicrosoftAccountsActivity : AppCompatActivity() {
         findViewById(R.id.accounts_dropdown)
     }
 
+    private val addAccountButton: Button by lazy {
+        findViewById(R.id.add_account)
+    }
+
     private val executorService: ExecutorService by lazy {
         Executors.newSingleThreadExecutor()
     }
@@ -48,17 +52,9 @@ class MicrosoftAccountsActivity : AppCompatActivity() {
             }
             setAdapter(accountsAdapter)
         }
-        findViewById<TextView>(R.id.add_account).apply {
-            setOnClickListener {
-                this@MicrosoftAccountsActivity.onAddAccount()
-            }
-        }
-        signOutButton.setOnClickListener {
-            onSignOut()
-        }
-        signOutAllButton.setOnClickListener {
-            onSignOutAllAccounts()
-        }
+        addAccountButton.setOnClickListener { onAddAccount() }
+        signOutButton.setOnClickListener { onSignOut() }
+        signOutAllButton.setOnClickListener { onSignOutAllAccounts() }
 
         withTokenBroker { tokenBroker ->
             val allAccounts = tokenBroker.allAccounts()
@@ -73,6 +69,8 @@ class MicrosoftAccountsActivity : AppCompatActivity() {
     }
 
     private fun addAccount(accountType: AccountType) {
+        addAccountButton.isEnabled = false
+
         withTokenBroker { tokenBroker ->
             tokenBroker.acquireToken(
                 this,
@@ -80,6 +78,10 @@ class MicrosoftAccountsActivity : AppCompatActivity() {
                 null,
                 accountType
             ) { result: AuthResult?, error: AuthError? ->
+                runOnUiThread {
+                    addAccountButton.isEnabled = true
+                }
+
                 when {
                     error != null -> showErrorMessage(
                         error.message ?: resources.getString(R.string.error_sign_in)

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MicrosoftAccountsActivity.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MicrosoftAccountsActivity.kt
@@ -2,7 +2,6 @@ package com.microsoft.reacttestapp.msal
 
 import android.content.ClipData
 import android.content.ClipboardManager
-import android.content.SharedPreferences
 import android.os.Bundle
 import android.widget.AdapterView
 import android.widget.AutoCompleteTextView

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MicrosoftAccountsActivity.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MicrosoftAccountsActivity.kt
@@ -8,8 +8,11 @@ import android.widget.AdapterView
 import android.widget.AutoCompleteTextView
 import android.widget.Button
 import android.widget.TextView
+import androidx.activity.viewModels
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.edit
+import androidx.lifecycle.Observer
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textfield.TextInputLayout
@@ -25,67 +28,111 @@ class MicrosoftAccountsActivity : AppCompatActivity() {
 
     private val accounts: MutableList<Account> = mutableListOf()
 
-    private val accountsAdapter: AccountsAdapter by lazy {
-        AccountsAdapter(this, accounts)
-    }
-
     private val accountsDropdown: TextInputLayout by lazy {
         findViewById(R.id.accounts_dropdown)
-    }
-
-    private val addAccountButton: Button by lazy {
-        findViewById(R.id.add_account)
     }
 
     private val executorService: ExecutorService by lazy {
         Executors.newSingleThreadExecutor()
     }
 
-    private val sharedPreferences: SharedPreferences by lazy {
-        getPreferences(MODE_PRIVATE)
-    }
-
-    private val signOutButton: Button by lazy {
-        findViewById(R.id.sign_out)
-    }
-
-    private val signOutAllButton: Button by lazy {
-        findViewById(R.id.sign_out_all)
-    }
+    private val viewModel: AccountsViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.microsoft_accounts)
 
+        val accountsAdapter = AccountsAdapter(this, accounts)
         (accountsDropdown.editText as? AutoCompleteTextView)?.apply {
             onItemClickListener = AdapterView.OnItemClickListener { _, _, position, _ ->
                 onAccountSelected(position)
             }
             setAdapter(accountsAdapter)
         }
-        addAccountButton.setOnClickListener { onAddAccount() }
-        signOutButton.setOnClickListener { onSignOut() }
+
+        findViewById<Button>(R.id.add_account).apply {
+            setOnClickListener { onAddAccount() }
+
+            val canAddAccountObserver = Observer<Boolean> { isEnabled = it }
+            viewModel.canAddAccount.observe(this@MicrosoftAccountsActivity, canAddAccountObserver)
+        }
+
+        findViewById<Button>(R.id.sign_out).apply {
+            setOnClickListener { onSignOut() }
+
+            val canSignOutObserver = Observer<Boolean> { isEnabled = it }
+            viewModel.canSignOut.observe(this@MicrosoftAccountsActivity, canSignOutObserver)
+        }
+
+        val signOutAllButton = findViewById<Button>(R.id.sign_out_all)
         signOutAllButton.setOnClickListener { onSignOutAllAccounts() }
+
+        val accountsObserver = Observer<List<Account>> { accounts ->
+            accountsAdapter.notifyDataSetChanged()
+            accountsDropdown.isEnabled = accounts.isNotEmpty()
+            signOutAllButton.isEnabled = accounts.size > 1
+        }
+        viewModel.accounts.observe(this, accountsObserver)
+
+        val sharedPreferences = getPreferences(MODE_PRIVATE)
+
+        val selectedAccountObserver = Observer<Account> { account ->
+            withTokenBroker { tokenBroker ->
+                if (tokenBroker.selectedAccount == account) {
+                    return@withTokenBroker
+                }
+
+                tokenBroker.selectedAccount = account
+
+                when (account) {
+                    null -> sharedPreferences.edit {
+                        remove(USERNAME_KEY)
+                        remove(ACCOUNT_TYPE_KEY)
+                    }
+                    else -> sharedPreferences.edit {
+                        putString(USERNAME_KEY, account.userPrincipalName)
+                        putString(ACCOUNT_TYPE_KEY, account.accountType.toString())
+                    }
+                }
+            }
+
+            when (account) {
+                null -> {
+                    accountsDropdown.editText?.text?.clear()
+                    viewModel.canSignOut.value = false
+                }
+                else -> {
+                    accountsDropdown.editText?.let {
+                        if (it.text?.length == 0) {
+                            it.setText(account.toString(), TextView.BufferType.EDITABLE)
+                        }
+                    }
+                    viewModel.canSignOut.value = true
+                }
+            }
+        }
+        viewModel.selectedAccount.observe(this, selectedAccountObserver)
 
         withTokenBroker { tokenBroker ->
             val allAccounts = tokenBroker.allAccounts()
             if (allAccounts.isNotEmpty()) {
                 accounts.addAll(allAccounts)
-                accountsAdapter.notifyDataSetChanged()
+                viewModel.accounts.postValue(accounts)
 
                 val userPrincipalName = sharedPreferences.getString(USERNAME_KEY, null)
                 val accountType = sharedPreferences.getString(ACCOUNT_TYPE_KEY, null)
                 val selectedAccount = allAccounts.find {
                     it.userPrincipalName == userPrincipalName && it.accountType.toString() == accountType
                 }
-                setSelectedAccount(tokenBroker, selectedAccount, false)
+                tokenBroker.selectedAccount = selectedAccount
+                viewModel.selectedAccount.postValue(selectedAccount)
             }
         }
     }
 
     private fun addAccount(accountType: AccountType) {
-        addAccountButton.isEnabled = false
+        viewModel.canAddAccount.value = false
 
         withTokenBroker { tokenBroker ->
             tokenBroker.acquireToken(
@@ -94,9 +141,7 @@ class MicrosoftAccountsActivity : AppCompatActivity() {
                 null,
                 accountType
             ) { result: AuthResult?, error: AuthError? ->
-                runOnUiThread {
-                    addAccountButton.isEnabled = true
-                }
+                viewModel.canAddAccount.postValue(true)
 
                 when {
                     error != null -> when (error.type) {
@@ -113,12 +158,12 @@ class MicrosoftAccountsActivity : AppCompatActivity() {
 
                         accounts.clear()
                         accounts.addAll(allAccounts)
-                        accountsAdapter.notifyDataSetChanged()
+                        viewModel.accounts.postValue(accounts)
 
                         val selectedAccount = allAccounts.findLast {
                             it.accountType == accountType && it.userPrincipalName == result.username
                         }
-                        setSelectedAccount(tokenBroker, selectedAccount)
+                        viewModel.selectedAccount.postValue(selectedAccount)
                     }
                 }
             }
@@ -126,12 +171,12 @@ class MicrosoftAccountsActivity : AppCompatActivity() {
     }
 
     private fun onAccountSelected(index: Int) {
-        withTokenBroker { tokenBroker ->
-            val account = accounts[index]
-            setSelectedAccount(tokenBroker, account)
+        val account = accounts[index]
+        viewModel.selectedAccount.value = account
 
-            val scopes = Config.scopesFor(account.accountType)
-            if (scopes.isNotEmpty()) {
+        val scopes = Config.scopesFor(account.accountType)
+        if (scopes.isNotEmpty()) {
+            withTokenBroker { tokenBroker ->
                 tokenBroker.acquireToken(
                     this,
                     scopes,
@@ -163,74 +208,35 @@ class MicrosoftAccountsActivity : AppCompatActivity() {
     }
 
     private fun onSignOut() {
-        signOutButton.isEnabled = false
+        viewModel.canSignOut.value = false
 
         withTokenBroker { tokenBroker ->
-            tokenBroker.signOut { exception ->
+            tokenBroker.signOut { account, exception ->
                 when (exception) {
                     null -> {
-                        val index = accounts.indexOf(tokenBroker.selectedAccount)
-                        accounts.removeAt(index)
-                        accountsAdapter.notifyDataSetChanged()
-
-                        withTokenBroker { tokenBroker ->
-                            setSelectedAccount(tokenBroker, null)
+                        val index = accounts.indexOf(account)
+                        if (index >= 0) {
+                            accounts.removeAt(index)
                         }
+                        viewModel.accounts.postValue(accounts)
+                        viewModel.selectedAccount.postValue(null)
                     }
-                    else -> showErrorMessage(R.string.error_sign_out)
+                    else -> {
+                        viewModel.canSignOut.postValue(true)
+                        showErrorMessage(R.string.error_sign_out)
+                    }
                 }
             }
         }
     }
 
     private fun onSignOutAllAccounts() {
-        accountsDropdown.editText?.text?.clear()
-        accountsDropdown.isEnabled = false
-        signOutButton.isEnabled = false
-        signOutAllButton.isEnabled = false
+        accounts.clear()
+        viewModel.accounts.value = accounts
+        viewModel.selectedAccount.value = null
 
         withTokenBroker { tokenBroker ->
             tokenBroker.removeAllAccounts()
-            accounts.clear()
-            accountsAdapter.notifyDataSetChanged()
-            setSelectedAccount(tokenBroker, null)
-        }
-    }
-
-    private fun setSelectedAccount(
-        tokenBroker: TokenBroker,
-        account: Account?,
-        updatePreferences: Boolean = true
-    ) {
-        tokenBroker.selectedAccount = account
-
-        runOnUiThread {
-            if (account == null) {
-                accountsDropdown.editText?.text?.clear()
-                signOutButton.isEnabled = false
-            } else {
-                accountsDropdown.editText?.let {
-                    if (it.text?.length == 0) {
-                        it.setText(account.toString(), TextView.BufferType.EDITABLE)
-                    }
-                }
-                signOutButton.isEnabled = true
-            }
-            accountsDropdown.isEnabled = accounts.isNotEmpty()
-            signOutAllButton.isEnabled = accounts.size > 1
-        }
-
-        if (updatePreferences) {
-            when (account) {
-                null -> sharedPreferences.edit()
-                    .remove(USERNAME_KEY)
-                    .remove(ACCOUNT_TYPE_KEY)
-                    .apply()
-                else -> sharedPreferences.edit()
-                    .putString(USERNAME_KEY, account.userPrincipalName)
-                    .putString(ACCOUNT_TYPE_KEY, account.accountType.toString())
-                    .apply()
-            }
         }
     }
 

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MicrosoftAccountsActivity.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MicrosoftAccountsActivity.kt
@@ -1,10 +1,13 @@
 package com.microsoft.reacttestapp.msal
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.widget.AdapterView
 import android.widget.AutoCompleteTextView
 import android.widget.Button
+import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -68,18 +71,15 @@ class MicrosoftAccountsActivity : AppCompatActivity() {
         withTokenBroker { tokenBroker ->
             val allAccounts = tokenBroker.allAccounts()
             if (allAccounts.isNotEmpty()) {
-                val userPrincipalName = sharedPreferences.getString(USERNAME_KEY, null)
-                val accountType = sharedPreferences.getString(ACCOUNT_TYPE_KEY, null)
-                tokenBroker.selectedAccount = allAccounts.find {
-                    it.userPrincipalName == userPrincipalName && it.accountType.toString() == accountType
-                }
-
                 accounts.addAll(allAccounts)
                 accountsAdapter.notifyDataSetChanged()
 
-                runOnUiThread {
-                    accountsDropdown.isEnabled = true
+                val userPrincipalName = sharedPreferences.getString(USERNAME_KEY, null)
+                val accountType = sharedPreferences.getString(ACCOUNT_TYPE_KEY, null)
+                val selectedAccount = allAccounts.find {
+                    it.userPrincipalName == userPrincipalName && it.accountType.toString() == accountType
                 }
+                setSelectedAccount(tokenBroker, selectedAccount, false)
             }
         }
     }
@@ -99,23 +99,26 @@ class MicrosoftAccountsActivity : AppCompatActivity() {
                 }
 
                 when {
-                    error != null -> showErrorMessage(
-                        error.message ?: resources.getString(R.string.error_sign_in)
-                    )
-                    result == null -> showErrorMessage(R.string.error_sign_in)
-                    else -> {
-                        val allAccounts = tokenBroker.allAccounts()
-                        tokenBroker.selectedAccount = allAccounts.findLast {
-                            it.accountType == accountType && it.userPrincipalName == result.username
+                    error != null -> when (error.type) {
+                        AuthErrorType.USER_CANCELED -> return@acquireToken
+                        else -> {
+                            val message =
+                                error.message ?: resources.getString(R.string.error_sign_in)
+                            showAlertDialog(R.string.error_sign_in, message)
                         }
+                    }
+                    result == null -> showErrorMessage(R.string.error_sign_in)
+                    else -> withTokenBroker { tokenBroker ->
+                        val allAccounts = tokenBroker.allAccounts()
+
                         accounts.clear()
                         accounts.addAll(allAccounts)
                         accountsAdapter.notifyDataSetChanged()
 
-                        runOnUiThread {
-                            accountsDropdown.isEnabled = allAccounts.isNotEmpty()
-                            signOutAllButton.isEnabled = allAccounts.size > 1
+                        val selectedAccount = allAccounts.findLast {
+                            it.accountType == accountType && it.userPrincipalName == result.username
                         }
+                        setSelectedAccount(tokenBroker, selectedAccount)
                     }
                 }
             }
@@ -124,17 +127,8 @@ class MicrosoftAccountsActivity : AppCompatActivity() {
 
     private fun onAccountSelected(index: Int) {
         withTokenBroker { tokenBroker ->
-            runOnUiThread {
-                signOutButton.isEnabled = true
-            }
-
             val account = accounts[index]
-            tokenBroker.selectedAccount = account
-
-            sharedPreferences.edit()
-                .putString(USERNAME_KEY, account.userPrincipalName)
-                .putString(ACCOUNT_TYPE_KEY, account.accountType.toString())
-                .apply()
+            setSelectedAccount(tokenBroker, account)
 
             val scopes = Config.scopesFor(account.accountType)
             if (scopes.isNotEmpty()) {
@@ -179,10 +173,8 @@ class MicrosoftAccountsActivity : AppCompatActivity() {
                         accounts.removeAt(index)
                         accountsAdapter.notifyDataSetChanged()
 
-                        runOnUiThread {
-                            accountsDropdown.editText?.text?.clear()
-                            accountsDropdown.isEnabled = accounts.isNotEmpty()
-                            signOutAllButton.isEnabled = accounts.size > 1
+                        withTokenBroker { tokenBroker ->
+                            setSelectedAccount(tokenBroker, null)
                         }
                     }
                     else -> showErrorMessage(R.string.error_sign_out)
@@ -201,7 +193,58 @@ class MicrosoftAccountsActivity : AppCompatActivity() {
             tokenBroker.removeAllAccounts()
             accounts.clear()
             accountsAdapter.notifyDataSetChanged()
+            setSelectedAccount(tokenBroker, null)
         }
+    }
+
+    private fun setSelectedAccount(
+        tokenBroker: TokenBroker,
+        account: Account?,
+        updatePreferences: Boolean = true
+    ) {
+        tokenBroker.selectedAccount = account
+
+        runOnUiThread {
+            if (account == null) {
+                accountsDropdown.editText?.text?.clear()
+                signOutButton.isEnabled = false
+            } else {
+                accountsDropdown.editText?.let {
+                    if (it.text?.length == 0) {
+                        it.setText(account.toString(), TextView.BufferType.EDITABLE)
+                    }
+                }
+                signOutButton.isEnabled = true
+            }
+            accountsDropdown.isEnabled = accounts.isNotEmpty()
+            signOutAllButton.isEnabled = accounts.size > 1
+        }
+
+        if (updatePreferences) {
+            when (account) {
+                null -> sharedPreferences.edit()
+                    .remove(USERNAME_KEY)
+                    .remove(ACCOUNT_TYPE_KEY)
+                    .apply()
+                else -> sharedPreferences.edit()
+                    .putString(USERNAME_KEY, account.userPrincipalName)
+                    .putString(ACCOUNT_TYPE_KEY, account.accountType.toString())
+                    .apply()
+            }
+        }
+    }
+
+    private fun showAlertDialog(@StringRes title: Int, message: String) {
+        MaterialAlertDialogBuilder(this)
+            .setTitle(title)
+            .setMessage(message)
+            .setNeutralButton(R.string.copy) { _, _ ->
+                val clipboard = getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+                val label = resources.getString(R.string.auth_error_message)
+                clipboard.setPrimaryClip(ClipData.newPlainText(label, message))
+            }
+            .setPositiveButton(R.string.ok, null)
+            .show()
     }
 
     private fun showErrorMessage(message: String) {

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MicrosoftAccountsActivity.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MicrosoftAccountsActivity.kt
@@ -1,0 +1,192 @@
+package com.microsoft.reacttestapp.msal
+
+import android.os.Bundle
+import android.widget.AdapterView
+import android.widget.AutoCompleteTextView
+import android.widget.Button
+import android.widget.TextView
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.textfield.TextInputLayout
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+@Suppress("unused")
+class MicrosoftAccountsActivity : AppCompatActivity() {
+    private val accounts: MutableList<Account> = mutableListOf(
+        Account("arnold@contoso.com", AccountType.MICROSOFT_ACCOUNT)
+    )
+
+    private val accountsAdapter: AccountsAdapter by lazy {
+        AccountsAdapter(this, accounts)
+    }
+
+    private val accountsDropdown: TextInputLayout by lazy {
+        findViewById(R.id.accounts_dropdown)
+    }
+
+    private val executorService: ExecutorService by lazy {
+        Executors.newSingleThreadExecutor()
+    }
+
+    private val signOutButton: Button by lazy {
+        findViewById(R.id.sign_out)
+    }
+
+    private val signOutAllButton: Button by lazy {
+        findViewById(R.id.sign_out_all)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(R.layout.microsoft_accounts)
+
+        (accountsDropdown.editText as? AutoCompleteTextView)?.apply {
+            onItemClickListener = AdapterView.OnItemClickListener { _, _, position, _ ->
+                onSwitchAccount(position)
+            }
+            setAdapter(accountsAdapter)
+        }
+        findViewById<TextView>(R.id.add_account).apply {
+            setOnClickListener {
+                this@MicrosoftAccountsActivity.onAddAccount()
+            }
+        }
+        signOutButton.setOnClickListener {
+            onSignOut()
+        }
+        signOutAllButton.setOnClickListener {
+            onSignOutAllAccounts()
+        }
+    }
+
+    private fun addAccount(accountType: AccountType) {
+        withTokenBroker { tokenBroker ->
+            tokenBroker.acquireToken(
+                this,
+                Config.scopesFor(accountType),
+                null,
+                accountType
+            ) { result: AuthResult?, error: AuthError? ->
+                when {
+                    error != null -> showErrorMessage(
+                        error.message ?: resources.getString(R.string.error_sign_in)
+                    )
+                    result == null -> showErrorMessage(R.string.error_sign_in)
+                    else -> {
+                        val allAccounts = tokenBroker.allAccounts()
+                        tokenBroker.currentAccount = allAccounts.findLast {
+                            it.accountType == accountType && it.userPrincipalName == result.username
+                        }
+                        accounts.clear()
+                        accounts.addAll(allAccounts)
+                        accountsAdapter.notifyDataSetChanged()
+
+                        runOnUiThread {
+                            accountsDropdown.isEnabled = allAccounts.isNotEmpty()
+                            signOutAllButton.isEnabled = allAccounts.size > 1
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun onAddAccount() {
+        MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.select_account_type)
+            .setNegativeButton(R.string.account_type_personal) { _, _ ->
+                addAccount(AccountType.MICROSOFT_ACCOUNT)
+            }
+            .setPositiveButton(R.string.account_type_work) { _, _ ->
+                addAccount(AccountType.ORGANIZATIONAL)
+            }
+            .setCancelable(true)
+            .show()
+    }
+
+    private fun onSignOut() {
+        signOutButton.isEnabled = false
+
+        withTokenBroker { tokenBroker ->
+            tokenBroker.signOut { exception ->
+                when (exception) {
+                    null -> {
+                        val index = accounts.indexOf(tokenBroker.currentAccount)
+                        accounts.removeAt(index)
+                        accountsAdapter.notifyDataSetChanged()
+
+                        runOnUiThread {
+                            accountsDropdown.editText?.text?.clear()
+                            accountsDropdown.isEnabled = accounts.isNotEmpty()
+                            signOutAllButton.isEnabled = accounts.size > 1
+                        }
+                    }
+                    else -> showErrorMessage(R.string.error_sign_out)
+                }
+            }
+        }
+    }
+
+    private fun onSignOutAllAccounts() {
+        accountsDropdown.editText?.text?.clear()
+        accountsDropdown.isEnabled = false
+        signOutButton.isEnabled = false
+        signOutAllButton.isEnabled = false
+
+        withTokenBroker { tokenBroker ->
+            tokenBroker.removeAllAccounts()
+            accounts.clear()
+            accountsAdapter.notifyDataSetChanged()
+        }
+    }
+
+    private fun onSwitchAccount(index: Int) {
+        withTokenBroker { tokenBroker ->
+            runOnUiThread {
+                signOutButton.isEnabled = true
+            }
+
+            val account = accounts[index]
+            tokenBroker.currentAccount = account
+
+            val scopes = Config.scopesFor(account.accountType)
+            if (scopes.isNotEmpty()) {
+                tokenBroker.acquireToken(
+                    this,
+                    scopes,
+                    account.userPrincipalName,
+                    account.accountType
+                ) { result: AuthResult?, error: AuthError? ->
+                    when {
+                        error != null -> showErrorMessage(
+                            error.message ?: resources.getString(R.string.error_refresh)
+                        )
+                        result == null -> showErrorMessage(R.string.error_refresh)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun showErrorMessage(message: String) {
+        Snackbar.make(accountsDropdown, message, Snackbar.LENGTH_LONG).show()
+    }
+
+    private fun showErrorMessage(@StringRes resId: Int) {
+        Snackbar.make(accountsDropdown, resId, Snackbar.LENGTH_LONG).show()
+    }
+
+    private fun withTokenBroker(execute: (tokenBroker: TokenBroker) -> Unit) {
+        executorService.execute {
+            try {
+                execute(TokenBroker.getInstance(this))
+            } catch (e: Exception) {
+                showErrorMessage(e.message ?: "Unknown error")
+            }
+        }
+    }
+}

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MsalPackage.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MsalPackage.kt
@@ -1,0 +1,19 @@
+package com.microsoft.reacttestapp.msal
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+/**
+ * Dummy `ReactPackage` implementation used solely for auto-linking purposes.
+ */
+class MsalPackage : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        return emptyList()
+    }
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+        return emptyList()
+    }
+}

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/TokenBroker.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/TokenBroker.kt
@@ -74,26 +74,29 @@ class TokenBroker private constructor(context: Context) {
         }
     }
 
-    fun signOut(onCompleted: (exception: Exception?) -> Unit) {
+    fun signOut(onCompleted: (account: Account?, exception: Exception?) -> Unit) {
         val account = selectedAccount?.let {
             multiAccountApp.accounts.find(it.userPrincipalName, it.accountType)
         }
         when (account) {
-            null -> onCompleted(null)
+            null -> {
+                onCompleted(selectedAccount, null)
+                selectedAccount = null
+            }
             else -> multiAccountApp.removeAccount(
                 account,
                 object : IMultipleAccountPublicClientApplication.RemoveAccountCallback {
                     override fun onRemoved() {
-                        onCompleted(null)
+                        onCompleted(selectedAccount, null)
+                        selectedAccount = null
                     }
 
                     override fun onError(exception: MsalException) {
-                        onCompleted(exception)
+                        onCompleted(selectedAccount, exception)
                     }
                 }
             )
         }
-        selectedAccount = null
     }
 
     private fun acquireTokenInteractive(

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/TokenBroker.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/TokenBroker.kt
@@ -1,0 +1,168 @@
+package com.microsoft.reacttestapp.msal
+
+import android.app.Activity
+import android.content.Context
+import com.microsoft.identity.client.AcquireTokenParameters
+import com.microsoft.identity.client.AuthenticationCallback
+import com.microsoft.identity.client.IAuthenticationResult
+import com.microsoft.identity.client.IMultipleAccountPublicClientApplication
+import com.microsoft.identity.client.PublicClientApplication
+import com.microsoft.identity.client.exception.MsalException
+import com.microsoft.identity.common.exception.BaseException
+import com.microsoft.identity.common.exception.UiRequiredException
+
+typealias TokenAcquiredHandler = (result: AuthResult?, error: AuthError?) -> Unit
+
+class TokenBroker private constructor(context: Context) {
+    companion object {
+        const val EMPTY_GUID = "00000000-0000-0000-0000-000000000000"
+
+        // Source: https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens
+        const val MSA_TENANT = "9188040d-6c67-4c5b-b112-36a304b66dad"
+
+        @Volatile
+        private var INSTANCE: TokenBroker? = null
+
+        fun getInstance(context: Context): TokenBroker =
+            INSTANCE ?: synchronized(this) {
+                INSTANCE ?: TokenBroker(context).also {
+                    INSTANCE = it
+                }
+            }
+    }
+
+    var currentAccount: Account? = null
+
+    private var multiAccountApp: IMultipleAccountPublicClientApplication
+
+    init {
+        val configFileResourceId = context.resources
+            .getIdentifier("raw/msal_config", null, context.packageName)
+        multiAccountApp = PublicClientApplication.createMultipleAccountPublicClientApplication(
+            context,
+            configFileResourceId
+        )
+    }
+
+    fun acquireToken(
+        activity: Activity,
+        scopes: Array<String>,
+        userPrincipalName: String?,
+        accountType: AccountType,
+        onTokenAcquired: TokenAcquiredHandler
+    ) {
+        acquireTokenSilent(
+            activity,
+            scopes,
+            userPrincipalName,
+            accountType,
+            onTokenAcquired
+        )
+    }
+
+    fun allAccounts(): List<Account> = multiAccountApp.accounts.map {
+        Account(
+            it.username,
+            AccountType.fromIssuer(it.claims?.get("iss").toString())
+        )
+    }
+
+    fun removeAllAccounts() {
+        currentAccount = null
+        multiAccountApp.accounts.forEach {
+            multiAccountApp.removeAccount(it)
+        }
+    }
+
+    fun signOut(onCompleted: (exception: Exception?) -> Unit) {
+        val account = currentAccount?.let {
+            multiAccountApp.accounts.find(it.userPrincipalName, it.accountType)
+        }
+        when (account) {
+            null -> onCompleted(null)
+            else -> multiAccountApp.removeAccount(
+                account,
+                object : IMultipleAccountPublicClientApplication.RemoveAccountCallback {
+                    override fun onRemoved() {
+                        onCompleted(null)
+                    }
+
+                    override fun onError(exception: MsalException) {
+                        onCompleted(exception)
+                    }
+                }
+            )
+        }
+        currentAccount = null
+    }
+
+    private fun acquireTokenInteractive(
+        activity: Activity,
+        scopes: Array<String>,
+        userPrincipalName: String?,
+        accountType: AccountType,
+        onTokenAcquired: TokenAcquiredHandler
+    ) {
+        val parameters = AcquireTokenParameters.Builder()
+            .startAuthorizationFromActivity(activity)
+            .withScopes(scopes.toMutableList())
+            .withCallback(object : AuthenticationCallback {
+                override fun onSuccess(result: IAuthenticationResult) {
+                    val redirectUri = multiAccountApp.configuration.redirectUri
+                    onTokenAcquired(AuthResult(result, redirectUri), null)
+                }
+
+                override fun onError(exception: MsalException) {
+                    onTokenAcquired(null, AuthError(exception))
+                }
+
+                override fun onCancel() {
+                    onTokenAcquired(
+                        null,
+                        AuthError(AuthErrorType.USER_CANCELED, EMPTY_GUID, null)
+                    )
+                }
+            })
+        userPrincipalName?.let { parameters.withLoginHint(it) }
+        multiAccountApp.acquireToken(parameters.build())
+    }
+
+    private fun acquireTokenSilent(
+        activity: Activity,
+        scopes: Array<String>,
+        userPrincipalName: String?,
+        accountType: AccountType,
+        onTokenAcquired: TokenAcquiredHandler
+    ) {
+        val account = userPrincipalName?.let {
+            multiAccountApp.accounts.find(userPrincipalName, accountType)
+        }
+        if (account == null) {
+            acquireTokenInteractive(
+                activity,
+                scopes,
+                userPrincipalName,
+                accountType,
+                onTokenAcquired
+            )
+            return
+        }
+
+        val authority = multiAccountApp.configuration.defaultAuthority.authorityURL.toString()
+        try {
+            val result = multiAccountApp.acquireTokenSilent(scopes, account, authority)
+            val redirectUri = multiAccountApp.configuration.redirectUri
+            onTokenAcquired(AuthResult(result, redirectUri), null)
+        } catch (_: UiRequiredException) {
+            acquireTokenInteractive(
+                activity,
+                scopes,
+                userPrincipalName,
+                accountType,
+                onTokenAcquired
+            )
+        } catch (exception: BaseException) {
+            onTokenAcquired(null, AuthError(exception))
+        }
+    }
+}

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/TokenBroker.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/TokenBroker.kt
@@ -106,6 +106,7 @@ class TokenBroker private constructor(context: Context) {
         val parameters = AcquireTokenParameters.Builder()
             .startAuthorizationFromActivity(activity)
             .withScopes(scopes.toMutableList())
+            .fromAuthority(Config.authorityFor(accountType))
             .withCallback(object : AuthenticationCallback {
                 override fun onSuccess(result: IAuthenticationResult) {
                     val redirectUri = multiAccountApp.configuration.redirectUri

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/TokenBroker.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/TokenBroker.kt
@@ -17,9 +17,6 @@ class TokenBroker private constructor(context: Context) {
     companion object {
         const val EMPTY_GUID = "00000000-0000-0000-0000-000000000000"
 
-        // Source: https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens
-        const val MSA_TENANT = "9188040d-6c67-4c5b-b112-36a304b66dad"
-
         @Volatile
         private var INSTANCE: TokenBroker? = null
 

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/TokenBroker.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/TokenBroker.kt
@@ -31,7 +31,7 @@ class TokenBroker private constructor(context: Context) {
             }
     }
 
-    var currentAccount: Account? = null
+    var selectedAccount: Account? = null
 
     private var multiAccountApp: IMultipleAccountPublicClientApplication
 
@@ -68,14 +68,14 @@ class TokenBroker private constructor(context: Context) {
     }
 
     fun removeAllAccounts() {
-        currentAccount = null
+        selectedAccount = null
         multiAccountApp.accounts.forEach {
             multiAccountApp.removeAccount(it)
         }
     }
 
     fun signOut(onCompleted: (exception: Exception?) -> Unit) {
-        val account = currentAccount?.let {
+        val account = selectedAccount?.let {
             multiAccountApp.accounts.find(it.userPrincipalName, it.accountType)
         }
         when (account) {
@@ -93,7 +93,7 @@ class TokenBroker private constructor(context: Context) {
                 }
             )
         }
-        currentAccount = null
+        selectedAccount = null
     }
 
     private fun acquireTokenInteractive(

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/TokenBroker.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/TokenBroker.kt
@@ -58,10 +58,7 @@ class TokenBroker private constructor(context: Context) {
     }
 
     fun allAccounts(): List<Account> = multiAccountApp.accounts.map {
-        Account(
-            it.username,
-            AccountType.fromIssuer(it.claims?.get("iss").toString())
-        )
+        Account(it.username, it.accountType())
     }
 
     fun removeAllAccounts() {

--- a/packages/react-native-test-app-msal/android/src/main/res/color/destructive_btn_bg_color_selector.xml
+++ b/packages/react-native-test-app-msal/android/src/main/res/color/destructive_btn_bg_color_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorError" android:state_enabled="true" />
+    <item android:alpha="0.12" android:color="?attr/colorOnSurface" />
+</selector>

--- a/packages/react-native-test-app-msal/android/src/main/res/color/destructive_btn_text_color_selector.xml
+++ b/packages/react-native-test-app-msal/android/src/main/res/color/destructive_btn_text_color_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorOnError" android:state_enabled="true" />
+    <item android:alpha="0.38" android:color="?attr/colorOnSurface" />
+</selector>

--- a/packages/react-native-test-app-msal/android/src/main/res/drawable/ic_person_add_24dp.xml
+++ b/packages/react-native-test-app-msal/android/src/main/res/drawable/ic_person_add_24dp.xml
@@ -1,0 +1,21 @@
+<!--
+  Copyright 2019 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<vector android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/darker_gray" android:pathData="M15,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM6,10L6,7L4,7v3L1,10v2h3v3h2v-3h3v-2L6,10zM15,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"/>
+</vector>

--- a/packages/react-native-test-app-msal/android/src/main/res/layout/account_item.xml
+++ b/packages/react-native-test-app-msal/android/src/main/res/layout/account_item.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/username"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
+        android:ellipsize="middle"
+        android:padding="0dp"
+        android:singleLine="true"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+        app:layout_constraintBottom_toTopOf="@+id/account_type"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="@tools:sample/first_names" />
+
+    <TextView
+        android:id="@+id/account_type"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginBottom="8dp"
+        android:ellipsize="middle"
+        android:padding="0dp"
+        android:singleLine="true"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/username"
+        tools:text="@tools:sample/last_names" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/packages/react-native-test-app-msal/android/src/main/res/layout/microsoft_accounts.xml
+++ b/packages/react-native-test-app-msal/android/src/main/res/layout/microsoft_accounts.xml
@@ -21,8 +21,10 @@
 
         <AutoCompleteTextView
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
             android:inputType="none"
+            android:singleLine="true"
             tools:text="@tools:sample/full_names" />
 
     </com.google.android.material.textfield.TextInputLayout>

--- a/packages/react-native-test-app-msal/android/src/main/res/layout/microsoft_accounts.xml
+++ b/packages/react-native-test-app-msal/android/src/main/res/layout/microsoft_accounts.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/accounts_dropdown"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginBottom="8dp"
+        android:hint="@string/current_account"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <AutoCompleteTextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:inputType="none"
+            tools:text="@tools:sample/full_names" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <Button
+        android:id="@+id/add_account"
+        style="@style/Widget.MaterialComponents.Button.TextButton.Icon"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginVertical="8dp"
+        android:text="@string/add_account"
+        android:textAlignment="textStart"
+        app:icon="@drawable/ic_person_add_24dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/accounts_dropdown" />
+
+    <Button
+        android:id="@+id/sign_out"
+        style="@style/Widget.ReactNativeTestAppMsal.DestructiveButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="8dp"
+        android:enabled="false"
+        android:text="@string/sign_out"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/add_account" />
+
+    <Button
+        android:id="@+id/sign_out_all"
+        style="@style/Widget.ReactNativeTestAppMsal.DestructiveButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="8dp"
+        android:enabled="false"
+        android:text="@string/sign_out_of_all_accounts"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/sign_out" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/packages/react-native-test-app-msal/android/src/main/res/layout/microsoft_accounts.xml
+++ b/packages/react-native-test-app-msal/android/src/main/res/layout/microsoft_accounts.xml
@@ -13,6 +13,7 @@
         android:layout_marginHorizontal="16dp"
         android:layout_marginTop="24dp"
         android:layout_marginBottom="8dp"
+        android:enabled="false"
         android:hint="@string/selected_account"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/packages/react-native-test-app-msal/android/src/main/res/layout/microsoft_accounts.xml
+++ b/packages/react-native-test-app-msal/android/src/main/res/layout/microsoft_accounts.xml
@@ -13,7 +13,7 @@
         android:layout_marginHorizontal="16dp"
         android:layout_marginTop="24dp"
         android:layout_marginBottom="8dp"
-        android:hint="@string/current_account"
+        android:hint="@string/selected_account"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">

--- a/packages/react-native-test-app-msal/android/src/main/res/values/destructive_button.xml
+++ b/packages/react-native-test-app-msal/android/src/main/res/values/destructive_button.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <style name="Widget.ReactNativeTestAppMsal.DestructiveButton" parent="Widget.MaterialComponents.Button">
+        <item name="android:textColor">@color/destructive_btn_text_color_selector</item>
+        <item name="backgroundTint">@color/destructive_btn_bg_color_selector</item>
+    </style>
+
+</resources>

--- a/packages/react-native-test-app-msal/android/src/main/res/values/strings.xml
+++ b/packages/react-native-test-app-msal/android/src/main/res/values/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="account_type">Account type: %1$s</string>
+    <string name="account_type_personal">Personal</string>
+    <string name="account_type_work">Work or school</string>
+    <string name="add_account">Add account</string>
+    <string name="current_account">Current account</string>
+    <string name="error_refresh">Failed to refresh access token</string>
+    <string name="error_sign_in">Failed to sign in</string>
+    <string name="error_sign_out">Failed to sign out</string>
+    <string name="select_account_type">Select account type</string>
+    <string name="sign_out">Sign out</string>
+    <string name="sign_out_of_all_accounts">Sign out of all accounts</string>
+</resources>

--- a/packages/react-native-test-app-msal/android/src/main/res/values/strings.xml
+++ b/packages/react-native-test-app-msal/android/src/main/res/values/strings.xml
@@ -4,9 +4,12 @@
     <string name="account_type_personal">Personal</string>
     <string name="account_type_work">Work or school</string>
     <string name="add_account">Add account</string>
+    <string name="auth_error_message">Auth error message</string>
+    <string name="copy">Copy</string>
     <string name="error_refresh">Failed to refresh access token</string>
     <string name="error_sign_in">Failed to sign in</string>
     <string name="error_sign_out">Failed to sign out</string>
+    <string name="ok">OK</string>
     <string name="select_account_type">Select account type</string>
     <string name="selected_account">Selected account</string>
     <string name="sign_out">Sign out</string>

--- a/packages/react-native-test-app-msal/android/src/main/res/values/strings.xml
+++ b/packages/react-native-test-app-msal/android/src/main/res/values/strings.xml
@@ -4,11 +4,11 @@
     <string name="account_type_personal">Personal</string>
     <string name="account_type_work">Work or school</string>
     <string name="add_account">Add account</string>
-    <string name="current_account">Current account</string>
     <string name="error_refresh">Failed to refresh access token</string>
     <string name="error_sign_in">Failed to sign in</string>
     <string name="error_sign_out">Failed to sign out</string>
     <string name="select_account_type">Select account type</string>
+    <string name="selected_account">Selected account</string>
     <string name="sign_out">Sign out</string>
     <string name="sign_out_of_all_accounts">Sign out of all accounts</string>
 </resources>

--- a/packages/react-native-test-app-msal/ios/AccountType.swift
+++ b/packages/react-native-test-app-msal/ios/AccountType.swift
@@ -7,23 +7,19 @@ public enum AccountType: Int, CaseIterable {
 }
 
 extension AccountType {
+    enum Constants {
+        // Source: https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens
+        static let MicrosoftAccountTenant = "9188040d-6c67-4c5b-b112-36a304b66dad"
+    }
+
     static func from(issuer: String) -> AccountType {
-        issuer.contains(TokenBroker.Constants.MicrosoftAccountTenant)
+        issuer.contains(Constants.MicrosoftAccountTenant)
             ? .microsoftAccount
             : .organizational
     }
 
     static func from(string: String) -> AccountType {
         allCases.first { $0.description == string } ?? .organizational
-    }
-
-    var authority: URL! {
-        switch self {
-        case .microsoftAccount:
-            return URL(string: "https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize")
-        case .organizational:
-            return URL(string: "https://login.microsoftonline.com/common/")
-        }
     }
 
     var description: String {

--- a/packages/react-native-test-app-msal/ios/AccountsView.swift
+++ b/packages/react-native-test-app-msal/ios/AccountsView.swift
@@ -12,7 +12,7 @@ struct AccountsView: View {
 
     @State private var selectedAccount: Account? {
         didSet {
-            onAccountChanged(selectedAccount)
+            onAccountSelected(selectedAccount)
         }
     }
 
@@ -48,7 +48,7 @@ struct AccountsView: View {
                 }
                 .onChange(of: selectedAccount) {
                     // `didSet` is not called when selection is changed
-                    onAccountChanged($0)
+                    onAccountSelected($0)
                 }
                 .disabled(accounts.isEmpty)
                 #if os(iOS)
@@ -128,12 +128,12 @@ struct AccountsView: View {
         .disabled(formDisabled)
     }
 
-    private func onAccountChanged(_ account: Account?) {
+    private func onAccountSelected(_ account: Account?) {
         guard didLoad else {
             return
         }
 
-        TokenBroker.shared.currentAccount = account
+        TokenBroker.shared.selectedAccount = account
 
         guard let accountId = account?.id else {
             SecretStore.remove()

--- a/packages/react-native-test-app-msal/ios/Config.swift
+++ b/packages/react-native-test-app-msal/ios/Config.swift
@@ -19,6 +19,15 @@ struct Config: Decodable {
         return manifest.msalConfig
     }
 
+    public func authority(for accountType: AccountType) -> URL! {
+        switch accountType {
+        case .microsoftAccount:
+            return URL(string: "https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize")
+        case .organizational:
+            return URL(string: "https://login.microsoftonline.com/common/")
+        }
+    }
+
     public func scopes(for accountType: AccountType) -> [String] {
         switch accountType {
         case .microsoftAccount:

--- a/packages/react-native-test-app-msal/ios/TokenBroker.swift
+++ b/packages/react-native-test-app-msal/ios/TokenBroker.swift
@@ -17,7 +17,7 @@ public final class TokenBroker: NSObject {
     public static let shared = TokenBroker()
 
     @objc
-    public var currentAccount: Account?
+    public var selectedAccount: Account?
 
     private let condition = NSCondition()
     private let dispatchQueue = DispatchQueue(label: "com.microsoft.ReactTestApp-MSAL.TokenBroker")
@@ -50,11 +50,11 @@ public final class TokenBroker: NSObject {
         sender: RTAViewController,
         onTokenAcquired: @escaping TokenAcquiredHandler
     ) {
-        guard let currentAccount = currentAccount else {
+        guard let selectedAccount = selectedAccount else {
             let error = AuthError(
                 type: .preconditionViolated,
                 correlationID: Constants.EmptyGUID,
-                message: "No current account"
+                message: "No selected account"
             )
             onTokenAcquired(nil, error)
             return
@@ -62,8 +62,8 @@ public final class TokenBroker: NSObject {
 
         acquireToken(
             scopes: scopes,
-            userPrincipalName: currentAccount.userPrincipalName,
-            accountType: currentAccount.accountType,
+            userPrincipalName: selectedAccount.userPrincipalName,
+            accountType: selectedAccount.accountType,
             sender: sender,
             onTokenAcquired: onTokenAcquired
         )
@@ -111,7 +111,7 @@ public final class TokenBroker: NSObject {
     @objc
     public func removeAllAccounts(sender: RTAViewController) {
         defer {
-            currentAccount = nil
+            selectedAccount = nil
         }
 
         guard let application = publicClientApplication,
@@ -132,10 +132,10 @@ public final class TokenBroker: NSObject {
         completion: @escaping (_ success: Bool, _ error: Error?) -> Void
     ) {
         defer {
-            currentAccount = nil
+            selectedAccount = nil
         }
 
-        guard let username = currentAccount?.userPrincipalName,
+        guard let username = selectedAccount?.userPrincipalName,
               let account = try? publicClientApplication?.account(forUsername: username)
         else {
             completion(true, nil)

--- a/packages/react-native-test-app-msal/ios/TokenBroker.swift
+++ b/packages/react-native-test-app-msal/ios/TokenBroker.swift
@@ -7,9 +7,6 @@ public typealias TokenAcquiredHandler = (_ result: AuthResult?, _ error: AuthErr
 public final class TokenBroker: NSObject {
     enum Constants {
         static let EmptyGUID = "00000000-0000-0000-0000-000000000000"
-
-        // Source: https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens
-        static let MicrosoftAccountTenant = "9188040d-6c67-4c5b-b112-36a304b66dad"
         static let RedirectURI = "msauth.\(Bundle.main.bundleIdentifier ?? "")://auth"
     }
 
@@ -182,7 +179,7 @@ public final class TokenBroker: NSObject {
             scopes: scopes,
             webviewParameters: MSALWebviewParameters(authPresentationViewController: sender)
         )
-        parameters.authority = try? MSALAuthority(url: accountType.authority)
+        parameters.authority = try? MSALAuthority(url: config.authority(for: accountType))
         parameters.promptType = .selectAccount
 
         DispatchQueue.main.async {
@@ -224,7 +221,7 @@ public final class TokenBroker: NSObject {
         }
 
         let parameters = MSALSilentTokenParameters(scopes: scopes, account: cachedAccount)
-        parameters.authority = try? MSALAuthority(url: accountType.authority)
+        parameters.authority = try? MSALAuthority(url: config.authority(for: accountType))
 
         DispatchQueue.main.async {
             application.acquireTokenSilent(with: parameters) { result, error in

--- a/packages/react-native-test-app-msal/package.json
+++ b/packages/react-native-test-app-msal/package.json
@@ -18,6 +18,7 @@
     "format": "echo Format done.",
     "format:swift": "swiftformat --swiftversion 5.5 ios",
     "lint": "echo Lint done.",
+    "lint:kt": "ktlint --relative --verbose 'android/src/**/*.kt'",
     "lint:swift": "swiftlint"
   },
   "peerDependencies": {

--- a/packages/react-native-test-app-msal/package.json
+++ b/packages/react-native-test-app-msal/package.json
@@ -22,6 +22,6 @@
     "lint:swift": "swiftlint"
   },
   "peerDependencies": {
-    "react-native-test-app": ">=0.9.8"
+    "react-native-test-app": ">=0.9.16"
   }
 }

--- a/packages/test-app/android/build.gradle
+++ b/packages/test-app/android/build.gradle
@@ -9,5 +9,6 @@ buildscript { scriptHandler ->
 
     dependencies {
         classpath "com.android.tools.build:gradle:$androidPluginVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/packages/test-app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/test-app/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/test-app/app.json
+++ b/packages/test-app/app.json
@@ -22,7 +22,7 @@
     "clientId": "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
     "msaScopes": ["user.read"],
     "orgScopes": ["user.read"],
-    "signatureHash": "RkoBBuhjNghl/EqKUoHB3yF3/IM=",
+    "signatureHash": "1wIqXSqBj7w+h11ZifsnqwgyKrY=",
     "userPrincipalName": "arnold@contoso.com"
   },
   "resources": {

--- a/packages/test-app/app.json
+++ b/packages/test-app/app.json
@@ -12,7 +12,7 @@
     },
     {
       "appKey": "MicrosoftAccounts",
-      "displayName": "MicrosoftAccounts (iOS)"
+      "displayName": "MicrosoftAccounts (iOS/macOS)"
     }
   ],
   "android": {

--- a/packages/test-app/app.json
+++ b/packages/test-app/app.json
@@ -7,13 +7,22 @@
       "displayName": "SampleCrossApp"
     },
     {
-      "appKey": "MicrosoftAccounts"
+      "appKey": "com.microsoft.reacttestapp.msal.MicrosoftAccountsActivity",
+      "displayName": "MicrosoftAccounts (Android)"
+    },
+    {
+      "appKey": "MicrosoftAccounts",
+      "displayName": "MicrosoftAccounts (iOS)"
     }
   ],
+  "android": {
+    "package": "com.msft.identity.client.sample.local"
+  },
   "react-native-test-app-msal": {
-    "clientId": "00000000-0000-0000-0000-000000000000",
+    "clientId": "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
     "msaScopes": ["user.read"],
     "orgScopes": ["user.read"],
+    "signatureHash": "RkoBBuhjNghl/EqKUoHB3yF3/IM=",
     "userPrincipalName": "arnold@contoso.com"
   },
   "resources": {

--- a/packages/test-app/ios/Podfile.lock
+++ b/packages/test-app/ios/Podfile.lock
@@ -278,7 +278,7 @@ PODS:
     - React-jsi (= 0.66.3)
     - React-logger (= 0.66.3)
     - React-perflogger (= 0.66.3)
-  - ReactTestApp-DevSupport (0.9.13):
+  - ReactTestApp-DevSupport (0.9.16):
     - React-Core
     - React-jsi
   - ReactTestApp-MSAL (0.2.0):
@@ -435,7 +435,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 50cfe7049167cfc7e83ac5542c6fff0c76791a9b
   React-runtimeexecutor: bbbdb3d8fcf327c6e2249ee71b6ef1764b7dc266
   ReactCommon: 9bac022ab71596f2b0fde1268272543184c63971
-  ReactTestApp-DevSupport: 37726b4af5c9717f93532dd9eec72245dcb65481
+  ReactTestApp-DevSupport: 56413d35b490409d734a4ef3d16e3177c5cf3361
   ReactTestApp-MSAL: 725b6ab2f837e7f5047803346512b3fd58723e05
   ReactTestApp-Resources: 74a1cf509f4e7962b16361ea4e73cba3648fff5d
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584

--- a/packages/test-app/ios/Podfile.lock
+++ b/packages/test-app/ios/Podfile.lock
@@ -278,10 +278,10 @@ PODS:
     - React-jsi (= 0.66.3)
     - React-logger (= 0.66.3)
     - React-perflogger (= 0.66.3)
-  - ReactTestApp-DevSupport (0.9.12):
+  - ReactTestApp-DevSupport (0.9.13):
     - React-Core
     - React-jsi
-  - ReactTestApp-MSAL (0.1.0):
+  - ReactTestApp-MSAL (0.2.0):
     - MSAL
   - ReactTestApp-Resources (1.0.0-dev)
   - SwiftLint (0.44.0)
@@ -435,8 +435,8 @@ SPEC CHECKSUMS:
   React-RCTVibration: 50cfe7049167cfc7e83ac5542c6fff0c76791a9b
   React-runtimeexecutor: bbbdb3d8fcf327c6e2249ee71b6ef1764b7dc266
   ReactCommon: 9bac022ab71596f2b0fde1268272543184c63971
-  ReactTestApp-DevSupport: 6a2031cb7472e83b44298643c22942e53b480d90
-  ReactTestApp-MSAL: 1397a05a37f3956c38179548d2eccbabc392a09f
+  ReactTestApp-DevSupport: 37726b4af5c9717f93532dd9eec72245dcb65481
+  ReactTestApp-MSAL: 725b6ab2f837e7f5047803346512b3fd58723e05
   ReactTestApp-Resources: 74a1cf509f4e7962b16361ea4e73cba3648fff5d
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
   Yoga: 32a18c0e845e185f4a2a66ec76e1fd1f958f22fa


### PR DESCRIPTION
### Description

Adds Android support to react-native-test-app-msal.

### Remaining work

- [x] https://github.com/microsoft/react-native-test-app/pull/606
  - [x] Bump react-native-test-app dependency
- [x] Populate initial list of accounts from MSAL
- [x] Restore last used account
- [ ] ~~In order to enable the [broker](https://docs.microsoft.com/en-gb/azure/active-directory/develop/msal-android-single-sign-on#sso-through-brokered-authentication), we need the ability to [configure the keystore](https://developer.android.com/studio/publish/app-signing) in react-native-test-app~~
  - Will be done separately: #900

### Test plan

| Account switcher | List of accounts from MSAL | Adding a new account |
|-|-|-|
| ![image](https://user-images.githubusercontent.com/4123478/143247996-ea20b650-8eae-4f09-a087-72d6d4798854.png) | ![image](https://user-images.githubusercontent.com/4123478/143248057-5b96e37e-4eea-4be2-b07e-53d33e0744a8.png) | ![image](https://user-images.githubusercontent.com/4123478/143248133-64e4f05e-9e44-4651-bc76-013524bf3897.png) |