### PR TITLE
ci: fix unexpected symbol in `build.yml`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   build_and_publish:
     name: "Build and publish"
-    if: github.repository == "microsoft/rnx-kit"
+    if: ${{ github.repository == 'microsoft/rnx-kit' }}
     runs-on: ubuntu-latest
     steps:
       - name: Set up Node 14


### PR DESCRIPTION
### Description

Fixes `The workflow is not valid. .github/workflows/build.yml (Line: 8, Col: 9): Unexpected symbol: '"microsoft/rnx-kit"'. Located at position 22 within expression: github.repository == "microsoft/rnx-kit"`

See https://github.com/microsoft/rnx-kit/actions/runs/2114153842

### Test plan

I wish.