### PR TITLE
docs(changeset): `findPackageDependencyDir` now also accepts package names [skip ci]

### DIFF
--- a/.changeset/honest-buses-join.md
+++ b/.changeset/honest-buses-join.md
@@ -1,5 +1,5 @@
 ---
-"@rnx-kit/tools-language": patch
+"@rnx-kit/tools-node": patch
 ---
 
 `findPackageDependencyDir` now also accepts package names


### PR DESCRIPTION
### Description

Add missing change log entry for `tools-node` changes introduced in #1228.

### Test plan

n/a