### PR TITLE
fix(cli): avoid `fs/promises` to be compatible with Node 12

### DIFF
--- a/.changeset/thick-plums-vanish.md
+++ b/.changeset/thick-plums-vanish.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Avoid `fs/promises` to be compatible with Node 12

--- a/packages/cli/src/clean.ts
+++ b/packages/cli/src/clean.ts
@@ -1,10 +1,10 @@
 import type { Config as CLIConfig } from "@react-native-community/cli-types";
 import { spawn } from "child_process";
 import { existsSync as fileExists } from "fs";
-import fs from "fs/promises";
+import * as fs from "fs-extra";
 import ora from "ora";
-import os from "os";
-import path from "path";
+import * as os from "os";
+import * as path from "path";
 
 type Args = {
   include?: string;

--- a/packages/cli/src/clean.ts
+++ b/packages/cli/src/clean.ts
@@ -1,6 +1,5 @@
 import type { Config as CLIConfig } from "@react-native-community/cli-types";
 import { spawn } from "child_process";
-import { existsSync as fileExists } from "fs";
 import * as fs from "fs-extra";
 import ora from "ora";
 import * as os from "os";
@@ -27,7 +26,7 @@ export async function rnxClean(
   cliOptions: Args
 ): Promise<void> {
   const projectRoot = cliOptions.projectRoot ?? process.cwd();
-  if (!fileExists(projectRoot)) {
+  if (!fs.existsSync(projectRoot)) {
     throw new Error(`Invalid path provided! ${projectRoot}`);
   }
 
@@ -152,7 +151,7 @@ export async function rnxClean(
 }
 
 function cleanDir(path: string): Promise<void> {
-  if (!fileExists(path)) {
+  if (!fs.existsSync(path)) {
     return Promise.resolve();
   }
 
@@ -163,7 +162,7 @@ function findPath(startPath: string, files: string[]): string | undefined {
   // TODO: Find project files via `@react-native-community/cli`
   for (const file of files) {
     const filename = path.resolve(startPath, file);
-    if (fileExists(filename)) {
+    if (fs.existsSync(filename)) {
       return filename;
     }
   }


### PR DESCRIPTION
### Description

We still have clients on Node 12. `fs/promises` wasn't added till Node 14.

### Test plan

```
cd packages/test-app
yarn build --dependencies
yarn react-native rnx-clean --include metro
```