### PR TITLE
fix(eslint-plugin): retry with `.ts` when module id contains `.js`

### DIFF
--- a/.changeset/three-gifts-laugh.md
+++ b/.changeset/three-gifts-laugh.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/eslint-plugin": patch
+---
+
+Fix no-export-all getting confused when the module id contains the `.js` extension due to how ESM works

--- a/packages/eslint-plugin/src/rules/no-export-all.js
+++ b/packages/eslint-plugin/src/rules/no-export-all.js
@@ -116,6 +116,11 @@ const resolveFrom =
             if (fs.existsSync(typedef)) {
               return typedef;
             }
+            // Alternatively, the `.ts` is just as good.
+            const source = m.replace(/\.js$/, ".ts");
+            if (fs.existsSync(source)) {
+              return source;
+            }
           }
           return m;
         } catch (e) {

--- a/packages/eslint-plugin/src/rules/no-export-all.js
+++ b/packages/eslint-plugin/src/rules/no-export-all.js
@@ -112,12 +112,9 @@ const resolveFrom =
           if (m.endsWith(".js")) {
             // `.js` files don't contain type information. If we find a `.d.ts`
             // next to it, we should use that instead.
-            const alternatives = [".d.ts", ".ts", ".tsx"];
-            for (const alt of alternatives) {
-              const source = m.replace(/\.js$/, alt);
-              if (fs.existsSync(source)) {
-                return source;
-              }
+            const typedef = m.replace(/\.js$/, ".d.ts");
+            if (fs.existsSync(typedef)) {
+              return typedef;
             }
           }
           return m;

--- a/packages/eslint-plugin/src/rules/no-export-all.js
+++ b/packages/eslint-plugin/src/rules/no-export-all.js
@@ -112,14 +112,12 @@ const resolveFrom =
           if (m.endsWith(".js")) {
             // `.js` files don't contain type information. If we find a `.d.ts`
             // next to it, we should use that instead.
-            const typedef = m.replace(/\.js$/, ".d.ts");
-            if (fs.existsSync(typedef)) {
-              return typedef;
-            }
-            // Alternatively, the `.ts` is just as good.
-            const source = m.replace(/\.js$/, ".ts");
-            if (fs.existsSync(source)) {
-              return source;
+            const alternatives = [".d.ts", ".ts", ".tsx"];
+            for (const alt of alternatives) {
+              const source = m.replace(/\.js$/, alt);
+              if (fs.existsSync(source)) {
+                return source;
+              }
             }
           }
           return m;
@@ -127,11 +125,14 @@ const resolveFrom =
           // If the module id contains the `.js` extension due to ESM,
           // retry with `.ts`
           if (moduleId.endsWith(".js")) {
-            try {
-              return resolve(fromDir, moduleId.replace(/\.js$/, ".ts"));
-            } catch (_) {
-              // Ignore the exception from the `.ts` file and rethrow
-              // the `.js` one to avoid confusion
+            const alternatives = [".ts", ".tsx"];
+            for (const alt of alternatives) {
+              try {
+                return resolve(fromDir, moduleId.replace(/\.js$/, alt));
+              } catch (_) {
+                // Ignore the exception from the `.ts` file and rethrow
+                // the `.js` one to avoid confusion
+              }
             }
           }
           throw e;


### PR DESCRIPTION
### Description

Due to how ESM works, you have to add the file extension to your imports. It looks like you have to add `.js` even though you use TypeScript. This makes the `no-export-all` rule trip.

### Test plan

Input:

```js
// index.ts
export * from "./types.js";


// types.ts
export type SomeType = true;
```

Before:

```
/~/src/index.ts
  5:1  error  Prefer explicit exports over `export *` to avoid name clashes, and improve tree-shakeability  @rnx-kit/no-export-all

✖ 1 problem (1 error, 0 warnings)

error Command failed with exit code 1.
```

After:

```
/~/src/index.ts
  5:1  error  Prefer explicit exports over `export *` to avoid name clashes, and improve tree-shakeability  @rnx-kit/no-export-all

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.

error Command failed with exit code 1.
```