### PR TITLE
fix(dep-check): fix dev version always being set

### DIFF
--- a/.changeset/shiny-beers-beam.md
+++ b/.changeset/shiny-beers-beam.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/dep-check": patch
+---
+
+Fix dev version being set regardless of whether a package was configured when running in `--vigilant` mode

--- a/packages/dep-check/src/check.ts
+++ b/packages/dep-check/src/check.ts
@@ -54,7 +54,11 @@ export function getCheckConfig(
     ...(supportedVersions
       ? { reactNativeVersion: supportedVersions }
       : undefined),
-    ...(targetVersion ? { reactNativeDevVersion: targetVersion } : undefined),
+    // We should not set dev version if the package is configured. It may have
+    // been intentionally left out to reuse `reactNativeVersion`.
+    ...(!kitConfig.reactNativeVersion && targetVersion
+      ? { reactNativeDevVersion: targetVersion }
+      : undefined),
     ...kitConfig,
   });
 


### PR DESCRIPTION
### Description

We should not set dev version if the package is configured. It may have been intentionally left out to reuse `reactNativeVersion`.

### Test plan

Tested internally.