### PR TITLE
fix(tools-language): fix missing `array` module

### DIFF
--- a/.changeset/ten-bees-chew.md
+++ b/.changeset/ten-bees-chew.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-language": patch
+---
+
+Fix missing `array` module

--- a/packages/tools-language/package.json
+++ b/packages/tools-language/package.json
@@ -5,13 +5,15 @@
   "homepage": "https://github.com/microsoft/rnx-kit/tree/main/packages/tools-language#readme",
   "license": "MIT",
   "files": [
-    "lib/*",
-    "function.js",
+    "array.d.ts",
+    "array.js",
     "function.d.ts",
-    "math.js",
+    "function.js",
+    "lib/*",
     "math.d.ts",
-    "properties.js",
-    "properties.d.ts"
+    "math.js",
+    "properties.d.ts",
+    "properties.js"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
### Description

`@rnx-kit/cli` fails to be recognised by `@react-native-community/cli` because of a missing module: `warn Package @rnx-kit/cli has been ignored because it contains invalid configuration. Reason: Cannot find module '@rnx-kit/tools-language/array'`

### Test plan

```sh
cd packages/tools-language
npm pack --dry-run
```

Ensure `array.d.ts` and `array.js` are included.