### PR TITLE
fix(build): better handling of iOS device selection

### DIFF
--- a/.changeset/violet-panthers-reply.md
+++ b/.changeset/violet-panthers-reply.md
@@ -1,0 +1,7 @@
+---
+"@rnx-kit/build": patch
+---
+
+Improved handling of iOS device selection. Builds for physical devices differ from simulator ones, meaning we should pick the right device when deploying the app. Note that this does not quite add the capability to deploy to physical devices just yet. We still need to figure out how to deal with developer certificates.
+
+This change also fixes an issue with corrupted artifacts.

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -6,6 +6,10 @@ on:
         description: "Supported architectures are `arm64`, `x64`"
         required: true
         default: "x64"
+      deviceType:
+        description: "Supported device types are `device`, `emulator`, `simulator`"
+        required: true
+        default: "simulator"
       packageManager:
         description: "Supported package managers are `npm`, `yarn`, `pnpm` (v6.10+)"
         required: true
@@ -50,7 +54,7 @@ jobs:
   build-ios:
     name: "Build iOS"
     if: ${{ github.event.inputs.platform == 'ios' }}
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -62,21 +66,39 @@ jobs:
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Pods
-        run: pod install --project-directory=ios
+        run: |
+          pod install --project-directory=ios
+        working-directory: ${{ github.event.inputs.projectRoot }}
+      - name: Disable Clang sanitizers
+        run: |
+          # We need to disable Clang sanitizers otherwise the app will crash on
+          # startup trying to load Clang sanitizer libraries that would only
+          # exist if Xcode was attached.
+          xcconfig=node_modules/.generated/ios/ReactTestApp/ReactTestApp.debug.xcconfig
+          sed -i '' 's/CLANG_ADDRESS_SANITIZER = YES/CLANG_ADDRESS_SANITIZER = NO/g' ${xcconfig}
+          sed -i '' 's/CLANG_UNDEFINED_BEHAVIOR_SANITIZER = YES/CLANG_UNDEFINED_BEHAVIOR_SANITIZER = NO/g' ${xcconfig}
+          sed -i '' 's/-fsanitize=bounds//g' ${xcconfig}
         working-directory: ${{ github.event.inputs.projectRoot }}
       - name: Build iOS app
         run: |
-          device_name='iPhone 13'
-          device=$(xcrun simctl list devices "${device_name}" available | grep "${device_name} (")
-          re='\(([-0-9A-Fa-f]+)\)'
-          [[ $device =~ $re ]] || exit 1
+          if [[ ${{ github.event.inputs.deviceType }} == 'device' ]]; then
+            destination='generic/platform=iOS'
+          else
+            destination='generic/platform=iOS Simulator'
+          fi
           xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
-          xcodebuild -workspace ${xcworkspace} -scheme ReactTestApp -destination "id=${BASH_REMATCH[1]}" -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build
+          xcodebuild -workspace ${xcworkspace} -scheme ReactTestApp -destination "${destination}" -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build
         working-directory: ${{ github.event.inputs.projectRoot }}/ios
       - name: Prepare build artifact
         run: |
-          tar -cvf ios-artifact.tar -C DerivedData/Build/Products/Debug-iphonesimulator ReactTestApp.app
-          shasum --algorithm 512 ios-artifact.tar
+          output_path=DerivedData/Build/Products
+          app=$(find ${output_path} -maxdepth 2 -name '*.app' -type d | head -1)
+          # bsdtar corrupts files when archiving due to APFS sparse files. A
+          # workaround is to use GNU Tar instead. See also:
+          #   - https://github.com/actions/cache/issues/403
+          #   - https://github.com/actions/virtual-environments/issues/2619
+          gtar -cvf ios-artifact.tar -C "$(dirname ${app})" "$(basename ${app})"
+          shasum --algorithm 256 ios-artifact.tar
         working-directory: ${{ github.event.inputs.projectRoot }}/ios
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
@@ -86,7 +108,7 @@ jobs:
   build-macos:
     name: "Build macOS"
     if: ${{ github.event.inputs.platform == 'macos' }}
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -107,8 +129,14 @@ jobs:
         working-directory: ${{ github.event.inputs.projectRoot }}/macos
       - name: Prepare build artifact
         run: |
-          tar -cvf macos-artifact.tar -C DerivedData/Build/Products/Debug ReactTestApp.app
-          shasum --algorithm 512 macos-artifact.tar
+          output_path=DerivedData/Build/Products
+          app=$(find ${output_path} -maxdepth 2 -name '*.app' -type d | head -1)
+          # bsdtar corrupts files when archiving due to APFS sparse files. A
+          # workaround is to use GNU Tar instead. See also:
+          #   - https://github.com/actions/cache/issues/403
+          #   - https://github.com/actions/virtual-environments/issues/2619
+          gtar -cvf macos-artifact.tar -C "$(dirname ${app})" "$(basename ${app})"
+          shasum --algorithm 256 macos-artifact.tar
         working-directory: ${{ github.event.inputs.projectRoot }}/macos
       - name: Upload build artifact
         uses: actions/upload-artifact@v3

--- a/incubator/build/README.md
+++ b/incubator/build/README.md
@@ -28,10 +28,11 @@ An experimental tool for building your apps in the cloud.
 npm run rnx-build --platform <platform>
 ```
 
-| Flag           | Description                                                  |
-| :------------- | :----------------------------------------------------------- |
-| -p, --platform | Supported platforms are `android`, `ios`, `macos`, `windows` |
-| --project-root | [Optional] Path to the root of the project                   |
+| Flag           | Description                                                             |
+| :------------- | :---------------------------------------------------------------------- |
+| -p, --platform | Supported platforms are `android`, `ios`, `macos`, `windows`            |
+| --device-type  | [Optional] Supported device types are `device`, `emulator`, `simulator` |
+| --project-root | [Optional] Path to the root of the project                              |
 
 ## Contributors' Notes
 
@@ -50,7 +51,8 @@ npm run rnx-build --platform <platform>
   - [x] Android emulator
   - [x] Android device
   - [x] iOS simulator
-  - [ ] iOS device
+  - [ ] iOS device (need to figure out how to sign on CI)
+    - https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
   - [x] macOS
   - [x] Windows
 - [x] Miscellaneous cleanup

--- a/incubator/build/src/build.ts
+++ b/incubator/build/src/build.ts
@@ -1,10 +1,7 @@
 import ora from "ora";
 import { extract } from "./archive";
 import { deleteBranch, pushCurrentChanges } from "./git";
-import { installAndLaunchApk } from "./platforms/android";
-import { installAndLaunchApp } from "./platforms/ios";
-import * as macos from "./platforms/macos";
-import * as windows from "./platforms/windows";
+import * as platforms from "./platforms";
 import type { BuildParams, Remote, RepositoryInfo } from "./types";
 
 export async function startBuild(
@@ -53,22 +50,8 @@ export async function startBuild(
     const buildArtifact = await extract(artifactFile);
     spinner.succeed(`Extracted ${buildArtifact}`);
 
-    switch (inputs.platform) {
-      case "android":
-        await installAndLaunchApk(buildArtifact, undefined, spinner);
-        break;
-      case "ios":
-        await installAndLaunchApp(buildArtifact, undefined, spinner);
-        break;
-      case "macos":
-        await macos.launch(buildArtifact, spinner);
-        break;
-      case "windows":
-        await windows.launch(buildArtifact, spinner);
-        break;
-      default:
-        break;
-    }
+    const platform = await platforms.get(inputs.platform);
+    await platform.deploy(buildArtifact, inputs, spinner);
   } catch (e) {
     spinner.fail();
     await cleanUp();

--- a/incubator/build/src/index.ts
+++ b/incubator/build/src/index.ts
@@ -29,8 +29,15 @@ async function main(): Promise<void> {
       type: "string",
       description:
         "Supported platforms are `android`, `ios`, `macos`, `windows`",
-      choices: ["android", "ios", "macos", "windows"],
+      choices: ["android", "ios", "macos", "windows"] as const,
       required: true,
+    })
+    .option("device-type", {
+      type: "string",
+      description:
+        "Supported device types are `device`, `emulator`, `simulator`",
+      choices: ["device", "emulator", "simulator"] as const,
+      default: "simulator" as const,
     })
     .option("project-root", {
       type: "string",
@@ -44,6 +51,7 @@ async function main(): Promise<void> {
     }).argv;
 
   process.exitCode = await startBuild(remote, repoInfo, {
+    deviceType: argv["device-type"],
     platform: argv.platform as Platform,
     projectRoot: argv["project-root"],
   });

--- a/incubator/build/src/platforms/android.ts
+++ b/incubator/build/src/platforms/android.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import type { Ora } from "ora";
 import { idle, retry } from "../async";
 import { ensure, makeCommand, makeCommandSync } from "../command";
+import type { BuildParams } from "../types";
 
 type EmulatorInfo = {
   product: string;
@@ -182,6 +183,7 @@ async function selectDevice(
   spinner.start(`Booting Android emulator @${avd}`);
   const emulator = await launchEmulator(avd);
   if (emulator instanceof Error) {
+    spinner.fail();
     spinner.fail(emulator.message);
     return null;
   }
@@ -199,9 +201,9 @@ function start(
   return adb("-s", serial, "shell", "am", "start", "-n", activity);
 }
 
-export async function installAndLaunchApk(
+export async function deploy(
   apk: string,
-  emulatorName: string | undefined,
+  { emulatorName }: BuildParams,
   spinner: Ora
 ): Promise<void> {
   if (!ANDROID_HOME) {
@@ -227,6 +229,7 @@ export async function installAndLaunchApk(
   spinner.start(`Installing ${apk}`);
   const error = await install(device, apk, packageName);
   if (error) {
+    spinner.fail();
     spinner.fail(error.message);
     return;
   }

--- a/incubator/build/src/platforms/index.ts
+++ b/incubator/build/src/platforms/index.ts
@@ -1,0 +1,19 @@
+import type { Ora } from "ora";
+import type { BuildParams, Platform } from "../types";
+
+type PlatformImpl = {
+  deploy: (artifact: string, param: BuildParams, spinner: Ora) => Promise<void>;
+};
+
+export function get(platform: Platform): Promise<PlatformImpl> {
+  switch (platform) {
+    case "android":
+      return import("./android");
+    case "ios":
+      return import("./ios");
+    case "macos":
+      return import("./macos");
+    case "windows":
+      return import("./windows");
+  }
+}

--- a/incubator/build/src/platforms/ios.ts
+++ b/incubator/build/src/platforms/ios.ts
@@ -1,11 +1,26 @@
+import * as os from "node:os";
 import * as path from "node:path";
 import type { Ora } from "ora";
 import { untar } from "../archive";
 import { retry } from "../async";
-import { ensure, makeCommand, makeCommandSync } from "../command";
+import {
+  ensure,
+  ensureInstalled,
+  makeCommand,
+  makeCommandSync,
+} from "../command";
+import type { BuildParams, DeviceType } from "../types";
 import { open } from "./macos";
 
-type SimDevice = {
+type Device = {
+  name: string;
+  type: "device" | "simulator" | "unknown";
+  osVersion: string;
+  accessories?: Device[];
+  udid: string;
+};
+
+type Simulator = {
   name: string;
   state: "Booted" | "Shutdown";
   deviceTypeIdentifier: string;
@@ -17,122 +32,307 @@ type SimDevice = {
   availabilityError?: string;
 };
 
-type Devices = {
-  devices: Record<string, SimDevice[]>;
-};
-
+const iosDeploy = makeCommand("ios-deploy");
 const xcrun = makeCommand("xcrun");
 
-async function bootSimulator({ udid }: SimDevice): Promise<Error | null> {
+async function getAvailableSimulators(
+  search = "iPhone"
+): Promise<Record<string, Simulator[]>> {
+  const ls = xcrun("simctl", "list", "--json", "devices", search, "available");
+  const { devices } = JSON.parse(ensure(await ls));
+  return Object.keys(devices)
+    .sort()
+    .reduce<Record<string, Simulator[]>>((filtered, runtime) => {
+      const simulators = devices[runtime];
+      if (simulators.length > 0) {
+        filtered[runtime] = simulators;
+      }
+      return filtered;
+    }, {});
+}
+
+function getDeveloperDirectory(): string | undefined {
+  const xcodeSelect = makeCommandSync("xcode-select");
+
+  const { stdout, status } = xcodeSelect("--print-path");
+  return status === 0 ? stdout.trim() : undefined;
+}
+
+async function getDevices(): Promise<Device[]> {
+  const { stdout, stderr, status } = await xcrun("xctrace", "list", "devices");
+  if (status !== 0) {
+    return [];
+  }
+
+  const devices: Device[] = [];
+
+  /**
+   * As of Xcode 13.4.1, the output may look like this:
+   *
+   * % xcrun xctrace list devices
+   * == Devices ==
+   * Arnold’s MacBook Pro 2019 (00000000-0000-0000-0000-000000000000)
+   * Arnold’s iPhone (15.5) (00000000-0000000000000000)
+   *
+   * == Simulators ==
+   * Apple TV Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * Apple TV 4K (2nd generation) Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * Apple TV 4K (at 1080p) (2nd generation) Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPad (9th generation) Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPad Air (4th generation) Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPad Air (5th generation) Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPad Pro (11-inch) (3rd generation) Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPad Pro (12.9-inch) (5th generation) Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPad Pro (9.7-inch) Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPad mini (6th generation) Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 11 Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 11 Pro Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 11 Pro Max Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 12 Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 12 Pro Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 12 Pro Simulator (15.5) + Apple Watch Series 5 - 40mm (8.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 12 Pro Max Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 12 Pro Max Simulator (15.5) + Apple Watch Series 5 - 44mm (8.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 12 mini Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 13 Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 13 Simulator (15.5) + Apple Watch Series 7 - 45mm (8.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 13 Pro Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 13 Pro Simulator (15.5) + Apple Watch Series 6 - 40mm (8.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 13 Pro Max Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 13 Pro Max Simulator (15.5) + Apple Watch Series 6 - 44mm (8.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 13 mini Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 13 mini Simulator (15.5) + Apple Watch Series 7 - 41mm (8.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 8 Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone 8 Plus Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone SE (2nd generation) Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPhone SE (3rd generation) Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   * iPod touch (7th generation) Simulator (15.5) (00000000-0000-0000-0000-000000000000)
+   *
+   * Note: Older versions of `xtrace` output to stderr instead of stdout.
+   */
+  (stdout || stderr).split("\n").reduce<Device["type"]>((type, line) => {
+    if (line === "== Devices ==") {
+      return "device";
+    } else if (line === "== Simulators ==") {
+      return "simulator";
+    }
+
+    const match = line.match(
+      /(.*?)(?:\sSimulator)?\s\(([.\d]+)\)(?:\s\+\s(.*?)\s\(([.\d]+)\))?\s\(([0-9A-Fa-f]{8}-[0-9A-Fa-f]{16}|[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})\)/
+    );
+    if (match) {
+      const [, name, osVersion, accessoryName, accessoryVersion, udid] = match;
+      devices.push({
+        name,
+        type,
+        osVersion,
+        ...(accessoryName
+          ? {
+              accessories: [
+                {
+                  name: accessoryName,
+                  type,
+                  osVersion: accessoryVersion,
+                  udid,
+                },
+              ],
+            }
+          : undefined),
+        udid,
+      });
+    }
+    return type;
+  }, "unknown");
+
+  return devices;
+}
+
+async function parsePlist(app: string): Promise<Error | Record<string, any>> {
+  const plutil = makeCommand("plutil");
+
+  const infoPlist = path.join(app, "Info.plist");
+  const convertPlist = plutil("-convert", "json", "-o", "-", infoPlist);
+  const { stdout, status } = await convertPlist;
+  return status === 0
+    ? JSON.parse(stdout)
+    : new Error(`Failed to parse 'Info.plist' of '${app}'`);
+}
+
+function pickSimulator(
+  simulators: Record<string, Simulator[]>
+): Simulator | null {
+  const runtimes = Object.keys(simulators);
+  const runtime = runtimes[runtimes.length - 1];
+  const deviceList = simulators[runtime];
+  return deviceList[deviceList.length - 1];
+}
+
+async function bootSimulator({ udid }: Simulator): Promise<Error | null> {
   const { stderr, status } = await xcrun("simctl", "boot", udid);
   if (status !== 0) {
     return new Error(stderr);
   }
 
   const result = await retry(async () => {
-    const dev = await getDevice(udid);
-    return dev?.state === "Booted" || null;
+    const simulators = await getAvailableSimulators(udid);
+    const device = pickSimulator(simulators);
+    return device?.state === "Booted" || null;
   }, 4);
   return result ? null : new Error("Timed out waiting for the simulator");
 }
 
-async function getAvailableDevices(
-  search = "iPhone"
-): Promise<Record<string, SimDevice[]>> {
-  const result = ensure(
-    await xcrun("simctl", "list", "--json", "devices", search, "available")
-  );
-  const { devices } = JSON.parse(result) as Devices;
-  return devices;
-}
+async function install(device: Device, app: string): Promise<Error | null> {
+  const { type, udid } = device;
+  const install =
+    type === "device"
+      ? () => iosDeploy("--id", udid, "--bundle", app)
+      : () => xcrun("simctl", "install", udid, app);
 
-function getDeveloperDirectory(): string | undefined {
-  const xcodeSelect = makeCommandSync("xcode-select");
-  const { stdout, status } = xcodeSelect("--print-path");
-  return status === 0 ? stdout.trim() : undefined;
-}
-
-async function getDevice(
-  deviceName: string | undefined
-): Promise<SimDevice | null> {
-  const devices = await getAvailableDevices(deviceName);
-  const runtime = Object.keys(devices)
-    .sort()
-    .reverse()
-    .find((runtime) => devices[runtime].length !== 0);
-  if (!runtime) {
-    return null;
-  }
-
-  const deviceList = devices[runtime];
-  return deviceList[deviceList.length - 1];
-}
-
-async function install(
-  app: string,
-  { udid }: SimDevice
-): Promise<Error | null> {
-  const { stderr, status } = await xcrun("simctl", "install", udid, app);
+  const { stderr, status } = await install();
   return status === 0 ? null : new Error(stderr);
 }
 
-async function launch(app: string, { udid }: SimDevice): Promise<void> {
-  const plutil = makeCommand("plutil");
-  const plistResult = await plutil(
-    "-convert",
-    "json",
-    "-o",
-    "-",
-    path.join(app, "Info.plist")
-  );
-  const plist = ensure(plistResult, `Failed to parse 'Info.plist' of '${app}'`);
-  const { CFBundleIdentifier } = JSON.parse(plist);
-  ensure(await xcrun("simctl", "launch", udid, CFBundleIdentifier));
+async function launch(device: Device, app: string): Promise<Error | null> {
+  const { type, udid } = device;
+  if (type === "device") {
+    const launch = iosDeploy("--id", udid, "--bundle", app, "--justlaunch");
+    const { stderr, status } = await launch;
+    if (status !== 0) {
+      return new Error(stderr);
+    }
+  } else {
+    const result = await parsePlist(app);
+    if (result instanceof Error) {
+      return result;
+    }
+
+    const { CFBundleIdentifier } = result;
+    const launch = xcrun("simctl", "launch", udid, CFBundleIdentifier);
+    const { stderr, status } = await launch;
+    if (status !== 0) {
+      return new Error(stderr);
+    }
+  }
+
+  return null;
 }
 
-export async function installAndLaunchApp(
-  archive: string,
+async function selectDevice(
   deviceName: string | undefined,
+  deviceType: DeviceType,
+  spinner: Ora
+): Promise<Device | null> {
+  const devices = await getDevices();
+
+  if (deviceType === "device") {
+    const search: (device: Device) => boolean = deviceName
+      ? ({ name, type }) => name === deviceName && type === "device"
+      : (device) => device.type === "device";
+    const physicalDevice = devices.find(search);
+    if (!physicalDevice) {
+      const message = deviceName
+        ? `Failed to find device: ${deviceName}`
+        : "Failed to find a physical device";
+      spinner.fail(message);
+      return null;
+    }
+
+    const { name, osVersion } = physicalDevice;
+    spinner.info(`Found ${name} (${osVersion})`);
+    return physicalDevice;
+  }
+
+  const device = deviceName
+    ? devices.find(
+        ({ name, type, accessories }) =>
+          name === deviceName && type === "simulator" && !accessories
+      )
+    : devices
+        .reverse()
+        .find(
+          ({ name, type, accessories }) =>
+            type === "simulator" && !accessories && /^iPhone \d\d$/.test(name)
+        );
+  if (!device) {
+    const message = deviceName
+      ? `Failed to find simulator: ${deviceName}`
+      : "Failed to find an iPhone simulator";
+    spinner.fail(message);
+    return null;
+  }
+
+  const availableSimulators = await getAvailableSimulators(device.udid);
+  for (const simulators of Object.values(availableSimulators)) {
+    for (const simulator of simulators) {
+      const { name, state, udid } = simulator;
+      if (udid === device.udid) {
+        if (state !== "Booted") {
+          spinner.start(`Booting ${name} simulator`);
+          const error = await bootSimulator(simulator);
+          if (error) {
+            spinner.fail();
+            spinner.fail(error.message);
+            return null;
+          }
+          spinner.succeed(`Booted ${name} simulator`);
+        } else {
+          spinner.info(`${name} simulator has already been booted`);
+        }
+        return device;
+      }
+    }
+  }
+
+  throw new Error(`Failed to find simulator: ${device.udid}`);
+}
+
+export async function deploy(
+  archive: string,
+  { deviceName, deviceType }: BuildParams,
   spinner: Ora
 ): Promise<void> {
+  if (os.platform() !== "darwin") {
+    return;
+  }
+
   const developerDir = getDeveloperDirectory();
   if (!developerDir) {
     spinner.warn("Xcode is required to install and launch apps");
     return;
   }
 
-  const device = await getDevice(deviceName);
+  const device = await selectDevice(deviceName, deviceType, spinner);
   if (!device) {
-    spinner.fail("Failed to find an appropriate simulator");
     return;
   }
 
-  if (device.state === "Booted") {
-    spinner.info(`${device.name} simulator is already connected`);
+  if (device.type === "device") {
+    await ensureInstalled(
+      () => iosDeploy("--version"),
+      `ios-deploy is required to install and launch apps on devices.\nInstall ios-deploy via Homebrew by running:\n\n    brew install ios-deploy\n\nPress any key to continue`
+    );
   } else {
-    spinner.start(`Booting ${device.name} simulator`);
-    const error = await bootSimulator(device);
-    if (error) {
-      spinner.fail(error.message);
-      return;
-    }
-    spinner.succeed(`Booted ${device.name} simulator`);
+    await open(path.join(developerDir, "Applications", "Simulator.app"));
   }
-
-  await open(path.join(developerDir, "Applications", "Simulator.app"));
 
   spinner.start(`Extracting ${archive}`);
   const app = await untar(archive);
 
   spinner.text = `Installing ${app}`;
-  const error = await install(app, device);
-  if (error) {
-    spinner.fail(error.message);
+  const installError = await install(device, app);
+  if (installError) {
+    spinner.fail();
+    spinner.fail(installError.message);
     return;
   }
 
   spinner.text = `Launching ${app}`;
-  await launch(app, device);
+  const launchError = await launch(device, app);
+  if (launchError) {
+    spinner.fail();
+    spinner.fail(launchError.message);
+    return;
+  }
 
   spinner.succeed(`Launched ${app}`);
 }

--- a/incubator/build/src/platforms/macos.ts
+++ b/incubator/build/src/platforms/macos.ts
@@ -2,10 +2,15 @@ import * as os from "node:os";
 import type { Ora } from "ora";
 import { untar } from "../archive";
 import { makeCommand } from "../command";
+import type { BuildParams } from "../types";
 
 export const open = makeCommand("open");
 
-export async function launch(archive: string, spinner: Ora): Promise<void> {
+export async function deploy(
+  archive: string,
+  _: BuildParams,
+  spinner: Ora
+): Promise<void> {
   if (os.platform() !== "darwin") {
     return;
   }

--- a/incubator/build/src/platforms/windows.ts
+++ b/incubator/build/src/platforms/windows.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import type { Ora } from "ora";
 import { retry } from "../async";
 import { makeCommand } from "../command";
+import type { BuildParams } from "../types";
 
 type PackageInfo = {
   packageName: string;
@@ -113,7 +114,11 @@ async function install(
   return result || new Error("App failed to install?");
 }
 
-export async function launch(app: string, spinner: Ora): Promise<void> {
+export async function deploy(
+  app: string,
+  _: BuildParams,
+  spinner: Ora
+): Promise<void> {
   if (os.platform() !== "win32") {
     return;
   }

--- a/incubator/build/src/types.ts
+++ b/incubator/build/src/types.ts
@@ -1,6 +1,14 @@
 import type { Ora } from "ora";
 
+export type DeviceType = "device" | "emulator" | "simulator";
 export type Platform = "android" | "ios" | "macos" | "windows";
+
+export type BuildParams = {
+  deviceType: DeviceType;
+  projectRoot: string;
+  platform: Platform;
+  [key: string]: string;
+};
 
 export type RepositoryInfo = {
   owner: string;
@@ -11,12 +19,6 @@ export type UserConfig = {
   tokens: {
     github?: string;
   };
-};
-
-export type BuildParams = {
-  projectRoot: string;
-  platform: Platform;
-  [key: string]: string;
 };
 
 export type Context = RepositoryInfo & {

--- a/incubator/build/workflows/github.yml
+++ b/incubator/build/workflows/github.yml
@@ -6,6 +6,10 @@ on:
         description: "Supported architectures are `arm64`, `x64`"
         required: true
         default: "x64"
+      deviceType:
+        description: "Supported device types are `device`, `emulator`, `simulator`"
+        required: true
+        default: "simulator"
       packageManager:
         description: "Supported package managers are `npm`, `yarn`, `pnpm` (v6.10+)"
         required: true
@@ -50,7 +54,7 @@ jobs:
   build-ios:
     name: "Build iOS"
     if: ${{ github.event.inputs.platform == 'ios' }}
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -62,21 +66,39 @@ jobs:
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Pods
-        run: pod install --project-directory=ios
+        run: |
+          pod install --project-directory=ios
+        working-directory: ${{ github.event.inputs.projectRoot }}
+      - name: Disable Clang sanitizers
+        run: |
+          # We need to disable Clang sanitizers otherwise the app will crash on
+          # startup trying to load Clang sanitizer libraries that would only
+          # exist if Xcode was attached.
+          xcconfig=node_modules/.generated/ios/ReactTestApp/ReactTestApp.debug.xcconfig
+          sed -i '' 's/CLANG_ADDRESS_SANITIZER = YES/CLANG_ADDRESS_SANITIZER = NO/g' ${xcconfig}
+          sed -i '' 's/CLANG_UNDEFINED_BEHAVIOR_SANITIZER = YES/CLANG_UNDEFINED_BEHAVIOR_SANITIZER = NO/g' ${xcconfig}
+          sed -i '' 's/-fsanitize=bounds//g' ${xcconfig}
         working-directory: ${{ github.event.inputs.projectRoot }}
       - name: Build iOS app
         run: |
-          device_name='iPhone 13'
-          device=$(xcrun simctl list devices "${device_name}" available | grep "${device_name} (")
-          re='\(([-0-9A-Fa-f]+)\)'
-          [[ $device =~ $re ]] || exit 1
+          if [[ ${{ github.event.inputs.deviceType }} == 'device' ]]; then
+            destination='generic/platform=iOS'
+          else
+            destination='generic/platform=iOS Simulator'
+          fi
           xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
-          xcodebuild -workspace ${xcworkspace} -scheme ReactTestApp -destination "id=${BASH_REMATCH[1]}" -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build
+          xcodebuild -workspace ${xcworkspace} -scheme ReactTestApp -destination "${destination}" -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build
         working-directory: ${{ github.event.inputs.projectRoot }}/ios
       - name: Prepare build artifact
         run: |
-          tar -cvf ios-artifact.tar -C DerivedData/Build/Products/Debug-iphonesimulator ReactTestApp.app
-          shasum --algorithm 512 ios-artifact.tar
+          output_path=DerivedData/Build/Products
+          app=$(find ${output_path} -maxdepth 2 -name '*.app' -type d | head -1)
+          # bsdtar corrupts files when archiving due to APFS sparse files. A
+          # workaround is to use GNU Tar instead. See also:
+          #   - https://github.com/actions/cache/issues/403
+          #   - https://github.com/actions/virtual-environments/issues/2619
+          gtar -cvf ios-artifact.tar -C "$(dirname ${app})" "$(basename ${app})"
+          shasum --algorithm 256 ios-artifact.tar
         working-directory: ${{ github.event.inputs.projectRoot }}/ios
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
@@ -86,7 +108,7 @@ jobs:
   build-macos:
     name: "Build macOS"
     if: ${{ github.event.inputs.platform == 'macos' }}
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -107,8 +129,14 @@ jobs:
         working-directory: ${{ github.event.inputs.projectRoot }}/macos
       - name: Prepare build artifact
         run: |
-          tar -cvf macos-artifact.tar -C DerivedData/Build/Products/Debug ReactTestApp.app
-          shasum --algorithm 512 macos-artifact.tar
+          output_path=DerivedData/Build/Products
+          app=$(find ${output_path} -maxdepth 2 -name '*.app' -type d | head -1)
+          # bsdtar corrupts files when archiving due to APFS sparse files. A
+          # workaround is to use GNU Tar instead. See also:
+          #   - https://github.com/actions/cache/issues/403
+          #   - https://github.com/actions/virtual-environments/issues/2619
+          gtar -cvf macos-artifact.tar -C "$(dirname ${app})" "$(basename ${app})"
+          shasum --algorithm 256 macos-artifact.tar
         working-directory: ${{ github.event.inputs.projectRoot }}/macos
       - name: Upload build artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### Description

Improved handling of iOS device selection. Builds for physical devices differ from simulator ones, meaning we should pick the right device when deploying the app. Note that this does not quite add the capability to deploy to physical devices just yet. We still need to figure out how to deal with developer certificates.

This change also fixes an issue with corrupted artifacts.

### Test plan

1. Build: `cd incubator/build && yarn build`
2. Build and deploy to simulator (even if you have a device plugged in): `yarn rnx-build --platform ios --project-root ../../packages/test-app`
3. Build and deploy to device (which will fail because of certificates): `yarn rnx-build --platform ios --device-type device --project-root ../../packages/test-app`