### PR TITLE
TypeScript+Metro fixes

### DIFF
--- a/.changeset/long-plums-collect.md
+++ b/.changeset/long-plums-collect.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/typescript-react-native-resolver": patch
+---
+
+When resolving imports in a .d.ts file, allow .json files when compilerOptions.resolveJsonModule is true.

--- a/.changeset/metal-llamas-sell.md
+++ b/.changeset/metal-llamas-sell.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Keep .d.ts files in the list when opening a TypeScript project.

--- a/packages/typescript-react-native-resolver/src/host.ts
+++ b/packages/typescript-react-native-resolver/src/host.ts
@@ -173,11 +173,15 @@ export function resolveModuleNames(
 
   //
   //  If the containing file is a type file (.d.ts), it can only import
-  //  other type files. Search for both .d.ts and .ts files, as some
+  //  other type files and JSON files. Also allow .ts files, as some
   //  modules import as "foo.d" with the intent to resolve to "foo.d.ts".
   //
+  const allowedExtensionsDts = [ts.Extension.Dts, ts.Extension.Ts];
+  if (options.resolveJsonModule) {
+    allowedExtensionsDts.push(ts.Extension.Json);
+  }
   const extensions = hasExtension(containingFile, ts.Extension.Dts)
-    ? [ts.Extension.Dts, ts.Extension.Ts]
+    ? allowedExtensionsDts
     : allowedExtensions;
 
   const resolutions: (ts.ResolvedModuleFull | undefined)[] = [];


### PR DESCRIPTION
### Description

Fix minor issues found while integrating with FURN.
- Resolver: allow .d.ts files to resolve .json modules when compilerOptions.resolveJsonModule = true
- CLI: keep .d.ts files in the list when opening a new TypeScript project

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
