### PR TITLE
fix(build): add macOS and Windows support

### DIFF
--- a/.changeset/fair-drinks-care.md
+++ b/.changeset/fair-drinks-care.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-test-app-msal": patch
+---
+
+Fixed build fail on macOS

--- a/.changeset/rare-starfishes-turn.md
+++ b/.changeset/rare-starfishes-turn.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+Added macOS support

--- a/.changeset/thin-dragons-float.md
+++ b/.changeset/thin-dragons-float.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+Added Windows support

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -2,6 +2,10 @@ name: rnx-build
 on:
   workflow_dispatch:
     inputs:
+      architecture:
+        description: "Supported architectures are `arm64`, `x64`"
+        required: true
+        default: "x64"
       packageManager:
         description: "Supported package managers are `npm`, `yarn`, `pnpm` (v6.10+)"
         required: true
@@ -79,3 +83,78 @@ jobs:
         with:
           name: ios-artifact
           path: ${{ github.event.inputs.projectRoot }}/ios/ios-artifact.tar
+  build-macos:
+    name: "Build macOS"
+    if: ${{ github.event.inputs.platform == 'macos' }}
+    runs-on: macos-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Node 16
+        uses: actions/setup-node@v3.3.0
+        with:
+          node-version: 16
+          cache: ${{ github.event.inputs.packageManager }}
+      - name: Install npm dependencies
+        run: ${{ github.event.inputs.packageManager }} install
+      - name: Install Pods
+        run: pod install --project-directory=macos
+        working-directory: ${{ github.event.inputs.projectRoot }}
+      - name: Build macOS app
+        run: |
+          xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
+          xcodebuild -workspace ${xcworkspace} -scheme ReactTestApp -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build
+        working-directory: ${{ github.event.inputs.projectRoot }}/macos
+      - name: Prepare build artifact
+        run: |
+          tar -cvf macos-artifact.tar -C DerivedData/Build/Products/Debug ReactTestApp.app
+          shasum --algorithm 512 macos-artifact.tar
+        working-directory: ${{ github.event.inputs.projectRoot }}/macos
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: macos-artifact
+          path: ${{ github.event.inputs.projectRoot }}/macos/macos-artifact.tar
+  build-windows:
+    name: "Build Windows"
+    if: ${{ github.event.inputs.platform == 'windows' }}
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up MSBuild
+        uses: microsoft/setup-msbuild@v1.1
+      - name: Set up Node 16
+        uses: actions/setup-node@v3.3.0
+        with:
+          node-version: 16
+          cache: ${{ github.event.inputs.packageManager }}
+      - name: Install npm dependencies
+        run: ${{ github.event.inputs.packageManager }} install
+      - name: Install Windows test app
+        run: |
+          npx --package react-native-test-app -- install-windows-test-app --use-nuget
+        working-directory: ${{ github.event.inputs.projectRoot }}
+      - name: Set OID for unsigned packages
+        run: |
+          # https://docs.microsoft.com/en-us/windows/msix/package/unsigned-package
+          (Get-Content node_modules\.generated\windows\ReactTestApp\Package.appxmanifest) -replace '"CN=ReactTestApp"', '"CN=ReactTestApp, OID.2.25.311729368913984317654407730594956997722=1"' | Out-File -Encoding utf8 node_modules\.generated\windows\ReactTestApp\Package.appxmanifest
+        working-directory: ${{ github.event.inputs.projectRoot }}
+      - name: Install NuGet packages
+        run: |
+          nuget restore
+        working-directory: ${{ github.event.inputs.projectRoot }}/windows
+      - name: Build Windows app
+        run: |
+          MSBuild -maxCpuCount -property:Configuration=Debug -property:Platform=${{ github.event.inputs.architecture }} -property:AppxBundlePlatforms=${{ github.event.inputs.architecture }} -property:AppxBundle=Always -property:UapAppxPackageBuildMode=SideloadOnly -property:UseBundle=false -target:Build
+        working-directory: ${{ github.event.inputs.projectRoot }}/windows
+      - name: Prepare build artifact
+        run: |
+          cp ${{ github.event.inputs.architecture }}/Debug/ReactTestApp/AppxManifest.xml AppPackages/ReactTestApp/*
+        shell: bash
+        working-directory: ${{ github.event.inputs.projectRoot }}/windows
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-artifact
+          path: ${{ github.event.inputs.projectRoot }}/windows/AppPackages/ReactTestApp

--- a/incubator/build/README.md
+++ b/incubator/build/README.md
@@ -9,7 +9,7 @@
 
 🚧🚧🚧🚧🚧🚧🚧🚧🚧🚧🚧
 
-An experimental tool for building your native apps in the cloud.
+An experimental tool for building your apps in the cloud.
 
 ## Requirements
 
@@ -24,13 +24,14 @@ An experimental tool for building your native apps in the cloud.
 
 🚧 TODO: Not quite ready for general consumption
 
-At the moment, running these two commands should trigger an iOS build, install
-it in a simulator, and launch the app.
-
 ```sh
-yarn build
-yarn rnx-build
+npm run rnx-build --platform <platform>
 ```
+
+| Flag           | Description                                                  |
+| :------------- | :----------------------------------------------------------- |
+| -p, --platform | Supported platforms are `android`, `ios`, `macos`, `windows` |
+| --project-root | [Optional] Path to the root of the project                   |
 
 ## Contributors' Notes
 
@@ -59,14 +60,9 @@ yarn rnx-build
 - [x] Cancel build job when user ctrl+c in the terminal
 - [x] Add `init` or `install` command to copy the correct workflow file to
       user's repo
-- [ ] Install currently only works for Windows 11, we need to support 10
+- [ ] Windows: Install currently only works on Windows 11, we need to support 10
 - [ ] Figure out appropriate storage for auth tokens
 - [ ] Figure out how to install artifacts with QR code
 - [ ] Figure out caching
 - [ ] Figure out how to skip native build when cached
 - [ ] Replace yauzl with something more native
-
-### Open Questions
-
-- Can we avoid depending on Android SDK?
-- Can we avoid depending on Xcode?

--- a/incubator/build/README.md
+++ b/incubator/build/README.md
@@ -61,6 +61,8 @@ npm run rnx-build --platform <platform>
 - [x] Add `init` or `install` command to copy the correct workflow file to
       user's repo
 - [ ] Windows: Install currently only works on Windows 11, we need to support 10
+- [ ] Build artifacts are currently hard-coded to look for ReactTestApp
+- [ ] Verify downloaded build artifacts using checksum
 - [ ] Figure out appropriate storage for auth tokens
 - [ ] Figure out how to install artifacts with QR code
 - [ ] Figure out caching

--- a/incubator/build/README.md
+++ b/incubator/build/README.md
@@ -42,27 +42,29 @@ yarn rnx-build
 - [x] Figure out how to push artifacts
   - [x] Android
   - [x] iOS
+  - [x] macOS
+  - [x] Windows
 - [x] Figure out how to download artifacts
-  - [x] Android
-  - [x] iOS
 - [ ] Figure out how to install artifacts
   - [x] Android emulator
   - [ ] Android device
   - [x] iOS simulator
   - [ ] iOS device
+  - [x] macOS
+  - [x] Windows
 - [x] Miscellaneous cleanup
   - [x] Implement proper CLI
   - [x] Download build artifacts to platform specific folders
   - [x] iOS: Detect workspace to build
 - [x] Cancel build job when user ctrl+c in the terminal
-- [ ] Figure out appropriate storage for auth tokens
 - [x] Add `init` or `install` command to copy the correct workflow file to
       user's repo
+- [ ] Install currently only works for Windows 11, we need to support 10
+- [ ] Figure out appropriate storage for auth tokens
 - [ ] Figure out how to install artifacts with QR code
 - [ ] Figure out caching
 - [ ] Figure out how to skip native build when cached
-- [ ] Implement support for macOS
-- [ ] Implement support for Windows
+- [ ] Replace yauzl with something more native
 
 ### Open Questions
 

--- a/incubator/build/package.json
+++ b/incubator/build/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@octokit/core": "^3.6.0",
     "@octokit/plugin-rest-endpoint-methods": "^5.14.0",
+    "fast-xml-parser": "^4.0.8",
     "ora": "^5.4.1",
     "pkg-dir": "^5.0.0",
     "yargs": "^16.0.0",

--- a/incubator/build/src/archive.ts
+++ b/incubator/build/src/archive.ts
@@ -1,28 +1,60 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import yauzl from "yauzl";
+import { ensure, makeCommand } from "./command";
 
 export function extract(filename: string): Promise<string> {
   return new Promise((resolve, reject) => {
+    const mkdirOptions = { recursive: true, mode: 0o755 } as const;
     const destination = path.dirname(filename);
+
     yauzl.open(filename, { lazyEntries: true }, (err, zipFile) => {
       if (err) {
         reject(err);
       }
 
-      zipFile.readEntry();
+      const readNextEntry = () => zipFile.readEntry();
+      let output = "";
+
       zipFile.on("entry", (entry) => {
         zipFile.openReadStream(entry, (err, readStream) => {
           if (err) {
             reject(err);
           }
 
-          const entryFilename = path.join(destination, entry.fileName);
-          readStream
-            .pipe(fs.createWriteStream(entryFilename))
-            .once("finish", () => resolve(entryFilename));
+          const absolutePath = path.join(destination, entry.fileName);
+
+          // Our workflows will always produce build artifacts that are either
+          // an APK (Android), an archive (iOS/macOS), or a folder (Windows).
+          output ||= absolutePath;
+
+          if (absolutePath.endsWith("/") || absolutePath.endsWith("\\")) {
+            fs.mkdir(absolutePath, mkdirOptions, readNextEntry);
+          } else {
+            readStream
+              .pipe(fs.createWriteStream(absolutePath))
+              .once("finish", readNextEntry);
+          }
         });
       });
+      zipFile.once("end", () => resolve(output));
+
+      readNextEntry();
     });
   });
+}
+
+export async function untar(archive: string): Promise<string> {
+  const buildDir = path.dirname(archive);
+  const tar = makeCommand("tar", { cwd: buildDir });
+
+  const filename = path.basename(archive);
+  const list = ensure(await tar("tf", filename));
+  const m = list.match(/(.*?)\//);
+  if (!m) {
+    throw new Error(`Failed to determine content of ${archive}`);
+  }
+
+  ensure(await tar("xf", filename));
+  return path.join(buildDir, m[1]);
 }

--- a/incubator/build/src/async.ts
+++ b/incubator/build/src/async.ts
@@ -2,6 +2,19 @@ export function idle(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export async function retry<R>(
+  func: () => Promise<R | null>,
+  retries: number,
+  counter = 0
+): Promise<R | null> {
+  const result = await func();
+  if (result === null && retries > 1) {
+    await idle(Math.pow(2, counter) * 1000);
+    return retry(func, retries - 1, counter + 1);
+  }
+  return result;
+}
+
 export async function withRetries<R>(
   func: () => Promise<R>,
   retries: number,

--- a/incubator/build/src/build.ts
+++ b/incubator/build/src/build.ts
@@ -3,6 +3,8 @@ import { extract } from "./archive";
 import { deleteBranch, pushCurrentChanges } from "./git";
 import { installAndLaunchApk } from "./platforms/android";
 import { installAndLaunchApp } from "./platforms/ios";
+import * as macos from "./platforms/macos";
+import * as windows from "./platforms/windows";
 import type { BuildParams, Remote, RepositoryInfo } from "./types";
 
 export async function startBuild(
@@ -57,6 +59,12 @@ export async function startBuild(
         break;
       case "ios":
         await installAndLaunchApp(buildArtifact, undefined, spinner);
+        break;
+      case "macos":
+        await macos.launch(buildArtifact, spinner);
+        break;
+      case "windows":
+        await windows.launch(buildArtifact, spinner);
         break;
       default:
         break;

--- a/incubator/build/src/index.ts
+++ b/incubator/build/src/index.ts
@@ -23,7 +23,6 @@ async function main(): Promise<void> {
     return;
   }
 
-  const repoRoot = getRepositoryRoot();
   const argv = yargs(hideBin(process.argv))
     .option("platform", {
       alias: "p",
@@ -36,9 +35,10 @@ async function main(): Promise<void> {
     .option("project-root", {
       type: "string",
       description: "Root of project",
-      default: path.relative(repoRoot, pkgDir.sync() || process.cwd()),
+      default: pkgDir.sync() || process.cwd(),
       coerce: (value) => {
         // `projectRoot` needs to be relative to repository root
+        const repoRoot = getRepositoryRoot();
         return path.relative(repoRoot, path.resolve(process.cwd(), value));
       },
     }).argv;

--- a/incubator/build/src/platforms/macos.ts
+++ b/incubator/build/src/platforms/macos.ts
@@ -15,5 +15,6 @@ export async function launch(archive: string, spinner: Ora): Promise<void> {
 
   spinner.text = `Launching ${app}`;
   await open(app);
+
   spinner.succeed(`Launched ${app}`);
 }

--- a/incubator/build/src/platforms/macos.ts
+++ b/incubator/build/src/platforms/macos.ts
@@ -1,0 +1,19 @@
+import * as os from "node:os";
+import type { Ora } from "ora";
+import { untar } from "../archive";
+import { makeCommand } from "../command";
+
+export const open = makeCommand("open");
+
+export async function launch(archive: string, spinner: Ora): Promise<void> {
+  if (os.platform() !== "darwin") {
+    return;
+  }
+
+  spinner.start(`Extracting ${archive}`);
+  const app = await untar(archive);
+
+  spinner.text = `Launching ${app}`;
+  await open(app);
+  spinner.succeed(`Launched ${app}`);
+}

--- a/incubator/build/src/platforms/windows.ts
+++ b/incubator/build/src/platforms/windows.ts
@@ -1,0 +1,127 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Ora } from "ora";
+import { retry } from "../async";
+import { makeCommand } from "../command";
+
+type PackageInfo = {
+  packageName: string;
+  appId: string;
+};
+
+function makePowerShell(
+  cwd: string,
+  elevated = false
+): ReturnType<typeof makeCommand> {
+  const withPowerShell = { cwd, shell: "powershell" };
+  const prelude = [
+    "-NoLogo",
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-Command",
+  ];
+  if (elevated) {
+    const start = makeCommand("Start-Process", withPowerShell);
+    const startArgs = prelude.join(" ");
+    return (...args: string[]) =>
+      start(
+        "-FilePath",
+        "powershell",
+        "-ArgumentList",
+        `'${startArgs} "${args.join(" ")}"'`,
+        "-PassThru",
+        "-Verb",
+        "RunAs"
+      );
+  } else {
+    const ps = makeCommand("powershell", withPowerShell);
+    return (...args: string[]) => ps(...prelude, `"${args.join(" ")}"`);
+  }
+}
+
+async function getPackageInfo(app: string): Promise<PackageInfo | null> {
+  const filename = path.join(app, "AppxManifest.xml");
+  const manifest = await fs.readFile(filename, { encoding: "utf-8" });
+  const m = manifest.match(/<Identity[^>]*Name="(.*?)"/s);
+  const packageName = m && m[1];
+  if (!packageName) {
+    return null;
+  }
+
+  const n = manifest.match(/<Application[^>]*Id="(.*?)"/s);
+  const appId = n && n[1];
+  if (!appId) {
+    return null;
+  }
+
+  return { packageName, appId };
+}
+
+async function install(app: string): Promise<string | Error> {
+  const packageInfo = await getPackageInfo(app);
+  if (!packageInfo) {
+    return new Error(
+      "Failed to get package name and/or app id from build artifact"
+    );
+  }
+
+  const files = await fs.readdir(app);
+  const msixbundle = files.find((file) => file.endsWith(".msixbundle"));
+  if (!msixbundle) {
+    return new Error("Missing MSIX package from build artifact");
+  }
+
+  const pwsh = makePowerShell(app);
+  const pwshElevated = makePowerShell(app, true);
+
+  const { stderr, status } = await pwshElevated(
+    "Add-AppxPackage",
+    "-AllowUnsigned",
+    path.join(app, msixbundle)
+  );
+  if (status !== 0) {
+    if (stderr?.includes("Install failed")) {
+      const { stdout: packageFullName } = await pwsh(
+        `(Get-AppxPackage ${packageInfo.packageName}).PackageFullName`
+      );
+      if (packageFullName) {
+        await pwsh("Remove-AppxPackage", packageFullName);
+        return install(app);
+      }
+    }
+    return new Error(stderr);
+  }
+
+  // We're just waiting for the app to be "registered"
+  const { packageName, appId } = packageInfo;
+  const result = await retry(async () => {
+    const { stdout: packageFamilyName } = await pwsh(
+      `(Get-AppxPackage ${packageName}).PackageFamilyName`
+    );
+    return packageFamilyName ? packageFamilyName + "!" + appId : null;
+  }, 3);
+
+  return result || new Error("App failed to install?");
+}
+
+export async function launch(app: string, spinner: Ora): Promise<void> {
+  if (os.platform() !== "win32") {
+    return;
+  }
+
+  spinner.start(`Installing ${app}`);
+  const result = await install(app);
+  if (result instanceof Error) {
+    spinner.warn(result.message);
+    spinner.fail();
+    return;
+  }
+
+  spinner.text = `Launching ${result}`;
+  await makeCommand("explorer")("shell:AppsFolder\\" + result);
+
+  spinner.succeed(`Launched ${result}`);
+}

--- a/incubator/build/src/platforms/windows.ts
+++ b/incubator/build/src/platforms/windows.ts
@@ -1,3 +1,4 @@
+import { XMLParser } from "fast-xml-parser";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -44,15 +45,17 @@ function makePowerShell(
 
 async function getPackageInfo(app: string): Promise<PackageInfo | null> {
   const filename = path.join(app, "AppxManifest.xml");
-  const manifest = await fs.readFile(filename, { encoding: "utf-8" });
-  const m = manifest.match(/<Identity[^>]*Name="(.*?)"/s);
-  const packageName = m && m[1];
+  const content = await fs.readFile(filename, { encoding: "utf-8" });
+
+  const xml = new XMLParser({ ignoreAttributes: false });
+  const manifest = xml.parse(content);
+
+  const packageName = manifest?.Package?.Identity?.["@_Name"];
   if (!packageName) {
     return null;
   }
 
-  const n = manifest.match(/<Application[^>]*Id="(.*?)"/s);
-  const appId = n && n[1];
+  const appId = manifest.Package.Applications?.Application?.["@_Id"];
   if (!appId) {
     return null;
   }

--- a/incubator/build/src/remotes/github.ts
+++ b/incubator/build/src/remotes/github.ts
@@ -90,6 +90,10 @@ function getPersonalAccessToken(): string | undefined {
     return process.env.GITHUB_TOKEN;
   }
 
+  if (!fileExists(USER_CONFIG_FILE)) {
+    return undefined;
+  }
+
   const content = fileReadSync(USER_CONFIG_FILE, { encoding: "utf-8" });
   const config: Partial<UserConfig> = JSON.parse(content);
   return config?.tokens?.github;

--- a/incubator/build/workflows/github.yml
+++ b/incubator/build/workflows/github.yml
@@ -2,6 +2,10 @@ name: rnx-build
 on:
   workflow_dispatch:
     inputs:
+      architecture:
+        description: "Supported architectures are `arm64`, `x64`"
+        required: true
+        default: "x64"
       packageManager:
         description: "Supported package managers are `npm`, `yarn`, `pnpm` (v6.10+)"
         required: true
@@ -21,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v3.3.0
+        uses: actions/setup-java@v3.4.0
         with:
           distribution: temurin
           java-version: 11
@@ -33,7 +37,7 @@ jobs:
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Build Android app
-        uses: gradle/gradle-build-action@v2.2.0
+        uses: gradle/gradle-build-action@v2.2.1
         with:
           gradle-version: wrapper
           arguments: --no-daemon clean assembleDebug
@@ -79,3 +83,78 @@ jobs:
         with:
           name: ios-artifact
           path: ${{ github.event.inputs.projectRoot }}/ios/ios-artifact.tar
+  build-macos:
+    name: "Build macOS"
+    if: ${{ github.event.inputs.platform == 'macos' }}
+    runs-on: macos-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Node 16
+        uses: actions/setup-node@v3.3.0
+        with:
+          node-version: 16
+          cache: ${{ github.event.inputs.packageManager }}
+      - name: Install npm dependencies
+        run: ${{ github.event.inputs.packageManager }} install
+      - name: Install Pods
+        run: pod install --project-directory=macos
+        working-directory: ${{ github.event.inputs.projectRoot }}
+      - name: Build macOS app
+        run: |
+          xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
+          xcodebuild -workspace ${xcworkspace} -scheme ReactTestApp -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build
+        working-directory: ${{ github.event.inputs.projectRoot }}/macos
+      - name: Prepare build artifact
+        run: |
+          tar -cvf macos-artifact.tar -C DerivedData/Build/Products/Debug ReactTestApp.app
+          shasum --algorithm 512 macos-artifact.tar
+        working-directory: ${{ github.event.inputs.projectRoot }}/macos
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: macos-artifact
+          path: ${{ github.event.inputs.projectRoot }}/macos/macos-artifact.tar
+  build-windows:
+    name: "Build Windows"
+    if: ${{ github.event.inputs.platform == 'windows' }}
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up MSBuild
+        uses: microsoft/setup-msbuild@v1.1
+      - name: Set up Node 16
+        uses: actions/setup-node@v3.3.0
+        with:
+          node-version: 16
+          cache: ${{ github.event.inputs.packageManager }}
+      - name: Install npm dependencies
+        run: ${{ github.event.inputs.packageManager }} install
+      - name: Install Windows test app
+        run: |
+          npx --package react-native-test-app -- install-windows-test-app --use-nuget
+        working-directory: ${{ github.event.inputs.projectRoot }}
+      - name: Set OID for unsigned packages
+        run: |
+          # https://docs.microsoft.com/en-us/windows/msix/package/unsigned-package
+          (Get-Content node_modules\.generated\windows\ReactTestApp\Package.appxmanifest) -replace '"CN=ReactTestApp"', '"CN=ReactTestApp, OID.2.25.311729368913984317654407730594956997722=1"' | Out-File -Encoding utf8 node_modules\.generated\windows\ReactTestApp\Package.appxmanifest
+        working-directory: ${{ github.event.inputs.projectRoot }}
+      - name: Install NuGet packages
+        run: |
+          nuget restore
+        working-directory: ${{ github.event.inputs.projectRoot }}/windows
+      - name: Build Windows app
+        run: |
+          MSBuild -maxCpuCount -property:Configuration=Debug -property:Platform=${{ github.event.inputs.architecture }} -property:AppxBundlePlatforms=${{ github.event.inputs.architecture }} -property:AppxBundle=Always -property:UapAppxPackageBuildMode=SideloadOnly -property:UseBundle=false -target:Build
+        working-directory: ${{ github.event.inputs.projectRoot }}/windows
+      - name: Prepare build artifact
+        run: |
+          cp ${{ github.event.inputs.architecture }}/Debug/ReactTestApp/AppxManifest.xml AppPackages/ReactTestApp/*
+        shell: bash
+        working-directory: ${{ github.event.inputs.projectRoot }}/windows
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-artifact
+          path: ${{ github.event.inputs.projectRoot }}/windows/AppPackages/ReactTestApp

--- a/packages/react-native-test-app-msal/ios/RNXAuthMSALModule.m
+++ b/packages/react-native-test-app-msal/ios/RNXAuthMSALModule.m
@@ -4,7 +4,7 @@
 
 #if TARGET_OS_OSX
 #import <AppKit/NSViewController.h>
-typedef NSViewController RTAViewController
+typedef NSViewController RTAViewController;
 #else
 #import <UIKit/UIKit.h>
 typedef UIViewController RTAViewController;

--- a/packages/test-app/macos/Podfile.lock
+++ b/packages/test-app/macos/Podfile.lock
@@ -2,14 +2,14 @@ PODS:
   - boost (1.76.0)
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.66.14)
-  - FBReactNativeSpec (0.66.14):
+  - FBLazyVector (0.66.58)
+  - FBReactNativeSpec (0.66.58):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.66.14)
-    - RCTTypeSafety (= 0.66.14)
-    - React-Core (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - ReactCommon/turbomodule/core (= 0.66.14)
+    - RCTRequired (= 0.66.58)
+    - RCTTypeSafety (= 0.66.58)
+    - React-Core (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - ReactCommon/turbomodule/core (= 0.66.58)
   - fmt (6.2.1)
   - glog (0.3.5)
   - MSAL (1.1.26):
@@ -26,266 +26,266 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.66.14)
-  - RCTTypeSafety (0.66.14):
-    - FBLazyVector (= 0.66.14)
+  - RCTRequired (0.66.58)
+  - RCTTypeSafety (0.66.58):
+    - FBLazyVector (= 0.66.58)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.66.14)
-    - React-Core (= 0.66.14)
-  - React (0.66.14):
-    - React-Core (= 0.66.14)
-    - React-Core/DevSupport (= 0.66.14)
-    - React-Core/RCTWebSocket (= 0.66.14)
-    - React-RCTActionSheet (= 0.66.14)
-    - React-RCTAnimation (= 0.66.14)
-    - React-RCTBlob (= 0.66.14)
-    - React-RCTImage (= 0.66.14)
-    - React-RCTLinking (= 0.66.14)
-    - React-RCTNetwork (= 0.66.14)
-    - React-RCTSettings (= 0.66.14)
-    - React-RCTText (= 0.66.14)
-    - React-RCTVibration (= 0.66.14)
-  - React-callinvoker (0.66.14)
-  - React-Core (0.66.14):
+    - RCTRequired (= 0.66.58)
+    - React-Core (= 0.66.58)
+  - React (0.66.58):
+    - React-Core (= 0.66.58)
+    - React-Core/DevSupport (= 0.66.58)
+    - React-Core/RCTWebSocket (= 0.66.58)
+    - React-RCTActionSheet (= 0.66.58)
+    - React-RCTAnimation (= 0.66.58)
+    - React-RCTBlob (= 0.66.58)
+    - React-RCTImage (= 0.66.58)
+    - React-RCTLinking (= 0.66.58)
+    - React-RCTNetwork (= 0.66.58)
+    - React-RCTSettings (= 0.66.58)
+    - React-RCTText (= 0.66.58)
+    - React-RCTVibration (= 0.66.58)
+  - React-callinvoker (0.66.58)
+  - React-Core (0.66.58):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.14)
-    - React-cxxreact (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-jsiexecutor (= 0.66.14)
-    - React-perflogger (= 0.66.14)
+    - React-Core/Default (= 0.66.58)
+    - React-cxxreact (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-jsiexecutor (= 0.66.58)
+    - React-perflogger (= 0.66.58)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.66.14):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-jsiexecutor (= 0.66.14)
-    - React-perflogger (= 0.66.14)
-    - Yoga
-  - React-Core/Default (0.66.14):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-jsiexecutor (= 0.66.14)
-    - React-perflogger (= 0.66.14)
-    - Yoga
-  - React-Core/DevSupport (0.66.14):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.14)
-    - React-Core/RCTWebSocket (= 0.66.14)
-    - React-cxxreact (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-jsiexecutor (= 0.66.14)
-    - React-jsinspector (= 0.66.14)
-    - React-perflogger (= 0.66.14)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.66.14):
+  - React-Core/CoreModulesHeaders (0.66.58):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-jsiexecutor (= 0.66.14)
-    - React-perflogger (= 0.66.14)
+    - React-cxxreact (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-jsiexecutor (= 0.66.58)
+    - React-perflogger (= 0.66.58)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.66.14):
+  - React-Core/Default (0.66.58):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-jsiexecutor (= 0.66.58)
+    - React-perflogger (= 0.66.58)
+    - Yoga
+  - React-Core/DevSupport (0.66.58):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.66.58)
+    - React-Core/RCTWebSocket (= 0.66.58)
+    - React-cxxreact (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-jsiexecutor (= 0.66.58)
+    - React-jsinspector (= 0.66.58)
+    - React-perflogger (= 0.66.58)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.66.58):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-jsiexecutor (= 0.66.14)
-    - React-perflogger (= 0.66.14)
+    - React-cxxreact (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-jsiexecutor (= 0.66.58)
+    - React-perflogger (= 0.66.58)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.66.14):
+  - React-Core/RCTAnimationHeaders (0.66.58):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-jsiexecutor (= 0.66.14)
-    - React-perflogger (= 0.66.14)
+    - React-cxxreact (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-jsiexecutor (= 0.66.58)
+    - React-perflogger (= 0.66.58)
     - Yoga
-  - React-Core/RCTImageHeaders (0.66.14):
+  - React-Core/RCTBlobHeaders (0.66.58):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-jsiexecutor (= 0.66.14)
-    - React-perflogger (= 0.66.14)
+    - React-cxxreact (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-jsiexecutor (= 0.66.58)
+    - React-perflogger (= 0.66.58)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.66.14):
+  - React-Core/RCTImageHeaders (0.66.58):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-jsiexecutor (= 0.66.14)
-    - React-perflogger (= 0.66.14)
+    - React-cxxreact (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-jsiexecutor (= 0.66.58)
+    - React-perflogger (= 0.66.58)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.66.14):
+  - React-Core/RCTLinkingHeaders (0.66.58):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-jsiexecutor (= 0.66.14)
-    - React-perflogger (= 0.66.14)
+    - React-cxxreact (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-jsiexecutor (= 0.66.58)
+    - React-perflogger (= 0.66.58)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.66.14):
+  - React-Core/RCTNetworkHeaders (0.66.58):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-jsiexecutor (= 0.66.14)
-    - React-perflogger (= 0.66.14)
+    - React-cxxreact (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-jsiexecutor (= 0.66.58)
+    - React-perflogger (= 0.66.58)
     - Yoga
-  - React-Core/RCTTextHeaders (0.66.14):
+  - React-Core/RCTSettingsHeaders (0.66.58):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-jsiexecutor (= 0.66.14)
-    - React-perflogger (= 0.66.14)
+    - React-cxxreact (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-jsiexecutor (= 0.66.58)
+    - React-perflogger (= 0.66.58)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.66.14):
+  - React-Core/RCTTextHeaders (0.66.58):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-jsiexecutor (= 0.66.14)
-    - React-perflogger (= 0.66.14)
+    - React-cxxreact (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-jsiexecutor (= 0.66.58)
+    - React-perflogger (= 0.66.58)
     - Yoga
-  - React-Core/RCTWebSocket (0.66.14):
+  - React-Core/RCTVibrationHeaders (0.66.58):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.14)
-    - React-cxxreact (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-jsiexecutor (= 0.66.14)
-    - React-perflogger (= 0.66.14)
+    - React-Core/Default
+    - React-cxxreact (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-jsiexecutor (= 0.66.58)
+    - React-perflogger (= 0.66.58)
     - Yoga
-  - React-CoreModules (0.66.14):
-    - FBReactNativeSpec (= 0.66.14)
+  - React-Core/RCTWebSocket (0.66.58):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.14)
-    - React-Core/CoreModulesHeaders (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-RCTImage (= 0.66.14)
-    - ReactCommon/turbomodule/core (= 0.66.14)
-  - React-cxxreact (0.66.14):
+    - React-Core/Default (= 0.66.58)
+    - React-cxxreact (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-jsiexecutor (= 0.66.58)
+    - React-perflogger (= 0.66.58)
+    - Yoga
+  - React-CoreModules (0.66.58):
+    - FBReactNativeSpec (= 0.66.58)
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.66.58)
+    - React-Core/CoreModulesHeaders (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-RCTImage (= 0.66.58)
+    - ReactCommon/turbomodule/core (= 0.66.58)
+  - React-cxxreact (0.66.58):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-jsinspector (= 0.66.14)
-    - React-logger (= 0.66.14)
-    - React-perflogger (= 0.66.14)
-    - React-runtimeexecutor (= 0.66.14)
-  - React-jsi (0.66.14):
+    - React-callinvoker (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-jsinspector (= 0.66.58)
+    - React-logger (= 0.66.58)
+    - React-perflogger (= 0.66.58)
+    - React-runtimeexecutor (= 0.66.58)
+  - React-jsi (0.66.58):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.66.14)
-  - React-jsi/Default (0.66.14):
+    - React-jsi/Default (= 0.66.58)
+  - React-jsi/Default (0.66.58):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.66.14):
+  - React-jsiexecutor (0.66.58):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-perflogger (= 0.66.14)
-  - React-jsinspector (0.66.14)
-  - React-logger (0.66.14):
+    - React-cxxreact (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-perflogger (= 0.66.58)
+  - React-jsinspector (0.66.58)
+  - React-logger (0.66.58):
     - glog
-  - React-perflogger (0.66.14)
-  - React-RCTActionSheet (0.66.14):
-    - React-Core/RCTActionSheetHeaders (= 0.66.14)
-  - React-RCTAnimation (0.66.14):
-    - FBReactNativeSpec (= 0.66.14)
+  - React-perflogger (0.66.58)
+  - React-RCTActionSheet (0.66.58):
+    - React-Core/RCTActionSheetHeaders (= 0.66.58)
+  - React-RCTAnimation (0.66.58):
+    - FBReactNativeSpec (= 0.66.58)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.14)
-    - React-Core/RCTAnimationHeaders (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - ReactCommon/turbomodule/core (= 0.66.14)
-  - React-RCTBlob (0.66.14):
-    - FBReactNativeSpec (= 0.66.14)
+    - RCTTypeSafety (= 0.66.58)
+    - React-Core/RCTAnimationHeaders (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - ReactCommon/turbomodule/core (= 0.66.58)
+  - React-RCTBlob (0.66.58):
+    - FBReactNativeSpec (= 0.66.58)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/RCTBlobHeaders (= 0.66.14)
-    - React-Core/RCTWebSocket (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-RCTNetwork (= 0.66.14)
-    - ReactCommon/turbomodule/core (= 0.66.14)
-  - React-RCTImage (0.66.14):
-    - FBReactNativeSpec (= 0.66.14)
+    - React-Core/RCTBlobHeaders (= 0.66.58)
+    - React-Core/RCTWebSocket (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-RCTNetwork (= 0.66.58)
+    - ReactCommon/turbomodule/core (= 0.66.58)
+  - React-RCTImage (0.66.58):
+    - FBReactNativeSpec (= 0.66.58)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.14)
-    - React-Core/RCTImageHeaders (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-RCTNetwork (= 0.66.14)
-    - ReactCommon/turbomodule/core (= 0.66.14)
-  - React-RCTLinking (0.66.14):
-    - FBReactNativeSpec (= 0.66.14)
-    - React-Core/RCTLinkingHeaders (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - ReactCommon/turbomodule/core (= 0.66.14)
-  - React-RCTNetwork (0.66.14):
-    - FBReactNativeSpec (= 0.66.14)
+    - RCTTypeSafety (= 0.66.58)
+    - React-Core/RCTImageHeaders (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-RCTNetwork (= 0.66.58)
+    - ReactCommon/turbomodule/core (= 0.66.58)
+  - React-RCTLinking (0.66.58):
+    - FBReactNativeSpec (= 0.66.58)
+    - React-Core/RCTLinkingHeaders (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - ReactCommon/turbomodule/core (= 0.66.58)
+  - React-RCTNetwork (0.66.58):
+    - FBReactNativeSpec (= 0.66.58)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.14)
-    - React-Core/RCTNetworkHeaders (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - ReactCommon/turbomodule/core (= 0.66.14)
-  - React-RCTSettings (0.66.14):
-    - FBReactNativeSpec (= 0.66.14)
+    - RCTTypeSafety (= 0.66.58)
+    - React-Core/RCTNetworkHeaders (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - ReactCommon/turbomodule/core (= 0.66.58)
+  - React-RCTSettings (0.66.58):
+    - FBReactNativeSpec (= 0.66.58)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.14)
-    - React-Core/RCTSettingsHeaders (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - ReactCommon/turbomodule/core (= 0.66.14)
-  - React-RCTText (0.66.14):
-    - React-Core/RCTTextHeaders (= 0.66.14)
-  - React-RCTVibration (0.66.14):
-    - FBReactNativeSpec (= 0.66.14)
+    - RCTTypeSafety (= 0.66.58)
+    - React-Core/RCTSettingsHeaders (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - ReactCommon/turbomodule/core (= 0.66.58)
+  - React-RCTText (0.66.58):
+    - React-Core/RCTTextHeaders (= 0.66.58)
+  - React-RCTVibration (0.66.58):
+    - FBReactNativeSpec (= 0.66.58)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/RCTVibrationHeaders (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - ReactCommon/turbomodule/core (= 0.66.14)
-  - React-runtimeexecutor (0.66.14):
-    - React-jsi (= 0.66.14)
-  - ReactCommon/turbomodule/core (0.66.14):
+    - React-Core/RCTVibrationHeaders (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - ReactCommon/turbomodule/core (= 0.66.58)
+  - React-runtimeexecutor (0.66.58):
+    - React-jsi (= 0.66.58)
+  - ReactCommon/turbomodule/core (0.66.58):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.66.14)
-    - React-Core (= 0.66.14)
-    - React-cxxreact (= 0.66.14)
-    - React-jsi (= 0.66.14)
-    - React-logger (= 0.66.14)
-    - React-perflogger (= 0.66.14)
-  - ReactTestApp-DevSupport (1.1.2):
+    - React-callinvoker (= 0.66.58)
+    - React-Core (= 0.66.58)
+    - React-cxxreact (= 0.66.58)
+    - React-jsi (= 0.66.58)
+    - React-logger (= 0.66.58)
+    - React-perflogger (= 0.66.58)
+  - ReactTestApp-DevSupport (1.3.10):
     - React-Core
     - React-jsi
-  - ReactTestApp-MSAL (1.0.0):
+  - ReactTestApp-MSAL (1.0.2):
     - MSAL
     - RNXAuth
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNXAuth (0.1.0):
+  - RNXAuth (0.1.2):
     - React-Core
   - SwiftLint (0.46.2)
   - Yoga (1.14.0)
@@ -413,42 +413,42 @@ SPEC CHECKSUMS:
   boost: 613e39eac4239cc72b15421247b5ab05361266a2
   boost-for-react-native: 8f7c9ecfe357664c072ffbe2432569667cbf1f1b
   DoubleConversion: ed15e075aa758ac0e4c1f8b830bd4e4d40d669e8
-  FBLazyVector: 175266a5f77d255f0169cfda01f0346c105075b3
-  FBReactNativeSpec: 92a9ef6d3e03ff24cc5f054c9e949bea97f6c550
+  FBLazyVector: 20f347de98e9108bb0379f1d0c33ff712f0bfcda
+  FBReactNativeSpec: 11c1d59c8e06d0cde0e093c2dff5b87f2d92baf8
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 42c4bf47024808486e90b25ea9e5ac3959047641
   MSAL: b479d8f1f62c71c34f7ff27cc441065b099856a6
-  RCT-Folly: 5c589d0de10e841479ad79352fae591dc0e9533a
-  RCTRequired: a9e2af8873217b0c8075c3feeb519988bb0fe366
-  RCTTypeSafety: d4d3373567b9a66883cd853f1682fc5cf48c5f64
-  React: 79ccf4dfb433228f162ae5af33f47d1fa32d1c81
-  React-callinvoker: 7a0667de884a23911ed7018120b7e4ed56694bd6
-  React-Core: bd198fb6516394c4dade26c1b10a4579800a246c
-  React-CoreModules: 21c8554a207849e7dc76b4f03e304b62c4593733
-  React-cxxreact: 721337b940e085dbd18a1412216269dc276bf4e4
-  React-jsi: 6a46bf76579f3a0fc95391e58ea9676bd10bf444
-  React-jsiexecutor: a9ba940f3ee72da4b57f995c58257a776e19eb29
-  React-jsinspector: 0b62261c84928d69b73a916b5a3837894529f5eb
-  React-logger: 3fc878ffa5e9d90ecf43d9b2f416a397f66b6784
-  React-perflogger: 741ec14fd61e61f18056ff1eef85296d1a5a7df7
-  React-RCTActionSheet: b42f85268b956c5a905bcfb505a33ce7e078f65c
-  React-RCTAnimation: d86228705557d83597c5a225cfee5513bad1a86e
-  React-RCTBlob: c828ed41f839a9f69c991d1c4b2afb5a18d30351
-  React-RCTImage: 69b70910197cb8b932951a83dbab364dc27e1c15
-  React-RCTLinking: da09ccab10fc4cabb3a4eac0751cefb9666274c7
-  React-RCTNetwork: 78a143681d28fd051415977b4816ed516b1b7335
-  React-RCTSettings: 8fe43d932d10ad4e1a897d888f0346215c8ad37e
-  React-RCTText: 181b283a110c5fe104722b75064e9218bf972e38
-  React-RCTVibration: 750078604afb9bb67a71f92535ea47d2ebe4a838
-  React-runtimeexecutor: 1c296a03368cc6808bf82fa4734cd4a41f824646
-  ReactCommon: 52df5c2e4b4bada6cc3bb365eab03f907f43092c
-  ReactTestApp-DevSupport: d838d01f9bd91eacfd5822cc78007429a7b72b38
-  ReactTestApp-MSAL: dc409154809b3a6c56d72026f063a444a8cd919f
+  RCT-Folly: 43adc9ce880eb76792f88c011773cb5c664c1419
+  RCTRequired: f7b28e52a6ffb66dac2797187b182071af901719
+  RCTTypeSafety: 001155a4b41dad0b63769b0c6fb26661dc2bc38b
+  React: d36efc781eb87a785f0cc6bc10db8f3ece669b43
+  React-callinvoker: f0083a3c0e9be4011449655542ae7d6001816cca
+  React-Core: 6285cb755f86c565385535089c7ccd1419da13e7
+  React-CoreModules: f233c67c2d4913653cfe68a262254c520687497e
+  React-cxxreact: 612aff8c1660fba329b0d117f4ed1a2fab9feb10
+  React-jsi: 78c19293bcb27f55017b17d9287a7c61513aad2f
+  React-jsiexecutor: 6bb839f0a094f077b29367e5d05c66a027aafc95
+  React-jsinspector: 876d512ac13328769bbbb955a5c8cb30fb5c0049
+  React-logger: 854fcc22763c7c87b5ea262f1c87112edc463885
+  React-perflogger: ef227a21812b9201e4ee4bb299a55c700386bc19
+  React-RCTActionSheet: 8633fdfc8e1897b149edfbe148dc6c4e0d17c596
+  React-RCTAnimation: 2fbcfde7c0c11e4503f7336e72c23fe0a0a6fdcf
+  React-RCTBlob: 6ea41a7d8d4022ad88460e7186c62d713eae2ff2
+  React-RCTImage: f09e564500f4796cd974560450952c4319d3d475
+  React-RCTLinking: 8901fab849db209b9a1902d6e2fb69da8f2eed2d
+  React-RCTNetwork: b76195a6afbd4c25e0dd29f01dd9651c60ec7e7b
+  React-RCTSettings: ff29f201c0c26136c9fb1429cf235d2a99bd9a44
+  React-RCTText: b34a5608b5982daaba6668f2acc7a97ee9940c5f
+  React-RCTVibration: f1c08efb7c529e199136b49e54d930785f30cda2
+  React-runtimeexecutor: 144f219bc33650626a224c2fb2a3d7f0525e8293
+  ReactCommon: 7aff5f881d46f2bd90d75741e75024d1f81874ee
+  ReactTestApp-DevSupport: 6275cb3b001d9d971f8328580f757409a1c1cf64
+  ReactTestApp-MSAL: 2fe4334f2e18008e6cc5323bb57d583f9b43b0d8
   ReactTestApp-Resources: bb546b3a5dca4b7931bee423d4ef28cd94b346cf
-  RNXAuth: c6f636730e4abf5b0c5406c50eb76d45306d1226
+  RNXAuth: e393a0547142ae4c3bdd2ba299cd9dfff4192e32
   SwiftLint: 6bc52a21f0fd44cab9aa2dc8e534fb9f5e3ec507
-  Yoga: 943375165f29e6c5521dff8ab2d53309e670348f
+  Yoga: 375d8228a7086723f3b05cc2d6268aa24613c692
 
 PODFILE CHECKSUM: 30b8aa30eb4eedd7c154dfbbfae609c9f071443d
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/packages/test-app/react-native.config.js
+++ b/packages/test-app/react-native.config.js
@@ -13,9 +13,9 @@ const project = (() => {
         sourceDir: "android",
         manifestPath: androidManifestPath(path.join(__dirname, "android")),
       },
-      windows: fs.existsSync("windows/Example.sln") && {
+      windows: fs.existsSync("windows/SampleCrossApp.sln") && {
         sourceDir: "windows",
-        solutionFile: "Example.sln",
+        solutionFile: "SampleCrossApp.sln",
         project: windowsProjectPath(path.join(__dirname, "windows")),
       },
       ...(iosProject ? { ios: { project: iosProject } } : undefined),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7773,6 +7773,13 @@ fast-url-parser@1.1.3:
   dependencies:
     punycode "^1.3.2"
 
+fast-xml-parser@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.0.8.tgz#abf0fbfe477b90b796118bd097a3afa4b9b4673f"
+  integrity sha512-N4XqZaRMuHMvOFwFlqeBTlvrnXU+QN8wvCl2g9fHzMx2BnLoIYRDwy6XwI8FxogHMFI9OfGQBCddgckvSLTnvg==
+  dependencies:
+    strnum "^1.0.5"
+
 fastest-levenshtein@^1.0.7:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
@@ -15152,6 +15159,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+strnum@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
 structured-headers@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
### Description

Adds macOS and Windows support.

### Test plan

1. Build
   ```
   cd incubator/build
   yarn build
   ```
2. Build for macOS: `yarn rnx-build --platform macos --project-root ../../packages/test-app`
3. Build for Windows: `yarn rnx-build --platform wWindows --project-root ../../packages/test-app`