### PR TITLE
fix(cli): fix `watchman::CommandValidationError`

### DIFF
--- a/.changeset/strong-moons-tease.md
+++ b/.changeset/strong-moons-tease.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Fix "watchman::CommandValidationError: failed to validate command: unknown command watchman-del-all" when running `rnx-clean`

--- a/packages/cli/react-native.config.js
+++ b/packages/cli/react-native.config.js
@@ -235,9 +235,10 @@ module.exports = {
       description: "Clears React Native project related caches",
       options: [
         {
-          name: "--include [android,cocoapods,npm,metro,watchman,yarn]",
+          name: "--include [android,cocoapods,metro,npm,watchman,yarn]",
           description:
-            "Comma-separated flag of caches to clear e.g npm,yarn . When not specified , only non-platform specific caches are cleared.",
+            "Comma-separated flag of caches to clear, e.g. `npm,yarn`. When not specified, only non-platform specific caches are cleared.",
+          default: "metro,npm,watchman,yarn",
         },
         {
           name: "--project-root <path>",

--- a/packages/cli/src/clean.ts
+++ b/packages/cli/src/clean.ts
@@ -1,10 +1,10 @@
 import type { Config as CLIConfig } from "@react-native-community/cli-types";
+import { error, info, warn } from "@rnx-kit/console";
 import chalk from "chalk";
-import path from "path";
+import { spawnSync } from "child_process";
 import fs from "fs";
 import os from "os";
-import { info, warn, error } from "@rnx-kit/console";
-import { spawnSync } from "child_process";
+import path from "path";
 
 type Args = {
   include: string;
@@ -113,7 +113,7 @@ export function rnxClean(
       {
         label: "Deleting watchman Cache",
         action: () => {
-          execute("watchman", ["watchman-del-all"], currentWorkingDirectory);
+          execute("watchman", ["watch-del-all"], currentWorkingDirectory);
         },
       },
     ],


### PR DESCRIPTION
### Description

The Watchman clean task fails:

```
% yarn react-native rnx-clean --include watchman
info Stopping watchman
info killall watchman
info Deleting watchman Cache
info watchman watchman-del-all
{
    "version": "2021.12.27.00",
    "error": "watchman::CommandValidationError: failed to validate command: unknown command watchman-del-all"
}
✨  Done in 4.02s.
```

### Test plan

```
cd packages/test-app
yarn build --dependencies
yarn react-native rnx-clean --include watchman
```