### PR TITLE
fix (docs): add more links to the default capabilities table

### DIFF
--- a/.changeset/fifty-hounds-march.md
+++ b/.changeset/fifty-hounds-march.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/docsite": patch
+---
+
+Adding more references to the default list of capabilities

--- a/docsite/docs/dependencies.md
+++ b/docsite/docs/dependencies.md
@@ -72,7 +72,9 @@ const profile_0_67: Profile = {
 ```
 
 Each React Native release >= 0.61 has its own base profile
-[in this folder](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check/src/presets/microsoft).
+[in this folder](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check/src/presets/microsoft),
+and you can tailor your local configuration by following this
+[customization guide](/docs/guides/dependency-management#customization).
 
 ## Meta Capabilities
 

--- a/docsite/docs/dependencies.md
+++ b/docsite/docs/dependencies.md
@@ -17,7 +17,9 @@ it uses that knowledge to keep your app healthy and up-to-date.
 
 The magic is in the data that comes with the dependency manager -- capabilities
 and profiles. Together, they describe a _curated_ and _tested_ list of packages
-that work with each major release of React Native.
+that work with each major release of React Native; you can find the full list of
+capabilities (_name & corresponding package_) that are supported by default
+[in this table](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check#capabilities).
 
 A capability is something your app needs to function. It has a well-known name,
 and it maps to a specific package and version:
@@ -48,7 +50,7 @@ const capabilities = {
 ```
 
 A profile is a collection of capabilities, known to work well with a specific
-release of React Native. Each React Native release has its own profile.
+release of React Native:
 
 ```typescript
 const reactNative: Package = {
@@ -68,6 +70,9 @@ const profile_0_67: Profile = {
   // ... etc ...
 };
 ```
+
+Each React Native release >= 0.61 has its own base profile
+[in this folder](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check/src/presets/microsoft).
 
 ## Meta Capabilities
 

--- a/docsite/docs/guides/dependency-management.mdx
+++ b/docsite/docs/guides/dependency-management.mdx
@@ -189,9 +189,10 @@ command with a `--write` parameter.
 
 ### Dependency Manager Updates
 
-The dependency manager comes with a built-in list of known/good React Native
-package versions and releases. Keeping the dependency manager up-to-date gives
-you the latest compatibility data.
+The dependency manager comes with a
+[built-in list](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check#capabilities)
+of known/good React Native package versions and releases. Keeping the dependency
+manager up-to-date gives you the latest compatibility data.
 
 If you are in GitHub, use Dependabot to keep your packages up-to-date, including
 the dependency manager. If you host your repo elsewhere, you can use tools like
@@ -233,7 +234,7 @@ as "0.66" or "0.68".
 ## Customization
 
 Did you know that you can add your own packages to the dependency manager's
-built-in list?
+[built-in list](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check#capabilities)?
 
 If your repo uses React Native packages that aren't known to the dependency
 manager, add them to the list! Or if you want to align other dependencies


### PR DESCRIPTION
### Description

This PR wants to add some more clarity around how rnx-kit has a default set of capabilities and link to that table, to avoid confusion as it happened here: https://github.com/microsoft/rnx-kit/issues/1621

### Test plan

N/A