### PR TITLE
fix(draft-patch-rnmacos): add bin entry to package.json

### DIFF
--- a/.changeset/brown-crabs-yell.md
+++ b/.changeset/brown-crabs-yell.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/draft-patch-rnmacos": patch
+---
+
+Fix package.json to include bin entry

--- a/packages/draft-patch-rnmacos/package.json
+++ b/packages/draft-patch-rnmacos/package.json
@@ -13,6 +13,9 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "bin": {
+    "draft-patch-rnmacos": "lib/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",


### PR DESCRIPTION
### Description

I'm really bad at coding 🤦‍♂️ I forgot the bin entry, so command wasn't working once bundled.

### Test plan

N/A
