### PR TITLE
docs(changeset): `findPackageDependencyDir` now also accepts package names

### DIFF
--- a/.changeset/honest-buses-join.md
+++ b/.changeset/honest-buses-join.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-language": patch
+---
+
+`findPackageDependencyDir` now also accepts package names


### PR DESCRIPTION
### Description

Add missing change log entry for `tools-language` changes introduced in #1228.

### Test plan

n/a