### PR TITLE
docs(tools-react-native): correct bump type to bump dependents

### DIFF
--- a/.changeset/eight-terms-promise.md
+++ b/.changeset/eight-terms-promise.md
@@ -1,5 +1,5 @@
 ---
-"@rnx-kit/tools-react-native": patch
+"@rnx-kit/tools-react-native": minor
 ---
 
 Added a function to get available React Native platforms


### PR DESCRIPTION
### Description

Bump type should be `minor` since we added a function. It will also ensure that dependents bump to the correct version number. See #978.

### Test plan

n/a