### PR TITLE
fix(metro-serializer-esbuild): add `analyze` option

### DIFF
--- a/.changeset/beige-cooks-appear.md
+++ b/.changeset/beige-cooks-appear.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Add `analyze` option to output a report about the contents of the bundle


### PR DESCRIPTION
### Description

Enabling analyze will output a report about the contents of your bundle.

See https://esbuild.github.io/api/#analyze for more details.

### Test plan

There's currently no easy way to pass options to the esbuild serializer from the CLI. First, patch cli to pass `analyze: true`:

```diff
diff --git a/packages/cli/src/metro-config.ts b/packages/cli/src/metro-config.ts
index f5add204..d8418bfe 100644
--- a/packages/cli/src/metro-config.ts
+++ b/packages/cli/src/metro-config.ts
@@ -135,7 +135,9 @@ export function customizeMetroConfig(
   }

   if (experimental_treeShake) {
-    metroConfig.serializer.customSerializer = MetroSerializerEsbuild(plugins);
+    metroConfig.serializer.customSerializer = MetroSerializerEsbuild(plugins, {
+      analyze: true,
+    });
     Object.assign(metroConfig.transformer, esbuildTransformerConfig);
   } else if (plugins.length > 0) {
     // MetroSerializer acts as a CustomSerializer, and it works with both
```

Then run:

```
cd packages/test-app
yarn build --dependencies
yarn bundle+esbuild --platform ios
```

You should get an output like below (scroll to the right):

```
% yarn bundle+esbuild --platform ios
yarn run v1.22.17
$ react-native rnx-bundle --bundle-prefix 'main+esbuild' --experimental-tree-shake --platform ios
info Bundling ios...
                    Welcome to Metro!
              Fast - Scalable - Integrated


Writing bundle output to: dist/main+esbuild.ios.jsbundle
Writing sourcemap output to: dist/main+esbuild.ios.jsbundle.map
Done writing bundle output
Done writing sourcemap output
info
  main.jsbundle                                                                                         3.7mb  100.0%
   ├ ../../node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js    606.8kb   16.1%
   ├ ../../node_modules/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js            593.8kb   15.8%
   ├ ../../node_modules/react-devtools-core/dist/backend.js                                           552.8kb   14.7%
   ├ ../../node_modules/react-native/Libraries/Lists/VirtualizedList.js                                68.8kb    1.8%
   ├ ../../node_modules/react/cjs/react.development.js                                                 64.9kb    1.7%
   [...]
```