### PR TITLE
fix(metro-resolver-symlinks): fix handling of empty modules

### DIFF
--- a/.changeset/light-dodos-juggle.md
+++ b/.changeset/light-dodos-juggle.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Fix empty modules not being handled correctly

--- a/packages/metro-resolver-symlinks/src/symlinkResolver.ts
+++ b/packages/metro-resolver-symlinks/src/symlinkResolver.ts
@@ -20,10 +20,6 @@ export function makeResolver({
     platform: string | null,
     requestedModuleName?: string
   ) => {
-    if (!platform) {
-      throw new Error("No platform was specified");
-    }
-
     let resolve: CustomResolver = metroResolver;
     const resolveRequest = context.resolveRequest;
     if (resolveRequest === symlinkResolver) {
@@ -50,6 +46,13 @@ export function makeResolver({
     }
 
     try {
+      // If a module was excluded, `_getEmptyModule()` will be called with no
+      // platform set. We should let Metro handle this without interfering. See
+      // https://github.com/facebook/metro/blob/e7419900d2e063f2d531313f810d18c487f807f8/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js#L97
+      if (!platform) {
+        return resolve(context, moduleName, platform, null);
+      }
+
       const modifiedModuleName = remappers.reduce(
         (modifiedName, remap) => remap(context, modifiedName, platform),
         moduleName

--- a/packages/metro-resolver-symlinks/src/symlinkResolver.ts
+++ b/packages/metro-resolver-symlinks/src/symlinkResolver.ts
@@ -48,7 +48,7 @@ export function makeResolver({
     try {
       // If a module was excluded, `_getEmptyModule()` will be called with no
       // platform set. We should let Metro handle this without interfering. See
-      // https://github.com/facebook/metro/blob/e7419900d2e063f2d531313f810d18c487f807f8/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js#L97
+      // https://github.com/facebook/metro/blob/v0.71.0/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js#L97
       if (!platform) {
         return resolve(context, moduleName, platform, null);
       }


### PR DESCRIPTION
### Description

Fix empty modules not being handled correctly. This happens when modules are excluded.

Resolves #1605.

### Test plan

```
git clone https://github.com/infinitered/ignite.git
cd ignite/boilerplate
git checkout issue-1942-react-state-update-bug
git chekcout 9d1c648da438079f2ff05963c2c0d42d3d2786e2 -- metro.config.js
pnpm i
pnpm ios
```