### PR TITLE
Update the typescript react-native resolver

### DIFF
--- a/.changeset/polite-rockets-hang.md
+++ b/.changeset/polite-rockets-hang.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/typescript-react-native-resolver": minor
+---
+
+Resolve modules in 3 passes - TS, then JS, then JSON. Also, always resolve to JS files -- don't gate on checkJs anymore.

--- a/packages/typescript-react-native-resolver/src/extension.ts
+++ b/packages/typescript-react-native-resolver/src/extension.ts
@@ -15,6 +15,10 @@ export const ExtensionsTypeScript = [
   ts.Extension.Dts,
 ];
 
+export const ExtensionsJavaScript = [ts.Extension.Js, ts.Extension.Jsx];
+
+export const ExtensionsJSON = [ts.Extension.Json];
+
 export function hasExtension(p: string, ext: ts.Extension): boolean {
   return p.endsWith(ext);
 }

--- a/packages/typescript-react-native-resolver/src/resolve.ts
+++ b/packages/typescript-react-native-resolver/src/resolve.ts
@@ -6,6 +6,7 @@ import {
 import path from "path";
 import ts from "typescript";
 
+import { ExtensionsTypeScript } from "./extension";
 import { findModuleFile } from "./module";
 import { ResolverContext } from "./types";
 
@@ -150,33 +151,24 @@ export function resolvePackageModule(
       // same file layout as the corresponding source code modules. For
       // example, type info could be in a single, hand-crafted file, while
       // the source code is spread across many files.
-      //
-      // Search for both .d.ts and .ts files, as some type modules import
-      // as "foo.d" with the intent to resolve to "foo.d.ts".
-      //
-      module = resolveModule(context, pkgDir, undefined, [
-        ts.Extension.Dts,
-        ts.Extension.Ts,
-      ]);
+      module = resolveModule(context, pkgDir, undefined, ExtensionsTypeScript);
     }
   }
 
   if (!module && moduleRef.scope !== "@types") {
     // The module wasn't resolved using the given package reference. Try again,
     // looking for a corresponding @types package.
-    //
-    // Allow both .d.ts and .ts file extensions, as some type modules import
-    // as "foo.d" with the intent to resolve to "foo.d.ts".
-    //
     const typesModuleRef: PackageModuleRef = {
       scope: "@types",
       name: getMangledPackageName(moduleRef),
       path: moduleRef.path,
     };
-    module = resolvePackageModule(context, typesModuleRef, searchDir, [
-      ts.Extension.Dts,
-      ts.Extension.Ts,
-    ]);
+    module = resolvePackageModule(
+      context,
+      typesModuleRef,
+      searchDir,
+      ExtensionsTypeScript
+    );
   }
 
   return module;

--- a/packages/typescript-react-native-resolver/src/types.ts
+++ b/packages/typescript-react-native-resolver/src/types.ts
@@ -68,12 +68,6 @@ export type ResolverContext = {
   readonly platformExtensions: string[];
 
   /**
-   * List of file extensions that can be used when resolving a module to a
-   * file. Controlled by compiler options `checkJs` and `resolveJsonModule`.
-   */
-  readonly allowedExtensions: ts.Extension[];
-
-  /**
    * Function which *may* replace references to the `react-native` module with
    * the target platform's out-of-tree NPM package name. For example, on
    * Windows, the replacement would be `react-native-windows`.

--- a/packages/typescript-react-native-resolver/test/extension.test.ts
+++ b/packages/typescript-react-native-resolver/test/extension.test.ts
@@ -1,3 +1,4 @@
+import "jest-extended";
 import ts from "typescript";
 import { hasExtension, getExtensionFromPath } from "../src/extension";
 


### PR DESCRIPTION
### Description

Change the order in which file extensions are searched. First, look for TypeScript files everywhere, then, look for JavaScript files. And, if JSON modules are enabled, look for them last. This multi-pass approach matches the way TypeScript resolves modules.

One important part of this PR is that now the resolver will always match on JavaScript files. It used to only do this when `checkJs` was enabled. That's not how TypeScript's resolver does it, so I've taken this condition out to better align with expected behavior.

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

Existing tests updated. All CI tests pass.

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
