### PR TITLE
fix(eslint/no-export-all): `const` enums should be exported as types

### DIFF
--- a/change/@rnx-kit-eslint-plugin-2c6ac533-ac8c-4d07-9f0c-5acd82e04525.json
+++ b/change/@rnx-kit-eslint-plugin-2c6ac533-ac8c-4d07-9f0c-5acd82e04525.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add proper support for `const` enums",
+  "packageName": "@rnx-kit/eslint-plugin",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/eslint-plugin/src/rules/no-export-all.js
+++ b/packages/eslint-plugin/src/rules/no-export-all.js
@@ -224,30 +224,38 @@ function extractExports(context, moduleId, depth) {
               return;
             }
 
-            if (node.declaration) {
-              switch (node.declaration.type) {
+            const declaration = node.declaration;
+            if (declaration) {
+              switch (declaration.type) {
                 case "ClassDeclaration":
                 // fallthrough
                 case "FunctionDeclaration":
                 // fallthrough
-                case "TSDeclareFunction":
-                // fallthrough
-                case "TSEnumDeclaration": {
-                  const name = node.declaration.id?.name;
+                case "TSDeclareFunction": {
+                  const name = declaration.id?.name;
                   if (name) {
                     exports.add(name);
                   }
                   break;
                 }
 
+                case "TSEnumDeclaration": {
+                  const name = declaration.id?.name;
+                  if (name) {
+                    const ex = declaration.const ? types : exports;
+                    ex.add(name);
+                  }
+                  break;
+                }
+
                 // export namespace N { ... }
                 case "TSModuleDeclaration": {
-                  switch (node.declaration.id.type) {
+                  switch (declaration.id.type) {
                     case "Identifier":
-                      exports.add(node.declaration.id.name);
+                      exports.add(declaration.id.name);
                       break;
                     case "Literal": {
-                      const name = node.declaration.id.value;
+                      const name = declaration.id.value;
                       if (typeof name === "string") {
                         exports.add(name);
                       }
@@ -260,7 +268,7 @@ function extractExports(context, moduleId, depth) {
                 case "TSInterfaceDeclaration":
                 // fallthrough
                 case "TSTypeAliasDeclaration": {
-                  const name = node.declaration.id?.name;
+                  const name = declaration.id?.name;
                   if (name) {
                     types.add(name);
                   }
@@ -268,7 +276,7 @@ function extractExports(context, moduleId, depth) {
                 }
 
                 case "VariableDeclaration":
-                  node.declaration.declarations.forEach((declaration) => {
+                  declaration.declarations.forEach((declaration) => {
                     if (declaration.id.type === "Identifier") {
                       exports.add(declaration.id.name);
                     }

--- a/packages/eslint-plugin/test/no-export-all.test.ts
+++ b/packages/eslint-plugin/test/no-export-all.test.ts
@@ -39,6 +39,13 @@ export interface IChopper {
 
 export declare function escape(): void;
 `,
+  "@fluentui/font-icons-mdl2": `
+export const enum IconNames {
+  PageLink = 'PageLink',
+  CommentSolid = 'CommentSolid',
+  ChangeEntitlements = 'ChangeEntitlements',
+}
+`,
   "@fluentui/react-focus": `
 export declare const FocusZoneTabbableElements: {
   none: 0;
@@ -131,6 +138,12 @@ describe("disallows `export *`", () => {
           "export type { IChopper, Predator } from 'types';"
         ),
         options: [{ expand: "external-only" }],
+      },
+      {
+        code: "export * from '@fluentui/font-icons-mdl2';",
+        errors: 1,
+        output:
+          "export type { IconNames } from '@fluentui/font-icons-mdl2';",
       },
       {
         code: "export * from '@fluentui/react-focus';",

--- a/packages/eslint-plugin/test/no-export-all.test.ts
+++ b/packages/eslint-plugin/test/no-export-all.test.ts
@@ -142,8 +142,7 @@ describe("disallows `export *`", () => {
       {
         code: "export * from '@fluentui/font-icons-mdl2';",
         errors: 1,
-        output:
-          "export type { IconNames } from '@fluentui/font-icons-mdl2';",
+        output: "export type { IconNames } from '@fluentui/font-icons-mdl2';",
       },
       {
         code: "export * from '@fluentui/react-focus';",


### PR DESCRIPTION
### Description

[`const` enums](https://www.typescriptlang.org/docs/handbook/enums.html#const-enums) are a weird beast. The following code:

```typescript
export const enum Foo {
    Bar,
    Baz,
}
```

Gets transpiled to:

```ts
// .js
export {};

// .d.ts
export declare const enum Foo {
    Bar = 0,
    Baz = 1
}
```

Since no code is exported, the fixer has to export it as a type instead.

Resolves #887.

### Test plan

See repro in #887. The new test should also pass.