### PR TITLE
Fix Metro type-checking

### DIFF
--- a/.changeset/nine-bikes-buy.md
+++ b/.changeset/nine-bikes-buy.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Scope Metro type-checking to files that TypeScript views as source code (ignore transpiled files).

--- a/packages/cli/src/metro-config.ts
+++ b/packages/cli/src/metro-config.ts
@@ -65,12 +65,17 @@ function createSerializerHook(options: TypeScriptValidationOptions) {
       //  Map each file to a TypeScript project, and apply its delta operation.
       const tsprojectsToValidate: Set<Project> = new Set();
       adds.concat(updates).forEach((sourceFile) => {
-        const tsproject = projectCache.getProject(sourceFile, platform);
-        tsproject.setFile(sourceFile);
-        tsprojectsToValidate.add(tsproject);
+        const { tsproject, tssourceFiles } = projectCache.getProjectInfo(
+          sourceFile,
+          platform
+        );
+        if (tssourceFiles.has(sourceFile)) {
+          tsproject.setFile(sourceFile);
+          tsprojectsToValidate.add(tsproject);
+        }
       });
       deletes.forEach((sourceFile) => {
-        const tsproject = projectCache.getProject(sourceFile, platform);
+        const { tsproject } = projectCache.getProjectInfo(sourceFile, platform);
         tsproject.removeFile(sourceFile);
         tsprojectsToValidate.add(tsproject);
       });


### PR DESCRIPTION
### Description

This PR limits the files which are type-checked during bundling/serving. When Metro reports a file add/update, we will only check that file if TypeScript considers it to be part of the "source code" file listing. This ignores transpiled files.

This addresses problems found while bumping the CLI forward in #857.

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

CI tests pass.

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
