### PR TITLE
fix(dep-check): allow specifying `--custom-profiles` with `--init`

### DIFF
--- a/.changeset/ten-pans-promise.md
+++ b/.changeset/ten-pans-promise.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/dep-check": patch
+---
+
+Allow specifying `--custom-profiles` with `--init`

--- a/packages/dep-check/src/cli.ts
+++ b/packages/dep-check/src/cli.ts
@@ -61,16 +61,21 @@ function getManifests(
   }
 }
 
-function makeInitializeCommand(kitType: string): Command | undefined {
+function makeInitializeCommand(
+  kitType: string,
+  customProfiles: string | undefined
+): Command | undefined {
   const verifiedKitType = ensureKitType(kitType);
   if (!verifiedKitType) {
     error(`Invalid kit type: '${kitType}'`);
     return undefined;
   }
 
-  const options = { kitType: verifiedKitType };
   return (manifest: string) => {
-    initializeConfig(manifest, options);
+    initializeConfig(manifest, {
+      kitType: verifiedKitType,
+      customProfilesPath: customProfiles,
+    });
     return 0;
   };
 }
@@ -106,7 +111,7 @@ async function makeCommand(args: Args): Promise<Command | undefined> {
   } = args;
 
   if (isString(init)) {
-    return makeInitializeCommand(init);
+    return makeInitializeCommand(init, customProfiles?.toString());
   }
 
   // When `--set-version` is without a value, `setVersion` is an empty string if
@@ -179,7 +184,6 @@ if (require.main === module) {
           "Path to custom profiles. This can be a path to a JSON file, a `.js` file, or a module name.",
         type: "string",
         requiresArg: true,
-        implies: "vigilant",
       },
       "exclude-packages": {
         description:

--- a/packages/dep-check/src/initialize.ts
+++ b/packages/dep-check/src/initialize.ts
@@ -22,6 +22,9 @@ export function initializeConfig(
     "rnx-kit": {
       ...manifest["rnx-kit"],
       ...capabilities,
+      ...(options.customProfilesPath
+        ? { customProfiles: options.customProfilesPath }
+        : undefined),
     },
   };
   modifyManifest(packageManifest, updatedManifest);


### PR DESCRIPTION
### Description

Allow specifying `--custom-profiles` with `--init` so it can be added to the config.

### Test plan

Tested internally.