### PR TITLE
fix(cli): make cache integrity verification optional

### DIFF
--- a/.changeset/heavy-donkeys-switch.md
+++ b/.changeset/heavy-donkeys-switch.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+`rnx-clean`: Make cache integrity verification optional

--- a/packages/cli/react-native.config.js
+++ b/packages/cli/react-native.config.js
@@ -242,8 +242,14 @@ module.exports = {
         },
         {
           name: "--project-root <path>",
-          description: "Root path to your React Native project (optional)",
+          description: "Root path to your React Native project",
+          default: process.cwd(),
           parse: (val) => path.resolve(val),
+        },
+        {
+          name: "--verify",
+          description: "Whether to verify the integrity of the cache",
+          default: false,
         },
       ],
     },

--- a/packages/cli/src/clean.ts
+++ b/packages/cli/src/clean.ts
@@ -9,6 +9,7 @@ import path from "path";
 type Args = {
   include?: string;
   projectRoot?: string;
+  verify?: boolean;
 };
 
 type Task = {
@@ -62,16 +63,6 @@ export async function rnxClean(
         action: () => execute("pod", ["cache", "clean", "--all"], projectRoot),
       },
     ],
-    npm: [
-      {
-        label: "Remove node_modules",
-        action: () => cleanDir(`${projectRoot}/node_modules`),
-      },
-      {
-        label: "Verify npm cache",
-        action: () => execute(npm, ["cache", "verify"], projectRoot),
-      },
-    ],
     metro: [
       {
         label: "Clean Metro cache",
@@ -85,6 +76,20 @@ export async function rnxClean(
         label: "Clean React Native cache",
         action: () => cleanDir(`${os.tmpdir()}/react-*`),
       },
+    ],
+    npm: [
+      {
+        label: "Remove node_modules",
+        action: () => cleanDir(`${projectRoot}/node_modules`),
+      },
+      ...(cliOptions.verify
+        ? [
+            {
+              label: "Verify npm cache",
+              action: () => execute(npm, ["cache", "verify"], projectRoot),
+            },
+          ]
+        : []),
     ],
     watchman: [
       {


### PR DESCRIPTION
### Description

Cache integrity verification can take a very long time to run (e.g. `npm cache verify`). Making it opt-in will make the clean command more useful for regular use.

### Test plan

1. `--include npm` will only remove `node_modules` folder.
   ```
   % yarn react-native rnx-clean --include npm
   ✔ Remove node_modules
   ✨  Done in 1.35s.
   ```
2. Cache verification will only happen if `--verify` is specified.
   ```
   % yarn react-native rnx-clean --include npm --verify
   ✔ Remove node_modules
   ⠙ Verify npm cache
   ```