### PR TITLE
fix(dep-check): do not rewrite superset ranges in vigilant mode

### DIFF
--- a/.changeset/tame-eyes-yawn.md
+++ b/.changeset/tame-eyes-yawn.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/dep-check": patch
+---
+
+Keep version ranges defined in `peerDependencies` if they are a superset

--- a/packages/dep-check/src/capabilities.ts
+++ b/packages/dep-check/src/capabilities.ts
@@ -1,6 +1,6 @@
 import type { Capability, KitCapabilities } from "@rnx-kit/config";
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
-import semver from "semver";
+import semverMinVersion from "semver/ranges/min-version";
 import { getProfilesFor, getProfileVersionsFor } from "./profiles";
 import { concatVersionRanges, keysOf } from "./helpers";
 import type {
@@ -46,7 +46,7 @@ export function capabilitiesFor(
       ? {
           reactNativeDevVersion:
             devDependencies?.["react-native"] ||
-            semver.minVersion(reactNativeVersion)?.version,
+            semverMinVersion(reactNativeVersion)?.version,
         }
       : undefined),
     kitType,

--- a/packages/dep-check/src/dependencies.ts
+++ b/packages/dep-check/src/dependencies.ts
@@ -1,9 +1,9 @@
 import type { Capability, KitConfig, KitType } from "@rnx-kit/config";
 import { getKitCapabilities, getKitConfig } from "@rnx-kit/config";
 import { error, warn } from "@rnx-kit/console";
+import type { PackageManifest } from "@rnx-kit/tools-node/package";
 import {
   findPackageDependencyDir,
-  PackageManifest,
   parsePackageRef,
   readPackage,
 } from "@rnx-kit/tools-node/package";

--- a/packages/dep-check/src/dependencies.ts
+++ b/packages/dep-check/src/dependencies.ts
@@ -1,14 +1,9 @@
-import {
-  Capability,
-  getKitCapabilities,
-  getKitConfig,
-  KitConfig,
-  KitType,
-} from "@rnx-kit/config";
+import type { Capability, KitConfig, KitType } from "@rnx-kit/config";
+import { getKitCapabilities, getKitConfig } from "@rnx-kit/config";
 import { error, warn } from "@rnx-kit/console";
 import {
-  PackageManifest,
   findPackageDependencyDir,
+  PackageManifest,
   parsePackageRef,
   readPackage,
 } from "@rnx-kit/tools-node/package";
@@ -101,7 +96,7 @@ export function getRequirements(
 
     visitDependencies(targetManifest, projectRoot, (module, modulePath) => {
       const kitConfig = getKitConfig({ cwd: modulePath });
-      if (!kitConfig) {
+      if (!kitConfig?.reactNativeVersion) {
         return;
       }
 

--- a/packages/dep-check/src/findBadPackages.ts
+++ b/packages/dep-check/src/findBadPackages.ts
@@ -1,11 +1,11 @@
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
-import semver from "semver";
+import semverSubset from "semver/ranges/subset";
 import banned from "./profiles/banned";
 import type { ExcludedPackage } from "./types";
 
 function isBanned(name: string, version: string): ExcludedPackage | undefined {
   const info = banned.find((pkg) => pkg.name === name);
-  return info && semver.subset(version, info.version) ? info : undefined;
+  return info && semverSubset(version, info.version) ? info : undefined;
 }
 
 export function findBadPackages({

--- a/packages/dep-check/src/manifest.ts
+++ b/packages/dep-check/src/manifest.ts
@@ -1,7 +1,7 @@
 import type { Capability, KitType } from "@rnx-kit/config";
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
 import omit from "lodash/omit";
-import semver from "semver";
+import semverSatisfies from "semver/functions/satisfies";
 import { resolveCapabilities } from "./capabilities";
 import type { DependencyType, Package, Profile } from "./types";
 
@@ -58,7 +58,7 @@ export function updateDependencies(
 
   // `Array.prototype.sort` is stable as of V8 7.0 (or Node 11). For users still
   // on Node 10 or below, we'll use a solution that throws away one more object.
-  if (semver.satisfies(nodeVersion, ">=11")) {
+  if (semverSatisfies(nodeVersion, ">=11")) {
     const entries = packageNames.reduce((result, dependency) => {
       const packageRange = packages[dependency];
       if (shouldBeAdded(packageRange[0])) {

--- a/packages/dep-check/src/profiles.ts
+++ b/packages/dep-check/src/profiles.ts
@@ -1,6 +1,10 @@
 import { error } from "@rnx-kit/console";
 import isString from "lodash/isString";
-import semver from "semver";
+import semverCoerce from "semver/functions/coerce";
+import semverSatisfies from "semver/functions/satisfies";
+import semverValid from "semver/functions/valid";
+import semverIntersects from "semver/ranges/intersects";
+import semverValidRange from "semver/ranges/valid";
 import { keysOf } from "./helpers";
 import profile_0_61 from "./profiles/profile-0.61";
 import profile_0_62 from "./profiles/profile-0.62";
@@ -37,16 +41,16 @@ function getVersionComparator(
 ): (profileVersion: ProfileVersion) => boolean {
   const includePrerelease = { includePrerelease: true };
 
-  const version = semver.valid(versionOrRange);
+  const version = semverValid(versionOrRange);
   if (version) {
     return (profileVersion: ProfileVersion) =>
-      semver.satisfies(version, "^" + profileVersion, includePrerelease);
+      semverSatisfies(version, "^" + profileVersion, includePrerelease);
   }
 
-  const range = semver.validRange(versionOrRange);
+  const range = semverValidRange(versionOrRange);
   if (range) {
     return (profileVersion: ProfileVersion) =>
-      semver.intersects("^" + profileVersion, range, includePrerelease);
+      semverIntersects("^" + profileVersion, range, includePrerelease);
   }
 
   throw new Error(`Invalid 'react-native' version range: ${versionOrRange}`);
@@ -170,7 +174,7 @@ export function parseProfilesString(
   const profileVersions = versions
     .toString()
     .split(",")
-    .map((value) => "^" + semver.coerce(value));
+    .map((value) => "^" + semverCoerce(value));
   const targetVersion = profileVersions[0];
 
   // Note: `.sort()` mutates the array

--- a/packages/dep-check/test/vigilant.test.ts
+++ b/packages/dep-check/test/vigilant.test.ts
@@ -218,6 +218,45 @@ describe("inspect()", () => {
     );
     expect(manifest.dependencies).not.toEqual(dependencies);
   });
+
+  test("does not rewrite peerDependencies if superset", () => {
+    const manifest = {
+      name: "@rnx-kit/dep-check",
+      version: "1.0.0",
+      dependencies: {
+        react: "^16.8.1",
+      },
+      peerDependencies: {
+        metro: "*",
+        react: ">=16.8.0 <18.0.0",
+        "react-native": ">=0.64",
+      },
+      devDependencies: {},
+    };
+    const profile = {
+      name: "@rnx-kit/dep-check",
+      version: "1.0.0",
+      dependencies: {
+        react: "~17.0.1",
+      },
+      peerDependencies: {
+        metro: "^0.66.2",
+        react: "~17.0.1",
+        "react-native": "^0.66.0-0",
+      },
+      devDependencies: {},
+    };
+    const expectedChanges = [
+      {
+        name: "react",
+        from: manifest.dependencies["react"],
+        to: profile.dependencies["react"],
+        section: "dependencies",
+      },
+    ];
+
+    expect(inspect(manifest, profile, false)).toEqual(expectedChanges);
+  });
 });
 
 describe("makeVigilantCommand()", () => {

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -55,5 +55,8 @@
   },
   "jest": {
     "preset": "@rnx-kit/scripts"
+  },
+  "rnx-kit": {
+    "customProfiles": "@rnx-kit/scripts/rnx-dep-check.js"
   }
 }

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -51,5 +51,8 @@
   },
   "jest": {
     "preset": "@rnx-kit/scripts"
+  },
+  "rnx-kit": {
+    "customProfiles": "@rnx-kit/scripts/rnx-dep-check.js"
   }
 }

--- a/scripts/rnx-dep-check.js
+++ b/scripts/rnx-dep-check.js
@@ -68,8 +68,6 @@ module.exports = {
 if (require.main === module) {
   require("@rnx-kit/dep-check").cli({
     "custom-profiles": __filename,
-    // the following packages support multiple versions of react-native
-    "exclude-packages": "@rnx-kit/jest-preset,@rnx-kit/metro-config",
     vigilant: "0.66",
     write: process.argv.includes("--write"),
   });


### PR DESCRIPTION
### Description

Keep version ranges defined in `peerDependencies` if they are a superset.

### Test plan

Tests were added.