### PR TITLE
chore: restore ability to build dependencies in package

### DIFF
--- a/scripts/src/commands/build.js
+++ b/scripts/src/commands/build.js
@@ -1,7 +1,30 @@
 // @ts-check
 
-const { runScript } = require("../process");
+const fs = require("fs/promises");
+const { runScript, sequence } = require("../process");
+const clean = require("./clean");
+const depcheck = require("./depcheck");
+const lint = require("./lint");
 
 /** @type {import("../process").Command} */
-module.exports = (_args, rawArgs = []) =>
-  runScript("tsc", "--outDir", "lib", ...rawArgs);
+module.exports = async (_args, rawArgs = []) => {
+  // If `--dependencies` is specified, also build the package's dependencies.
+  if (rawArgs.includes("--dependencies")) {
+    const manifest = await fs.readFile("package.json", { encoding: "utf-8" });
+    const { name } = JSON.parse(manifest);
+    return runScript(
+      "lage",
+      "build",
+      "--grouped",
+      "--log-level",
+      "info",
+      "--no-deps",
+      "--scope",
+      name
+    );
+  }
+
+  return sequence(clean, depcheck, lint, () =>
+    runScript("tsc", "--outDir", "lib", ...rawArgs)
+  );
+};

--- a/scripts/src/index.js
+++ b/scripts/src/index.js
@@ -1,12 +1,6 @@
 #!/usr/bin/env node
 // @ts-check
 
-const build = require("./commands/build");
-const clean = require("./commands/clean");
-const depcheck = require("./commands/depcheck");
-const lint = require("./commands/lint");
-const { sequence } = require("./process");
-
 /**
  * @param {Record<string, { description: string; command: import("./process").Command }>} commands
  * @returns
@@ -29,8 +23,7 @@ function init(commands) {
 init({
   build: {
     description: "Builds the current package",
-    command: (args, rawArgs) =>
-      sequence(clean, depcheck, lint, () => build(args, rawArgs)),
+    command: require("./commands/build"),
   },
   bundle: {
     description: "Bundles the current package",
@@ -38,11 +31,11 @@ init({
   },
   clean: {
     description: "Removes build and test artifacts",
-    command: clean,
+    command: require("./commands/clean"),
   },
   depcheck: {
     description: "Scans package for unused or missing dependencies",
-    command: depcheck,
+    command: require("./commands/depcheck"),
   },
   format: {
     description: "Formats source files",
@@ -54,7 +47,7 @@ init({
   },
   lint: {
     description: "Lints source files",
-    command: lint,
+    command: require("./commands/lint"),
   },
   test: {
     description: "Runs tests",


### PR DESCRIPTION
### Description

Restores the ability to navigate directly to a package and build it including its dependencies when `--dependencies` is specified.

### Test plan

```
git clean -dfqx
yarn
cd packages/metro-resolver-symlinks

# This should fail
yarn build

# This should succeed
yarn build --dependencies

# Now this should also succeed
yarn build
```