### PR TITLE
fix(build): also cancel build when terminating

### DIFF
--- a/.changeset/smart-kings-rush.md
+++ b/.changeset/smart-kings-rush.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+Cancel remote job when user terminates

--- a/incubator/build/README.md
+++ b/incubator/build/README.md
@@ -54,7 +54,7 @@ yarn rnx-build
   - [x] Implement proper CLI
   - [x] Download build artifacts to platform specific folders
   - [x] iOS: Detect workspace to build
-- [ ] Cancel build job when user ctrl+c in the terminal
+- [x] Cancel build job when user ctrl+c in the terminal
 - [ ] Figure out appropriate storage for auth tokens
 - [ ] Add `init` or `install` command to copy the correct workflow file to
       user's repo

--- a/incubator/build/package.json
+++ b/incubator/build/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@rnx-kit/build",
   "version": "0.0.0",
-  "description": "EXPERIMENTAL - USE WITH CAUTION - New package called build",
+  "description": "EXPERIMENTAL - USE WITH CAUTION - @rnx-kit/build builds your app in the cloud",
   "homepage": "https://github.com/microsoft/rnx-kit/tree/main/incubator/build#readme",
   "license": "MIT",
   "author": {

--- a/incubator/build/src/types.ts
+++ b/incubator/build/src/types.ts
@@ -26,4 +26,5 @@ export type Context = RepositoryInfo & {
 export type Remote = {
   isSetUp(spinner: Ora): boolean;
   build(context: Context, inputs: BuildParams, spinner: Ora): Promise<string>;
+  cancelBuild(context: Context): Promise<void>;
 };


### PR DESCRIPTION
### Description

`ctrl+c` should also cancel the remote job.

### Test plan

1. Start a build, e.g.: `yarn rnx-build --platform ios --project-root ../../packages/test-app`
2. Press `ctrl+c` after a build has been queued

Example output:
```
✔ Created build branch rnx-build/tido/rnx-build-cancel-build/20220521-082250.238-ab773281
✔ Build queued: https://github.com/tido64/rnx-kit/actions/runs/2534030903
✖ Starting build
⠋ Cancelling build
✔ Deleted rnx-build/tido/rnx-build-cancel-build/20220521-082250.238-ab773281
```
