### PR TITLE
fix(tools-react-native): `ERR_PACKAGE_PATH_NOT_EXPORTED` when importing ESM

### DIFF
--- a/.changeset/green-mangos-promise.md
+++ b/.changeset/green-mangos-promise.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-react-native": patch
+---
+
+Fix `ERR_PACKAGE_PATH_NOT_EXPORTED` when importing packages using the `exports` field

--- a/packages/tools-node/src/package.ts
+++ b/packages/tools-node/src/package.ts
@@ -205,10 +205,12 @@ export type FindPackageDependencyOptions = {
  * @returns Path to the package dependency's directory, or `undefined` if not found.
  */
 export function findPackageDependencyDir(
-  ref: PackageRef,
+  ref: string | PackageRef,
   options?: FindPackageDependencyOptions
 ): string | undefined {
-  return findUp.sync(path.join("node_modules", ref.scope ?? "", ref.name), {
+  const pkgName =
+    typeof ref === "string" ? ref : path.join(ref.scope ?? "", ref.name);
+  return findUp.sync(path.join("node_modules", pkgName), {
     ...pickValues(
       options ?? {},
       ["startDir", "allowSymlinks"],

--- a/packages/tools-node/test/package.test.ts
+++ b/packages/tools-node/test/package.test.ts
@@ -153,6 +153,15 @@ describe("Node > Package", () => {
     );
   });
 
+  test("findPackageDependencyDir() accepts strings", () => {
+    const pkgDir = findPackageDependencyDir("@babel/core", {
+      startDir: fixtureDir,
+    });
+    expect(pkgDir).toEqual(
+      path.join(fixtureDir, "node_modules", "@babel/core")
+    );
+  });
+
   test("findPackageDependencyDir() finds a symlink package dir by default", () => {
     const coreLinkedPath = path.join(
       fixtureDir,

--- a/packages/tools-react-native/package.json
+++ b/packages/tools-react-native/package.json
@@ -23,6 +23,9 @@
     "test": "rnx-kit-scripts test",
     "update-readme": "rnx-kit-scripts update-api-readme"
   },
+  "dependencies": {
+    "@rnx-kit/tools-node": "^1.2.6"
+  },
   "devDependencies": {
     "@rnx-kit/scripts": "*",
     "@types/node": "^16.0.0",

--- a/packages/tools-react-native/src/platform.ts
+++ b/packages/tools-react-native/src/platform.ts
@@ -1,3 +1,4 @@
+import { findPackageDependencyDir } from "@rnx-kit/tools-node";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -62,15 +63,19 @@ export function getAvailablePlatformsUncached(
       : getAvailablePlatformsUncached(path.dirname(startDir), platformMap);
   }
 
-  const resolveOptions = { paths: [startDir] };
-  const { dependencies, devDependencies } = require(packageJson);
+  const options = { startDir };
+  const { dependencies, devDependencies } = JSON.parse(
+    fs.readFileSync(packageJson, { encoding: "utf-8" })
+  );
+
   [
     ...(dependencies ? Object.keys(dependencies) : []),
     ...(devDependencies ? Object.keys(devDependencies) : []),
   ].forEach((pkgName) => {
-    const pkgPath = path.dirname(
-      require.resolve(`${pkgName}/package.json`, resolveOptions)
-    );
+    const pkgPath = findPackageDependencyDir(pkgName, options);
+    if (!pkgPath) {
+      return;
+    }
 
     const configPath = path.join(pkgPath, "react-native.config.js");
     if (fs.existsSync(configPath)) {


### PR DESCRIPTION
### Description

Modules have started using the [`exports`](https://nodejs.org/api/packages.html#packages_exports) field, preventing us from importing their `package.json` directly.

Resolves #1227

### Test plan

Due to limitations in Jest, it's currently not possible to test the `exports` field.