### PR TITLE
chore: add @kelset to `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @afoxman @JasonVMo @tido64
+* @afoxman @kelset @JasonVMo @tido64
 
 # Miscellaneous
 /CODE_OF_CONDUCT.md  @microsoftopensource


### PR DESCRIPTION
### Description

I keep adding him manually so he might as well be on the list of owners.

### Test plan

n/a