### PR TITLE
fix(cli): allow assembling arbitrary modules

### DIFF
--- a/.changeset/itchy-jobs-matter.md
+++ b/.changeset/itchy-jobs-matter.md
@@ -2,4 +2,4 @@
 "@rnx-kit/cli": patch
 ---
 
-test: don't require package.json as it may not be exported
+test: don't require `package.json` directly as it may not be exported

--- a/.changeset/itchy-jobs-matter.md
+++ b/.changeset/itchy-jobs-matter.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+test: don't require package.json as it may not be exported

--- a/.changeset/sixty-experts-live.md
+++ b/.changeset/sixty-experts-live.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+copy-assets: Allow assembling arbitrary modules

--- a/packages/cli/src/copy-assets.ts
+++ b/packages/cli/src/copy-assets.ts
@@ -173,7 +173,7 @@ function getAndroidPaths(
   }
 }
 
-async function assembleAarBundle(
+export async function assembleAarBundle(
   context: Context,
   packageName: string,
   { aar }: NativeAssets
@@ -203,7 +203,6 @@ async function assembleAarBundle(
 
   const { env: customEnv, dependencies, android } = aar;
   const env = {
-    ENABLE_HERMES: "true",
     NODE_MODULES_PATH: path.join(process.cwd(), "node_modules"),
     REACT_NATIVE_VERSION: versionOf("react-native"),
     ...process.env,

--- a/packages/cli/src/copy-assets.ts
+++ b/packages/cli/src/copy-assets.ts
@@ -2,7 +2,11 @@ import type { Config as CLIConfig } from "@react-native-community/cli-types";
 import { error, info, warn } from "@rnx-kit/console";
 import { isNonEmptyArray } from "@rnx-kit/tools-language/array";
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
-import { findPackageDir, readPackage } from "@rnx-kit/tools-node/package";
+import {
+  findPackageDependencyDir,
+  findPackageDir,
+  readPackage,
+} from "@rnx-kit/tools-node/package";
 import type { AllPlatforms } from "@rnx-kit/tools-react-native";
 import { parsePlatform } from "@rnx-kit/tools-react-native";
 import { spawnSync } from "child_process";
@@ -11,9 +15,17 @@ import * as os from "os";
 import * as path from "path";
 
 export type AndroidArchive = {
-  targetName: string;
+  targetName?: string;
   version?: string;
   output?: string;
+  android?: {
+    androidPluginVersion?: string;
+    compileSdkVersion?: number;
+    defaultConfig?: {
+      minSdkVersion?: number;
+      targetSdkVersion?: number;
+    };
+  };
 };
 
 export type NativeAssets = {
@@ -44,6 +56,15 @@ export type AssetsConfig = {
   getAssets?: (context: Context) => Promise<NativeAssets>;
 };
 
+const defaultAndroidConfig: Required<Required<AndroidArchive>["android"]> = {
+  androidPluginVersion: "7.1.3",
+  compileSdkVersion: 31,
+  defaultConfig: {
+    minSdkVersion: 23,
+    targetSdkVersion: 29,
+  },
+};
+
 function ensureOption(options: Options, opt: string, flag = opt) {
   if (options[opt] == null) {
     error(`Missing required option: --${flag}`);
@@ -61,6 +82,12 @@ function findGradleProject(projectRoot: string): string | undefined {
   return undefined;
 }
 
+function gradleTargetName(packageName: string): string {
+  return (
+    packageName.startsWith("@") ? packageName.slice(1) : packageName
+  ).replace(/[^\w\-.]+/g, "_");
+}
+
 function isAssetsConfig(config: unknown): config is AssetsConfig {
   return typeof config === "object" && config !== null && "getAssets" in config;
 }
@@ -70,7 +97,12 @@ function keysOf(record: Record<string, unknown> | undefined): string[] {
 }
 
 export function versionOf(pkgName: string): string {
-  const { version } = readPackage(require.resolve(`${pkgName}/package.json`));
+  const packageDir = findPackageDependencyDir(pkgName);
+  if (!packageDir) {
+    throw new Error(`Could not find module '${pkgName}'`);
+  }
+
+  const { version } = readPackage(packageDir);
   return version;
 }
 
@@ -79,13 +111,19 @@ function getAndroidPaths(
   packageName: string,
   { targetName, version, output }: AndroidArchive
 ) {
-  const projectRoot = path.dirname(
-    require.resolve(`${packageName}/package.json`)
-  );
+  const projectRoot = findPackageDependencyDir(packageName);
+  if (!projectRoot) {
+    throw new Error(`Could not find module '${packageName}'`);
+  }
+
+  const gradleFriendlyName = targetName || gradleTargetName(packageName);
+  const aarVersion = version || versionOf(packageName);
 
   switch (packageName) {
     case "hermes-engine":
       return {
+        targetName: gradleFriendlyName,
+        version: aarVersion,
         projectRoot,
         output: path.join(projectRoot, "android", "hermes-release.aar"),
         destination: path.join(
@@ -97,6 +135,8 @@ function getAndroidPaths(
 
     case "react-native":
       return {
+        targetName: gradleFriendlyName,
+        version: aarVersion,
         projectRoot,
         output: path.join(projectRoot, "android"),
         destination: path.join(
@@ -109,6 +149,8 @@ function getAndroidPaths(
     default: {
       const androidProject = findGradleProject(projectRoot);
       return {
+        targetName: gradleFriendlyName,
+        version: aarVersion,
         projectRoot,
         androidProject,
         output:
@@ -119,12 +161,12 @@ function getAndroidPaths(
               "build",
               "outputs",
               "aar",
-              `${targetName}-release.aar`
+              `${gradleFriendlyName}-release.aar`
             )),
         destination: path.join(
           context.options.assetsDest,
           "aar",
-          `${targetName}-${version || versionOf(packageName)}.aar`
+          `${gradleFriendlyName}-${aarVersion}.aar`
         ),
       };
     }
@@ -149,55 +191,127 @@ async function assembleAarBundle(
     return;
   }
 
-  const { androidProject, output } = getAndroidPaths(context, packageName, aar);
+  const { targetName, version, androidProject, output } = getAndroidPaths(
+    context,
+    packageName,
+    aar
+  );
   if (!androidProject || !output) {
     warn(`Skipped \`${packageName}\`: cannot find \`build.gradle\``);
     return;
   }
 
-  const { targetName, version, env, dependencies } = aar;
+  const { env: customEnv, dependencies, android } = aar;
+  const env = {
+    ENABLE_HERMES: "true",
+    NODE_MODULES_PATH: path.join(process.cwd(), "node_modules"),
+    REACT_NATIVE_VERSION: versionOf("react-native"),
+    ...process.env,
+    ...customEnv,
+  };
+
+  const outputDir = path.join(context.options.assetsDest, "aar");
+  await fs.ensureDir(outputDir);
+
+  const dest = path.join(outputDir, `${targetName}-${version}.aar`);
+
   const targets = [`:${targetName}:assembleRelease`];
-  const targetsToCopy: [string, string][] = [];
-  if (dependencies) {
-    for (const [dependencyName, aar] of Object.entries(dependencies)) {
-      const { output, destination } = getAndroidPaths(
-        context,
-        dependencyName,
-        aar
-      );
-      if (output) {
-        if (!fs.existsSync(output)) {
-          targets.push(`:${aar.targetName}:assembleRelease`);
-          targetsToCopy.push([output, destination]);
-        } else if (!fs.existsSync(destination)) {
-          targetsToCopy.push([output, destination]);
+  const targetsToCopy: [string, string][] = [[output, dest]];
+
+  const settings = path.join(androidProject, "settings.gradle");
+  if (fs.existsSync(settings)) {
+    if (dependencies) {
+      for (const [dependencyName, aar] of Object.entries(dependencies)) {
+        const { targetName, output, destination } = getAndroidPaths(
+          context,
+          dependencyName,
+          aar
+        );
+        if (output) {
+          if (!fs.existsSync(output)) {
+            targets.push(`:${targetName}:assembleRelease`);
+            targetsToCopy.push([output, destination]);
+          } else if (!fs.existsSync(destination)) {
+            targetsToCopy.push([output, destination]);
+          }
         }
       }
     }
+
+    // Run only one Gradle task at a time
+    spawnSync(gradlew, targets, { cwd: androidProject, stdio: "inherit", env });
+  } else {
+    const buildGradle = [
+      "buildscript {",
+      "  ext {",
+      `      compileSdkVersion = ${
+        android?.compileSdkVersion ?? defaultAndroidConfig.compileSdkVersion
+      }`,
+      `      minSdkVersion = ${
+        android?.defaultConfig?.minSdkVersion ??
+        defaultAndroidConfig.defaultConfig.minSdkVersion
+      }`,
+      `      targetSdkVersion = ${
+        android?.defaultConfig?.targetSdkVersion ??
+        defaultAndroidConfig.defaultConfig.targetSdkVersion
+      }`,
+      `      androidPluginVersion = "${
+        android?.androidPluginVersion ??
+        defaultAndroidConfig.androidPluginVersion
+      }"`,
+      "  }",
+      "",
+      "  repositories {",
+      "      mavenCentral()",
+      "      google()",
+      "  }",
+      "",
+      "  dependencies {",
+      '      classpath("com.android.tools.build:gradle:${project.ext.androidPluginVersion}")',
+      "  }",
+      "}",
+      "",
+      "allprojects {",
+      "  repositories {",
+      "      maven {",
+      "          // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm",
+      '          url("${rootDir}/../../react-native/android")',
+      "      }",
+      "      mavenCentral()",
+      "      google()",
+      "  }",
+      "}",
+      "",
+    ].join("\n");
+
+    const gradleProperties = "android.useAndroidX=true\n";
+
+    const settingsGradle = [
+      `include(":${targetName}")`,
+      `project(":${targetName}").projectDir = file("${androidProject}")`,
+      "",
+    ].join("\n");
+
+    const buildDir = path.join(
+      process.cwd(),
+      "node_modules",
+      ".rnx-gradle-build",
+      targetName
+    );
+
+    await fs.ensureDir(buildDir);
+    await fs.writeFile(path.join(buildDir, "build.gradle"), buildGradle);
+    await fs.writeFile(
+      path.join(buildDir, "gradle.properties"),
+      gradleProperties
+    );
+    await fs.writeFile(path.join(buildDir, "settings.gradle"), settingsGradle);
+
+    // Run only one Gradle task at a time
+    spawnSync(gradlew, targets, { cwd: buildDir, stdio: "inherit", env });
   }
 
-  // Run only one Gradle task at a time
-  spawnSync(gradlew, targets, {
-    cwd: androidProject,
-    stdio: "inherit",
-    env: {
-      ENABLE_HERMES: "true",
-      NODE_MODULES_PATH: path.join(process.cwd(), "node_modules"),
-      REACT_NATIVE_VERSION: versionOf("react-native"),
-      ...process.env,
-      ...env,
-    },
-  });
-
-  const destination = path.join(context.options.assetsDest, "aar");
-  await fs.ensureDir(destination);
-
-  const aarVersion = version || versionOf(packageName);
-  const dest = path.join(destination, `${targetName}-${aarVersion}.aar`);
-  await Promise.all([
-    fs.copy(output, dest),
-    ...targetsToCopy.map(([src, dest]) => fs.copy(src, dest)),
-  ]);
+  await Promise.all(targetsToCopy.map(([src, dest]) => fs.copy(src, dest)));
 }
 
 async function copyFiles(files: unknown, destination: string): Promise<void> {

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -1,7 +1,7 @@
 import type { Config as CLIConfig } from "@react-native-community/cli-types";
+import { findPackageDependencyDir } from "@rnx-kit/tools-node";
 import { parsePlatform } from "@rnx-kit/tools-react-native/platform";
 import { run as runJest } from "jest-cli";
-import path from "path";
 
 type Args = {
   platform: "android" | "ios" | "macos" | "windows" | "win32";
@@ -54,8 +54,8 @@ function jestOptions(): Options[] {
   //
   // To work around this, resolve `jest-cli` first, then use the resolved path
   // to import `./build/cli/args`.
-  const jestPath = require.resolve("jest-cli/package.json");
-  const { options } = require(`${path.dirname(jestPath)}/build/cli/args`);
+  const jestPath = findPackageDependencyDir("jest-cli") || "jest-cli";
+  const { options } = require(`${jestPath}/build/cli/args`);
 
   return Object.keys(options).map((option) => {
     const { default: defaultValue, description, type } = options[option];

--- a/packages/cli/test/__mocks__/child_process.js
+++ b/packages/cli/test/__mocks__/child_process.js
@@ -1,0 +1,5 @@
+const child_process = jest.createMockFromModule("child_process");
+
+child_process.spawnSync(() => undefined);
+
+module.exports = child_process;

--- a/packages/cli/test/__mocks__/fs-extra.js
+++ b/packages/cli/test/__mocks__/fs-extra.js
@@ -14,7 +14,9 @@ fs.__toJSON = () => vol.toJSON();
 
 fs.copy = (...args) => vol.promises.copyFile(...args);
 fs.ensureDir = (dir) => vol.promises.mkdir(dir, { recursive: true });
+fs.existsSync = (...args) => vol.existsSync(...args);
 fs.pathExists = (...args) => Promise.resolve(vol.existsSync(...args));
 fs.readFile = (...args) => vol.promises.readFile(...args);
+fs.writeFile = (...args) => vol.promises.writeFile(...args);
 
 module.exports = fs;

--- a/packages/cli/test/__mocks__/fs.js
+++ b/packages/cli/test/__mocks__/fs.js
@@ -1,0 +1,19 @@
+const fs = jest.createMockFromModule("fs");
+
+const { vol } = require("memfs");
+
+/** @type {(newMockFiles: { [filename: string]: string }) => void} */
+fs.__setMockFiles = (files) => {
+  vol.reset();
+  vol.fromJSON(files);
+};
+
+fs.__toJSON = () => vol.toJSON();
+
+fs.lstat = (...args) => Promise.resolve(vol.lstat(...args));
+fs.lstatSync = (...args) => vol.lstatSync(...args);
+fs.readFileSync = (...args) => vol.readFileSync(...args);
+fs.stat = (...args) => Promise.resolve(vol.stat(...args));
+fs.statSync = (...args) => vol.statSync(...args);
+
+module.exports = fs;

--- a/packages/cli/test/copy-assets/assembleAarBundle.test.ts
+++ b/packages/cli/test/copy-assets/assembleAarBundle.test.ts
@@ -115,7 +115,7 @@ describe("assembleAarBundle", () => {
 
     expect(consoleWarnSpy).not.toHaveBeenCalled();
     expect(spawnSync).toHaveBeenCalledWith(
-      expect.stringMatching(/[/\\]gradlew$/),
+      expect.stringMatching(/[/\\]gradlew(?:\.bat)?$/),
       [":rnx-kit_react-native-auth:assembleRelease"],
       expect.objectContaining({
         cwd: expect.stringMatching(
@@ -201,7 +201,7 @@ describe("assembleAarBundle", () => {
 
     expect(consoleWarnSpy).not.toHaveBeenCalled();
     expect(spawnSync).toHaveBeenCalledWith(
-      expect.stringMatching(/[/\\]gradlew$/),
+      expect.stringMatching(/[/\\]gradlew(?:\.bat)?$/),
       [":rnx-kit_react-native-auth:assembleRelease"],
       expect.objectContaining({
         cwd: expect.stringMatching(

--- a/packages/cli/test/copy-assets/assembleAarBundle.test.ts
+++ b/packages/cli/test/copy-assets/assembleAarBundle.test.ts
@@ -1,0 +1,253 @@
+import { spawnSync } from "child_process";
+import * as path from "path";
+import { findFiles, mockFiles } from "./helpers";
+import { assembleAarBundle } from "../../src/copy-assets";
+
+jest.mock("child_process");
+jest.mock("fs");
+
+export const options = {
+  platform: "android" as const,
+  assetsDest: "dist",
+  bundleAar: true,
+};
+
+export const context = {
+  projectRoot: path.resolve(__dirname, "..", ".."),
+  manifest: {
+    name: "@rnx-kit/cli",
+    version: "0.0.0-dev",
+  },
+  options,
+};
+
+describe("assembleAarBundle", () => {
+  const consoleWarnSpy = jest.spyOn(global.console, "warn");
+
+  afterEach(() => {
+    mockFiles();
+    consoleWarnSpy.mockReset();
+    spawnSync.mockReset();
+  });
+
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  test("returns early if there is nothing to assemble", async () => {
+    await assembleAarBundle(context, context.manifest.name, {});
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(findFiles()).toEqual([]);
+  });
+
+  test("returns early if Gradle wrapper cannot be found", async () => {
+    await assembleAarBundle(context, context.manifest.name, { aar: {} });
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringMatching(/cannot find `gradlew`$/)
+    );
+    expect(spawnSync).not.toHaveBeenCalled();
+    expect(findFiles()).toEqual([]);
+  });
+
+  test("throws if target package cannot be found", async () => {
+    mockFiles({
+      gradlew: "",
+      "gradlew.bat": "",
+    });
+
+    expect(
+      assembleAarBundle(context, context.manifest.name, { aar: {} })
+    ).rejects.toThrow();
+    expect(findFiles()).toEqual([
+      [expect.stringMatching(/[/\\]gradlew$/), ""],
+      [expect.stringMatching(/[/\\]gradlew.bat$/), ""],
+    ]);
+  });
+
+  test("returns early if Gradle project cannot be found", async () => {
+    mockFiles({
+      gradlew: "",
+      "gradlew.bat": "",
+      "node_modules/@rnx-kit/react-native-auth/package.json": JSON.stringify({
+        version: "0.0.0-dev",
+      }),
+    });
+
+    await assembleAarBundle(context, "@rnx-kit/react-native-auth", { aar: {} });
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringMatching(/cannot find `build.gradle`/)
+    );
+    expect(spawnSync).not.toHaveBeenCalled();
+    expect(findFiles()).toEqual([
+      [expect.stringMatching(/[/\\]gradlew$/), ""],
+      [expect.stringMatching(/[/\\]gradlew.bat$/), ""],
+      [
+        expect.stringMatching(
+          /[/\\]node_modules[/\\]@rnx-kit[/\\]react-native-auth[/\\]package.json$/
+        ),
+        JSON.stringify({ version: "0.0.0-dev" }),
+      ],
+    ]);
+  });
+
+  test("generates Android project if necessary", async () => {
+    mockFiles({
+      gradlew: "",
+      "gradlew.bat": "",
+      "node_modules/@rnx-kit/react-native-auth/android/build.gradle":
+        "build.gradle",
+      "node_modules/@rnx-kit/react-native-auth/android/build/outputs/aar/rnx-kit_react-native-auth-release.aar":
+        "rnx-kit_react-native-auth-release.aar",
+      "node_modules/@rnx-kit/react-native-auth/package.json": JSON.stringify({
+        version: "0.0.0-dev",
+      }),
+      "node_modules/react-native/package.json": JSON.stringify({
+        version: "1000.0.0-dev",
+      }),
+    });
+
+    await assembleAarBundle(context, "@rnx-kit/react-native-auth", { aar: {} });
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(spawnSync).toHaveBeenCalledWith(
+      expect.stringMatching(/[/\\]gradlew$/),
+      [":rnx-kit_react-native-auth:assembleRelease"],
+      expect.objectContaining({
+        cwd: expect.stringMatching(
+          /[/\\]node_modules[/\\].rnx-gradle-build[/\\]rnx-kit_react-native-auth$/
+        ),
+      })
+    );
+    expect(findFiles()).toEqual([
+      [expect.stringMatching(/[/\\]gradlew$/), ""],
+      [expect.stringMatching(/[/\\]gradlew.bat$/), ""],
+      [
+        expect.stringMatching(
+          /[/\\]node_modules[/\\]@rnx-kit[/\\]react-native-auth[/\\]android[/\\]build.gradle$/
+        ),
+        "build.gradle",
+      ],
+      [
+        expect.stringMatching(
+          /[/\\]node_modules[/\\]@rnx-kit[/\\]react-native-auth[/\\]android[/\\]build[/\\]outputs[/\\]aar[/\\]rnx-kit_react-native-auth-release.aar$/
+        ),
+        "rnx-kit_react-native-auth-release.aar",
+      ],
+      [
+        expect.stringMatching(
+          /[/\\]node_modules[/\\]@rnx-kit[/\\]react-native-auth[/\\]package.json$/
+        ),
+        JSON.stringify({ version: "0.0.0-dev" }),
+      ],
+      [
+        expect.stringMatching(
+          /[/\\]node_modules[/\\]react-native[/\\]package.json$/
+        ),
+        JSON.stringify({ version: "1000.0.0-dev" }),
+      ],
+      [
+        expect.stringMatching(
+          /[/\\]node_modules[/\\].rnx-gradle-build[/\\]rnx-kit_react-native-auth[/\\]build.gradle$/
+        ),
+        expect.stringMatching(/^buildscript/),
+      ],
+      [
+        expect.stringMatching(
+          /[/\\]node_modules[/\\].rnx-gradle-build[/\\]rnx-kit_react-native-auth[/\\]gradle.properties/
+        ),
+        expect.stringMatching(/^android.useAndroidX=true/),
+      ],
+      [
+        expect.stringMatching(
+          /[/\\]node_modules[/\\].rnx-gradle-build[/\\]rnx-kit_react-native-auth[/\\]settings.gradle$/
+        ),
+        expect.stringMatching(
+          /include\(":rnx-kit_react-native-auth"\)\nproject\(":rnx-kit_react-native-auth"\).projectDir = file\(".*?[/\\]node_modules[/\\]@rnx-kit[/\\]react-native-auth[/\\]android"\)/
+        ),
+      ],
+      [
+        expect.stringMatching(
+          /[/\\]dist[/\\]aar[/\\]rnx-kit_react-native-auth-0.0.0-dev.aar$/
+        ),
+        "rnx-kit_react-native-auth-release.aar",
+      ],
+    ]);
+  });
+
+  test("assembles Android archive using existing project", async () => {
+    mockFiles({
+      gradlew: "",
+      "gradlew.bat": "",
+      "node_modules/@rnx-kit/react-native-auth/android/build.gradle":
+        "build.gradle",
+      "node_modules/@rnx-kit/react-native-auth/android/build/outputs/aar/rnx-kit_react-native-auth-release.aar":
+        "rnx-kit_react-native-auth-release.aar",
+      "node_modules/@rnx-kit/react-native-auth/android/settings.gradle":
+        "settings.gradle",
+      "node_modules/@rnx-kit/react-native-auth/package.json": JSON.stringify({
+        version: "0.0.0-dev",
+      }),
+      "node_modules/react-native/package.json": JSON.stringify({
+        version: "1000.0.0-dev",
+      }),
+    });
+
+    await assembleAarBundle(context, "@rnx-kit/react-native-auth", { aar: {} });
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(spawnSync).toHaveBeenCalledWith(
+      expect.stringMatching(/[/\\]gradlew$/),
+      [":rnx-kit_react-native-auth:assembleRelease"],
+      expect.objectContaining({
+        cwd: expect.stringMatching(
+          /[/\\]node_modules[/\\]@rnx-kit[/\\]react-native-auth[/\\]android$/
+        ),
+      })
+    );
+    expect(findFiles()).toEqual([
+      [expect.stringMatching(/[/\\]gradlew$/), ""],
+      [expect.stringMatching(/[/\\]gradlew.bat$/), ""],
+      [
+        expect.stringMatching(
+          /[/\\]node_modules[/\\]@rnx-kit[/\\]react-native-auth[/\\]android[/\\]build.gradle$/
+        ),
+        "build.gradle",
+      ],
+      [
+        expect.stringMatching(
+          /[/\\]node_modules[/\\]@rnx-kit[/\\]react-native-auth[/\\]android[/\\]build[/\\]outputs[/\\]aar[/\\]rnx-kit_react-native-auth-release.aar$/
+        ),
+        "rnx-kit_react-native-auth-release.aar",
+      ],
+      [
+        expect.stringMatching(
+          /[/\\]node_modules[/\\]@rnx-kit[/\\]react-native-auth[/\\]android[/\\]settings.gradle$/
+        ),
+        "settings.gradle",
+      ],
+      [
+        expect.stringMatching(
+          /[/\\]node_modules[/\\]@rnx-kit[/\\]react-native-auth[/\\]package.json$/
+        ),
+        JSON.stringify({ version: "0.0.0-dev" }),
+      ],
+      [
+        expect.stringMatching(
+          /[/\\]node_modules[/\\]react-native[/\\]package.json$/
+        ),
+        JSON.stringify({ version: "1000.0.0-dev" }),
+      ],
+      [
+        expect.stringMatching(
+          /[/\\]dist[/\\]aar[/\\]rnx-kit_react-native-auth-0.0.0-dev.aar$/
+        ),
+        "rnx-kit_react-native-auth-release.aar",
+      ],
+    ]);
+  });
+});

--- a/packages/cli/test/copy-assets/assembleAarBundle.test.ts
+++ b/packages/cli/test/copy-assets/assembleAarBundle.test.ts
@@ -250,4 +250,57 @@ describe("assembleAarBundle", () => {
       ],
     ]);
   });
+
+  test("allows the generated Android project to be configured", async () => {
+    mockFiles({
+      gradlew: "",
+      "gradlew.bat": "",
+      "node_modules/@rnx-kit/react-native-auth/android/build.gradle":
+        "build.gradle",
+      "node_modules/@rnx-kit/react-native-auth/android/build/outputs/aar/rnx-kit_react-native-auth-release.aar":
+        "rnx-kit_react-native-auth-release.aar",
+      "node_modules/@rnx-kit/react-native-auth/package.json": JSON.stringify({
+        version: "0.0.0-dev",
+      }),
+      "node_modules/react-native/package.json": JSON.stringify({
+        version: "1000.0.0-dev",
+      }),
+    });
+
+    await assembleAarBundle(context, "@rnx-kit/react-native-auth", {
+      aar: {
+        android: {
+          androidPluginVersion: "7.1.3",
+          compileSdkVersion: 31,
+          defaultConfig: {
+            minSdkVersion: 26,
+            targetSdkVersion: 30,
+          },
+        },
+      },
+    });
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(spawnSync).toHaveBeenCalledWith(
+      expect.stringMatching(/[/\\]gradlew(?:\.bat)?$/),
+      [":rnx-kit_react-native-auth:assembleRelease"],
+      expect.objectContaining({
+        cwd: expect.stringMatching(
+          /[/\\]node_modules[/\\].rnx-gradle-build[/\\]rnx-kit_react-native-auth$/
+        ),
+      })
+    );
+    expect(findFiles()).toEqual(
+      expect.arrayContaining([
+        [
+          expect.stringMatching(
+            /[/\\]node_modules[/\\].rnx-gradle-build[/\\]rnx-kit_react-native-auth[/\\]build.gradle$/
+          ),
+          expect.stringMatching(
+            /compileSdkVersion = 31\s+minSdkVersion = 26\s+targetSdkVersion = 30\s+androidPluginVersion = "7\.1\.3"/
+          ),
+        ],
+      ])
+    );
+  });
 });

--- a/packages/cli/test/copy-assets/copyAssets.test.ts
+++ b/packages/cli/test/copy-assets/copyAssets.test.ts
@@ -1,6 +1,6 @@
-import fs from "fs-extra";
 import * as path from "path";
-import { copyAssets, gatherConfigs, versionOf } from "../src/copy-assets";
+import { findFiles, mockFiles } from "./helpers";
+import { copyAssets, gatherConfigs, versionOf } from "../../src/copy-assets";
 
 const options = {
   platform: "ios" as const,
@@ -10,23 +10,13 @@ const options = {
 };
 
 const context = {
-  projectRoot: path.resolve(__dirname, ".."),
+  projectRoot: path.resolve(__dirname, "..", ".."),
   manifest: {
     name: "@rnx-kit/cli",
     version: "0.0.0-dev",
   },
   options,
 };
-
-function findFiles() {
-  // @ts-ignore `__toJSON`
-  return Object.entries(fs.__toJSON());
-}
-
-function mockFiles(files: Record<string, string> = {}) {
-  // @ts-ignore `__setMockFiles`
-  fs.__setMockFiles(files);
-}
 
 describe("copyAssets", () => {
   afterEach(() => {

--- a/packages/cli/test/copy-assets/helpers.ts
+++ b/packages/cli/test/copy-assets/helpers.ts
@@ -1,0 +1,13 @@
+// istanbul ignore file
+
+import * as fs from "fs-extra";
+
+export function findFiles() {
+  // @ts-ignore `__toJSON`
+  return Object.entries(fs.__toJSON());
+}
+
+export function mockFiles(files: Record<string, string> = {}) {
+  // @ts-ignore `__setMockFiles`
+  fs.__setMockFiles(files);
+}


### PR DESCRIPTION
### Description

Implement ability to assemble arbitrary modules.

### Test plan

Tested in an internal app using:

```js
module.exports = {
    "react-native-svg": {
      getAssets: _context => {
        return Promise.resolve({
          aar: {
            android: {
              androidPluginVersion: "7.1.3",
              compileSdkVersion: 31,
              defaultConfig: {
                minSdkVersion: 26,
                targetSdkVersion: 30
              }
            }
          }
        });
      }
    }
};
```