### PR TITLE
fix(third-party-notices): support unlicensed packages

### DIFF
--- a/.changeset/soft-ants-develop.md
+++ b/.changeset/soft-ants-develop.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/third-party-notices": patch
+---
+
+Ignore packages that are explicitly unlicensed

--- a/packages/third-party-notices/package.json
+++ b/packages/third-party-notices/package.json
@@ -34,8 +34,7 @@
     "@rnx-kit/eslint-config": "*",
     "@rnx-kit/scripts": "*",
     "@types/jest": "^27.0.0",
-    "@types/yargs": "^16.0.0",
-    "typescript": "^4.0.0"
+    "@types/yargs": "^16.0.0"
   },
   "eslintConfig": {
     "extends": "@rnx-kit/eslint-config"

--- a/packages/third-party-notices/src/extractors.js
+++ b/packages/third-party-notices/src/extractors.js
@@ -61,11 +61,13 @@ function _getPackageJsonInformations(modules) {
     module.licenseURLs = [];
     if (pkg.license && typeof pkg.license == "string") {
       module.license = pkg.license;
-      _getSpdxLicenseInformation(module.license).forEach(function (license) {
-        module.licenseURLs.push(
-          "https://spdx.org/licenses/" + license + ".html"
-        );
-      });
+      _getSpdxLicenseInformation(module.license, module.name).forEach(
+        (license) => {
+          module.licenseURLs.push(
+            "https://spdx.org/licenses/" + license + ".html"
+          );
+        }
+      );
     } else if (
       (pkg.license && Array.isArray(pkg.license)) ||
       (pkg.licenses && Array.isArray(pkg.licenses))
@@ -107,7 +109,7 @@ function _findLicenseFiles(modules) {
   return modules;
 }
 
-function _getSpdxLicenseInformation(license) {
+function _getSpdxLicenseInformation(license, moduleName) {
   var licenses = [];
   try {
     var tree;
@@ -126,7 +128,11 @@ function _getSpdxLicenseInformation(license) {
       licenses = licenses.concat(_getSpdxLicenseInformation(tree.right));
     }
   } catch (e) {
-    console.warn(`WARNING: Unable to parse license "${license}"`);
+    if (license.toUpperCase() !== "UNLICENSED") {
+      console.warn(
+        `WARNING: Unable to parse license "${license}" in ${moduleName}`
+      );
+    }
   }
   return licenses;
 }

--- a/packages/third-party-notices/src/output/text.ts
+++ b/packages/third-party-notices/src/output/text.ts
@@ -25,6 +25,11 @@ export function createLicenseFileContents(
 
   // Emit combined license text
   licenses.forEach(({ name, version, license, licenseText, licenseURLs }) => {
+    if (license?.toUpperCase() === "UNLICENSED") {
+      // Ignore unlicensed/private packages
+      return;
+    }
+
     if (!licenseText) {
       if (!license && (!licenseURLs || licenseURLs.length === 0)) {
         throw new Error(
@@ -35,7 +40,7 @@ export function createLicenseFileContents(
     }
     writeLine("================================================");
     writeLine(`${name} ${version}`);
-    writeLine("=====");
+    writeLine("--");
     writeMultipleLines(licenseText.trim());
     writeLine("================================================");
     writeLine("");

--- a/packages/third-party-notices/test/__snapshots__/licence.test.ts.snap
+++ b/packages/third-party-notices/test/__snapshots__/licence.test.ts.snap
@@ -3,13 +3,13 @@
 exports[`license createLicenseFileContents 1`] = `
 "================================================
 @rnx-kit/cli 1.2.3-fixedVersionForTesting
-=====
+--
 MIT (https://spdx.org/licenses/MIT.html)
 ================================================
 
 ================================================
 react 1.2.3-fixedVersionForTesting
-=====
+--
 MIT License
 
 Copyright (c) Facebook, Inc. and its affiliates.
@@ -35,7 +35,7 @@ SOFTWARE.
 
 ================================================
 react-native 1.2.3-fixedVersionForTesting
-=====
+--
 MIT License
 
 Copyright (c) Facebook, Inc. and its affiliates.
@@ -70,13 +70,13 @@ exports[`license createLicenseFileContentsWithWrappers 1`] = `
 Preamble 2
 ================================================
 @rnx-kit/cli 1.2.3-fixedVersionForTesting
-=====
+--
 MIT (https://spdx.org/licenses/MIT.html)
 ================================================
 
 ================================================
 react 1.2.3-fixedVersionForTesting
-=====
+--
 MIT License
 
 Copyright (c) Facebook, Inc. and its affiliates.
@@ -102,7 +102,7 @@ SOFTWARE.
 
 ================================================
 react-native 1.2.3-fixedVersionForTesting
-=====
+--
 MIT License
 
 Copyright (c) Facebook, Inc. and its affiliates.
@@ -154,6 +154,12 @@ Object {
       "license": "MIT",
       "name": "react-native",
       "version": "1.2.3-fixedVersionForTesting",
+    },
+    Object {
+      "copyright": "No copyright notice",
+      "license": "Unlicensed",
+      "name": "private-package",
+      "version": "1.0.0",
     },
   ],
 }
@@ -233,6 +239,13 @@ SOFTWARE.
     "name": "react-native",
     "path": "~/node_modules/react-native",
     "version": "1.2.3-fixedVersionForTesting",
+  },
+  Object {
+    "license": "Unlicensed",
+    "licenseURLs": Array [],
+    "name": "private-package",
+    "path": ".",
+    "version": "1.0.0",
   },
 ]
 `;

--- a/packages/third-party-notices/test/licence.test.ts
+++ b/packages/third-party-notices/test/licence.test.ts
@@ -5,13 +5,14 @@ import type { License } from "../src/types";
 import { extractLicenses } from "../src/write-third-party-notices";
 
 async function getSampleLicenseData(): Promise<License[]> {
-  const map = new Map();
-  // License data in package.json
-  map.set("@rnx-kit/cli", path.resolve("../../node_modules/@rnx-kit/cli"));
-  // License data package.json and LICENCE file
-  map.set("react-native", path.resolve("../../node_modules/react-native"));
-  // License data package.json and LICENSE file
-  map.set("react", path.resolve("../../node_modules/react"));
+  const map = new Map([
+    // License data in package.json
+    ["@rnx-kit/cli", path.resolve("../../node_modules/@rnx-kit/cli")],
+    // License data package.json and LICENCE file
+    ["react-native", path.resolve("../../node_modules/react-native")],
+    // License data package.json and LICENSE file
+    ["react", path.resolve("../../node_modules/react")],
+  ]);
 
   const licenses = await extractLicenses(map);
 
@@ -19,6 +20,15 @@ async function getSampleLicenseData(): Promise<License[]> {
   for (const license of licenses) {
     license.version = "1.2.3-fixedVersionForTesting";
   }
+
+  // Private packages should excluded from text output
+  licenses.push({
+    name: "private-package",
+    version: "1.0.0",
+    license: "Unlicensed",
+    licenseURLs: [],
+    path: ".",
+  });
 
   return licenses;
 }

--- a/packages/third-party-notices/test/licence.test.ts
+++ b/packages/third-party-notices/test/licence.test.ts
@@ -21,7 +21,7 @@ async function getSampleLicenseData(): Promise<License[]> {
     license.version = "1.2.3-fixedVersionForTesting";
   }
 
-  // Private packages should excluded from text output
+  // Private packages should be excluded from text output
   licenses.push({
     name: "private-package",
     version: "1.0.0",


### PR DESCRIPTION
### Description

`third-party-notices` currently produces lines for packages that are private/internal. This will filter them out.

### Test plan

Tests were added.