### PR TITLE
fix(jest-preset): use public `loadConfig` if it exists

### DIFF
--- a/.changeset/tame-rabbits-double.md
+++ b/.changeset/tame-rabbits-double.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/jest-preset": patch
+---
+
+Use publicly exported `loadConfig` if it exists

--- a/nx.json
+++ b/nx.json
@@ -22,6 +22,9 @@
     "update-readme": ["build"]
   },
   "implicitDependencies": {
+    "packages/eslint-config/*": "*",
+    "packages/eslint-plugin/*": "*",
+    "packages/jest-preset/*": "*",
     "yarn.lock": "*"
   },
   "affected": {

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -51,7 +51,10 @@
     ]
   },
   "eslintConfig": {
-    "extends": "@rnx-kit/eslint-config"
+    "extends": "@rnx-kit/eslint-config",
+    "rules": {
+      "@typescript-eslint/ban-ts-comment": "off"
+    }
   },
   "jest": {
     "preset": "@rnx-kit/scripts"

--- a/packages/jest-preset/src/index.js
+++ b/packages/jest-preset/src/index.js
@@ -79,7 +79,8 @@ function getTargetPlatform(defaultPlatform) {
 
   /** @type {() => CLIConfig} */
   const loadConfig =
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore could not find a declaration file
+    require("@react-native-community/cli").loadConfig ||
     // @ts-ignore could not find a declaration file
     require("@react-native-community/cli/build/tools/config").default;
 


### PR DESCRIPTION
### Description

We should use the publicly exported `loadConfig` when possible.

### Test plan

All current tests should pass.