### PR TITLE
fix(babel-plugin-import-path-remapper): fails to resolve package in pnpm-like setups

### DIFF
--- a/.changeset/heavy-plants-itch.md
+++ b/.changeset/heavy-plants-itch.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/babel-plugin-import-path-remapper": patch
+---
+
+Resolve modules starting from the requester's path


### PR DESCRIPTION
### Description

The remapper relies on hoisting to find modules. We should instead resolve modules starting from the requester's path.

### Test plan

Tested internally.