### PR TITLE
fix(react-native-auth): rename `acquireToken` to fit Swift naming conventions

### DIFF
--- a/.changeset/five-zebras-doubt.md
+++ b/.changeset/five-zebras-doubt.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-test-app-msal": patch
+---
+
+Fix git tag format in podspec

--- a/.changeset/plenty-plums-attack.md
+++ b/.changeset/plenty-plums-attack.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-auth": patch
+---
+
+Rename `acquireToken` to better fit Swift naming conventions

--- a/packages/react-native-auth/ios/RNXAuthModule.h
+++ b/packages/react-native-auth/ios/RNXAuthModule.h
@@ -50,7 +50,8 @@ typedef void (^TokenAcquiredHandler)(RNXAuthResult *_Nullable result,
 - (void)acquireTokenWithScopes:(NSArray<NSString *> *)scopes
              userPrincipalName:(NSString *)userPrincipalName
                    accountType:(RNXAccountType)accountType
-               onTokenAcquired:(TokenAcquiredHandler)onTokenAcquired;
+               onTokenAcquired:(TokenAcquiredHandler)onTokenAcquired
+    NS_SWIFT_NAME(acquireToken(scopes:userPrincipalName:accountType:onTokenAcquired:));
 
 @end
 

--- a/packages/react-native-test-app-msal/ReactTestApp-MSAL.podspec
+++ b/packages/react-native-test-app-msal/ReactTestApp-MSAL.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.author    = { package['author']['name'] => package['author']['email'] }
   s.license   = package['license']
   s.homepage  = package['homepage']
-  s.source    = { :git => package['repository']['url'], :tag => "#{package['name']}_v#{version}" }
+  s.source    = { :git => package['repository']['url'], :tag => "#{package['name']}@#{version}" }
   s.summary   = package['description']
 
   s.ios.deployment_target = '14.0'

--- a/packages/test-app/ios/Podfile.lock
+++ b/packages/test-app/ios/Podfile.lock
@@ -284,7 +284,7 @@ PODS:
     - MSAL
     - RNXAuth
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNXAuth (0.1.0):
+  - RNXAuth (0.1.1):
     - React-Core
   - SwiftLint (0.46.2)
   - Yoga (1.14.0)
@@ -440,7 +440,7 @@ SPEC CHECKSUMS:
   ReactTestApp-DevSupport: 1075d13c9f78457e4e7365dffb30f131e5b16a5b
   ReactTestApp-MSAL: 01ce59a7dccd3b099f6de76d1bc0b1ea9b24d88a
   ReactTestApp-Resources: 74a1cf509f4e7962b16361ea4e73cba3648fff5d
-  RNXAuth: c9e39e4206fd4c5e11144951d7955051da7c35ca
+  RNXAuth: 60c26d03e192279f9880da69e2876cc90786769d
   SwiftLint: 6bc52a21f0fd44cab9aa2dc8e534fb9f5e3ec507
   Yoga: e7dc4e71caba6472ff48ad7d234389b91dadc280
 


### PR DESCRIPTION
### Description

If we don't explicitly specify the signature, Swift will rename it to `acquireToken(withScopes:userPrincipalName:accountType:onTokenAcquired:)`

### Test plan

n/a