### PR TITLE
ci: disable publish in forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   build_and_publish:
     name: "Build and publish"
+    if: github.repository == "microsoft/rnx-kit"
     runs-on: ubuntu-latest
     steps:
       - name: Set up Node 14


### PR DESCRIPTION
### Description

This prevents Changesets from making noisy PRs in forks.

### Test plan

n/a