### PR TITLE
fix(metro-serializer-esbuild): prevent `"use strict"` like Metro does

### DIFF
--- a/.changeset/silly-donkeys-glow.md
+++ b/.changeset/silly-donkeys-glow.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Metro does not inject `"use strict"`, but esbuild does. If we're targeting ES5, we should strip them out.

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -126,11 +126,33 @@ export function MetroSerializer(
       plugin(entryPoint, preModules, graph, options)
     );
 
+    // To ensure that Hermes is able to consume this bundle, we must target ES5.
+    // Hermes is missing a bunch of ES6 features, such as block scoping (see
+    // https://github.com/facebook/hermes/issues/575).
+    const target = buildOptions?.target ?? "es5";
+
     const { dependencies } = graph;
     const metroPlugin: Plugin = {
       name: require("../package.json").name,
       setup: (build) => {
         const pluginOptions = { filter: /.*/ };
+
+        // Metro does not inject `"use strict"`, but esbuild does. If we're
+        // targeting ES5, we should strip them out. See also
+        // https://github.com/facebook/metro/blob/0fe1253cc4f76aa2a7683cfb2ad0253d0a768c83/packages/metro-react-native-babel-preset/src/configs/main.js#L68
+        if (!options.dev && target === "es5") {
+          const encoder = new TextEncoder();
+          build.onEnd(({ outputFiles }) => {
+            outputFiles?.forEach(({ path, text }, index) => {
+              const newText = text.replace(/"use strict";\s*/g, "");
+              outputFiles[index] = {
+                path,
+                contents: encoder.encode(newText),
+                text: newText,
+              };
+            });
+          });
+        }
 
         build.onResolve(pluginOptions, (args) => {
           if (dependencies.has(args.path)) {
@@ -278,12 +300,7 @@ export function MetroSerializer(
         outfile,
         plugins,
         sourcemap: "external",
-
-        // To ensure that Hermes is able to consume this bundle, we must target
-        // ES5. Hermes is missing a bunch of ES6 features, such as block scoping
-        // (see https://github.com/facebook/hermes/issues/575).
-        target: buildOptions?.target ?? "es5",
-
+        target,
         write: false,
       })
       .then(({ metafile, outputFiles }: BuildResult) => {

--- a/packages/metro-serializer-esbuild/test/index.test.ts
+++ b/packages/metro-serializer-esbuild/test/index.test.ts
@@ -6,14 +6,14 @@ describe("metro-serializer-esbuild", () => {
 
   const consoleWarnSpy = jest.spyOn(global.console, "warn");
 
-  async function bundle(entryFile: string): Promise<string> {
+  async function bundle(entryFile: string, dev = true): Promise<string> {
     let result: string | undefined = undefined;
     await buildBundle(
       {
         entryFile,
         bundleEncoding: "utf8",
         bundleOutput: ".test-output.jsbundle",
-        dev: true,
+        dev,
         platform: "native",
         resetCache: false,
         resetGlobalCache: false,
@@ -54,7 +54,8 @@ describe("metro-serializer-esbuild", () => {
   test("removes unused code", async () => {
     const result = await bundle("test/__fixtures__/direct.ts");
     expect(result).toMatchInlineSnapshot(`
-      "(function() {
+      "\\"use strict\\";
+      (function() {
         // lib/index.js
         var global = new Function(\\"return this;\\")();
 
@@ -73,7 +74,8 @@ describe("metro-serializer-esbuild", () => {
   test("removes unused code (export *)", async () => {
     const result = await bundle("test/__fixtures__/exportAll.ts");
     expect(result).toMatchInlineSnapshot(`
-      "(function() {
+      "\\"use strict\\";
+      (function() {
         // lib/index.js
         var global = new Function(\\"return this;\\")();
 
@@ -92,7 +94,8 @@ describe("metro-serializer-esbuild", () => {
   test("removes unused code (nested export *)", async () => {
     const result = await bundle("test/__fixtures__/nestedExportAll.ts");
     expect(result).toMatchInlineSnapshot(`
-      "(function() {
+      "\\"use strict\\";
+      (function() {
         // lib/index.js
         var global = new Function(\\"return this;\\")();
 
@@ -111,7 +114,8 @@ describe("metro-serializer-esbuild", () => {
   test("removes unused code (import *)", async () => {
     const result = await bundle("test/__fixtures__/importAll.ts");
     expect(result).toMatchInlineSnapshot(`
-      "(function() {
+      "\\"use strict\\";
+      (function() {
         // lib/index.js
         var global = new Function(\\"return this;\\")();
 
@@ -130,7 +134,8 @@ describe("metro-serializer-esbuild", () => {
   test("removes unused code (import * <- export *)", async () => {
     const result = await bundle("test/__fixtures__/importExportAll.ts");
     expect(result).toMatchInlineSnapshot(`
-      "(function() {
+      "\\"use strict\\";
+      (function() {
         // lib/index.js
         var global = new Function(\\"return this;\\")();
 
@@ -149,7 +154,8 @@ describe("metro-serializer-esbuild", () => {
   test("tree-shakes lodash-es", async () => {
     const result = await bundle("test/__fixtures__/lodash-es.ts");
     expect(result).toMatchInlineSnapshot(`
-      "(function() {
+      "\\"use strict\\";
+      (function() {
         // lib/index.js
         var global = new Function(\\"return this;\\")();
 
@@ -169,7 +175,8 @@ describe("metro-serializer-esbuild", () => {
   test("handles `sideEffects` array", async () => {
     const result = await bundle("test/__fixtures__/sideEffectsArray.ts");
     expect(result).toMatchInlineSnapshot(`
-      "(function() {
+      "\\"use strict\\";
+      (function() {
         var __getOwnPropNames = Object.getOwnPropertyNames;
         var __esm = function(fn, res) {
           return function __init() {
@@ -202,6 +209,14 @@ describe("metro-serializer-esbuild", () => {
         // test/__fixtures__/sideEffectsArray.ts
         warn(\\"this should _not_ be removed\\");
       })();
+      "
+    `);
+  });
+
+  test('strips out `"use strict"`', async () => {
+    const result = await bundle("test/__fixtures__/direct.ts", false);
+    expect(result).toMatchInlineSnapshot(`
+      "(function(){var e=new Function(\\"return this;\\")();})();
       "
     `);
   });

--- a/packages/metro-serializer-esbuild/test/index.test.ts
+++ b/packages/metro-serializer-esbuild/test/index.test.ts
@@ -54,8 +54,7 @@ describe("metro-serializer-esbuild", () => {
   test("removes unused code", async () => {
     const result = await bundle("test/__fixtures__/direct.ts");
     expect(result).toMatchInlineSnapshot(`
-      "\\"use strict\\";
-      (function() {
+      "(function() {
         // lib/index.js
         var global = new Function(\\"return this;\\")();
 
@@ -74,8 +73,7 @@ describe("metro-serializer-esbuild", () => {
   test("removes unused code (export *)", async () => {
     const result = await bundle("test/__fixtures__/exportAll.ts");
     expect(result).toMatchInlineSnapshot(`
-      "\\"use strict\\";
-      (function() {
+      "(function() {
         // lib/index.js
         var global = new Function(\\"return this;\\")();
 
@@ -94,8 +92,7 @@ describe("metro-serializer-esbuild", () => {
   test("removes unused code (nested export *)", async () => {
     const result = await bundle("test/__fixtures__/nestedExportAll.ts");
     expect(result).toMatchInlineSnapshot(`
-      "\\"use strict\\";
-      (function() {
+      "(function() {
         // lib/index.js
         var global = new Function(\\"return this;\\")();
 
@@ -114,8 +111,7 @@ describe("metro-serializer-esbuild", () => {
   test("removes unused code (import *)", async () => {
     const result = await bundle("test/__fixtures__/importAll.ts");
     expect(result).toMatchInlineSnapshot(`
-      "\\"use strict\\";
-      (function() {
+      "(function() {
         // lib/index.js
         var global = new Function(\\"return this;\\")();
 
@@ -134,8 +130,7 @@ describe("metro-serializer-esbuild", () => {
   test("removes unused code (import * <- export *)", async () => {
     const result = await bundle("test/__fixtures__/importExportAll.ts");
     expect(result).toMatchInlineSnapshot(`
-      "\\"use strict\\";
-      (function() {
+      "(function() {
         // lib/index.js
         var global = new Function(\\"return this;\\")();
 
@@ -154,8 +149,7 @@ describe("metro-serializer-esbuild", () => {
   test("tree-shakes lodash-es", async () => {
     const result = await bundle("test/__fixtures__/lodash-es.ts");
     expect(result).toMatchInlineSnapshot(`
-      "\\"use strict\\";
-      (function() {
+      "(function() {
         // lib/index.js
         var global = new Function(\\"return this;\\")();
 
@@ -175,8 +169,7 @@ describe("metro-serializer-esbuild", () => {
   test("handles `sideEffects` array", async () => {
     const result = await bundle("test/__fixtures__/sideEffectsArray.ts");
     expect(result).toMatchInlineSnapshot(`
-      "\\"use strict\\";
-      (function() {
+      "(function() {
         var __getOwnPropNames = Object.getOwnPropertyNames;
         var __esm = function(fn, res) {
           return function __init() {


### PR DESCRIPTION
### Description

Metro does not inject `"use strict"`, but esbuild does. If we're targeting ES5, we should strip them out.

### Test plan

Tests should pass.