### PR TITLE
fix(cli): print warning if `cli-clean` can be found

### DIFF
--- a/.changeset/spotty-jobs-brush.md
+++ b/.changeset/spotty-jobs-brush.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+`rnx-clean` has been upstreamed to `@react-native-community/cli`. Print a warning if `cli-clean` can be found.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,6 +58,7 @@
   },
   "depcheck": {
     "ignoreMatches": [
+      "@react-native-community/cli-clean",
       "metro",
       "metro-config",
       "readline"

--- a/packages/cli/src/clean.ts
+++ b/packages/cli/src/clean.ts
@@ -31,6 +31,16 @@ export async function rnxClean(
     throw new Error(`Invalid path provided! ${projectRoot}`);
   }
 
+  const spinner = ora();
+  try {
+    require.resolve("@react-native-community/cli-clean");
+    spinner.warn(
+      "`rnx-clean` has been upstreamed to `@react-native-community/cli`. Please use `npx react-native clean` instead."
+    );
+  } catch (_) {
+    // Ignore
+  }
+
   const npm = os.platform() === "win32" ? "npm.cmd" : "npm";
   const yarn = os.platform() === "win32" ? "yarn.cmd" : "yarn";
 
@@ -121,7 +131,6 @@ export async function rnxClean(
     "yarn",
   ];
 
-  const spinner = ora();
   for (const category of categories) {
     const commands = COMMANDS[category];
     if (!commands) {


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

`rnx-clean` should work as before if `@react-native-community/cli-clean` is not installed:

```
% npx react-native rnx-clean --include 'test'
⚠ Unknown category: test
```

A warning should be output if `@react-native-community/cli-clean` is installed:

```
% yarn link @react-native-community/cli-clean
yarn link v1.22.18
success Using linked package for "@react-native-community/cli-clean".
✨  Done in 0.05s.

% npx react-native rnx-clean --include 'test'
⚠ `rnx-clean` has been upstreamed to `@react-native-community/cli`. Please use `npx react-native clean` instead.
⚠ Unknown category: test
```