### PR TITLE
CLI updates

### DIFF
--- a/.changeset/poor-spoons-love.md
+++ b/.changeset/poor-spoons-love.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Update the CLI to support type-checking across many projects in a monorepo. Further, when bundling, fail on type errors. On serving, print type errors but continue without failure.

--- a/packages/cli/src/bundle.ts
+++ b/packages/cli/src/bundle.ts
@@ -2,7 +2,6 @@ import type { Config as CLIConfig } from "@react-native-community/cli-types";
 import { BundleArgs, loadMetroConfig } from "@rnx-kit/metro-service";
 import { extendObjectArray } from "@rnx-kit/tools-language/properties";
 import type { AllPlatforms } from "@rnx-kit/tools-react-native/platform";
-import { Service } from "@rnx-kit/typescript-service";
 import { getKitBundleConfigs } from "./bundle/kit-config";
 import { metroBundle } from "./bundle/metro";
 import { applyKitBundleConfigOverrides } from "./bundle/overrides";
@@ -51,10 +50,8 @@ export async function rnxBundle(
     }
   );
 
-  const tsservice = new Service();
-
   for (const bundleConfig of bundleConfigs) {
-    await metroBundle(tsservice, metroConfig, bundleConfig);
+    await metroBundle(metroConfig, bundleConfig);
   }
 
   return Promise.resolve();

--- a/packages/cli/src/bundle/metro.ts
+++ b/packages/cli/src/bundle/metro.ts
@@ -1,13 +1,11 @@
-import { info, warn } from "@rnx-kit/console";
+import { info } from "@rnx-kit/console";
 import { bundle, BundleArgs as MetroBundleArgs } from "@rnx-kit/metro-service";
 import { createDirectory } from "@rnx-kit/tools-node/fs";
-import { findConfigFile, Service } from "@rnx-kit/typescript-service";
-import chalk from "chalk";
 import type { ConfigT } from "metro-config";
 import path from "path";
 import { customizeMetroConfig } from "../metro-config";
-import type { TSProjectInfo } from "../types";
 import type { BundleConfig } from "./types";
+import type { TypeScriptValidationOptions } from "../types";
 
 /**
  * Create Metro bundler arguments from a bundle configuration.
@@ -64,38 +62,19 @@ export function createMetroBundleArgs({
  * @param bundleConfig Bundle configuration
  */
 export async function metroBundle(
-  tsservice: Service,
   metroConfig: ConfigT,
   bundleConfig: BundleConfig
 ): Promise<void> {
   info(`Bundling ${bundleConfig.platform}...`);
 
-  let tsprojectInfo: TSProjectInfo | undefined;
-  if (bundleConfig.typescriptValidation) {
-    const configFileName = findConfigFile(
-      bundleConfig.entryPath,
-      "tsconfig.json"
-    );
-    if (!configFileName) {
-      warn(
-        chalk.yellow(
-          "skipping TypeScript validation -- cannot find tsconfig.json for entry file %o"
-        ),
-        bundleConfig.entryPath
-      );
-    } else {
-      tsprojectInfo = {
-        service: tsservice,
-        configFileName,
-      };
-    }
-  }
-
+  const typescriptValidationOptions: TypeScriptValidationOptions = {
+    throwOnError: true,
+  };
   customizeMetroConfig(
     metroConfig,
     bundleConfig.detectCyclicDependencies,
     bundleConfig.detectDuplicateDependencies,
-    tsprojectInfo,
+    bundleConfig.typescriptValidation ? typescriptValidationOptions : false,
     bundleConfig.experimental_treeShake
   );
 

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -5,7 +5,6 @@ import {
   loadMetroConfig,
   startServer,
 } from "@rnx-kit/metro-service";
-import { findConfigFile, Service } from "@rnx-kit/typescript-service";
 import chalk from "chalk";
 import type { Reporter, ReportableEvent } from "metro";
 import type Server from "metro/src/Server";
@@ -14,7 +13,7 @@ import path from "path";
 import readline from "readline";
 import { getKitServerConfig } from "./serve/kit-config";
 import { customizeMetroConfig } from "./metro-config";
-import type { TSProjectInfo } from "./types";
+import type { TypeScriptValidationOptions } from "./types";
 
 export type CLIStartOptions = {
   host: string;
@@ -120,35 +119,17 @@ export async function rnxStart(
       : undefined),
   });
 
-  // prepare for typescript validation, if requested
-  let tsprojectInfo: TSProjectInfo | undefined;
-  if (serverConfig.typescriptValidation) {
-    const tsservice = new Service((message) => terminal.log(message));
-
-    const configFileName = findConfigFile(
-      metroConfig.projectRoot,
-      "tsconfig.json"
-    );
-    if (!configFileName) {
-      terminal.log(
-        chalk.yellow(
-          `Warning: cannot find tsconfig.json under project root '${metroConfig.projectRoot}' -- skipping TypeScript validation`
-        )
-      );
-    } else {
-      tsprojectInfo = {
-        service: tsservice,
-        configFileName,
-      };
-    }
-  }
-
   // customize the metro config to include plugins, presets, etc.
+  const typescriptValidationOptions: TypeScriptValidationOptions = {
+    print: (message: string): void => {
+      terminal.log(message);
+    },
+  };
   customizeMetroConfig(
     metroConfig,
     serverConfig.detectCyclicDependencies,
     serverConfig.detectDuplicateDependencies,
-    tsprojectInfo,
+    serverConfig.typescriptValidation ? typescriptValidationOptions : false,
     serverConfig.experimental_treeShake
   );
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,6 +1,4 @@
-import type { Service } from "@rnx-kit/typescript-service";
-
-export type TSProjectInfo = {
-  service: Service;
-  configFileName: string;
+export type TypeScriptValidationOptions = {
+  print?: (message: string) => void;
+  throwOnError?: boolean;
 };

--- a/packages/cli/src/typescript/project-cache.ts
+++ b/packages/cli/src/typescript/project-cache.ts
@@ -138,8 +138,9 @@ export function createProjectCache(
 
   function clearPlatform(platform: AllPlatforms): void {
     Object.values(projects).forEach((projectsByPlatform) => {
-      if (projectsByPlatform[platform]) {
-        projectsByPlatform[platform]!.dispose();
+      const project = projectsByPlatform[platform];
+      if (project) {
+        project.dispose();
         delete projectsByPlatform[platform];
       }
     });

--- a/packages/cli/src/typescript/project-cache.ts
+++ b/packages/cli/src/typescript/project-cache.ts
@@ -1,0 +1,152 @@
+import { findPackageDir } from "@rnx-kit/tools-node";
+import {
+  AllPlatforms,
+  platformExtensions,
+} from "@rnx-kit/tools-react-native/platform";
+import { changeHostToUseReactNativeResolver } from "@rnx-kit/typescript-react-native-resolver";
+import {
+  createDiagnosticWriter,
+  Project,
+  readConfigFile,
+} from "@rnx-kit/typescript-service";
+import path from "path";
+import ts from "typescript";
+
+/**
+ * Collection of TypeScript projects, separated by their target platform.
+ *
+ * Target platform is a react-native concept, not a TypeScript concept.
+ * However, each project is configured with react-native module resolution,
+ * which means the module file graph could vary by platform. And that means
+ * each platform could yield different type errors.
+ *
+ * For example, `import { f } from "./utils"` could load `./utils.android.ts`
+ * for Android and `./utils.ios.ts` iOS.
+ */
+export interface ProjectCache {
+  /**
+   * Discard all cached projects targeting a specific platform.
+   *
+   * @param platform Target platform
+   */
+  clearPlatform(platform: AllPlatforms): void;
+
+  /**
+   * Get the project which targets a specific platform and contains a specific
+   * source file. If the project is not cached, load it and add it to the cache.
+   *
+   * @param platform Target platform
+   * @param sourceFile Source file
+   * @returns Project targeting the given platform and containing the given source file
+   */
+  getProject(sourceFile: string, platform: AllPlatforms): Project;
+}
+
+/**
+ * Create an empty cache for holding TypeScript projects.
+ *
+ * @param print Optional method for printing messages. When not set, messages are printed to the console.
+ * @returns Empty project cache
+ */
+export function createProjectCache(
+  print?: (message: string) => void
+): ProjectCache {
+  const documentRegistry = ts.createDocumentRegistry();
+  const diagnosticWriter = createDiagnosticWriter(print);
+
+  // Collection of projects organized by root directory, then by platform.
+  const projects: Record<string, Partial<Record<AllPlatforms, Project>>> = {};
+
+  function findProjectRoot(sourceFile: string): string {
+    // Search known root directories to see if the source file is in one of them.
+    for (const root of Object.keys(projects)) {
+      if (sourceFile.startsWith(root)) {
+        return root;
+      }
+    }
+
+    // Search the file system for the root of source file's package.
+    const root = findPackageDir(path.dirname(sourceFile));
+    if (!root) {
+      throw new Error(
+        `Cannot find project root for source file '${sourceFile}'`
+      );
+    }
+
+    return root;
+  }
+
+  function readTSConfig(root: string): ts.ParsedCommandLine {
+    const configFileName = path.join(root, "tsconfig.json");
+
+    const cmdLine = readConfigFile(configFileName);
+    if (!cmdLine) {
+      throw new Error(`Failed to load '${configFileName}'`);
+    } else if (cmdLine.errors.length > 0) {
+      const writer = createDiagnosticWriter();
+      cmdLine.errors.forEach((e) => writer.print(e));
+      throw new Error(`Failed to load '${configFileName}'`);
+    }
+
+    return cmdLine;
+  }
+
+  function createProject(root: string, platform: AllPlatforms): Project {
+    // Load the TypeScript configuration file for this project.
+    const cmdLine = readTSConfig(root);
+
+    // Create a TypeScript project using the configuration file. Enhance the
+    // underlying TS language service with our react-native module resolver.
+    const enhanceLanguageServiceHost = (host: ts.LanguageServiceHost): void => {
+      const platformExtensionNames = platformExtensions(platform);
+      const disableReactNativePackageSubstitution = true;
+      const traceReactNativeModuleResolutionErrors = false;
+      const traceResolutionLog = undefined;
+      changeHostToUseReactNativeResolver({
+        host,
+        options: cmdLine.options,
+        platform,
+        platformExtensionNames,
+        disableReactNativePackageSubstitution,
+        traceReactNativeModuleResolutionErrors,
+        traceResolutionLog,
+      });
+    };
+    const tsproject = new Project(
+      documentRegistry,
+      diagnosticWriter,
+      cmdLine,
+      enhanceLanguageServiceHost
+    );
+
+    // Start with an empty project, ignoring the file graph from tsconfig.json.
+    tsproject.removeAllFiles();
+
+    return tsproject;
+  }
+
+  function getProject(sourceFile: string, platform: AllPlatforms): Project {
+    const root = findProjectRoot(sourceFile);
+    if (!projects[root]) {
+      projects[root] = {};
+    }
+    if (!projects[root][platform]) {
+      projects[root][platform] = createProject(root, platform);
+    }
+    return projects[root][platform]!;
+  }
+
+  function clearPlatform(platform: AllPlatforms): void {
+    Object.values(projects).forEach((projectsByPlatform) => {
+      if (projectsByPlatform[platform]) {
+        projectsByPlatform[platform]!.dispose();
+        delete projectsByPlatform[platform];
+      }
+    });
+  }
+
+  return {
+    clearPlatform,
+    getProject,
+  };
+}


### PR DESCRIPTION
### Description

The CLI's TypeScript support is currently limited to validating source files in one package -- the app being bundled/served. If the app depends on other packages in the same monorepo, sources from those packages won't be type-checked.

This PR expands the reach of the CLI, allowing it to type-check sources from all packages in the monorepo. External packages (anything under node_modules) are ignored.

The CLI buckets source files by their parent package, and uses the package's tsconfig when checking those files.

This PR also adds type-checking options, which vary between bundling and serving. Bundling, for example, will throw when validation fails, causing the entire bundling run to fail. Serving, will only print type errors to the console, and continue without interruption.

Resolves #521.

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

Existing CI tests pass. There isn't much test coverage in this area of the CLI. That issue is tracked under #375.

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
