### PR TITLE
fix(eslint-plugin): remove unused `eslint-plugin-jest`

### DIFF
--- a/.changeset/yellow-turtles-sit.md
+++ b/.changeset/yellow-turtles-sit.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/eslint-plugin": patch
+---
+
+Remove unused `eslint-plugin-jest`

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -30,7 +30,6 @@
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "enhanced-resolve": "^5.8.3",
-    "eslint-plugin-jest": "^25.0.0",
     "eslint-plugin-react": "^7.26.0"
   },
   "peerDependencies": {
@@ -48,7 +47,6 @@
     "ignoreMatches": [
       "@typescript-eslint/eslint-plugin",
       "@typescript-eslint/parser",
-      "eslint-plugin-jest",
       "eslint-plugin-react"
     ]
   },


### PR DESCRIPTION
### Description

It's currently unused and enabling it causes false positives, e.g.:

```
ERR! [@rnx-kit/babel-plugin-import-path-remapper lint] ERROR DETECTED
ERR! started
ERR! Running /var/folders/qc/zygl93h53zb3ctbyw0f0jbzm0000gn/T/yarn--1643625206294-0.40715523527082476/yarn run lint
ERR! $ rnx-kit-scripts lint
ERR!
ERR! /~/packages/babel-plugin-import-path-remapper/src/index.js
ERR!   124:1   error    Do not export from a test file     jest/no-export
ERR!   159:29  warning  Test is missing function argument  jest/no-disabled-tests
ERR!   159:29  warning  Test has no assertions             jest/expect-expect
ERR!   159:34  error    Title must be a string             jest/valid-title
ERR!   174:14  warning  Test is missing function argument  jest/no-disabled-tests
ERR!   174:14  warning  Test has no assertions             jest/expect-expect
ERR!   174:19  error    Title must be a string             jest/valid-title
ERR!
ERR! ✖ 7 problems (3 errors, 4 warnings)
```

### Test plan

Nothing to test.