### PR TITLE
Do not remap externals in esbuild-plugin-import-path-remapper

### DIFF
--- a/.changeset/stale-beds-trade.md
+++ b/.changeset/stale-beds-trade.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/esbuild-plugin-import-path-remapper": minor
+---
+
+Do not remap externals.

--- a/packages/esbuild-plugin-import-path-remapper/src/index.ts
+++ b/packages/esbuild-plugin-import-path-remapper/src/index.ts
@@ -5,7 +5,6 @@ const ESBUILD_DEFAULT_EXTENSIONS = [
   ".ts",
   ".jsx",
   ".js",
-  ".mjs",
   ".css",
   ".json",
 ];

--- a/packages/esbuild-plugin-import-path-remapper/src/index.ts
+++ b/packages/esbuild-plugin-import-path-remapper/src/index.ts
@@ -5,6 +5,7 @@ const ESBUILD_DEFAULT_EXTENSIONS = [
   ".ts",
   ".jsx",
   ".js",
+  ".mjs",
   ".css",
   ".json",
 ];
@@ -88,9 +89,16 @@ const ImportPathRemapperPlugin = (packageNameFilter: RegExp): Plugin => ({
     // `main` entry.
     build.onResolve(
       { filter: new RegExp(`^${packageNameFilter.source}[/]+[^/]+[/]*$`) },
-      ({ path, resolveDir }) => ({
-        path: findMainSourceFile(path, resolveDir),
-      })
+      ({ path, resolveDir }) => {
+        // Check if the package being resolved is marked as external. If so, it should stay external
+        // and we should not try to resolve it to a TypeScript module.
+        const external = Boolean(build.initialOptions.external?.includes(path));
+        if (external) {
+          return { path, external };
+        } else {
+          return { path: findMainSourceFile(path, resolveDir), external };
+        }
+      }
     );
   },
 });

--- a/packages/esbuild-plugin-import-path-remapper/test/esbuild-plugin-import-path-remapper.test.js
+++ b/packages/esbuild-plugin-import-path-remapper/test/esbuild-plugin-import-path-remapper.test.js
@@ -140,4 +140,26 @@ describe("@rnx-kit/esbuild-plugin-import-path-remapper", () => {
       expect.not.stringContaining('location = "lib/index"')
     );
   });
+
+  test("does not remap externals.", async () => {
+    const result = await esbuild.build({
+      entryPoints: ["./test/__fixtures__/import-@test-pkg.ts"],
+
+      bundle: true,
+      write: false,
+      plugins: [ImportPathRemapperPlugin(/@test/)],
+      external: ["@test/pkg"],
+    });
+
+    const output = String.fromCodePoint(...result.outputFiles[0].contents);
+    expect(output).toEqual(
+      expect.stringContaining('var import_pkg = __require("@test/pkg");')
+    );
+    expect(output).toEqual(
+      expect.not.stringContaining('location = "src/index"')
+    );
+    expect(output).toEqual(
+      expect.not.stringContaining('location = "lib/index"')
+    );
+  });
 });


### PR DESCRIPTION
### Description

The onResolve hook in the esbuild plugin has the potential to override the resolution of externals. The esbuild-plugin-import-path-remapper plugin accidentally does this by potentially intercepting the resolution of @foo/bar and translating it into something like @foo/bar/src/index.ts. This should not be done if "@foo/bar" is in the list of externals in the build config.

### Test plan

Reproduced the issue and validated the fix in the unit tests.