### PR TITLE
fix(metro-config): prefer `module` main field

### DIFF
--- a/.changeset/fifty-clocks-work.md
+++ b/.changeset/fifty-clocks-work.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Prefer `module` main field

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -182,6 +182,7 @@ module.exports = {
     return mergeConfig(
       {
         resolver: {
+          resolverMainFields: ["module", "browser", "main"],
           blacklistRE: blockList, // For Metro < 0.60
           blockList, // For Metro >= 0.60
         },


### PR DESCRIPTION
### Description

By default, we should prefer `module` field over the current default ones.

### Test plan

n/a