### PR TITLE
feat(dep-check): allow setting `customProfiles` only

### DIFF
--- a/.changeset/chatty-eels-hide.md
+++ b/.changeset/chatty-eels-hide.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/dep-check": minor
+---
+
+dep-check should pick up `customProfiles` when running in `--vigilant` mode to allow individual packages to use different profiles without having to re-declare which React Native versions they support.

--- a/packages/dep-check/src/check.ts
+++ b/packages/dep-check/src/check.ts
@@ -44,6 +44,8 @@ export function getCheckConfig(
     capabilities: targetCapabilities,
     customProfiles,
   } = getKitCapabilities({
+    // React Native versions declared in the package's config should always
+    // override the ones specified with the `--vigilant` flag.
     ...(versions ? { reactNativeVersion: versions } : undefined),
     ...kitConfig,
   });

--- a/packages/dep-check/src/check.ts
+++ b/packages/dep-check/src/check.ts
@@ -13,7 +13,7 @@ import type { CheckConfig, CheckOptions, Command } from "./types";
 
 export function getCheckConfig(
   manifestPath: string,
-  { loose, uncheckedReturnCode = 0 }: CheckOptions
+  { loose, uncheckedReturnCode = 0, versions }: CheckOptions
 ): number | CheckConfig {
   const manifest = readPackage(manifestPath);
   if (!isPackageManifest(manifest)) {
@@ -43,7 +43,10 @@ export function getCheckConfig(
     kitType,
     capabilities: targetCapabilities,
     customProfiles,
-  } = getKitCapabilities(kitConfig);
+  } = getKitCapabilities({
+    ...(versions ? { reactNativeVersion: versions } : undefined),
+    ...kitConfig,
+  });
 
   const customProfilesPath = resolveCustomProfiles(projectRoot, customProfiles);
 

--- a/packages/dep-check/src/profiles.ts
+++ b/packages/dep-check/src/profiles.ts
@@ -13,7 +13,7 @@ import type { Profile, ProfileVersion } from "./types";
 
 type ProfileMap = Record<ProfileVersion, Profile>;
 
-type ProfilesInfo = {
+export type ProfilesInfo = {
   supportedProfiles: Profile[];
   supportedVersions: string;
   targetProfile: Profile[];

--- a/packages/dep-check/src/types.ts
+++ b/packages/dep-check/src/types.ts
@@ -29,6 +29,7 @@ export type CheckConfig = {
 export type CheckOptions = Options & {
   uncheckedReturnCode?: number;
   config?: number | CheckConfig;
+  versions?: string;
 };
 
 export type VigilantOptions = Options & {

--- a/packages/dep-check/src/vigilant.ts
+++ b/packages/dep-check/src/vigilant.ts
@@ -142,7 +142,7 @@ export function makeVigilantCommand({
     return undefined;
   }
 
-  const checkOptions = { loose, write };
+  const checkOptions = { loose, write, versions };
 
   const exclusionList = isString(excludePackages)
     ? excludePackages.split(",")

--- a/packages/dep-check/test/__fixtures__/config-custom-profiles-only/packageSpecificProfiles.js
+++ b/packages/dep-check/test/__fixtures__/config-custom-profiles-only/packageSpecificProfiles.js
@@ -1,0 +1,12 @@
+module.exports = {
+  0.64: {
+    core: {
+      name: "react-native",
+      version: "0.64.3",
+    },
+    react: {
+      name: "react",
+      version: "17.0.2",
+    },
+  },
+};

--- a/packages/dep-check/test/__fixtures__/config-custom-profiles-only/packageSpecificProfiles.js
+++ b/packages/dep-check/test/__fixtures__/config-custom-profiles-only/packageSpecificProfiles.js
@@ -9,4 +9,14 @@ module.exports = {
       version: "17.0.2",
     },
   },
+  0.65: {
+    core: {
+      name: "react-native",
+      version: "0.65.2",
+    },
+    react: {
+      name: "react",
+      version: "17.0.2",
+    },
+  },
 };


### PR DESCRIPTION
### Description

dep-check should pick up `customProfiles` when running in `--vigilant` mode to allow individual packages to use different profiles without having to re-declare which React Native versions they support.

Resolves #998.

### Test plan

Tests were added.