### PR TITLE
fix(metro-serializer-esbuild): forward `sideEffects` property

### DIFF
--- a/.changeset/swift-ladybugs-juggle.md
+++ b/.changeset/swift-ladybugs-juggle.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Forward `sideEffects` property to help esbuild tree-shake more unused code

--- a/packages/metro-serializer-esbuild/babel.config.js
+++ b/packages/metro-serializer-esbuild/babel.config.js
@@ -1,0 +1,16 @@
+if (process.env.NODE_ENV !== "test") {
+  module.exports = {
+    presets: [
+      [
+        "module:metro-react-native-babel-preset",
+        { disableImportExportTransform: true },
+      ],
+    ],
+    plugins: [
+      [
+        "@rnx-kit/babel-plugin-import-path-remapper",
+        { test: (source) => source.startsWith("@rnx-kit/") },
+      ],
+    ],
+  };
+}

--- a/packages/metro-serializer-esbuild/metro.config.js
+++ b/packages/metro-serializer-esbuild/metro.config.js
@@ -1,0 +1,19 @@
+const { exclusionList, makeMetroConfig } = require("@rnx-kit/metro-config");
+const { MetroSerializer, esbuildTransformerConfig } = require(".");
+
+// Metro will pick up mocks if we don't exclude them
+const blockList = exclusionList([/.*__fixtures__.*package.json/]);
+
+module.exports = makeMetroConfig({
+  reporter: { update: () => undefined },
+  resetCache: true,
+  resolver: {
+    blacklistRE: blockList,
+    blockList,
+  },
+  serializer: {
+    customSerializer: MetroSerializer(),
+    getPolyfills: () => [],
+  },
+  transformer: esbuildTransformerConfig,
+});

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -17,10 +17,12 @@
   "scripts": {
     "build": "rnx-kit-scripts build",
     "format": "rnx-kit-scripts format",
-    "lint": "rnx-kit-scripts lint"
+    "lint": "rnx-kit-scripts lint",
+    "test": "rnx-kit-scripts test"
   },
   "dependencies": {
     "@rnx-kit/console": "^1.0.11",
+    "@rnx-kit/tools-node": "^1.2.6",
     "esbuild": "^0.14.10",
     "esbuild-plugin-lodash": "^1.1.0",
     "semver": "^7.0.0"
@@ -29,13 +31,17 @@
     "metro": ">=0.66.1"
   },
   "devDependencies": {
+    "@react-native-community/cli-plugin-metro": "^6.2.0",
+    "@rnx-kit/metro-config": "*",
     "@rnx-kit/metro-serializer": "*",
     "@rnx-kit/scripts": "*",
     "@types/metro": "^0.66.0",
     "@types/metro-config": "^0.66.0",
     "@types/metro-transform-worker": "^0.66.0",
     "@types/semver": "^7.0.0",
-    "metro": "^0.66.2"
+    "lodash-es": "^4.17.21",
+    "metro": "^0.66.2",
+    "react-native": "^0.66.0-0"
   },
   "depcheck": {
     "ignoreMatches": [

--- a/packages/metro-serializer-esbuild/test/__fixtures__/base.ts
+++ b/packages/metro-serializer-esbuild/test/__fixtures__/base.ts
@@ -1,0 +1,13 @@
+export const UNUSED = "this should be removed";
+
+export function app() {
+  "this should _not_ be removed";
+}
+
+export function thisShouldBeRemoved() {
+  "this should be removed";
+}
+
+export function thisShouldBeRemoved2() {
+  "this should be removed";
+}

--- a/packages/metro-serializer-esbuild/test/__fixtures__/direct.ts
+++ b/packages/metro-serializer-esbuild/test/__fixtures__/direct.ts
@@ -1,0 +1,2 @@
+import { app } from "./base";
+app();

--- a/packages/metro-serializer-esbuild/test/__fixtures__/exportAll.ts
+++ b/packages/metro-serializer-esbuild/test/__fixtures__/exportAll.ts
@@ -1,0 +1,2 @@
+import { app } from "./exportAllPublic";
+app();

--- a/packages/metro-serializer-esbuild/test/__fixtures__/exportAllPublic.ts
+++ b/packages/metro-serializer-esbuild/test/__fixtures__/exportAllPublic.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @rnx-kit/no-export-all
+export * from "./base";

--- a/packages/metro-serializer-esbuild/test/__fixtures__/importAll.ts
+++ b/packages/metro-serializer-esbuild/test/__fixtures__/importAll.ts
@@ -1,0 +1,2 @@
+import * as Base from "./base";
+Base.app();

--- a/packages/metro-serializer-esbuild/test/__fixtures__/importExportAll.ts
+++ b/packages/metro-serializer-esbuild/test/__fixtures__/importExportAll.ts
@@ -1,0 +1,2 @@
+import * as Base from "./nestedExportAllInternal";
+Base.app();

--- a/packages/metro-serializer-esbuild/test/__fixtures__/lodash-es.ts
+++ b/packages/metro-serializer-esbuild/test/__fixtures__/lodash-es.ts
@@ -1,0 +1,2 @@
+import { head } from "lodash-es";
+console.log(head([]));

--- a/packages/metro-serializer-esbuild/test/__fixtures__/nestedExportAll.ts
+++ b/packages/metro-serializer-esbuild/test/__fixtures__/nestedExportAll.ts
@@ -1,0 +1,2 @@
+import { app } from "./nestedExportAllPublic";
+app();

--- a/packages/metro-serializer-esbuild/test/__fixtures__/nestedExportAllInternal.ts
+++ b/packages/metro-serializer-esbuild/test/__fixtures__/nestedExportAllInternal.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @rnx-kit/no-export-all
+export * from "./exportAllPublic";

--- a/packages/metro-serializer-esbuild/test/__fixtures__/nestedExportAllPublic.ts
+++ b/packages/metro-serializer-esbuild/test/__fixtures__/nestedExportAllPublic.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @rnx-kit/no-export-all
+export * from "./nestedExportAllInternal";

--- a/packages/metro-serializer-esbuild/test/__mocks__/@rnx-kit/console.js
+++ b/packages/metro-serializer-esbuild/test/__mocks__/@rnx-kit/console.js
@@ -1,0 +1,5 @@
+function noop() {}
+
+exports.error = noop;
+exports.info = noop;
+exports.warn = noop;

--- a/packages/metro-serializer-esbuild/test/index.test.ts
+++ b/packages/metro-serializer-esbuild/test/index.test.ts
@@ -1,0 +1,174 @@
+import buildBundle from "@react-native-community/cli-plugin-metro/build/commands/bundle/buildBundle";
+import * as path from "path";
+
+describe("metro-serializer-esbuild", () => {
+  jest.setTimeout(30000);
+
+  const consoleWarnSpy = jest.spyOn(global.console, "warn");
+
+  async function bundle(entryFile: string): Promise<string> {
+    let result: string | undefined = undefined;
+    await buildBundle(
+      {
+        entryFile,
+        bundleEncoding: "utf8",
+        bundleOutput: ".test-output.jsbundle",
+        dev: true,
+        platform: "native",
+        resetCache: true,
+        resetGlobalCache: false,
+        sourcemapUseAbsolutePath: true,
+        verbose: false,
+      },
+      {
+        root: path.dirname(__dirname),
+        reactNativePath: path.dirname(
+          require.resolve("react-native/package.json")
+        ),
+        dependencies: {},
+        commands: [],
+        assets: [],
+        healthChecks: [],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        platforms: { android: {}, ios: {} } as any,
+        project: {},
+      },
+      {
+        ...require("metro/src/shared/output/bundle"),
+        save: ({ code }) => {
+          result = code;
+        },
+      }
+    );
+    return result;
+  }
+
+  beforeEach(() => {
+    consoleWarnSpy.mockReset();
+  });
+
+  afterAll(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  test("removes unused code", async () => {
+    const result = await bundle("test/__fixtures__/direct.ts");
+    expect(result).toMatchInlineSnapshot(`
+      "\\"use strict\\";
+      (function() {
+        // lib/index.js
+        var global = new Function(\\"return this;\\")();
+
+        // test/__fixtures__/base.ts
+        function app() {
+          \\"this should _not_ be removed\\";
+        }
+
+        // test/__fixtures__/direct.ts
+        app();
+      })();
+      "
+    `);
+  });
+
+  test("removes unused code (export *)", async () => {
+    const result = await bundle("test/__fixtures__/exportAll.ts");
+    expect(result).toMatchInlineSnapshot(`
+      "\\"use strict\\";
+      (function() {
+        // lib/index.js
+        var global = new Function(\\"return this;\\")();
+
+        // test/__fixtures__/base.ts
+        function app() {
+          \\"this should _not_ be removed\\";
+        }
+
+        // test/__fixtures__/exportAll.ts
+        app();
+      })();
+      "
+    `);
+  });
+
+  test("removes unused code (nested export *)", async () => {
+    const result = await bundle("test/__fixtures__/nestedExportAll.ts");
+    expect(result).toMatchInlineSnapshot(`
+      "\\"use strict\\";
+      (function() {
+        // lib/index.js
+        var global = new Function(\\"return this;\\")();
+
+        // test/__fixtures__/base.ts
+        function app() {
+          \\"this should _not_ be removed\\";
+        }
+
+        // test/__fixtures__/nestedExportAll.ts
+        app();
+      })();
+      "
+    `);
+  });
+
+  test("removes unused code (import *)", async () => {
+    const result = await bundle("test/__fixtures__/importAll.ts");
+    expect(result).toMatchInlineSnapshot(`
+      "\\"use strict\\";
+      (function() {
+        // lib/index.js
+        var global = new Function(\\"return this;\\")();
+
+        // test/__fixtures__/base.ts
+        function app() {
+          \\"this should _not_ be removed\\";
+        }
+
+        // test/__fixtures__/importAll.ts
+        app();
+      })();
+      "
+    `);
+  });
+
+  test("removes unused code (import * <- export *)", async () => {
+    const result = await bundle("test/__fixtures__/importExportAll.ts");
+    expect(result).toMatchInlineSnapshot(`
+      "\\"use strict\\";
+      (function() {
+        // lib/index.js
+        var global = new Function(\\"return this;\\")();
+
+        // test/__fixtures__/base.ts
+        function app() {
+          \\"this should _not_ be removed\\";
+        }
+
+        // test/__fixtures__/importExportAll.ts
+        app();
+      })();
+      "
+    `);
+  });
+
+  test("tree-shakes lodash-es", async () => {
+    const result = await bundle("test/__fixtures__/lodash-es.ts");
+    expect(result).toMatchInlineSnapshot(`
+      "\\"use strict\\";
+      (function() {
+        // lib/index.js
+        var global = new Function(\\"return this;\\")();
+
+        // ../../node_modules/lodash-es/head.js
+        function head(array) {
+          return array && array.length ? array[0] : void 0;
+        }
+        var head_default = head;
+
+        // test/__fixtures__/lodash-es.ts
+        console.log(head_default([]));
+      })();
+      "
+    `);
+  });
+});

--- a/packages/metro-serializer-esbuild/test/index.test.ts
+++ b/packages/metro-serializer-esbuild/test/index.test.ts
@@ -2,7 +2,7 @@ import buildBundle from "@react-native-community/cli-plugin-metro/build/commands
 import * as path from "path";
 
 describe("metro-serializer-esbuild", () => {
-  jest.setTimeout(30000);
+  jest.setTimeout(60000);
 
   const consoleWarnSpy = jest.spyOn(global.console, "warn");
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6605,6 +6605,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"


### PR DESCRIPTION
### Description

Forward `sideEffects` property to help esbuild tree-shake more unused code.

### Test plan

Tests should pass.