### PR TITLE
feat(rn-changelog-generator): Prepend changelogs to the supplied file

### DIFF
--- a/.changeset/tasty-birds-give.md
+++ b/.changeset/tasty-birds-give.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/rn-changelog-generator": minor
+---
+
+prepend the newly generated changelog to the supplied --changelog file

--- a/packages/rn-changelog-generator/README.md
+++ b/packages/rn-changelog-generator/README.md
@@ -67,7 +67,7 @@ Generate a changelog for `react-native` commits between versions 0.65.0 and
 0.66.0:
 
 ```sh
-npx rn-changelog-generator --base v0.65.0 --compare v0.66.0 --repo ../../../react-native --changelog ../../../react-native/CHANGELOG.md > NEW_CHANGES.md
+npx @rnx-kit/rn-changelog-generator --base v0.65.0 --compare v0.66.0 --repo ../../../react-native --changelog ../../../react-native/CHANGELOG.md
 ```
 
 As explained above, you will need to have a local clone of `react-native`, which

--- a/packages/rn-changelog-generator/src/generator.ts
+++ b/packages/rn-changelog-generator/src/generator.ts
@@ -514,8 +514,18 @@ function handler(argv: GenerateArgs) {
     .then(async () => {
       const existingChangelogData = fs.readFileSync(argv.changelog, "utf-8");
       const base = await getOffsetBaseCommit(gitDir, argv.base, argv.compare);
-      const data = await run({ ...argv, base, gitDir, existingChangelogData });
-      return console.log(data);
+      const newChangeLogData = await run({
+        ...argv,
+        base,
+        gitDir,
+        existingChangelogData,
+      });
+      const fd = fs.openSync(argv.changelog, "w+");
+      const insert = Buffer.from(newChangeLogData + existingChangelogData);
+      fs.writeSync(fd, insert, 0, insert.length, 0);
+      fs.close(fd, (err) => {
+        if (err) throw err;
+      });
     })
     .catch((e) => {
       console.error(e);

--- a/packages/rn-changelog-generator/src/generator.ts
+++ b/packages/rn-changelog-generator/src/generator.ts
@@ -520,12 +520,20 @@ function handler(argv: GenerateArgs) {
         gitDir,
         existingChangelogData,
       });
-      const fd = fs.openSync(argv.changelog, "w+");
-      const insert = Buffer.from(newChangeLogData + existingChangelogData);
-      fs.writeSync(fd, insert, 0, insert.length, 0);
-      fs.close(fd, (err) => {
-        if (err) throw err;
+
+      const changelogHeader = "# Changelog";
+      fs.writeFileSync(argv.changelog, changelogHeader, {
+        encoding: "utf8",
+        flag: "w",
       });
+      fs.appendFileSync(argv.changelog, newChangeLogData);
+      fs.appendFileSync(
+        argv.changelog,
+        existingChangelogData.substring(
+          existingChangelogData.indexOf(changelogHeader) +
+            changelogHeader.length
+        )
+      );
     })
     .catch((e) => {
       console.error(e);


### PR DESCRIPTION
### Description

This updates the `rn-changelog-generator` to prepend the newly generated changelog to the supplied --changelog file instead of relying on redirecting the terminal output to a file. It also updates the `rn-changelog-generator` readme to point to the new `@rnx-kit/rn-changelog-generator`  package

Resolves https://github.com/facebook/react-native/issues/33011  
 

### Test plan

Run `node lib/index.js --base v0.66.4 --compare v0.67.0-rc.0 --repo ../../../react-native/ --changelog ../../../react-native/CHANGELOG.md` and ensure the file provided is prepended
