### PR TITLE
fix(cli): add support for `@react-native-community/cli` 7.0.3

### DIFF
--- a/.changeset/weak-steaks-rest.md
+++ b/.changeset/weak-steaks-rest.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Add support for `@react-native-community/cli` 7.0.3


### PR DESCRIPTION
### Description

The return type of `createDevServerMiddleware()` changed in https://github.com/react-native-community/cli/pull/1560.

Resolves #1483.

### Test plan

```
git clone https://github.com/fbeccaceci/rnx-kit-issue-example.git
cd rnx-kit-issue-example
yarn
npx react-native rnx-start
```