### PR TITLE
fix: Rush workspaces is not detected in esoteric setups

### DIFF
--- a/.changeset/loud-geckos-tell.md
+++ b/.changeset/loud-geckos-tell.md
@@ -1,0 +1,9 @@
+---
+"@rnx-kit/dep-check": patch
+"@rnx-kit/eslint-plugin": patch
+"@rnx-kit/golang": patch
+"@rnx-kit/metro-config": patch
+"@rnx-kit/scripts": patch
+---
+
+Fix Rush workspaces not being detected when set up as a post-install step

--- a/packages/dep-check/package.json
+++ b/packages/dep-check/package.json
@@ -48,7 +48,7 @@
     "pacote": "^12.0.0",
     "prompts": "^2.4.0",
     "semver": "^7.0.0",
-    "workspace-tools": "^0.18.2",
+    "workspace-tools": "^0.18.3",
     "yargs": "^16.0.0"
   },
   "engines": {

--- a/packages/golang/package.json
+++ b/packages/golang/package.json
@@ -26,7 +26,7 @@
     "find-up": "^5.0.0",
     "got": "^11.8.2",
     "hasha": "^5.2.2",
-    "workspace-tools": "^0.18.2"
+    "workspace-tools": "^0.18.3"
   },
   "devDependencies": {
     "@types/node": "^16.0.0",

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@rnx-kit/babel-preset-metro-react-native": "^1.0.17",
     "@rnx-kit/tools-node": "^1.2.7",
-    "workspace-tools": "^0.18.2"
+    "workspace-tools": "^0.18.3"
   },
   "peerDependencies": {
     "metro-config": ">=0.58.0",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -27,7 +27,7 @@
     "markdown-table": "^2.0.0",
     "midgard-yarn": "^1.23.24",
     "typescript": "^4.0.0",
-    "workspace-tools": "^0.18.2",
+    "workspace-tools": "^0.18.3",
     "yargs": "^16.0.0"
   },
   "devDependencies": {

--- a/scripts/rnx-dep-check.js
+++ b/scripts/rnx-dep-check.js
@@ -57,7 +57,7 @@ module.exports = {
   },
   "workspace-tools": {
     name: "workspace-tools",
-    version: "^0.18.2",
+    version: "^0.18.3",
   },
   yargs: {
     name: "yargs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14965,7 +14965,7 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-workspace-tools@^0.18.2:
+workspace-tools@^0.18.2, workspace-tools@^0.18.3:
   version "0.18.3"
   resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.18.3.tgz#55864c76a92b50556ddcd756cf0c6db5618b0cb1"
   integrity sha512-AsUScmMM+HrDzBjbxlpc041VNLRnP9EzAOk0YxZHxAT0wnVtZmoe+FgKPOGX4s7oRUobwKqBRhaJDAuaAP78ZQ==


### PR DESCRIPTION
### Description

Bumps `workspace-tools` to 0.18.3 to get [fix for Rush workspaces not being detected correctly](https://github.com/microsoft/workspace-tools/pull/100).

### Test plan

n/a