### PR TITLE
fix(dep-check): dep-check fails to visit dependencies

### DIFF
--- a/.changeset/cold-rats-battle.md
+++ b/.changeset/cold-rats-battle.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-node": minor
+---
+
+Added a flag, `resolveSymlinks`, to `findPackageDependencyDir` to make it return fully resolved symlinks

--- a/.changeset/silent-insects-vanish.md
+++ b/.changeset/silent-insects-vanish.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/dep-check": patch
+---
+
+Fix dep-check failing to visit dependencies in a repository using pnpm or pnpm-like solutions

--- a/packages/dep-check/package.json
+++ b/packages/dep-check/package.json
@@ -27,14 +27,12 @@
     "update-profile": "node scripts/update-profile.mjs",
     "update-readme": "node scripts/update-readme.js"
   },
-  "dependencies": {
-    "@rnx-kit/console": "^1.0.11",
-    "@rnx-kit/tools-language": "^1.2.6",
-    "@rnx-kit/tools-node": "^1.2.7"
-  },
   "devDependencies": {
     "@rnx-kit/config": "*",
+    "@rnx-kit/console": "*",
     "@rnx-kit/scripts": "*",
+    "@rnx-kit/tools-language": "*",
+    "@rnx-kit/tools-node": "*",
     "@types/jest": "^27.0.0",
     "@types/lodash": "^4.14.172",
     "@types/pacote": "^11.0.0",

--- a/packages/dep-check/src/dependencies.ts
+++ b/packages/dep-check/src/dependencies.ts
@@ -56,6 +56,7 @@ export function visitDependencies(
     const packageRef = parsePackageRef(dependency);
     const packageDir = findPackageDependencyDir(packageRef, {
       startDir: projectRoot,
+      resolveSymlinks: true,
     });
     if (!packageDir) {
       warn(`Unable to resolve module '${dependency}'`);

--- a/packages/dep-check/src/dependencies.ts
+++ b/packages/dep-check/src/dependencies.ts
@@ -4,7 +4,6 @@ import { error, warn } from "@rnx-kit/console";
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
 import {
   findPackageDependencyDir,
-  parsePackageRef,
   readPackage,
 } from "@rnx-kit/tools-node/package";
 import { concatVersionRanges } from "./helpers";
@@ -53,8 +52,7 @@ export function visitDependencies(
 
     visited.add(dependency);
 
-    const packageRef = parsePackageRef(dependency);
-    const packageDir = findPackageDependencyDir(packageRef, {
+    const packageDir = findPackageDependencyDir(dependency, {
       startDir: projectRoot,
       resolveSymlinks: true,
     });

--- a/packages/dep-check/test/__mocks__/fs.js
+++ b/packages/dep-check/test/__mocks__/fs.js
@@ -11,6 +11,7 @@ fs.__setMockFileWriter = (writer) => {
   fs.writeFileSync = writer;
 };
 
+fs.lstatSync = (...args) => actualFs.lstatSync(...args);
 fs.readFileSync = (...args) => data || actualFs.readFileSync(...args);
 fs.statSync = actualFs.statSync; // used by cosmiconfig
 fs.writeFileSync = undefined;

--- a/scripts/rnx-dep-check.js
+++ b/scripts/rnx-dep-check.js
@@ -3,11 +3,6 @@
 "use strict";
 
 module.exports = {
-  "@rnx-kit/tools-node": {
-    name: "@rnx-kit/tools-node",
-    version: "^1.2.7",
-    devOnly: true,
-  },
   "@types/jest": {
     name: "@types/jest",
     version: "^27.0.0",


### PR DESCRIPTION
### Description

dep-check fails to visit dependencies in a repository using pnpm or pnpm-like solutions

### Test plan

Use the same repro as in #1581, but run `yarn check-deps` instead of starting Metro dev server.