### PR TITLE
Fix TS errors/failures when bundling with type validation on non-TS packages

### DIFF
--- a/.changeset/eighty-sheep-judge.md
+++ b/.changeset/eighty-sheep-judge.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+When doing typescript validation during bundling, ignore non-TS projects rather than failing.


### PR DESCRIPTION
### Description

When doing typescript validation during bundling, ignore non-TS projects rather than failing.

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

Manual validation of both failure and success using internal test-app.

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
