### PR TITLE
fix(draft-patch-rnmacos): add missing shebang to invoke with node

### DIFF
--- a/.changeset/five-buses-cheer.md
+++ b/.changeset/five-buses-cheer.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/draft-patch-rnmacos": patch
+---
+
+Add missing shebang to invoke with node

--- a/packages/draft-patch-rnmacos/src/index.ts
+++ b/packages/draft-patch-rnmacos/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import diffRepos from "./diffRepos";
 import patchRepo from "./patchRepo";
 import patchFile from "./patchFile";


### PR DESCRIPTION
### Description

Add missing shebang to invoke with node.

### Test plan

n/a