### PR TITLE
feat(cli): add `rnx-copy-assets` command

### DIFF
--- a/.changeset/hungry-apricots-sing.md
+++ b/.changeset/hungry-apricots-sing.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-language": minor
+---
+
+Add `isNonEmptyArray()`

--- a/.changeset/shiny-kangaroos-rhyme.md
+++ b/.changeset/shiny-kangaroos-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": minor
+---
+
+Add a command, `rnx-copy-assets`, to copy assets that are not referenced from JS. Usually, Metro copies imported assets for you, but sometimes you need additional files if they are only accessed from native modules.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -59,7 +59,7 @@ yarn react-native rnx-bundle --bundle-prefix test-app --experimental-tree-shake 
       "targets": ["ios", "android", "windows", "macos"],
       "platforms": {
         "android": {
-          "assetsPath": "dist/reså"
+          "assetsPath": "dist/res"
         },
         "macos": {
           "typescriptValidation": false

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
     "@rnx-kit/typescript-react-native-resolver": "^0.2.0",
     "@rnx-kit/typescript-service": "^1.5.3",
     "chalk": "^4.1.0",
+    "find-up": "^5.0.0",
     "fs-extra": "^10.0.0",
     "ora": "^5.4.1",
     "qrcode": "^1.5.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
     "@rnx-kit/typescript-react-native-resolver": "^0.2.0",
     "@rnx-kit/typescript-service": "^1.5.3",
     "chalk": "^4.1.0",
+    "fs-extra": "^10.0.0",
     "ora": "^5.4.1",
     "qrcode": "^1.5.0",
     "readline": "^1.3.0"
@@ -54,6 +55,7 @@
     "@types/metro-config": "^0.66.0",
     "@types/qrcode": "^1.4.2",
     "jest-extended": "^0.11.5",
+    "memfs": "^3.4.1",
     "typescript": "^4.0.0"
   },
   "depcheck": {

--- a/packages/cli/react-native.config.js
+++ b/packages/cli/react-native.config.js
@@ -3,6 +3,7 @@ const path = require("path");
 const {
   parseBoolean,
   rnxBundle,
+  rnxCopyAssetsCommand,
   rnxStart,
   rnxDepCheckCommand,
   rnxTestCommand,
@@ -181,6 +182,7 @@ module.exports = {
         },
       ],
     },
+    rnxCopyAssetsCommand,
     rnxDepCheckCommand,
     rnxTestCommand,
     {

--- a/packages/cli/src/copy-assets.ts
+++ b/packages/cli/src/copy-assets.ts
@@ -235,12 +235,12 @@ export async function copyProjectAssets(options: Options): Promise<void> {
       continue;
     }
 
-    info(`Copying assets for "${packageName}"`);
-
     const assets = await getAssets(context);
-    await copyAssets(context, packageName, assets);
     if (options.bundleAar) {
       assembleAarBundle(context, packageName, assets);
+    } else {
+      info(`Copying assets for "${packageName}"`);
+      await copyAssets(context, packageName, assets);
     }
   }
 }

--- a/packages/cli/src/copy-assets.ts
+++ b/packages/cli/src/copy-assets.ts
@@ -2,7 +2,7 @@ import type { Config as CLIConfig } from "@react-native-community/cli-types";
 import { error, info, warn } from "@rnx-kit/console";
 import { isNonEmptyArray } from "@rnx-kit/tools-language/array";
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
-import { findPackageDir } from "@rnx-kit/tools-node/package";
+import { findPackageDir, readPackage } from "@rnx-kit/tools-node/package";
 import type { AllPlatforms } from "@rnx-kit/tools-react-native";
 import { parsePlatform } from "@rnx-kit/tools-react-native";
 import { spawnSync } from "child_process";
@@ -70,7 +70,7 @@ function keysOf(record: Record<string, unknown> | undefined): string[] {
 }
 
 function versionOf(pkgName: string): string {
-  const { version } = require(`${pkgName}/package.json`);
+  const { version } = readPackage(`${pkgName}/package.json`);
   return version;
 }
 
@@ -167,7 +167,7 @@ async function assembleAarBundle(
       );
       if (output) {
         if (!fs.existsSync(output)) {
-          targets.push(`:${aar?.targetName}:assembleRelease`);
+          targets.push(`:${aar.targetName}:assembleRelease`);
           targetsToCopy.push([output, destination]);
         } else if (!fs.existsSync(destination)) {
           targetsToCopy.push([output, destination]);

--- a/packages/cli/src/copy-assets.ts
+++ b/packages/cli/src/copy-assets.ts
@@ -1,0 +1,225 @@
+import type { Config as CLIConfig } from "@react-native-community/cli-types";
+import { error, info, warn } from "@rnx-kit/console";
+import { isNonEmptyArray } from "@rnx-kit/tools-language/array";
+import type { PackageManifest } from "@rnx-kit/tools-node/package";
+import { findPackageDir } from "@rnx-kit/tools-node/package";
+import type { AllPlatforms } from "@rnx-kit/tools-react-native";
+import { parsePlatform } from "@rnx-kit/tools-react-native";
+import * as fs from "fs-extra";
+import * as path from "path";
+
+export type NativeAssets = {
+  assets?: string[];
+  strings?: string[];
+  aar?: {
+    targetName: string;
+    version?: string;
+    env?: Record<string, string | number>;
+  };
+  xcassets?: string[];
+};
+
+export type Options = {
+  platform: AllPlatforms;
+  assetsDest: string;
+  bundleAar: boolean;
+  xcassetsDest?: string;
+  [key: string]: unknown;
+};
+
+export type AssetsConfig = {
+  getAssets?: (context: Context) => Promise<NativeAssets>;
+};
+
+export type Context = {
+  projectRoot: string;
+  manifest: PackageManifest;
+  options: Options;
+};
+
+function ensureOption(options: Options, opt: string, flag = opt) {
+  if (options[opt] == null) {
+    error(`Missing required option: --${flag}`);
+    process.exit(1);
+  }
+}
+
+function isAssetsConfig(config: unknown): config is AssetsConfig {
+  return typeof config === "object" && config !== null && "getAssets" in config;
+}
+
+function keysOf(record: Record<string, unknown> | undefined): string[] {
+  return record ? Object.keys(record) : [];
+}
+
+async function assembleAarBundle(
+  _context: Context,
+  _packageName: string,
+  { aar }: NativeAssets
+): Promise<void> {
+  if (!aar) {
+    return;
+  }
+
+  const { targetName } = aar;
+  console.log(`./gradlew :${targetName}:assembleRelease`);
+}
+
+async function copyFiles(files: unknown, destination: string): Promise<void> {
+  if (!isNonEmptyArray<string>(files)) {
+    return;
+  }
+
+  await fs.ensureDir(destination);
+  await Promise.all(
+    files.map((file) => {
+      const basename = path.basename(file);
+      return fs.copy(file, `${destination}/${basename}`);
+    })
+  );
+}
+
+async function copyXcodeAssets(
+  xcassets: unknown,
+  destination: string
+): Promise<void> {
+  if (!isNonEmptyArray<string>(xcassets)) {
+    return;
+  }
+
+  await fs.ensureDir(destination);
+  await Promise.all(
+    xcassets.map((catalog) => {
+      const dest = `${destination}/${path.basename(catalog)}`;
+      return fs.copy(catalog, dest);
+    })
+  );
+}
+
+export async function copyAssets(
+  { options: { assetsDest, xcassetsDest } }: Context,
+  packageName: string,
+  { assets, strings, xcassets }: NativeAssets
+): Promise<void> {
+  const tasks = [
+    copyFiles(assets, `${assetsDest}/assets/${packageName}`),
+    copyFiles(strings, `${assetsDest}/strings/${packageName}`),
+  ];
+
+  if (typeof xcassetsDest === "string") {
+    tasks.push(copyXcodeAssets(xcassets, xcassetsDest));
+  }
+
+  await Promise.all(tasks);
+}
+
+export async function gatherConfigs({
+  projectRoot,
+  manifest,
+}: Context): Promise<Record<string, AssetsConfig | null> | undefined> {
+  const { dependencies, devDependencies } = manifest;
+  const packages = [...keysOf(dependencies), ...keysOf(devDependencies)];
+  if (packages.length === 0) {
+    return;
+  }
+
+  const resolveOptions = { paths: [projectRoot] };
+  const assetConfigs: Record<string, AssetsConfig | null> = {};
+
+  for (const pkg of packages) {
+    try {
+      const pkgPath = path.dirname(
+        require.resolve(`${pkg}/package.json`, resolveOptions)
+      );
+      const reactNativeConfig = `${pkgPath}/react-native.config.js`;
+      if (await fs.pathExists(reactNativeConfig)) {
+        const { nativeAssets } = require(reactNativeConfig);
+        if (nativeAssets) {
+          assetConfigs[pkg] = nativeAssets;
+        }
+      }
+    } catch (err) {
+      warn(err);
+    }
+  }
+
+  // Overrides from project config
+  const reactNativeConfig = `${projectRoot}/react-native.config.js`;
+  if (await fs.pathExists(reactNativeConfig)) {
+    const { nativeAssets } = require(reactNativeConfig);
+    const overrides = Object.entries(nativeAssets);
+    for (const [pkgName, config] of overrides) {
+      if (config === null || isAssetsConfig(config)) {
+        assetConfigs[pkgName] = config;
+      }
+    }
+  }
+
+  return assetConfigs;
+}
+
+export async function copyProjectAssets(options: Options): Promise<void> {
+  const projectRoot = findPackageDir() || process.cwd();
+  const content = await fs.readFile(`${projectRoot}/package.json`, {
+    encoding: "utf-8",
+  });
+  const manifest: PackageManifest = JSON.parse(content);
+  const context = { projectRoot, manifest, options };
+  const assetConfigs = await gatherConfigs(context);
+  if (!assetConfigs) {
+    return;
+  }
+
+  const dependencies = Object.entries(assetConfigs);
+  for (const [packageName, config] of dependencies) {
+    if (!isAssetsConfig(config)) {
+      continue;
+    }
+
+    const { getAssets } = config;
+    if (typeof getAssets !== "function") {
+      warn(`Skipped "${packageName}": getAssets is not a function`);
+      continue;
+    }
+
+    info(`Copying assets for "${packageName}"`);
+
+    const assets = await getAssets(context);
+    await copyAssets(context, packageName, assets);
+    if (options.bundleAar) {
+      assembleAarBundle(context, packageName, assets);
+    }
+  }
+}
+
+export const rnxCopyAssetsCommand = {
+  name: "rnx-copy-assets",
+  description:
+    "Copies additional assets not picked by bundlers into desired directory.",
+  func: (_argv: string[], _config: CLIConfig, options: Options) => {
+    ensureOption(options, "platform");
+    ensureOption(options, "assetsDest", "assets-dest");
+    return copyProjectAssets(options);
+  },
+  options: [
+    {
+      name: "--platform <string>",
+      description: "platform to target",
+      parse: parsePlatform,
+    },
+    {
+      name: "--assets-dest <string>",
+      description: "path of the directory to copy assets into",
+    },
+    {
+      name: "--bundle-aar <boolean>",
+      description: "whether to bundle AARs of dependencies",
+      default: false,
+    },
+    {
+      name: "--xcassets-dest <string>",
+      description:
+        "path of the directory to copy Xcode asset catalogs into. Asset catalogs will only be copied if a destination path is specified.",
+    },
+  ],
+};

--- a/packages/cli/src/copy-assets.ts
+++ b/packages/cli/src/copy-assets.ts
@@ -158,6 +158,59 @@ export async function gatherConfigs({
   return assetConfigs;
 }
 
+/**
+ * Copies additional assets not picked by bundlers into desired directory.
+ *
+ * The way this works is by scanning all direct dependencies of the current
+ * project for a file, `react-native.config.js`, whose contents include a
+ * field, `nativeAssets`, and a function that returns assets to copy:
+ *
+ * ```js
+ * // react-native.config.js
+ * module.exports = {
+ *   nativeAssets: {
+ *     getAssets: (context) => {
+ *       return {
+ *         assets: [],
+ *         strings: [],
+ *         xcassets: [],
+ *       };
+ *     }
+ *   }
+ * };
+ * ```
+ *
+ * We also allow the project itself to override this where applicable. The
+ * format is similar and looks like this:
+ *
+ * ```js
+ * // react-native.config.js
+ * module.exports = {
+ *   nativeAssets: {
+ *     "some-library": {
+ *       getAssets: (context) => {
+ *         return {
+ *           assets: [],
+ *           strings: [],
+ *           xcassets: [],
+ *         };
+ *       }
+ *     },
+ *     "another-library": {
+ *       getAssets: (context) => {
+ *         return {
+ *           assets: [],
+ *           strings: [],
+ *           xcassets: [],
+ *         };
+ *       }
+ *     }
+ *   }
+ * };
+ * ```
+ *
+ * @param options Options dictate what gets copied where
+ */
 export async function copyProjectAssets(options: Options): Promise<void> {
   const projectRoot = findPackageDir() || process.cwd();
   const content = await fs.readFile(`${projectRoot}/package.json`, {

--- a/packages/cli/src/copy-assets.ts
+++ b/packages/cli/src/copy-assets.ts
@@ -124,7 +124,7 @@ export async function gatherConfigs({
   }
 
   const resolveOptions = { paths: [projectRoot] };
-  const assetConfigs: Record<string, AssetsConfig | null> = {};
+  const assetsConfigs: Record<string, AssetsConfig | null> = {};
 
   for (const pkg of packages) {
     try {
@@ -135,7 +135,7 @@ export async function gatherConfigs({
       if (await fs.pathExists(reactNativeConfig)) {
         const { nativeAssets } = require(reactNativeConfig);
         if (nativeAssets) {
-          assetConfigs[pkg] = nativeAssets;
+          assetsConfigs[pkg] = nativeAssets;
         }
       }
     } catch (err) {
@@ -150,12 +150,12 @@ export async function gatherConfigs({
     const overrides = Object.entries(nativeAssets);
     for (const [pkgName, config] of overrides) {
       if (config === null || isAssetsConfig(config)) {
-        assetConfigs[pkgName] = config;
+        assetsConfigs[pkgName] = config;
       }
     }
   }
 
-  return assetConfigs;
+  return assetsConfigs;
 }
 
 /**

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,5 @@
 export { rnxBundle } from "./bundle";
+export { copyProjectAssets, rnxCopyAssetsCommand } from "./copy-assets";
 export { rnxDepCheck, rnxDepCheckCommand } from "./dep-check";
 export { rnxStart } from "./start";
 export { rnxTest, rnxTestCommand } from "./test";

--- a/packages/cli/test/__mocks__/fs-extra.js
+++ b/packages/cli/test/__mocks__/fs-extra.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const fs = jest.createMockFromModule("fs-extra");
+
+const { vol } = require("memfs");
+
+/** @type {(newMockFiles: { [filename: string]: string }) => void} */
+fs.__setMockFiles = (files) => {
+  vol.reset();
+  vol.fromJSON(files);
+};
+
+fs.__toJSON = () => vol.toJSON();
+
+fs.copy = (...args) => vol.promises.copyFile(...args);
+fs.ensureDir = (dir) => vol.promises.mkdir(dir, { recursive: true });
+fs.pathExists = (...args) => Promise.resolve(vol.existsSync(...args));
+fs.readFile = (...args) => vol.promises.readFile(...args);
+
+module.exports = fs;

--- a/packages/cli/test/copy-assets.test.ts
+++ b/packages/cli/test/copy-assets.test.ts
@@ -1,0 +1,113 @@
+import fs from "fs-extra";
+import * as path from "path";
+import { copyAssets, gatherConfigs } from "../src/copy-assets";
+
+const options = {
+  platform: "ios" as const,
+  assetsDest: "dist",
+  bundleAar: false,
+  xcassetsDest: "xcassets",
+};
+
+const context = {
+  projectRoot: path.resolve(__dirname, ".."),
+  manifest: {
+    name: "@rnx-kit/cli",
+    version: "0.0.0-dev",
+  },
+  options,
+};
+
+function findFiles() {
+  // @ts-ignore `__toJSON`
+  return Object.entries(fs.__toJSON());
+}
+
+function mockFiles(files: Record<string, string> = {}) {
+  // @ts-ignore `__setMockFiles`
+  fs.__setMockFiles(files);
+}
+
+describe("copyAssets", () => {
+  afterEach(() => {
+    mockFiles();
+  });
+
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  test("returns early if there is nothing to copy", async () => {
+    await copyAssets(context, "test", {});
+    expect(findFiles()).toEqual([]);
+  });
+
+  test("copies assets", async () => {
+    const filename = "arnolds-greatest-movies.md";
+    const content = "all of them";
+    mockFiles({ [filename]: content });
+
+    await copyAssets(context, "test", { assets: [filename] });
+
+    expect(findFiles()).toEqual([
+      [expect.stringContaining(filename), content],
+      [
+        expect.stringMatching(
+          `dist[/\\\\]assets[/\\\\]test[/\\\\]${filename}$`
+        ),
+        content,
+      ],
+    ]);
+  });
+
+  test("copies strings", async () => {
+    const filename = "arnolds-greatest-lines.md";
+    const content = "all of them";
+    mockFiles({ [filename]: content });
+
+    await copyAssets(context, "test", { strings: [filename] });
+
+    expect(findFiles()).toEqual([
+      [expect.stringContaining(filename), content],
+      [
+        expect.stringMatching(
+          `dist[/\\\\]strings[/\\\\]test[/\\\\]${filename}$`
+        ),
+        content,
+      ],
+    ]);
+  });
+
+  test("copies Xcode asset catalogs", async () => {
+    const filename = "arnolds-greatest-assets.xcassets";
+    const content = "all of them";
+    mockFiles({ [filename]: content });
+
+    await copyAssets(context, "test", { xcassets: [filename] });
+
+    expect(findFiles()).toEqual([
+      [expect.stringContaining(filename), content],
+      [expect.stringMatching(`xcassets[/\\\\]${filename}$`), content],
+    ]);
+  });
+
+  test("does not copy Xcode asset catalogs if destination path is unset", async () => {
+    const filename = "arnolds-greatest-assets.xcassets";
+    const content = "all of them";
+    mockFiles({ [filename]: content });
+
+    await copyAssets(
+      { ...context, options: { ...options, xcassetsDest: undefined } },
+      "test",
+      { xcassets: [filename] }
+    );
+
+    expect(findFiles()).toEqual([[expect.stringContaining(filename), content]]);
+  });
+});
+
+describe("gatherConfigs", () => {
+  test("returns early if there is nothing to copy", async () => {
+    expect(await gatherConfigs(context)).toBeUndefined();
+  });
+});

--- a/packages/tools-language/README.md
+++ b/packages/tools-language/README.md
@@ -27,6 +27,7 @@ import * from "@rnx-kit/tools-language/properties";
 | Category   | Function                                  | Description                                                                                                                                                 |
 | ---------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | array      | `addRange(to, from, start, end)`          | Add elements from one array to another, returning the resulting array.                                                                                      |
+| array      | `isNonEmptyArray(array)`                  | Returns whether the specified object is a non-empty array.                                                                                                  |
 | array      | `toIndex(array, offset)`                  | Convert an array offset to an array index. An offset can be positive or negative, while an index is always positive.                                        |
 | function   | `tryInvoke(fn)`                           | Invoke the given function, returning its result or a thrown error.                                                                                          |
 | math       | `isApproximatelyEqual(f1, f2, tolerance)` | Decide if two numbers, integer or decimal, are "approximately" equal. They're equal if they are close enough to be within the given tolerance.              |

--- a/packages/tools-language/src/array.ts
+++ b/packages/tools-language/src/array.ts
@@ -46,3 +46,11 @@ export function addRange<T>(
   }
   return to;
 }
+
+/**
+ * Returns whether the specified object is a non-empty array.
+ * @param array The array to check
+ */
+export function isNonEmptyArray<T = unknown>(array: unknown): array is T[] {
+  return Array.isArray(array) && array.length > 0;
+}

--- a/packages/tools-language/test/array.test.ts
+++ b/packages/tools-language/test/array.test.ts
@@ -1,4 +1,4 @@
-import { toIndex, addRange } from "../src/array";
+import { toIndex, addRange, isNonEmptyArray } from "../src/array";
 
 describe("Language > Array > toIndex()", () => {
   const testArray = ["a", "b", "c"];
@@ -90,5 +90,35 @@ describe("Language > Array > addRange()", () => {
     const r = addRange(undefined, from, -2);
     expect(r).not.toBe(from);
     expect(r).toEqual(from.slice(-2));
+  });
+});
+
+describe("Language > Array > isNonEmptyArray()", () => {
+  test("isNonEmptyArray returns false when given object is undefined", () => {
+    expect(isNonEmptyArray(undefined)).toBe(false);
+  });
+
+  test("isNonEmptyArray returns false when given object is null", () => {
+    expect(isNonEmptyArray(null)).toBe(false);
+  });
+
+  test("isNonEmptyArray returns false when given object is not an array", () => {
+    expect(isNonEmptyArray({ a: true })).toBe(false);
+  });
+
+  test("isNonEmptyArray returns false when given object is an array of length 0", () => {
+    expect(isNonEmptyArray([])).toBe(false);
+  });
+
+  test("isNonEmptyArray returns true when given object is an array with an empty string", () => {
+    expect(isNonEmptyArray([""])).toBe(true);
+  });
+
+  test("isNonEmptyArray returns true when given object is an array with an undefined value", () => {
+    expect(isNonEmptyArray([undefined])).toBe(true);
+  });
+
+  test("isNonEmptyArray returns true when given object is an array with 2 elements", () => {
+    expect(isNonEmptyArray([true, false])).toBe(true);
   });
 });

--- a/packages/typescript-service/package.json
+++ b/packages/typescript-service/package.json
@@ -21,6 +21,7 @@
     "test": "rnx-kit-scripts test"
   },
   "dependencies": {
+    "@rnx-kit/tools-language": "^1.2.6",
     "@rnx-kit/tools-node": "^1.2.6",
     "chalk": "^4.1.0"
   },

--- a/packages/typescript-service/src/project.ts
+++ b/packages/typescript-service/src/project.ts
@@ -1,8 +1,8 @@
+import { isNonEmptyArray } from "@rnx-kit/tools-language/array";
 import chalk from "chalk";
 import ts from "typescript";
 import { ExternalFileCache, ProjectFileCache } from "./cache";
 import { DiagnosticWriter } from "./diagnostics";
-import { isNonEmptyArray } from "./util";
 
 export class Project {
   private diagnosticWriter: DiagnosticWriter;

--- a/packages/typescript-service/src/util.ts
+++ b/packages/typescript-service/src/util.ts
@@ -7,7 +7,3 @@ export function getCanonicalFileName(fileName: string): string {
 export function getNewLine(): string {
   return ts.sys.newLine;
 }
-
-export function isNonEmptyArray(a: unknown): a is Array<unknown> {
-  return Array.isArray(a) && a.length > 0;
-}

--- a/packages/typescript-service/test/util.test.ts
+++ b/packages/typescript-service/test/util.test.ts
@@ -11,32 +11,4 @@ describe("Utility", () => {
   test("getNewLine returns CR, LF, or CRLF", () => {
     expect(getNewLine()).toBeOneOf(["\r", "\n", "\r\n"]);
   });
-
-  test("isNonEmptyArray returns false when given object is undefined", () => {
-    expect(isNonEmptyArray(undefined)).toBeFalse();
-  });
-
-  test("isNonEmptyArray returns false when given object is null", () => {
-    expect(isNonEmptyArray(null)).toBeFalse();
-  });
-
-  test("isNonEmptyArray returns false when given object is not an array", () => {
-    expect(isNonEmptyArray({ a: true })).toBeFalse();
-  });
-
-  test("isNonEmptyArray returns false when given object is an array of length 0", () => {
-    expect(isNonEmptyArray([])).toBeFalse();
-  });
-
-  test("isNonEmptyArray returns true when given object is an array with an empty string", () => {
-    expect(isNonEmptyArray([""])).toBeTrue();
-  });
-
-  test("isNonEmptyArray returns true when given object is an array with an undefined value", () => {
-    expect(isNonEmptyArray([undefined])).toBeTrue();
-  });
-
-  test("isNonEmptyArray returns true when given object is an array with 2 elements", () => {
-    expect(isNonEmptyArray([true, false])).toBeTrue();
-  });
 });


### PR DESCRIPTION
### Description

Adds a command to copy assets that are not referenced from JS. Usually, Metro copies imported assets for you, but sometimes you need additional files if they are only accessed from native modules.

The aim of this command is to generalize/standardize on how to get native assets into an app bundle. While this currently works for our internal app, it is incomplete. As such, I'm avoiding advertising it in the README for now.

### Test plan

Currently using this in an internal app.