### PR TITLE
docs: fix Visual Studio Code badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React Native Developer Tools
 
-[![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/microsoft/rnx-kit)
+[![Open in Visual Studio Code](https://img.shields.io/static/v1?logo=visualstudiocode&label=&message=Open%20in%20Visual%20Studio%20Code&color=007acc&labelColor=444444&logoColor=007acc)](https://vscode.dev/github/microsoft/rnx-kit)
 [![Build](https://github.com/microsoft/rnx-kit/actions/workflows/build.yml/badge.svg)](https://github.com/microsoft/rnx-kit/actions/workflows/build.yml)
 
 Tools which help developers build, deliver, and maintain React Native apps and


### PR DESCRIPTION
### Description

The badge was removed at some point. Made a custom one at [Shields.io](https://shields.io/) using the [official colour palette](https://code.visualstudio.com/brand#brand-colors).

### Test plan

n/a