### PR TITLE
fix(tools-react-native): ignore errors in `react-native.config.js`

### DIFF
--- a/.changeset/ten-chefs-dress.md
+++ b/.changeset/ten-chefs-dress.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-react-native": patch
+---
+
+Ignore errors in `react-native.config.js`

--- a/packages/tools-react-native/src/platform.ts
+++ b/packages/tools-react-native/src/platform.ts
@@ -79,16 +79,20 @@ export function getAvailablePlatformsUncached(
 
     const configPath = path.join(pkgPath, "react-native.config.js");
     if (fs.existsSync(configPath)) {
-      const { platforms } = require(configPath);
-      if (platforms) {
-        Object.keys(platforms).forEach((platform) => {
-          if (typeof platformMap[platform] === "undefined") {
-            const { npmPackageName } = platforms[platform];
-            if (npmPackageName) {
-              platformMap[platform] = npmPackageName;
+      try {
+        const { platforms } = require(configPath);
+        if (platforms) {
+          Object.keys(platforms).forEach((platform) => {
+            if (typeof platformMap[platform] === "undefined") {
+              const { npmPackageName } = platforms[platform];
+              if (npmPackageName) {
+                platformMap[platform] = npmPackageName;
+              }
             }
-          }
-        });
+          });
+        }
+      } catch (_) {
+        // ignore
       }
     }
   });


### PR DESCRIPTION
### Description

Packages may publish `react-native.config.js` with errors. We should ignore them rather than crash the whole process.

### Test plan

n/a