### PR TITLE
fix(metro-resolver-symlinks): don't interfere with browser redirection

### DIFF
--- a/.changeset/new-geckos-kneel.md
+++ b/.changeset/new-geckos-kneel.md
@@ -2,4 +2,4 @@
 "@rnx-kit/metro-resolver-symlinks": patch
 ---
 
-Metro enters a different code path than it should have when `resolveRequest` is set and the target package uses the `browser` field to redirect modules. If detected, we need to unset `resolveRequest` and retry with Metro's resolver to avoid interference.
+Fix `browser` field module redirection not being handled correctly

--- a/.changeset/new-geckos-kneel.md
+++ b/.changeset/new-geckos-kneel.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Metro enters a different code path than it should have when `resolveRequest` is set and the target package uses the `browser` field to redirect modules. If detected, we need to unset `resolveRequest` and retry with Metro's resolver to avoid interference.

--- a/packages/metro-resolver-symlinks/src/symlinkResolver.ts
+++ b/packages/metro-resolver-symlinks/src/symlinkResolver.ts
@@ -33,6 +33,8 @@ export function makeResolver({
       // is set and the target package uses the `browser` field to redirect
       // modules. If detected, we need to unset `resolveRequest` and retry with
       // Metro's resolver to avoid interference.
+      //
+      // Ref: https://github.com/facebook/metro/blob/v0.67.0/packages/metro-resolver/src/resolve.js#L59
       if (
         typeof requestedModuleName === "string" &&
         requestedModuleName !== moduleName

--- a/packages/metro-resolver-symlinks/src/symlinkResolver.ts
+++ b/packages/metro-resolver-symlinks/src/symlinkResolver.ts
@@ -1,5 +1,5 @@
 import { normalizePath } from "@rnx-kit/tools-node";
-import type { CustomResolver } from "metro-resolver";
+import type { CustomResolver, ResolutionContext } from "metro-resolver";
 import {
   getMetroResolver,
   remapReactNativeModule,
@@ -14,7 +14,12 @@ export function makeResolver({
   const metroResolver = getMetroResolver();
   const remappers = [remapModule, remapReactNativeModule, resolveModulePath];
 
-  const symlinkResolver: MetroResolver = (context, moduleName, platform) => {
+  const symlinkResolver = (
+    context: ResolutionContext,
+    moduleName: string,
+    platform: string | null,
+    requestedModuleName?: string
+  ) => {
     if (!platform) {
       throw new Error("No platform was specified");
     }
@@ -23,6 +28,19 @@ export function makeResolver({
     const resolveRequest = context.resolveRequest;
     if (resolveRequest === symlinkResolver) {
       delete context.resolveRequest;
+
+      // If the module was redirected using the `browser` field, we need to let
+      // Metro handle this without interfering.
+      if (
+        typeof requestedModuleName === "string" &&
+        requestedModuleName !== moduleName
+      ) {
+        try {
+          return resolve(context, requestedModuleName, platform, null);
+        } finally {
+          context.resolveRequest = resolveRequest;
+        }
+      }
     } else if (resolveRequest) {
       resolve = resolveRequest;
     }
@@ -46,7 +64,7 @@ export function makeResolver({
       }
     }
   };
-  return symlinkResolver;
+  return symlinkResolver as MetroResolver;
 }
 
 makeResolver.remapImportPath = remapImportPath;

--- a/packages/metro-resolver-symlinks/src/symlinkResolver.ts
+++ b/packages/metro-resolver-symlinks/src/symlinkResolver.ts
@@ -29,8 +29,10 @@ export function makeResolver({
     if (resolveRequest === symlinkResolver) {
       delete context.resolveRequest;
 
-      // If the module was redirected using the `browser` field, we need to let
-      // Metro handle this without interfering.
+      // Metro enters a different code path than it should when `resolveRequest`
+      // is set and the target package uses the `browser` field to redirect
+      // modules. If detected, we need to unset `resolveRequest` and retry with
+      // Metro's resolver to avoid interference.
       if (
         typeof requestedModuleName === "string" &&
         requestedModuleName !== moduleName


### PR DESCRIPTION
### Description

Metro enters a different code path than it should when `resolveRequest` is set and the target package uses the `browser` field to redirect modules. If detected, we need to unset `resolveRequest` and retry with Metro's resolver to avoid interference.

Resolves #1548.

### Test plan

1. Add `engine.io-client` to test app:
   ```diff
   diff --git a/packages/test-app/package.json b/packages/test-app/package.json
   index adf5a430..ea415f64 100644
   --- a/packages/test-app/package.json
   +++ b/packages/test-app/package.json
   @@ -45,6 +45,7 @@
        "@rnx-kit/scripts": "*",
        "@types/react": "^17.0.2",
        "@types/react-native": "^0.64.0",
   +    "engine.io-client": "3",
        "metro-react-native-babel-preset": "^0.66.2",
        "react-native-codegen": "^0.0.7",
        "react-native-test-app": "^1.0.6",
   diff --git a/packages/test-app/src/App.native.tsx b/packages/test-app/src/App.native.tsx
   index 2c89368b..f401b505 100644
   --- a/packages/test-app/src/App.native.tsx
   +++ b/packages/test-app/src/App.native.tsx
   @@ -18,7 +18,10 @@ import {
    } from "react-native/Libraries/NewAppScreen";
    import manifest from "../app.json";
   
   +require("engine.io-client");
   +
    const App = (): React.ReactElement => {
      const startAcquireToken = React.useCallback(async () => {
        try {
          const authConfig = manifest["react-native-test-app-msal"];
   ```
2. Install and build test app:
   ```
   yarn
   cd packages/test-app
   yarn build --dependencies
   ```
3. Start Metro dev server:
   ```
   yarn start
   ```
4. In a different terminal, trigger the bundle: 
   ```
   curl -v 'http://localhost:8081/index.bundle?platform=ios'
   ```