### PR TITLE
fix(dep-check): fix dev version not being correctly set

### DIFF
--- a/.changeset/twelve-geckos-report.md
+++ b/.changeset/twelve-geckos-report.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/dep-check": patch
+---
+
+Fix dev version not being set correctly in `--vigilant` mode

--- a/packages/dep-check/src/check.ts
+++ b/packages/dep-check/src/check.ts
@@ -13,7 +13,12 @@ import type { CheckConfig, CheckOptions, Command } from "./types";
 
 export function getCheckConfig(
   manifestPath: string,
-  { loose, uncheckedReturnCode = 0, versions }: CheckOptions
+  {
+    loose,
+    uncheckedReturnCode = 0,
+    supportedVersions,
+    targetVersion,
+  }: CheckOptions
 ): number | CheckConfig {
   const manifest = readPackage(manifestPath);
   if (!isPackageManifest(manifest)) {
@@ -46,7 +51,10 @@ export function getCheckConfig(
   } = getKitCapabilities({
     // React Native versions declared in the package's config should always
     // override the ones specified with the `--vigilant` flag.
-    ...(versions ? { reactNativeVersion: versions } : undefined),
+    ...(supportedVersions
+      ? { reactNativeVersion: supportedVersions }
+      : undefined),
+    ...(targetVersion ? { reactNativeDevVersion: targetVersion } : undefined),
     ...kitConfig,
   });
 

--- a/packages/dep-check/src/types.ts
+++ b/packages/dep-check/src/types.ts
@@ -29,7 +29,8 @@ export type CheckConfig = {
 export type CheckOptions = Options & {
   uncheckedReturnCode?: number;
   config?: number | CheckConfig;
-  versions?: string;
+  supportedVersions?: string;
+  targetVersion?: string;
 };
 
 export type VigilantOptions = Options & {

--- a/packages/dep-check/src/vigilant.ts
+++ b/packages/dep-check/src/vigilant.ts
@@ -146,7 +146,8 @@ export function makeVigilantCommand({
   const checkOptions = {
     loose,
     write,
-    versions: profilesInfo.supportedVersions,
+    supportedVersions: profilesInfo.supportedVersions,
+    targetVersion: profilesInfo.targetVersion,
   };
 
   const exclusionList = isString(excludePackages)


### PR DESCRIPTION
### Description

Fix dev version not being set correctly in `--vigilant` mode.

Resolves #1140

### Test plan

Tested internally.