### PR TITLE
Transition tree shaking out of experimental mode

### DIFF
--- a/.changeset/good-mirrors-melt.md
+++ b/.changeset/good-mirrors-melt.md
@@ -1,0 +1,9 @@
+---
+"@rnx-kit/docsite": patch
+"@rnx-kit/cli": patch
+"@rnx-kit/config": patch
+"@rnx-kit/metro-serializer-esbuild": patch
+"@rnx-kit/test-app": patch
+---
+
+Transition tree shaking from experimental to production. Deprecate experimental config/cmdline props, while still supporting them for this major version. They will be removed on the next major version bump.

--- a/.changeset/good-mirrors-melt.md
+++ b/.changeset/good-mirrors-melt.md
@@ -1,9 +1,9 @@
 ---
-"@rnx-kit/docsite": patch
+"@rnx-kit/docsite": none
 "@rnx-kit/cli": patch
 "@rnx-kit/config": patch
 "@rnx-kit/metro-serializer-esbuild": patch
-"@rnx-kit/test-app": patch
+"@rnx-kit/test-app": none
 ---
 
-Transition tree shaking from experimental to production. Deprecate experimental config/cmdline props, while still supporting them for this major version. They will be removed on the next major version bump.
+Transition tree shaking from experimental to production. Deprecate experimental config/cmdline props, while still supporting them for this major version. They will be removed on the next major version bump. Update documentation and tests.

--- a/docsite/docs/guides/bundling.mdx
+++ b/docsite/docs/guides/bundling.mdx
@@ -227,19 +227,11 @@ unused code. Some times, your app bundle gets A LOT smaller.
 {
   "rnx-kit": {
     "bundle": {
-      "experimental_treeShake": true
+      "treeShake": true
     }
   }
 }
 ```
-
-This feature is marked as `experimental` because it occasionally produces larger
-bundles when used with code-splitting (an internal project which hasn't shipped
-yet).
-
-Double-check that your app bundle is smaller. If you run into trouble, please
-share what you are seeing in
-[a new issue](https://github.com/microsoft/rnx-kit/issues/new/choose).
 
 :::info Performance Gain
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -37,7 +37,7 @@ yarn react-native rnx-bundle --platform ios --dev false --minify true
 ```
 
 ```bash
-yarn react-native rnx-bundle --bundle-prefix test-app --experimental-tree-shake true
+yarn react-native rnx-bundle --bundle-prefix test-app --tree-shake true
 ```
 
 ### Example Configuration
@@ -55,7 +55,7 @@ yarn react-native rnx-bundle --bundle-prefix test-app --experimental-tree-shake 
         "ignoredModules": ["react-is"]
       },
       "typescriptValidation": true,
-      "experimental_treeShake": true,
+      "treeShake": true,
       "targets": ["ios", "android", "windows", "macos"],
       "platforms": {
         "android": {
@@ -72,24 +72,24 @@ yarn react-native rnx-bundle --bundle-prefix test-app --experimental-tree-shake 
 
 ### Command-Line Overrides
 
-| Override                                                                           | Description                                                                                                                                                         |
-| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| --id [id]                                                                          | Target bundle definition. This is only needed when the kit configuration has multiple bundle definitions.                                                           |
-| --platform [`ios` &#124; `android` &#124; `windows` &#124; `win32` &#124; `macos`] | Target platform. When not given, all platforms in the kit configuration are bundled.                                                                                |
-| --entry-path [file]                                                                | Path to the root JavaScript file, either absolute or relative to the kit package.                                                                                   |
-| --dist-path [path]                                                                 | Path where the bundle is written, either absolute or relative to the kit package.                                                                                   |
-| --assets-path [path]                                                               | Path where bundle assets like images are written, either absolute or relative to the kit package.                                                                   |
-| --bundle-prefix [prefix]                                                           | Bundle file prefix. This is followed by the platform and bundle file extension.                                                                                     |
-| --bundle-encoding [`utf8` &#124; `utf16le` &#124; `ascii`]                         | [Character encoding](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings) to use when writing the bundle file.                                |
-| --dev [boolean]                                                                    | If false, warnings are disabled and the bundle is minified (default: true).                                                                                         |
-| --minify [boolean]                                                                 | Controls whether or not the bundle is minified. Disabling minification is useful for test builds.                                                                   |
-| --experimental-tree-shake [boolean]                                                | Controls whether or not the bundle is tree shaken. Enabling it turns on dead-code elimination, potentially making the bundle smaller. This feature is experimental. |
-| --max-workers [number]                                                             | Specifies the maximum number of parallel worker threads to use for transforming files. This defaults to the number of cores available on your machine.              |
-| --sourcemap-output [string]                                                        | Path where the bundle source map is written, either absolute or relative to the dist-path.                                                                          |
-| --sourcemap-sources-root [string]                                                  | Path to use when relativizing file entries in the bundle source map.                                                                                                |
-| --reset-cache                                                                      | Reset the Metro cache.                                                                                                                                              |
-| --config [string]                                                                  | Path to the Metro configuration file.                                                                                                                               |
-| -h, --help                                                                         | Show usage information.                                                                                                                                             |
+| Override                                                                           | Description                                                                                                                                            |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| --id [id]                                                                          | Target bundle definition. This is only needed when the kit configuration has multiple bundle definitions.                                              |
+| --platform [`ios` &#124; `android` &#124; `windows` &#124; `win32` &#124; `macos`] | Target platform. When not given, all platforms in the kit configuration are bundled.                                                                   |
+| --entry-path [file]                                                                | Path to the root JavaScript file, either absolute or relative to the kit package.                                                                      |
+| --dist-path [path]                                                                 | Path where the bundle is written, either absolute or relative to the kit package.                                                                      |
+| --assets-path [path]                                                               | Path where bundle assets like images are written, either absolute or relative to the kit package.                                                      |
+| --bundle-prefix [prefix]                                                           | Bundle file prefix. This is followed by the platform and bundle file extension.                                                                        |
+| --bundle-encoding [`utf8` &#124; `utf16le` &#124; `ascii`]                         | [Character encoding](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings) to use when writing the bundle file.                   |
+| --dev [boolean]                                                                    | If false, warnings are disabled and the bundle is minified (default: true).                                                                            |
+| --minify [boolean]                                                                 | Controls whether or not the bundle is minified. Disabling minification is useful for test builds.                                                      |
+| --tree-shake [boolean]                                                             | Controls whether or not the bundle is tree shaken. Enabling it turns on dead-code elimination, potentially making the bundle smaller.                  |
+| --max-workers [number]                                                             | Specifies the maximum number of parallel worker threads to use for transforming files. This defaults to the number of cores available on your machine. |
+| --sourcemap-output [string]                                                        | Path where the bundle source map is written, either absolute or relative to the dist-path.                                                             |
+| --sourcemap-sources-root [string]                                                  | Path to use when relativizing file entries in the bundle source map.                                                                                   |
+| --reset-cache                                                                      | Reset the Metro cache.                                                                                                                                 |
+| --config [string]                                                                  | Path to the Metro configuration file.                                                                                                                  |
+| -h, --help                                                                         | Show usage information.                                                                                                                                |
 
 ## Start a Bundle Server
 
@@ -121,7 +121,7 @@ yarn react-native rnx-start --host localhost --port 8812
         "throwOnError": false
       },
       "typescriptValidation": true,
-      "experimental_treeShake": true
+      "treeShake": true
     }
   }
 }

--- a/packages/cli/react-native.config.js
+++ b/packages/cli/react-native.config.js
@@ -69,7 +69,12 @@ module.exports = {
         },
         {
           name: "--experimental-tree-shake [boolean]",
-          description: "Experimental: Enable tree shaking.",
+          description: "Deprecated. Use --tree-shake [boolean] instead.",
+          parse: parseBoolean,
+        },
+        {
+          name: "--tree-shake [boolean]",
+          description: "Enable tree shaking.",
           parse: parseBoolean,
         },
         {

--- a/packages/cli/src/bundle.ts
+++ b/packages/cli/src/bundle.ts
@@ -31,14 +31,16 @@ export async function rnxBundle(
   cliConfig: CLIConfig,
   cliOptions: CLIBundleOptions
 ): Promise<void> {
-  // experimentalTreeShake is Deprecated. Only use it when treeShake is not specified.
-  if (
-    cliOptions.experimentalTreeShake !== undefined &&
-    cliOptions.treeShake === undefined
-  ) {
-    cliOptions.treeShake = cliOptions.experimentalTreeShake;
+  // experimentalTreeShake is deprecated. Only use it when treeShake is not specified.
+  if (cliOptions.experimentalTreeShake !== undefined) {
+    console.warn(
+      "Warning: The command-line parameter '--experimental-tree-shake' is deprecated. Use `--tree-shake` instead."
+    );
+    if (cliOptions.treeShake === undefined) {
+      cliOptions.treeShake = cliOptions.experimentalTreeShake;
+    }
+    delete cliOptions.experimentalTreeShake;
   }
-  delete cliOptions.experimentalTreeShake;
 
   const metroConfig = await loadMetroConfig(cliConfig, cliOptions);
 

--- a/packages/cli/src/bundle.ts
+++ b/packages/cli/src/bundle.ts
@@ -17,7 +17,8 @@ export type CLIBundleOptions = {
   bundleEncoding?: BundleArgs["bundleEncoding"];
   dev: boolean;
   minify?: boolean;
-  experimentalTreeShake?: boolean;
+  experimentalTreeShake?: boolean; // Deprecated
+  treeShake?: boolean;
   maxWorkers?: number;
   sourcemapOutput?: string;
   sourcemapSourcesRoot?: string;
@@ -30,6 +31,15 @@ export async function rnxBundle(
   cliConfig: CLIConfig,
   cliOptions: CLIBundleOptions
 ): Promise<void> {
+  // experimentalTreeShake is Deprecated. Only use it when treeShake is not specified.
+  if (
+    cliOptions.experimentalTreeShake !== undefined &&
+    cliOptions.treeShake === undefined
+  ) {
+    cliOptions.treeShake = cliOptions.experimentalTreeShake;
+  }
+  delete cliOptions.experimentalTreeShake;
+
   const metroConfig = await loadMetroConfig(cliConfig, cliOptions);
 
   const kitBundleConfigs = getKitBundleConfigs(

--- a/packages/cli/src/bundle/metro.ts
+++ b/packages/cli/src/bundle/metro.ts
@@ -75,7 +75,7 @@ export async function metroBundle(
     bundleConfig.detectCyclicDependencies,
     bundleConfig.detectDuplicateDependencies,
     bundleConfig.typescriptValidation ? typescriptValidationOptions : false,
-    bundleConfig.experimental_treeShake
+    bundleConfig.treeShake
   );
 
   const metroBundleArgs = createMetroBundleArgs(bundleConfig);

--- a/packages/cli/src/bundle/overrides.ts
+++ b/packages/cli/src/bundle/overrides.ts
@@ -43,7 +43,7 @@ export function applyKitBundleConfigOverrides(
       "bundleEncoding",
       "sourcemapOutput",
       "sourcemapSourcesRoot",
-      "experimental_treeShake",
+      "treeShake",
     ]
   );
   if (overridesToApply) {

--- a/packages/cli/src/bundle/overrides.ts
+++ b/packages/cli/src/bundle/overrides.ts
@@ -10,7 +10,7 @@ export type KitBundleConfigOverrides = {
   bundleEncoding?: BundleArgs["bundleEncoding"];
   sourcemapOutput?: string;
   sourcemapSourcesRoot?: string;
-  experimentalTreeShake?: boolean;
+  treeShake?: boolean;
 };
 
 /**
@@ -33,7 +33,7 @@ export function applyKitBundleConfigOverrides(
       "bundleEncoding",
       "sourcemapOutput",
       "sourcemapSourcesRoot",
-      "experimentalTreeShake",
+      "treeShake",
     ],
     [
       "entryPath",

--- a/packages/cli/src/metro-config.ts
+++ b/packages/cli/src/metro-config.ts
@@ -109,14 +109,14 @@ const emptySerializerHook = (_graph: Graph, _delta: DeltaResult): void => {
  * @param detectCyclicDependencies When true, cyclic dependency checking is enabled with a default set of options. Otherwise the object allows for fine-grained control over the detection process.
  * @param detectDuplicateDependencies When true, duplicate dependency checking is enabled with a default set of options. Otherwise, the object allows for fine-grained control over the detection process.
  * @param typescriptValidation When true, TypeScript type-checking is enabled with a default set of options. Otherwise, the object allows for fine-grained control over the type-checking process.
- * @param experimental_treeShake When true, experimental tree shaking is enabled.
+ * @param treeShake When true, tree shaking is enabled.
  */
 export function customizeMetroConfig(
   metroConfigReadonly: InputConfigT,
   detectCyclicDependencies: boolean | CyclicDetectorOptions,
   detectDuplicateDependencies: boolean | DuplicateDetectorOptions,
   typescriptValidation: boolean | TypeScriptValidationOptions,
-  experimental_treeShake: boolean
+  treeShake: boolean
 ): void {
   //  We will be making changes to the Metro configuration. Coerce from a
   //  type with readonly props to a type where the props are writeable.
@@ -134,7 +134,7 @@ export function customizeMetroConfig(
     plugins.push(CyclicDependencies());
   }
 
-  if (experimental_treeShake) {
+  if (treeShake) {
     metroConfig.serializer.customSerializer = MetroSerializerEsbuild(plugins);
     Object.assign(metroConfig.transformer, esbuildTransformerConfig);
   } else if (plugins.length > 0) {

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -131,7 +131,7 @@ export async function rnxStart(
     serverConfig.detectCyclicDependencies,
     serverConfig.detectDuplicateDependencies,
     serverConfig.typescriptValidation ? typescriptValidationOptions : false,
-    serverConfig.experimental_treeShake
+    serverConfig.treeShake
   );
 
   // create middleware -- a collection of plugins which handle incoming

--- a/packages/cli/test/bundle/kit-config.test.ts
+++ b/packages/cli/test/bundle/kit-config.test.ts
@@ -80,7 +80,7 @@ describe("CLI > Bundle > Kit Config > getKitBundleConfigs", () => {
     detectCyclicDependencies: true,
     detectDuplicateDependencies: true,
     typescriptValidation: true,
-    experimental_treeShake: true,
+    treeShake: true,
     targets: ["ios", "android"],
     platforms: {
       ios: {
@@ -122,5 +122,27 @@ describe("CLI > Bundle > Kit Config > getKitBundleConfigs", () => {
       ...definition,
       platform: "android",
     });
+  });
+
+  test("uses deprecated experimental_treeShake", () => {
+    const d: Record<string, unknown> = { ...definition };
+    delete d.treeShake;
+    d.experimental_treeShake = true;
+    rnxKitConfig.__setMockConfig({
+      bundle: {
+        ...d,
+      },
+    });
+    consoleWarnSpy.mockReset();
+
+    const kitBundleConfigs = getKitBundleConfigs(undefined, "ios");
+    expect(kitBundleConfigs[0].treeShake).toBe(true);
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+    expect(consoleWarnSpy).toBeCalledWith(
+      expect.stringContaining("deprecated")
+    );
+    expect(consoleWarnSpy).toBeCalledWith(
+      expect.stringContaining("experimental_treeShake")
+    );
   });
 });

--- a/packages/cli/test/bundle/metro.test.ts
+++ b/packages/cli/test/bundle/metro.test.ts
@@ -8,7 +8,7 @@ describe("CLI > Bundle > Metro > createMetroBundleArgs", () => {
     detectCyclicDependencies: true,
     detectDuplicateDependencies: true,
     typescriptValidation: true,
-    experimental_treeShake: true,
+    treeShake: true,
     entryPath: "out/entry.js",
     distPath: "out",
     assetsPath: "out/assets",

--- a/packages/cli/test/bundle/overrides.test.ts
+++ b/packages/cli/test/bundle/overrides.test.ts
@@ -63,11 +63,11 @@ describe("CLI > Bundle > Overrides > applyKitBundleConfigOverrides", () => {
     testOverride("sourcemapSourcesRoot", "out");
   });
 
-  test("set experimental_treeShake using override experimentalTreeShake", () => {
+  test("set experimental_treeShake using override treeShake", () => {
     const copy = { ...config };
     applyKitBundleConfigOverrides(
       {
-        experimentalTreeShake: true,
+        treeShake: true,
       },
       [copy]
     );

--- a/packages/cli/test/bundle/overrides.test.ts
+++ b/packages/cli/test/bundle/overrides.test.ts
@@ -7,7 +7,7 @@ describe("CLI > Bundle > Overrides > applyKitBundleConfigOverrides", () => {
     detectCyclicDependencies: true,
     detectDuplicateDependencies: true,
     typescriptValidation: true,
-    experimental_treeShake: true,
+    treeShake: true,
     entryPath: "dist/index.js",
     distPath: "dist",
     assetsPath: "dist",
@@ -63,17 +63,7 @@ describe("CLI > Bundle > Overrides > applyKitBundleConfigOverrides", () => {
     testOverride("sourcemapSourcesRoot", "out");
   });
 
-  test("set experimental_treeShake using override treeShake", () => {
-    const copy = { ...config };
-    applyKitBundleConfigOverrides(
-      {
-        treeShake: true,
-      },
-      [copy]
-    );
-    expect(copy).toEqual({
-      ...config,
-      experimental_treeShake: true,
-    });
+  test("changes treeShake using an override", () => {
+    testOverride("treeShake", true);
   });
 });

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -60,7 +60,7 @@ Union of: "ios", "android", "windows", "win32", "macos"
 | detectCyclicDependencies    | boolean, `CyclicDetectorOptions`, undefined    | true    | Choose whether to detect cycles in the dependency graph. If true, then a default set of options will be used. If `CyclicDetectorOptions` is given, the object is a detailed specification of cyclic detector configuration.                       |
 | detectDuplicateDependencies | boolean, `DuplicateDetectorOptions`, undefined | true    | Choose whether to detect duplicate packages in the dependency graph. If true, then a default set of options will be used. If `DuplicateDetectorOptions` is given, the object is a detailed specification of the duplicate detector configuration. |
 | typescriptValidation        | boolean, undefined                             | true    | Choose whether to type-check the application during bundling and serving.                                                                                                                                                                         |
-| experimental_treeShake      | boolean, undefined                             | false   | **EXPERIMENTAL** -- Choose whether to enable tree shaking.                                                                                                                                                                                        |
+| treeShake                   | boolean, undefined                             | false   | Choose whether to enable tree shaking.                                                                                                                                                                                                            |
 
 ### `CyclicDetectorOptions`
 

--- a/packages/config/schema.json
+++ b/packages/config/schema.json
@@ -84,7 +84,7 @@
           "type": "boolean",
           "default": true
         },
-        "experimental_treeShake": {
+        "treeShake": {
           "description": "Choose whether to enable tree shaking.",
           "type": "boolean",
           "default": false

--- a/packages/config/src/bundleConfig.ts
+++ b/packages/config/src/bundleConfig.ts
@@ -40,11 +40,9 @@ export type BundlerRuntimeParameters = {
   /**
    * Choose whether to enable tree shaking.
    *
-   * ⚠️ **THIS FEATURE IS HIGHLY EXPERIMENTAL** ⚠️
-   *
    * @default false
    */
-  experimental_treeShake: boolean;
+  treeShake: boolean;
 };
 
 /**

--- a/packages/config/src/getServerConfig.ts
+++ b/packages/config/src/getServerConfig.ts
@@ -17,7 +17,7 @@ export function getServerConfig(
     detectCyclicDependencies: true,
     detectDuplicateDependencies: true,
     typescriptValidation: true,
-    experimental_treeShake: false,
+    treeShake: false,
   };
 
   return { ...defaultConfig, ...(config.server ?? {}) };

--- a/packages/config/test/getServerConfig.test.ts
+++ b/packages/config/test/getServerConfig.test.ts
@@ -15,7 +15,7 @@ const kitConfigWithServer: KitConfig = {
     detectCyclicDependencies: true,
     detectDuplicateDependencies: false,
     typescriptValidation: true,
-    experimental_treeShake: false,
+    treeShake: false,
     assetPlugins: ["asset-plugin-package"],
     sourceExts: ["json", "jsrc"],
   },
@@ -26,13 +26,13 @@ function validateDefaultConfig(c: ServerConfig) {
     "detectCyclicDependencies",
     "detectDuplicateDependencies",
     "typescriptValidation",
-    "experimental_treeShake",
+    "treeShake",
   ]);
   expect(c.projectRoot).toBeUndefined();
   expect(c.detectCyclicDependencies).toBeTrue();
   expect(c.detectDuplicateDependencies).toBeTrue();
   expect(c.typescriptValidation).toBeTrue();
-  expect(c.experimental_treeShake).toBeFalse();
+  expect(c.treeShake).toBeFalse();
 }
 
 describe("getServerConfig()", () => {
@@ -52,7 +52,7 @@ describe("getServerConfig()", () => {
     expect(c.detectCyclicDependencies).toBeTrue();
     expect(c.detectDuplicateDependencies).toBeFalse();
     expect(c.typescriptValidation).toBeTrue();
-    expect(c.experimental_treeShake).toBeFalse();
+    expect(c.treeShake).toBeFalse();
     expect(c.assetPlugins).toBeArrayOfSize(1);
     expect(c.assetPlugins).toIncludeSameMembers(["asset-plugin-package"]);
     expect(c.sourceExts).toBeArrayOfSize(2);

--- a/packages/metro-serializer-esbuild/README.md
+++ b/packages/metro-serializer-esbuild/README.md
@@ -3,12 +3,9 @@
 # @rnx-kit/metro-serializer-esbuild
 
 [![Build](https://github.com/microsoft/rnx-kit/actions/workflows/build.yml/badge.svg)](https://github.com/microsoft/rnx-kit/actions/workflows/build.yml)
-![This plugin is highly experimental](https://img.shields.io/badge/state-experimental-critical)
 [![npm version](https://img.shields.io/npm/v/@rnx-kit/metro-serializer-esbuild)](https://www.npmjs.com/package/@rnx-kit/metro-serializer-esbuild)
 
 <!--remove-block end-->
-
-⚠️ **THIS PLUGIN IS HIGHLY EXPERIMENTAL** ⚠️
 
 Allow Metro to use [esbuild](https://esbuild.github.io) for bundling and
 serialization.
@@ -101,6 +98,7 @@ react-native bundle --entry-file index.js --platform ios --dev false ...
   you can save the esbuild specific Metro config to a separate file and only
   specify it when needed, e.g.:
   ```sh
+  ???  FIX THIS IN THE CLI, AND CHANGE TO rnx-bundle BEFORE COMMITTING  ???
   react-native bundle ... --config metro+esbuild.config.js
   ```
 - esbuild does not properly tree-shake `export *`. This is a known limitation

--- a/packages/metro-serializer-esbuild/README.md
+++ b/packages/metro-serializer-esbuild/README.md
@@ -4,11 +4,15 @@
 
 [![Build](https://github.com/microsoft/rnx-kit/actions/workflows/build.yml/badge.svg)](https://github.com/microsoft/rnx-kit/actions/workflows/build.yml)
 [![npm version](https://img.shields.io/npm/v/@rnx-kit/metro-serializer-esbuild)](https://www.npmjs.com/package/@rnx-kit/metro-serializer-esbuild)
+![Stability Beta](https://img.shields.io/badge/Stability-Beta-3bf)
 
 <!--remove-block end-->
 
 Allow Metro to use [esbuild](https://esbuild.github.io) for bundling and
 serialization.
+
+This tool is in Beta, and has been yielding good results so far. See the list of
+known issues below for more information.
 
 ## Motivation
 
@@ -98,7 +102,6 @@ react-native bundle --entry-file index.js --platform ios --dev false ...
   you can save the esbuild specific Metro config to a separate file and only
   specify it when needed, e.g.:
   ```sh
-  ???  FIX THIS IN THE CLI, AND CHANGE TO rnx-bundle BEFORE COMMITTING  ???
   react-native bundle ... --config metro+esbuild.config.js
   ```
 - esbuild does not properly tree-shake `export *`. This is a known limitation

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rnx-kit/metro-serializer-esbuild",
   "version": "0.1.5",
-  "description": "Experimental esbuild serializer for Metro",
+  "description": "esbuild serializer for Metro",
   "homepage": "https://github.com/microsoft/rnx-kit/tree/main/packages/metro-serializer-esbuild#readme",
   "license": "MIT",
   "files": [

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -72,7 +72,7 @@
         ]
       },
       "typescriptValidation": true,
-      "experimental_treeShake": false,
+      "treeShake": false,
       "targets": [
         "android",
         "ios",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -10,7 +10,7 @@
     "lint": "rnx-kit-scripts lint",
     "test": "react-native rnx-test --platform ios",
     "bundle": "react-native rnx-bundle",
-    "bundle+esbuild": "react-native rnx-bundle --bundle-prefix 'main+esbuild' --experimental-tree-shake",
+    "bundle+esbuild": "react-native rnx-bundle --bundle-prefix 'main+esbuild' --tree-shake",
     "bundle:android": "react-native rnx-bundle --platform android",
     "bundle:ios": "react-native rnx-bundle --platform ios",
     "bundle:macos": "react-native rnx-bundle --platform macos",


### PR DESCRIPTION
### Description

Remove the experimental moniker from tree shaking, making it a fully supported feature.

The "experimental" config property and command-line parameter are still both supported, but both trigger a console warning message indicating that they are deprecated.

Resolves #1278 

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

Manually verified with test-app. Update automated tests to attempt using deprecated config and command-line "experimental" names. Update other tests to use new name.

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
