### PR TITLE
feat(babel-plugin-import-path-remapper): add ability to set custom remapper

### DIFF
--- a/.changeset/selfish-kangaroos-promise.md
+++ b/.changeset/selfish-kangaroos-promise.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/babel-plugin-import-path-remapper": minor
+---
+
+Add ability to set custom remapper

--- a/packages/babel-plugin-import-path-remapper/README.md
+++ b/packages/babel-plugin-import-path-remapper/README.md
@@ -48,3 +48,10 @@ module.exports = makeBabelConfig([
   ],
 ]);
 ```
+
+### Options
+
+| Option | Type                                           | Description                                                                                                                |
+| :----- | :--------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------- |
+| test   | `(source: string) => boolean`                  | **[Required]** A function returning whether the passed source should be redirected to another module.                      |
+| remap  | `(moduleName: string, path: string) => string` | **[Optional]** A function returning the module that should be used instead, e.g. `contoso/index.js` -> `contoso/index.ts`. |

--- a/packages/babel-plugin-import-path-remapper/package.json
+++ b/packages/babel-plugin-import-path-remapper/package.json
@@ -36,9 +36,7 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "roots": [
-      "test"
-    ],
+    "preset": "@rnx-kit/scripts",
     "testRegex": "/test/.*\\.test\\.js$"
   }
 }

--- a/packages/babel-plugin-import-path-remapper/test/__fixtures__/with-main/node_modules/@rnx-kit/example/package.json
+++ b/packages/babel-plugin-import-path-remapper/test/__fixtures__/with-main/node_modules/@rnx-kit/example/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@rnx-kit/example",
+  "version": "0.0.0-dev",
+  "main": "index.js"
+}


### PR DESCRIPTION
### Description

Adds ability to set a custom remapper.

Resolves #988.

### Test plan

Tests were added. I also tested this internally with two other repos.