### PR TITLE
fix: enable `resolveSymlinks` and remove dupe code

### DIFF
--- a/.changeset/shy-nails-fly.md
+++ b/.changeset/shy-nails-fly.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/metro-config": patch
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Enable `resolveSymlinks` and remove dupe code

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -1,7 +1,6 @@
 /* jshint esversion: 8, node: true */
 // @ts-check
 
-const fs = require("fs");
 const path = require("path");
 
 /**
@@ -63,17 +62,10 @@ function defaultWatchFolders(projectRoot) {
  */
 function resolveModule(name, startDir) {
   const { findPackageDependencyDir } = require("@rnx-kit/tools-node/package");
-  const result = findPackageDependencyDir(name, {
+  return findPackageDependencyDir(name, {
     startDir,
-    allowSymlinks: true,
+    resolveSymlinks: true,
   });
-  if (!result) {
-    return undefined;
-  }
-
-  return fs.lstatSync(result).isSymbolicLink()
-    ? path.resolve(path.dirname(result), fs.readlinkSync(result))
-    : result;
 }
 
 /**

--- a/packages/metro-resolver-symlinks/src/resolver.ts
+++ b/packages/metro-resolver-symlinks/src/resolver.ts
@@ -5,19 +5,18 @@ import {
   readPackage,
 } from "@rnx-kit/tools-node";
 import { getAvailablePlatforms } from "@rnx-kit/tools-react-native";
-import * as fs from "fs";
 import * as path from "path";
 import type { MetroResolver, ModuleResolver } from "./types";
 
 function resolveFrom(moduleName: string, startDir: string): string {
-  const p = findPackageDependencyDir(moduleName, { startDir });
+  const p = findPackageDependencyDir(moduleName, {
+    startDir,
+    resolveSymlinks: true,
+  });
   if (!p) {
     throw new Error(`Cannot find module '${moduleName}'`);
   }
-
-  return fs.lstatSync(p).isSymbolicLink()
-    ? path.resolve(path.dirname(p), fs.readlinkSync(p))
-    : p;
+  return p;
 }
 
 /**


### PR DESCRIPTION
### Description

Enable new `resolveSymlinks` setting and remove dupe code.

### Test plan

Existing tests should pass.