### PR TITLE
fix(build): reduce job polling frequency

### DIFF
--- a/.changeset/pretty-horses-rescue.md
+++ b/.changeset/pretty-horses-rescue.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+Added elapsed time to remote build job, and reduced job polling frequency to avoid hitting the hourly rate limit.

--- a/incubator/build/package.json
+++ b/incubator/build/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@octokit/core": "^3.6.0",
     "@octokit/plugin-rest-endpoint-methods": "^5.14.0",
+    "@octokit/request-error": "^2.0.5",
     "fast-xml-parser": "^4.0.8",
     "ora": "^5.4.1",
     "pkg-dir": "^5.0.0",

--- a/incubator/build/src/remotes/github.ts
+++ b/incubator/build/src/remotes/github.ts
@@ -1,6 +1,7 @@
 import { Octokit } from "@octokit/core";
 import type { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
 import { restEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
+import { RequestError } from "@octokit/request-error";
 import {
   existsSync as fileExists,
   readFileSync as fileReadSync,
@@ -50,11 +51,12 @@ async function downloadArtifact(
   runId: WorkflowRunId,
   { platform, projectRoot }: BuildParams
 ): Promise<string> {
+  const listParams = { ...runId };
   const artifacts = await withRetries(async () => {
-    const { data } = await octokit().rest.actions.listWorkflowRunArtifacts(
-      runId
-    );
+    const { data, headers } =
+      await octokit().rest.actions.listWorkflowRunArtifacts(listParams);
     if (data.total_count === 0) {
+      listParams.headers = { "if-none-match": headers.etag };
       throw new Error("No artifacts were uploaded");
     }
     return data.artifacts;
@@ -100,13 +102,17 @@ function getPersonalAccessToken(): string | undefined {
 async function getWorkflowRunId(
   params: WorkflowRunsParams
 ): Promise<WorkflowRunId> {
+  const listParams = { ...params };
   const run_id = await withRetries(async () => {
-    const result = await octokit().rest.actions.listWorkflowRuns(params);
-    if (result.data.total_count === 0) {
+    const { data, headers } = await octokit().rest.actions.listWorkflowRuns(
+      listParams
+    );
+    if (data.total_count === 0) {
+      listParams.headers = { "if-none-match": headers.etag };
       throw new Error("Failed to get workflow run id");
     }
 
-    return result.data.workflow_runs[0].id;
+    return data.workflow_runs[0].id;
   }, MAX_ATTEMPTS);
 
   return {
@@ -122,43 +128,62 @@ async function watchWorkflowRun(
 ): Promise<string | null> {
   spinner.start("Starting build");
 
+  const params = { ...runId };
   let count = 0;
   let currentStep: string | undefined = "";
   let startTime = "";
+
   while (runId) {
     await idle(1000);
 
-    // Poll job updates every 5 seconds. Note that GitHub currently limits
-    // user-to-server requests to 5000 per hour. That's only ~1.3 requests
-    // per second. For more details, see
-    // https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
-    if (++count % 5 === 0) {
-      const result = await octokit().rest.actions.listJobsForWorkflowRun(runId);
-      const job = result.data.jobs.find((job) => job.conclusion !== "skipped");
-      if (!job) {
-        continue;
-      }
+    // Note that GitHub currently limits user-to-server requests to 5000 per
+    // hour. That's only ~1.3 requests per second. Besides reducing the poll
+    // frequency, we can also use conditional requests to reduce the number of
+    // requests that count against the limit.
+    //
+    // For more details, see
+    //   - https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
+    //   - https://docs.github.com/en/rest/overview/resources-in-the-rest-api#conditional-requests
+    if (count++ % 5 === 0) {
+      try {
+        const result = await octokit().rest.actions.listJobsForWorkflowRun(
+          params
+        );
+        const job = result.data.jobs.find(
+          (job) => job.conclusion !== "skipped"
+        );
+        if (job) {
+          const { status, conclusion, started_at, steps } = job;
 
-      const { status, conclusion, started_at, steps } = job;
+          if (status === "completed") {
+            const elapsed = elapsedTime(started_at, job.completed_at);
+            switch (conclusion) {
+              case "failure":
+                spinner.fail(`Build failed (${elapsed})`);
+                break;
+              case "success":
+                spinner.succeed(`Build succeeded (${elapsed})`);
+                break;
+              default:
+                spinner.fail(`Build ${conclusion} (${elapsed})`);
+                break;
+            }
+            return conclusion;
+          }
 
-      if (status === "completed") {
-        const elapsed = elapsedTime(started_at, job.completed_at);
-        switch (conclusion) {
-          case "failure":
-            spinner.fail(`Build failed (${elapsed})`);
-            break;
-          case "success":
-            spinner.succeed(`Build succeeded (${elapsed})`);
-            break;
-          default:
-            spinner.fail(`Build ${conclusion} (${elapsed})`);
-            break;
+          currentStep = steps?.find(
+            (step) => step.status !== "completed"
+          )?.name;
+          startTime = started_at;
+          params.headers = { "if-none-match": result.headers.etag };
         }
-        return conclusion;
+      } catch (e) {
+        if (e instanceof RequestError && e.status === 304) {
+          // Status is unchanged since last request
+        } else {
+          throw e;
+        }
       }
-
-      currentStep = steps?.find((step) => step.status !== "completed")?.name;
-      startTime = started_at;
     }
 
     if (!currentStep) {

--- a/incubator/build/src/time.ts
+++ b/incubator/build/src/time.ts
@@ -1,0 +1,26 @@
+const SECONDS = 1000;
+const MINUTES = 60 * SECONDS;
+const HOURS = 60 * MINUTES;
+
+const { now, parse: parseDate } = Date;
+const floor = Math.floor;
+
+export function elapsedTime(
+  startTime: string,
+  endTime?: string | null
+): string {
+  const end = endTime ? parseDate(endTime) : now();
+  const elapsed = end - parseDate(startTime);
+
+  const hours = floor(elapsed / HOURS);
+  const minutes = floor((elapsed % HOURS) / MINUTES);
+  const seconds = floor((elapsed % MINUTES) / SECONDS);
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m ${seconds}s`;
+  } else if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  } else {
+    return `${seconds}s`;
+  }
+}

--- a/incubator/build/src/time.ts
+++ b/incubator/build/src/time.ts
@@ -1,6 +1,6 @@
-const SECONDS = 1000;
-const MINUTES = 60 * SECONDS;
-const HOURS = 60 * MINUTES;
+const MS_PER_SECOND = 1000;
+const MS_PER_MINUTE = 60 * MS_PER_SECOND;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
 
 const { now, parse: parseDate } = Date;
 const floor = Math.floor;
@@ -12,9 +12,9 @@ export function elapsedTime(
   const end = endTime ? parseDate(endTime) : now();
   const elapsed = end - parseDate(startTime);
 
-  const hours = floor(elapsed / HOURS);
-  const minutes = floor((elapsed % HOURS) / MINUTES);
-  const seconds = floor((elapsed % MINUTES) / SECONDS);
+  const hours = floor(elapsed / MS_PER_HOUR);
+  const minutes = floor((elapsed % MS_PER_HOUR) / MS_PER_MINUTE);
+  const seconds = floor((elapsed % MS_PER_MINUTE) / MS_PER_SECOND);
 
   if (hours > 0) {
     return `${hours}h ${minutes}m ${seconds}s`;


### PR DESCRIPTION
### Description

Added elapsed time to remote build job, and reduced job polling frequency to avoid hitting the hourly rate limit.

### Test plan

```
cd incubator/build
yarn build
yarn rnx-build --platform ios --project-root ../../packages/test-app
```

Example output:

```
✔ Created build branch rnx-build/tido/rnx-build-job-poll/20220526-081124.641-e787785b
✔ Build queued: https://github.com/tido64/rnx-kit/actions/runs/2563493469
⠏ Install Pods (3m 53s)
```