### PR TITLE
fix(react-native-test-app-msal): throw if `msal_config.json` is missing

### DIFF
--- a/.changeset/lucky-tigers-cross.md
+++ b/.changeset/lucky-tigers-cross.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-test-app-msal": patch
+---
+
+Throw if `msal_config.json` is missing, otherwise Android will throw a cryptic/generic exception that's hard to debug.

--- a/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/TokenBroker.kt
+++ b/packages/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/TokenBroker.kt
@@ -2,6 +2,7 @@ package com.microsoft.reacttestapp.msal
 
 import android.app.Activity
 import android.content.Context
+import android.content.res.Resources.NotFoundException
 import com.microsoft.identity.client.AcquireTokenParameters
 import com.microsoft.identity.client.AuthenticationCallback
 import com.microsoft.identity.client.IAuthenticationResult
@@ -35,6 +36,9 @@ class TokenBroker private constructor(context: Context) {
     init {
         val configFileResourceId = context.resources
             .getIdentifier("raw/msal_config", null, context.packageName)
+        if (configFileResourceId == 0) {
+            throw NotFoundException("Can't find MSAL configuration file")
+        }
         multiAccountApp = PublicClientApplication.createMultipleAccountPublicClientApplication(
             context,
             configFileResourceId


### PR DESCRIPTION
### Description

Throw if `msal_config.json` is missing, otherwise Android will throw a cryptic/generic exception that's hard to debug.

### Test plan

n/a