### PR TITLE
fix: bump @rnx-kit/tools-node to v1.2.7 in all packages

### DIFF
--- a/.changeset/tiny-hotels-brake.md
+++ b/.changeset/tiny-hotels-brake.md
@@ -1,0 +1,15 @@
+---
+"@rnx-kit/babel-plugin-import-path-remapper": patch
+"@rnx-kit/cli": patch
+"@rnx-kit/dep-check": patch
+"@rnx-kit/metro-plugin-cyclic-dependencies-detector": patch
+"@rnx-kit/metro-plugin-duplicates-checker": patch
+"@rnx-kit/metro-resolver-symlinks": patch
+"@rnx-kit/metro-serializer-esbuild": patch
+"@rnx-kit/third-party-notices": patch
+"@rnx-kit/typescript-react-native-compiler": patch
+"@rnx-kit/typescript-react-native-resolver": patch
+"@rnx-kit/typescript-service": patch
+---
+
+Bump @rnx-kit/tools-node to v1.2.7

--- a/packages/babel-plugin-import-path-remapper/package.json
+++ b/packages/babel-plugin-import-path-remapper/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@babel/core": "^7.0.0",
     "@babel/helper-plugin-utils": "^7.0.0",
-    "@rnx-kit/tools-node": "^1.2.6"
+    "@rnx-kit/tools-node": "^1.2.7"
   },
   "devDependencies": {
     "@rnx-kit/scripts": "*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "@rnx-kit/metro-service": "^1.1.13",
     "@rnx-kit/third-party-notices": "^1.2.13",
     "@rnx-kit/tools-language": "^1.3.0",
-    "@rnx-kit/tools-node": "^1.2.6",
+    "@rnx-kit/tools-node": "^1.2.7",
     "@rnx-kit/tools-react-native": "^1.2.0",
     "@rnx-kit/typescript-react-native-resolver": "^0.2.0",
     "@rnx-kit/typescript-service": "^1.5.3",

--- a/packages/dep-check/package.json
+++ b/packages/dep-check/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@rnx-kit/console": "^1.0.11",
     "@rnx-kit/tools-language": "^1.2.6",
-    "@rnx-kit/tools-node": "^1.2.6"
+    "@rnx-kit/tools-node": "^1.2.7"
   },
   "devDependencies": {
     "@rnx-kit/config": "*",

--- a/packages/metro-plugin-cyclic-dependencies-detector/package.json
+++ b/packages/metro-plugin-cyclic-dependencies-detector/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@rnx-kit/console": "^1.0.11",
-    "@rnx-kit/tools-node": "^1.2.6"
+    "@rnx-kit/tools-node": "^1.2.7"
   },
   "devDependencies": {
     "@rnx-kit/metro-serializer": "*",

--- a/packages/metro-plugin-duplicates-checker/package.json
+++ b/packages/metro-plugin-duplicates-checker/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@rnx-kit/console": "^1.0.11",
-    "@rnx-kit/tools-node": "^1.2.6"
+    "@rnx-kit/tools-node": "^1.2.7"
   },
   "devDependencies": {
     "@rnx-kit/metro-serializer": "*",

--- a/packages/metro-resolver-symlinks/package.json
+++ b/packages/metro-resolver-symlinks/package.json
@@ -22,7 +22,7 @@
     "test": "rnx-kit-scripts test"
   },
   "dependencies": {
-    "@rnx-kit/tools-node": "^1.2.6",
+    "@rnx-kit/tools-node": "^1.2.7",
     "@rnx-kit/tools-react-native": "^1.2.0",
     "enhanced-resolve": "^5.8.3"
   },

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@rnx-kit/console": "^1.0.11",
-    "@rnx-kit/tools-node": "^1.2.6",
+    "@rnx-kit/tools-node": "^1.2.7",
     "esbuild": "^0.14.10",
     "esbuild-plugin-lodash": "^1.1.0",
     "fast-glob": "^3.2.7",

--- a/packages/third-party-notices/package.json
+++ b/packages/third-party-notices/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@rnx-kit/console": "^1.0.11",
-    "@rnx-kit/tools-node": "^1.2.6",
+    "@rnx-kit/tools-node": "^1.2.7",
     "spdx-expression-parse": "^3.0.1",
     "yargs": "^16.0.0"
   },

--- a/packages/typescript-react-native-compiler/package.json
+++ b/packages/typescript-react-native-compiler/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@rnx-kit/tools-language": "^1.2.6",
-    "@rnx-kit/tools-node": "^1.2.6",
+    "@rnx-kit/tools-node": "^1.2.7",
     "@rnx-kit/typescript-react-native-resolver": "^0.2.0",
     "@rnx-kit/typescript-service": "^1.5.3",
     "chalk": "^4.1.0"

--- a/packages/typescript-react-native-resolver/package.json
+++ b/packages/typescript-react-native-resolver/package.json
@@ -21,7 +21,7 @@
     "test": "rnx-kit-scripts test"
   },
   "dependencies": {
-    "@rnx-kit/tools-node": "^1.2.6",
+    "@rnx-kit/tools-node": "^1.2.7",
     "@rnx-kit/tools-react-native": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/typescript-service/package.json
+++ b/packages/typescript-service/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@rnx-kit/tools-language": "^1.2.6",
-    "@rnx-kit/tools-node": "^1.2.6",
+    "@rnx-kit/tools-node": "^1.2.7",
     "chalk": "^4.1.0"
   },
   "devDependencies": {

--- a/scripts/rnx-dep-check.js
+++ b/scripts/rnx-dep-check.js
@@ -3,6 +3,11 @@
 "use strict";
 
 module.exports = {
+  "@rnx-kit/tools-node": {
+    name: "@rnx-kit/tools-node",
+    version: "^1.2.7",
+    devOnly: true,
+  },
   "@types/jest": {
     name: "@types/jest",
     version: "^27.0.0",


### PR DESCRIPTION
### Description

Bumps `@rnx-kit/tools-node` to v1.2.7 in all packages.

### Test plan

n/a