### PR TITLE
feat(cli): show QR code for use with react-native-test-app

### DIFF
--- a/.changeset/purple-cameras-check.md
+++ b/.changeset/purple-cameras-check.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": minor
+---
+
+Added command to show QR code. This QR code can be scanned in React Native Test App to load the bundle from the dev server, eliminating the need to manually configure the bundler address.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v2.1.7
         with:
           path: .yarn-offline-mirror
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-2
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-3
       - name: Install package dependencies
         run: yarn ci
         env:
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache@v2.1.7
         with:
           path: .yarn-offline-mirror
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-2
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-3
       - name: Install package dependencies
         run: yarn ci
       - name: Build and test packages
@@ -106,7 +106,7 @@ jobs:
         uses: actions/cache@v2.1.7
         with:
           path: .yarn-offline-mirror
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-2
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-3
       - name: Install npm dependencies
         run: yarn ci
         env:
@@ -131,7 +131,7 @@ jobs:
         uses: actions/cache@v2.1.7
         with:
           path: .yarn-offline-mirror
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-2
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-3
       - name: Install npm dependencies
         run: yarn ci
         env:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
     "@rnx-kit/typescript-react-native-resolver": "^0.2.0",
     "@rnx-kit/typescript-service": "^1.5.3",
     "chalk": "^4.1.0",
+    "qrcode": "^1.5.0",
     "readline": "^1.3.0"
   },
   "peerDependencies": {
@@ -50,6 +51,7 @@
     "@rnx-kit/scripts": "*",
     "@types/metro": "^0.66.0",
     "@types/metro-config": "^0.66.0",
+    "@types/qrcode": "^1.4.2",
     "jest-extended": "^0.11.5",
     "typescript": "^4.0.0"
   },

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -92,7 +92,7 @@ export async function rnxStart(
         [
           ["r", "reload the app"],
           ["d", "open developer menu"],
-          ["a", "show QR code"],
+          ["a", "show bundler address QR code"],
           ["ctrl-c", "quit"],
         ].forEach(([key, description]) => {
           terminal.log(press + key + dim(` to ${description}.`));
@@ -204,30 +204,13 @@ export async function rnxStart(
         switch (name) {
           case "a": {
             const protocol = cliOptions.https ? "https" : "http";
+            const host = cliOptions.host || os.hostname();
             const port = metroConfig.server.port;
-            const hosts = cliOptions.host
-              ? [cliOptions.host]
-              : Object.entries(os.networkInterfaces()).reduce<string[]>(
-                  (hosts, [name, intf]) => {
-                    // Skip interfaces used for tunneling, e.g. VPNs
-                    if (intf && !name.startsWith("utun")) {
-                      intf.forEach(({ address, family, internal }) => {
-                        if (family === "IPv4" && !internal) {
-                          hosts.push(address);
-                        }
-                      });
-                    }
-                    return hosts;
-                  },
-                  []
-                );
-            hosts.forEach((address) => {
-              const url = `${protocol}://${address}:${port}/index.bundle`;
-              qrcode.toString(url, { type: "terminal" }, (_err, qr) => {
-                terminal.log("");
-                terminal.log(url + ":");
-                terminal.log(qr);
-              });
+            const url = `${protocol}://${host}:${port}/index.bundle`;
+            qrcode.toString(url, { type: "terminal" }, (_err, qr) => {
+              terminal.log("");
+              terminal.log(url + ":");
+              terminal.log(qr);
             });
             break;
           }

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -211,8 +211,9 @@ export async function rnxStart(
 
               intf.forEach(({ address, family, internal }) => {
                 if (family === "IPv4" && !internal) {
+                  const protocol = cliOptions.https ? "https" : "http";
                   const port = metroConfig.server.port;
-                  const url = `http://${address}:${port}/index.bundle`;
+                  const url = `${protocol}://${address}:${port}/index.bundle`;
                   qrcode.toString(url, { type: "terminal" }, (_err, qr) => {
                     terminal.log("");
                     terminal.log(url + ":");

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -6,13 +6,15 @@ import {
   startServer,
 } from "@rnx-kit/metro-service";
 import chalk from "chalk";
-import type { Reporter, ReportableEvent } from "metro";
-import type Server from "metro/src/Server";
+import type { ReportableEvent, Reporter } from "metro";
 import type { Middleware } from "metro-config";
+import type Server from "metro/src/Server";
+import os from "os";
 import path from "path";
+import qrcode from "qrcode";
 import readline from "readline";
-import { getKitServerConfig } from "./serve/kit-config";
 import { customizeMetroConfig } from "./metro-config";
+import { getKitServerConfig } from "./serve/kit-config";
 import type { TypeScriptValidationOptions } from "./types";
 
 export type CLIStartOptions = {
@@ -85,17 +87,16 @@ export async function rnxStart(
         reportEventDelegate(event);
       }
       if (interactive && event.type === "dep_graph_loading") {
-        terminal.log("To reload the app press '" + chalk.cyanBright("r") + "'");
-        terminal.log(
-          "To open developer menu press '" + chalk.cyanBright("d") + "'"
-        );
-        terminal.log(
-          "To quit, press '" +
-            chalk.cyanBright("control") +
-            "-" +
-            chalk.cyanBright("c") +
-            "'"
-        );
+        const dim = chalk.dim;
+        const press = dim(" › Press ");
+        [
+          ["r", "reload the app"],
+          ["d", "open developer menu"],
+          ["a", "show QR code"],
+          ["ctrl-c", "quit"],
+        ].forEach(([key, description]) => {
+          terminal.log(press + key + dim(` to ${description}.`));
+        });
       }
     },
   };
@@ -199,14 +200,39 @@ export async function rnxStart(
             process.emit("SIGTSTP", "SIGTSTP");
             break;
         }
-      } else if (name === "r") {
-        terminal.log(chalk.green("Reloading app..."));
-        messageSocket.broadcast("reload", undefined);
-      } else if (name === "d") {
-        terminal.log(chalk.green("Opening developer menu..."));
-        messageSocket.broadcast("devMenu", undefined);
       } else {
-        terminal.log(chalk.grey(_key));
+        switch (name) {
+          case "a":
+            Object.entries(os.networkInterfaces()).forEach(([name, intf]) => {
+              if (!intf || name.startsWith("utun")) {
+                // Skip interfaces used for tunneling, e.g. VPNs
+                return;
+              }
+
+              intf.forEach(({ address, family, internal }) => {
+                if (family === "IPv4" && !internal) {
+                  const port = metroConfig.server.port;
+                  const url = `http://${address}:${port}/index.bundle`;
+                  qrcode.toString(url, { type: "terminal" }, (_err, qr) => {
+                    terminal.log("");
+                    terminal.log(url + ":");
+                    terminal.log(qr);
+                  });
+                }
+              });
+            });
+            break;
+
+          case "d":
+            terminal.log(chalk.green("Opening developer menu..."));
+            messageSocket.broadcast("devMenu", undefined);
+            break;
+
+          case "r":
+            terminal.log(chalk.green("Reloading app..."));
+            messageSocket.broadcast("reload", undefined);
+            break;
+        }
       }
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2426,6 +2426,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
+"@types/qrcode@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@types/qrcode/-/qrcode-1.4.2.tgz#7d7142d6fa9921f195db342ed08b539181546c74"
+  integrity sha512-7uNT9L4WQTNJejHTSTdaJhfBSCN73xtXaHFyBJ8TSwiLhe4PRuTue7Iph0s2nG9R/ifUaSnGhLUOZavlBEqDWQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/react-native@^0.64.0":
   version "0.64.19"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.64.19.tgz#2b888c082ad293fa0fa6ae34c5e9457cfb38e50a"
@@ -4118,6 +4125,11 @@ diff-sequences@^27.4.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.4.0.tgz#d783920ad8d06ec718a060d00196dfef25b132a5"
   integrity sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==
 
+dijkstrajs@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/dijkstrajs/-/dijkstrajs-1.0.2.tgz#2e48c0d3b825462afe75ab4ad5e829c8ece36257"
+  integrity sha512-QV6PMaHTCNmKSeP6QoXhVTw9snc9VD8MulTT0Bd99Pacp4SS1cjcrYPgBPmibqKVtMJJfqC6XvOXgPMEEPH/fg==
+
 dir-glob@^2.0.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
@@ -4189,6 +4201,11 @@ emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
+encode-utf8@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/encode-utf8/-/encode-utf8-1.0.3.tgz#f30fdd31da07fb596f281beb2f6b027851994cda"
+  integrity sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -7794,6 +7811,11 @@ plist@^3.0.1, plist@^3.0.2:
     base64-js "^1.5.1"
     xmlbuilder "^9.0.7"
 
+pngjs@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-5.0.0.tgz#e79dd2b215767fd9c04561c01236df960bce7fbb"
+  integrity sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==
+
 postcss-modules-extract-imports@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz#cda1f047c0ae80c97dbe28c3e76a43b88025741d"
@@ -7994,6 +8016,16 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+qrcode@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.5.0.tgz#95abb8a91fdafd86f8190f2836abbfc500c72d1b"
+  integrity sha512-9MgRpgVc+/+47dFvQeD6U2s0Z92EsKzcHogtum4QB+UNd025WOJSHvn/hjk9xmzj7Stj95CyUAs31mrjxliEsQ==
+  dependencies:
+    dijkstrajs "^1.0.1"
+    encode-utf8 "^1.0.3"
+    pngjs "^5.0.0"
+    yargs "^15.3.1"
 
 qs@^6.9.1, qs@^6.9.4:
   version "6.10.1"


### PR DESCRIPTION
### Description

Added command to show QR code. This QR code can be scanned in React Native Test App to load the bundle from the dev server, eliminating the need to manually configure the bundler address.

| macOS (iTerm) | Windows (Command Prompt)  | Windows (Terminal) |
|:-:|:-:|:-:|
| ![image](https://user-images.githubusercontent.com/4123478/148378920-9b99ca04-ce56-4038-bc1c-34c2cfb5fdb0.png) | ![image](https://user-images.githubusercontent.com/4123478/148379792-72a4ea86-c24f-467e-9f3a-11f64168a28b.png) | ![image](https://user-images.githubusercontent.com/4123478/148379682-1481f51c-cb95-4296-abfb-0b56d3b6355c.png) |

### Test plan

```
cd packages/test-app
yarn build --dependencies
yarn start
```

- Once the dev server starts, press `a` to show the QR code.
- If you have the test app installed on a device, open it. Shake the device to open the dev menu, select "Scan QR Code", and point it at the QR code. The test app should start loading the bundle from your local machine.