### PR TITLE
fix(metro-serializer-esbuild): correctly handle `sideEffects` array

### DIFF
--- a/.changeset/tender-panthers-jump.md
+++ b/.changeset/tender-panthers-jump.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Manually handle `sideEffects` set to an array of globs as esbuild only accepts boolean values.

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -25,12 +25,14 @@
     "@rnx-kit/tools-node": "^1.2.6",
     "esbuild": "^0.14.10",
     "esbuild-plugin-lodash": "^1.1.0",
+    "fast-glob": "^3.2.7",
     "semver": "^7.0.0"
   },
   "peerDependencies": {
     "metro": ">=0.66.1"
   },
   "devDependencies": {
+    "@fluentui/utilities": "^8.3.9",
     "@react-native-community/cli-plugin-metro": "^6.2.0",
     "@rnx-kit/metro-config": "*",
     "@rnx-kit/metro-serializer": "*",

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -52,10 +52,12 @@ const getSideEffects = (() => {
       const { sideEffects } = JSON.parse(content);
       if (Array.isArray(sideEffects)) {
         const fg = require("fast-glob");
-        pkgCache[pkgJson] = fg.sync(sideEffects, {
-          cwd: path.dirname(pkgJson),
-          absolute: true,
-        });
+        pkgCache[pkgJson] = fg
+          .sync(sideEffects, {
+            cwd: path.dirname(pkgJson),
+            absolute: true,
+          })
+          .map((p: string) => p.replace(/[/\\]/g, path.sep));
       } else {
         pkgCache[pkgJson] = sideEffects;
       }

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -47,7 +47,7 @@ function fixSourceMap(outputPath: string, text: string): string {
 const getSideEffects = (() => {
   const pkgCache: Record<string, boolean | string[]> = {};
   const getSideEffects = (pkgJson: string) => {
-    if (!pkgCache[pkgJson]) {
+    if (!(pkgJson in pkgCache)) {
       const content = fs.readFileSync(pkgJson, { encoding: "utf-8" });
       const { sideEffects } = JSON.parse(content);
       if (Array.isArray(sideEffects)) {

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -3,7 +3,6 @@ import type { MetroPlugin } from "@rnx-kit/metro-serializer";
 import { findPackage, readPackage } from "@rnx-kit/tools-node";
 import type { BuildOptions, BuildResult, Plugin } from "esbuild";
 import * as esbuild from "esbuild";
-import * as fs from "fs";
 import type { Dependencies, Graph, Module, SerializerOptions } from "metro";
 import type { SerializerConfigT } from "metro-config";
 import * as path from "path";

--- a/packages/metro-serializer-esbuild/test/__fixtures__/sideEffectsArray.ts
+++ b/packages/metro-serializer-esbuild/test/__fixtures__/sideEffectsArray.ts
@@ -1,0 +1,2 @@
+import { warn } from "@fluentui/utilities";
+warn("this should _not_ be removed");

--- a/packages/metro-serializer-esbuild/test/index.test.ts
+++ b/packages/metro-serializer-esbuild/test/index.test.ts
@@ -171,4 +171,45 @@ describe("metro-serializer-esbuild", () => {
       "
     `);
   });
+
+  test("handles `sideEffects` array", async () => {
+    const result = await bundle("test/__fixtures__/sideEffectsArray.ts");
+    expect(result).toMatchInlineSnapshot(`
+      "\\"use strict\\";
+      (function() {
+        var __getOwnPropNames = Object.getOwnPropertyNames;
+        var __esm = function(fn, res) {
+          return function __init() {
+            return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
+          };
+        };
+
+        // lib/index.js
+        var global;
+        var init_lib = __esm({
+          \\"lib/index.js\\": function() {
+            global = new Function(\\"return this;\\")();
+          }
+        });
+
+        // test/__fixtures__/sideEffectsArray.ts
+        init_lib();
+
+        // ../../node_modules/@fluentui/utilities/lib/warn/warn.js
+        init_lib();
+        var _warningCallback = void 0;
+        function warn(message) {
+          if (_warningCallback && true) {
+            _warningCallback(message);
+          } else if (console && console.warn) {
+            console.warn(message);
+          }
+        }
+
+        // test/__fixtures__/sideEffectsArray.ts
+        warn(\\"this should _not_ be removed\\");
+      })();
+      "
+    `);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1348,6 +1348,39 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fluentui/dom-utilities@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/dom-utilities/-/dom-utilities-2.1.5.tgz#21ba77c8bfe64d15ffc16a8e055255bbb23600b2"
+  integrity sha512-OLDYV5ZGIiK/JXx/DFFib4vSa7PELvznbdAujDcX2wjt3V3Lt2N5ucv59JsVxk5LlwXjasUHJI2NZadagmnM6A==
+  dependencies:
+    "@fluentui/set-version" "^8.1.5"
+    tslib "^2.1.0"
+
+"@fluentui/merge-styles@^8.2.3":
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/@fluentui/merge-styles/-/merge-styles-8.2.3.tgz#3cd596fc0d83d3f23edcd57d69a50b6e18e4ffa3"
+  integrity sha512-kwjY56C0ACMkYUikOX6krIwfuEworq6+A7V4zE1w8jRc7RSYHQfyfavu6ptNVgPPR/Bmho3AgriyhnnoFq+6fQ==
+  dependencies:
+    "@fluentui/set-version" "^8.1.5"
+    tslib "^2.1.0"
+
+"@fluentui/set-version@^8.1.5":
+  version "8.1.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/set-version/-/set-version-8.1.5.tgz#68d3d8c7fbefba20b3d1aef71fcc730ca46dd353"
+  integrity sha512-AfaycaduWd/aErqEmrAUWpr2gpZrkaSe6D9noXhtVH3JlreRuFM78Ji1oE4f8cpWxSA/K5qb7BT6x4z4I2Bs+A==
+  dependencies:
+    tslib "^2.1.0"
+
+"@fluentui/utilities@^8.3.9":
+  version "8.3.9"
+  resolved "https://registry.yarnpkg.com/@fluentui/utilities/-/utilities-8.3.9.tgz#d5dad90b03b26a947c066800a2db18ba7d3f9c65"
+  integrity sha512-UNz/5RjEmCtllzpCXEUkK/ScxjYkEG5tHIdUqxe+vg70UL92qlcSLo7E2NKuCuD7HM3z/tVbbE18ZEKJM6AOFg==
+  dependencies:
+    "@fluentui/dom-utilities" "^2.1.5"
+    "@fluentui/merge-styles" "^8.2.3"
+    "@fluentui/set-version" "^8.1.5"
+    tslib "^2.1.0"
+
 "@hapi/hoek@^9.0.0":
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.0.tgz#f3933a44e365864f4dad5db94158106d511e8131"
@@ -4728,17 +4761,16 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.1.1, fast-glob@^3.2.2:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
-  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
+fast-glob@^3.1.1, fast-glob@^3.2.2, fast-glob@^3.2.7:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.0"
+    glob-parent "^5.1.2"
     merge2 "^1.3.0"
-    micromatch "^4.0.2"
-    picomatch "^2.2.1"
+    micromatch "^4.0.4"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
@@ -5092,7 +5124,7 @@ git-url-parse@^11.1.2:
   dependencies:
     git-up "^4.0.0"
 
-glob-parent@^5.1.0, glob-parent@~5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -9295,10 +9327,10 @@ tslib@^1.10.0, tslib@^1.14.1, tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
-  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
### Description

We need to manually handle `sideEffects` set to an array of globs as esbuild only accepts boolean values.

### Test plan

A test was added.