### PR TITLE
feat(babel-preset): allow enabling loose mode on `@babel/plugin-transform-classes`

### DIFF
--- a/.changeset/eighty-bats-crash.md
+++ b/.changeset/eighty-bats-crash.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/babel-preset-metro-react-native": minor
+---
+
+Allow enabling loose mode on `@babel/plugin-transform-classes`

--- a/packages/babel-preset-metro-react-native/README.md
+++ b/packages/babel-preset-metro-react-native/README.md
@@ -37,6 +37,34 @@ module.exports = {
 If you're looking to reduce the bundle size, here are a couple of things you can
 try.
 
+### Enable compiler assumptions
+
+Since 7.13.0, Babel can make certain assumptions about your code to reduce the
+amount of generated code. You can read more about it at
+<https://babeljs.io/docs/en/assumptions>.
+
+### Enable loose mode when transforming classes
+
+If you make heavy use of classes, but can't use compiler assumptions, you can
+enable `looseClassTransform` to remove helper functions:
+
+```js
+module.exports = {
+  presets: [
+    [
+      "@rnx-kit/babel-preset-metro-react-native",
+      {
+        looseClassTransform: true,
+      },
+    ],
+  ],
+};
+```
+
+This is equivalent to passing
+[`{ loose: true }`](https://babeljs.io/docs/en/babel-plugin-transform-classes#loose)
+to `@babel/plugin-transform-classes`.
+
 ### Enable experimental import/export support
 
 In your `metro.config.js`, enable `experimentalImportSupport`:

--- a/packages/babel-preset-metro-react-native/package.json
+++ b/packages/babel-preset-metro-react-native/package.json
@@ -46,7 +46,10 @@
     ]
   },
   "eslintConfig": {
-    "extends": "@rnx-kit/eslint-config"
+    "extends": "@rnx-kit/eslint-config",
+    "rules": {
+      "@typescript-eslint/ban-ts-comment": "off"
+    }
   },
   "jest": {
     "roots": [

--- a/packages/babel-preset-metro-react-native/test/__fixtures__/App.ts
+++ b/packages/babel-preset-metro-react-native/test/__fixtures__/App.ts
@@ -22,3 +22,5 @@ function takeDirection(direction: Direction): string {
 }
 
 console.log(takeDirection(Direction.Up));
+
+export { takeDirection };

--- a/packages/babel-preset-metro-react-native/test/__fixtures__/Class.ts
+++ b/packages/babel-preset-metro-react-native/test/__fixtures__/Class.ts
@@ -1,0 +1,1 @@
+export class Foo {}

--- a/packages/babel-preset-metro-react-native/test/__snapshots__/index.test.js.snap
+++ b/packages/babel-preset-metro-react-native/test/__snapshots__/index.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`@rnx-kit/babel-preset-metro-react-native applies additional plugins 1`] = `
-"require(\\"typescript/src/remap-test/lib/lib\\");
+"Object.defineProperty(exports, \\"__esModule\\", { value: true });
+exports.takeDirection = takeDirection;
+require(\\"typescript/src/remap-test/lib/lib\\");
 var Direction;
 (function (Direction) {
   Direction[(Direction[\\"Up\\"] = 0)] = \\"Up\\";
@@ -26,7 +28,9 @@ console.log(takeDirection(Direction.Up));
 `;
 
 exports[`@rnx-kit/babel-preset-metro-react-native can be further extended 1`] = `
-"require(\\"typescript/src/remap-test/lib/lib\\");
+"Object.defineProperty(exports, \\"__esModule\\", { value: true });
+exports.takeDirection = takeDirection;
+require(\\"typescript/src/remap-test/lib/lib\\");
 var Direction;
 (function (Direction) {
   Direction[(Direction[\\"Up\\"] = 0)] = \\"Up\\";
@@ -50,8 +54,41 @@ console.log(takeDirection(Direction.Up));
 "
 `;
 
-exports[`@rnx-kit/babel-preset-metro-react-native transforms \`const enum\`s 1`] = `
+exports[`@rnx-kit/babel-preset-metro-react-native forwards options to \`metro-react-native-babel-preset\` 1`] = `
 "require(\\"typescript/lib/remap-test/lib/lib\\");
+var Direction;
+(function (Direction) {
+  Direction[(Direction[\\"Up\\"] = 0)] = \\"Up\\";
+  Direction[(Direction[\\"Down\\"] = 1)] = \\"Down\\";
+  Direction[(Direction[\\"Left\\"] = 2)] = \\"Left\\";
+  Direction[(Direction[\\"Right\\"] = 3)] = \\"Right\\";
+})(Direction || (Direction = {}));
+function takeDirection(direction) {
+  switch (direction) {
+    case Direction.Up:
+      return \\"up\\";
+    case Direction.Down:
+      return \\"down\\";
+    case Direction.Left:
+      return \\"left\\";
+    case Direction.Right:
+      return \\"right\\";
+  }
+}
+console.log(takeDirection(Direction.Up));
+export { takeDirection };
+"
+`;
+
+exports[`@rnx-kit/babel-preset-metro-react-native passes \`loose: true\` to \`@babel/plugin-transform-classes\` 1`] = `
+"export var Foo = function Foo() {};
+"
+`;
+
+exports[`@rnx-kit/babel-preset-metro-react-native transforms \`const enum\`s 1`] = `
+"Object.defineProperty(exports, \\"__esModule\\", { value: true });
+exports.takeDirection = takeDirection;
+require(\\"typescript/lib/remap-test/lib/lib\\");
 var Direction;
 (function (Direction) {
   Direction[(Direction[\\"Up\\"] = 0)] = \\"Up\\";


### PR DESCRIPTION
### Description

Allow enabling loose mode on `@babel/plugin-transform-classes`. Depending on how heavy classes are used, it can add up to a significant number of bytes saved. If you're using TypeScript, this should be safe to enable.

### Test plan

Tested internally.