### PR TITLE
fix(cli): fix `copy-assets` failing to resolve dependencies

### DIFF
--- a/.changeset/poor-garlics-fry.md
+++ b/.changeset/poor-garlics-fry.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Fix `copy-assets` failing to resolve dependencies

--- a/packages/cli/src/copy-assets.ts
+++ b/packages/cli/src/copy-assets.ts
@@ -69,8 +69,8 @@ function keysOf(record: Record<string, unknown> | undefined): string[] {
   return record ? Object.keys(record) : [];
 }
 
-function versionOf(pkgName: string): string {
-  const { version } = readPackage(`${pkgName}/package.json`);
+export function versionOf(pkgName: string): string {
+  const { version } = readPackage(require.resolve(`${pkgName}/package.json`));
   return version;
 }
 

--- a/packages/cli/test/copy-assets.test.ts
+++ b/packages/cli/test/copy-assets.test.ts
@@ -1,6 +1,6 @@
 import fs from "fs-extra";
 import * as path from "path";
-import { copyAssets, gatherConfigs } from "../src/copy-assets";
+import { copyAssets, gatherConfigs, versionOf } from "../src/copy-assets";
 
 const options = {
   platform: "ios" as const,
@@ -109,5 +109,15 @@ describe("copyAssets", () => {
 describe("gatherConfigs", () => {
   test("returns early if there is nothing to copy", async () => {
     expect(await gatherConfigs(context)).toBeUndefined();
+  });
+});
+
+describe("versionOf", () => {
+  test("returns the version of specified package", () => {
+    expect(versionOf("@rnx-kit/tools-node")).toMatch(/^\d+[.\d]+$/);
+  });
+
+  test("throws if package is not installed", () => {
+    expect(() => versionOf("some-package-that-does-not-exist")).toThrow();
   });
 });


### PR DESCRIPTION
### Description

`readPackage` needs the full path to the package.

### Test plan

Tests were added.