### PR TITLE
fix(metro-config): add helper function for `extraNodeModules`

### DIFF
--- a/.changeset/proud-lions-jump.md
+++ b/.changeset/proud-lions-jump.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Add a helper function that returns both the path to a specified package and a regex pattern that excludes other copies of it.

--- a/packages/metro-config/README.md
+++ b/packages/metro-config/README.md
@@ -138,19 +138,20 @@ like this:
 
 ```js
 const {
-  excludeExtraCopiesOf,
   exclusionList,
   makeMetroConfig,
+  resolveUniqueModule,
 } = require("@rnx-kit/metro-config");
 
-const additionalExclusions = [excludeExtraCopiesOf("react-native-msal")];
+const [msalPath, msalExcludePattern] = resolveUniqueModule("react-native-msal");
+const additionalExclusions = [msalExcludePattern];
 const blockList = exclusionList(additionalExclusions);
 
 module.exports = makeMetroConfig({
   projectRoot: __dirname,
   resolver: {
     extraNodeModules: {
-      "react-native-msal": `${__dirname}/node_modules/react-native-msal`,
+      "react-native-msal": msalPath,
     },
     blacklistRE: blockList, // For Metro < 0.60
     blockList, // For Metro >= 0.60

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@rnx-kit/babel-preset-metro-react-native": "^1.0.17",
-    "@rnx-kit/tools-node": "^1.2.6",
+    "@rnx-kit/tools-node": "^1.2.7",
     "workspace-tools": "^0.18.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description

Add a helper function that returns both the path to a specified package and a regex pattern that excludes other copies of it.

### Test plan

Tests should pass.