### PR TITLE
chore: put docsite under the @rnx-kit scope

### DIFF
--- a/.changeset/great-peas-speak.md
+++ b/.changeset/great-peas-speak.md
@@ -1,5 +1,5 @@
 ---
-"docsite": minor
+"@rnx-kit/docsite": minor
 ---
 
 Update navigation and landing page

--- a/docsite/CHANGELOG.md
+++ b/docsite/CHANGELOG.md
@@ -1,4 +1,4 @@
-# docsite
+# @rnx-kit/docsite
 
 ## 0.0.1
 

--- a/docsite/package.json
+++ b/docsite/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "docsite",
+  "name": "@rnx-kit/docsite",
   "version": "0.0.1",
   "private": true,
   "scripts": {


### PR DESCRIPTION
### Description

Similar to what we did for `@rnx-kit/scripts` to avoid accidentally consuming an external package with a similar name.

### Test plan

n/a