### PR TITLE
fix(build): handle multiple attached Android devices

### DIFF
--- a/.changeset/proud-terms-kick.md
+++ b/.changeset/proud-terms-kick.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+Better handling of multiple attached Android devices

--- a/incubator/build/README.md
+++ b/incubator/build/README.md
@@ -48,7 +48,7 @@ npm run rnx-build --platform <platform>
 - [x] Figure out how to download artifacts
 - [ ] Figure out how to install artifacts
   - [x] Android emulator
-  - [ ] Android device
+  - [x] Android device
   - [x] iOS simulator
   - [ ] iOS device
   - [x] macOS


### PR DESCRIPTION
### Description

Better handling of multiple attached Android devices.

### Test plan

- Only device, or both device and emulator attached:
  ```
  ℹ Found Android device RF8M80ZEAKL
  ✔ Started com.msft.identity.client.sample.local
  ```
- Emulator already attached:
  ```
  ℹ An Android emulator is already attached
  ✔ Started com.msft.identity.client.sample.local
  ```
- Nothing attached:
  ```
  ✔ Booted @Pixel_5_API_30
  ✔ Started com.msft.identity.client.sample.local
  ```