### PR TITLE
fix(cli): exit if encountering an error

### DIFF
--- a/.changeset/gold-keys-roll.md
+++ b/.changeset/gold-keys-roll.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+rnx-copy-assets: exit if encountering an error

--- a/packages/cli/src/copy-assets.ts
+++ b/packages/cli/src/copy-assets.ts
@@ -9,6 +9,7 @@ import {
 } from "@rnx-kit/tools-node/package";
 import type { AllPlatforms } from "@rnx-kit/tools-react-native";
 import { parsePlatform } from "@rnx-kit/tools-react-native";
+import type { SpawnSyncOptions } from "child_process";
 import { spawnSync } from "child_process";
 import * as fs from "fs-extra";
 import * as os from "os";
@@ -173,6 +174,13 @@ function getAndroidPaths(
   }
 }
 
+function run(command: string, args: string[], options: SpawnSyncOptions) {
+  const { status } = spawnSync(command, args, options);
+  if (status !== 0) {
+    process.exit(status || 1);
+  }
+}
+
 export async function assembleAarBundle(
   context: Context,
   packageName: string,
@@ -238,7 +246,7 @@ export async function assembleAarBundle(
     }
 
     // Run only one Gradle task at a time
-    spawnSync(gradlew, targets, { cwd: androidProject, stdio: "inherit", env });
+    run(gradlew, targets, { cwd: androidProject, stdio: "inherit", env });
   } else {
     const reactNativePath = findPackageDependencyDir("react-native");
     if (!reactNativePath) {
@@ -317,7 +325,7 @@ export async function assembleAarBundle(
     await fs.writeFile(path.join(buildDir, "settings.gradle"), settingsGradle);
 
     // Run only one Gradle task at a time
-    spawnSync(gradlew, targets, { cwd: buildDir, stdio: "inherit", env });
+    run(gradlew, targets, { cwd: buildDir, stdio: "inherit", env });
   }
 
   await Promise.all(targetsToCopy.map(([src, dest]) => fs.copy(src, dest)));

--- a/packages/cli/test/__mocks__/child_process.js
+++ b/packages/cli/test/__mocks__/child_process.js
@@ -1,5 +1,5 @@
 const child_process = jest.createMockFromModule("child_process");
 
-child_process.spawnSync(() => undefined);
+child_process.spawnSync = () => ({ status: 0 });
 
 module.exports = child_process;

--- a/packages/cli/test/copy-assets/assembleAarBundle.test.ts
+++ b/packages/cli/test/copy-assets/assembleAarBundle.test.ts
@@ -23,11 +23,11 @@ export const context = {
 
 describe("assembleAarBundle", () => {
   const consoleWarnSpy = jest.spyOn(global.console, "warn");
+  const spawnSyncSpy = jest.spyOn(require("child_process"), "spawnSync");
 
   afterEach(() => {
     mockFiles();
     consoleWarnSpy.mockReset();
-    spawnSync.mockReset();
   });
 
   afterAll(() => {
@@ -48,7 +48,7 @@ describe("assembleAarBundle", () => {
       expect.anything(),
       expect.stringMatching(/cannot find `gradlew`$/)
     );
-    expect(spawnSync).not.toHaveBeenCalled();
+    expect(spawnSyncSpy).not.toHaveBeenCalled();
     expect(findFiles()).toEqual([]);
   });
 
@@ -82,7 +82,7 @@ describe("assembleAarBundle", () => {
       expect.anything(),
       expect.stringMatching(/cannot find `build.gradle`/)
     );
-    expect(spawnSync).not.toHaveBeenCalled();
+    expect(spawnSyncSpy).not.toHaveBeenCalled();
     expect(findFiles()).toEqual([
       [expect.stringMatching(/[/\\]gradlew$/), ""],
       [expect.stringMatching(/[/\\]gradlew.bat$/), ""],
@@ -114,7 +114,7 @@ describe("assembleAarBundle", () => {
     await assembleAarBundle(context, "@rnx-kit/react-native-auth", { aar: {} });
 
     expect(consoleWarnSpy).not.toHaveBeenCalled();
-    expect(spawnSync).toHaveBeenCalledWith(
+    expect(spawnSyncSpy).toHaveBeenCalledWith(
       expect.stringMatching(/[/\\]gradlew(?:\.bat)?$/),
       [":rnx-kit_react-native-auth:assembleRelease"],
       expect.objectContaining({
@@ -200,7 +200,7 @@ describe("assembleAarBundle", () => {
     await assembleAarBundle(context, "@rnx-kit/react-native-auth", { aar: {} });
 
     expect(consoleWarnSpy).not.toHaveBeenCalled();
-    expect(spawnSync).toHaveBeenCalledWith(
+    expect(spawnSyncSpy).toHaveBeenCalledWith(
       expect.stringMatching(/[/\\]gradlew(?:\.bat)?$/),
       [":rnx-kit_react-native-auth:assembleRelease"],
       expect.objectContaining({
@@ -281,7 +281,7 @@ describe("assembleAarBundle", () => {
     });
 
     expect(consoleWarnSpy).not.toHaveBeenCalled();
-    expect(spawnSync).toHaveBeenCalledWith(
+    expect(spawnSyncSpy).toHaveBeenCalledWith(
       expect.stringMatching(/[/\\]gradlew(?:\.bat)?$/),
       [":rnx-kit_react-native-auth:assembleRelease"],
       expect.objectContaining({


### PR DESCRIPTION
### Description

`rnx-copy-assets` keeps on going even if the Gradle command fails.

### Test plan

Tested in an internal app.