### PR TITLE
fix(eslint-plugin): declarations should be exported as types

### DIFF
--- a/.changeset/early-jokes-flash.md
+++ b/.changeset/early-jokes-flash.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/eslint-plugin": patch
+---
+
+Declarations should be exported as types

--- a/packages/eslint-plugin/src/rules/no-export-all.js
+++ b/packages/eslint-plugin/src/rules/no-export-all.js
@@ -237,7 +237,8 @@ function extractExports(context, moduleId, depth) {
                 case "TSDeclareFunction": {
                   const name = declaration.id && declaration.id.name;
                   if (name) {
-                    exports.add(name);
+                    const set = declaration.declare ? types : exports;
+                    set.add(name);
                   }
                   break;
                 }

--- a/packages/eslint-plugin/test/no-export-all.test.ts
+++ b/packages/eslint-plugin/test/no-export-all.test.ts
@@ -33,6 +33,10 @@ export type { IChopper as IChopperRe, Predator as PredatorRe };
   types: `
 export type Predator = { kind: "$predator" };
 
+export declare class Helicopter {
+  private kind: "$helicopter";
+}
+
 export interface IChopper {
   kind: "$helicopter"
 };
@@ -124,18 +128,15 @@ describe("disallows `export *`", () => {
       {
         code: "export * from 'types';",
         errors: 1,
-        output: lines(
-          "export { escape } from 'types';",
-          "export type { IChopper, Predator } from 'types';"
-        ),
+        output:
+          "export type { Helicopter, IChopper, Predator, escape } from 'types';",
       },
       {
         code: lines("export * from './internal';", "export * from 'types';"),
         errors: 1,
         output: lines(
           "export * from './internal';",
-          "export { escape } from 'types';",
-          "export type { IChopper, Predator } from 'types';"
+          "export type { Helicopter, IChopper, Predator, escape } from 'types';"
         ),
         options: [{ expand: "external-only" }],
       },


### PR DESCRIPTION
### Description

Declarations should be exported as types.

### Test plan

A test was added, and it was tested in an internal repo.