### PR TITLE
fix(build): use bsdtar to extract ZIP files

### DIFF
--- a/.changeset/chilled-actors-kiss.md
+++ b/.changeset/chilled-actors-kiss.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+Use bsdtar to extract ZIP files. Note that if we're inside Git Bash shell on Windows, we should use UnZip instead as GNU Tar does not support ZIP.

--- a/incubator/build/README.md
+++ b/incubator/build/README.md
@@ -60,6 +60,7 @@ npm run rnx-build --platform <platform>
 - [x] Cancel build job when user ctrl+c in the terminal
 - [x] Add `init` or `install` command to copy the correct workflow file to
       user's repo
+- [x] Replace yauzl with something more native
 - [ ] Windows: Install currently only works on Windows 11, we need to support 10
 - [ ] Build artifacts are currently hard-coded to look for ReactTestApp
 - [ ] Verify downloaded build artifacts using checksum
@@ -67,4 +68,3 @@ npm run rnx-build --platform <platform>
 - [ ] Figure out how to install artifacts with QR code
 - [ ] Figure out caching
 - [ ] Figure out how to skip native build when cached
-- [ ] Replace yauzl with something more native

--- a/incubator/build/README.md
+++ b/incubator/build/README.md
@@ -16,9 +16,18 @@ An experimental tool for building your apps in the cloud.
 🚧 TODO: Reduce the number of requirements
 
 - GitHub hosted repository
-- [Android Studio](https://developer.android.com/studio)
 - [Node.js](https://nodejs.org/en/download/) LTS 14.15 or greater
-- [Xcode](https://developer.apple.com/xcode/)
+
+| Feature                      | Android | iOS | macOS | Windows |
+| :--------------------------- | :-----: | :-: | :---: | :-----: |
+| Remote build                 |    ✓    |  ✓  |   ✓   |    ✓    |
+| Launch in device             |   ✓¹    | 🚧² |   ✓   |   ✓³    |
+| Launch in emulator/simulator |   ✓¹    | ✓²  |   -   |    -    |
+| Launch from QR code          |   🚧    | 🚧  |   -   |    -    |
+
+1. Requires [Android Studio](https://developer.android.com/studio)
+2. Requires [Xcode](https://developer.apple.com/xcode/)
+3. Currently requires Windows 11. We are working on a solution for Windows 10.
 
 ## Usage
 

--- a/incubator/build/package.json
+++ b/incubator/build/package.json
@@ -35,12 +35,10 @@
     "fast-xml-parser": "^4.0.8",
     "ora": "^5.4.1",
     "pkg-dir": "^5.0.0",
-    "yargs": "^16.0.0",
-    "yauzl": "2.10.0"
+    "yargs": "^16.0.0"
   },
   "devDependencies": {
-    "@rnx-kit/scripts": "*",
-    "@types/yauzl": "2.10.0"
+    "@rnx-kit/scripts": "*"
   },
   "engines": {
     "node": ">=14.15"

--- a/incubator/build/src/archive.ts
+++ b/incubator/build/src/archive.ts
@@ -1,49 +1,26 @@
-import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
-import yauzl from "yauzl";
-import { ensure, makeCommand } from "./command";
-import { ensureDir } from "./filesystem";
+import { ensure, makeCommand, makeCommandSync } from "./command";
 
-export function extract(filename: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const destination = path.dirname(filename);
+export const extract: (filename: string) => Promise<string> = (() => {
+  switch (os.platform()) {
+    case "darwin":
+      // macOS ships bsdtar. bsdtar can extract ZIP files (unlike GNU Tar).
+      return untar;
 
-    yauzl.open(filename, { lazyEntries: true }, (err, zipFile) => {
-      if (err) {
-        reject(err);
-      }
+    case "win32": {
+      // Windows 10 ships bsdtar since build 17063. Use bsdtar unless we are
+      // inside a Git Bash shell. Git Bash ships GNU Tar which does not support
+      // ZIP. Luckily, it also ships UnZip.
+      const tar = makeCommandSync("tar");
+      const output = ensure(tar("--version"));
+      return output.includes("bsdtar") ? untar : unzip;
+    }
 
-      const readNextEntry = () => zipFile.readEntry();
-      let output = "";
-
-      zipFile.on("entry", (entry) => {
-        zipFile.openReadStream(entry, async (err, readStream) => {
-          if (err) {
-            reject(err);
-          }
-
-          const absolutePath = path.join(destination, entry.fileName);
-
-          // Our workflows will always produce build artifacts that are either
-          // an APK (Android), an archive (iOS/macOS), or a folder (Windows).
-          output ||= absolutePath;
-
-          if (absolutePath.endsWith("/") || absolutePath.endsWith("\\")) {
-            await ensureDir(absolutePath);
-            readNextEntry();
-          } else {
-            readStream
-              .pipe(fs.createWriteStream(absolutePath))
-              .once("finish", readNextEntry);
-          }
-        });
-      });
-      zipFile.once("end", () => resolve(output));
-
-      readNextEntry();
-    });
-  });
-}
+    default:
+      return unzip;
+  }
+})();
 
 export async function untar(archive: string): Promise<string> {
   const buildDir = path.dirname(archive);
@@ -51,11 +28,26 @@ export async function untar(archive: string): Promise<string> {
 
   const filename = path.basename(archive);
   const list = ensure(await tar("tf", filename));
-  const m = list.match(/(.*?)\//);
-  if (!m) {
-    throw new Error(`Failed to determine content of ${archive}`);
-  }
+
+  // Our workflows will always produce build artifacts that are either an APK
+  // (Android), an archive (iOS/macOS), or a folder (Windows).
+  const file = list.split("\n")[0].trimEnd();
 
   ensure(await tar("xf", filename));
-  return path.join(buildDir, m[1]);
+  return path.join(buildDir, file);
+}
+
+export async function unzip(archive: string): Promise<string> {
+  const buildDir = path.dirname(archive);
+  const unzip = makeCommand("unzip", { cwd: buildDir });
+
+  const filename = path.basename(archive);
+  const list = ensure(await unzip("-Z1", filename));
+
+  // Our workflows will always produce build artifacts that are either an APK
+  // (Android), an archive (iOS/macOS), or a folder (Windows).
+  const file = list.split("\n")[0].trimEnd();
+
+  ensure(await unzip("-o", filename));
+  return path.join(buildDir, file);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4060,13 +4060,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yauzl@2.10.0":
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.10.0.tgz#b3248295276cf8c6f153ebe6a9aba0c988cb2599"
-  integrity sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==
-  dependencies:
-    "@types/node" "*"
-
 "@typescript-eslint/eslint-plugin@^5.0.0":
   version "5.29.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.29.0.tgz#c67794d2b0fd0b4a47f50266088acdc52a08aab6"
@@ -5340,11 +5333,6 @@ buffer-alloc@^1.1.0:
   dependencies:
     buffer-alloc-unsafe "^1.1.0"
     buffer-fill "^1.0.0"
-
-buffer-crc32@~0.2.3:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
 
 buffer-fill@^1.0.0:
   version "1.0.0"
@@ -7820,13 +7808,6 @@ fbjs@^3.0.0, fbjs@^3.0.1:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.30"
-
-fd-slicer@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
-  integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
-  dependencies:
-    pend "~1.2.0"
 
 fecha@^4.2.0:
   version "4.2.1"
@@ -12659,11 +12640,6 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pend@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
-  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
-
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -16681,14 +16657,6 @@ yargs@^17.1.1, yargs@^17.4.0:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
-
-yauzl@2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
-  integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
-  dependencies:
-    buffer-crc32 "~0.2.3"
-    fd-slicer "~1.1.0"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
### Description

Use bsdtar to extract ZIP files.  Note that if we're inside Git Bash shell on Windows, we should use UnZip instead as GNU Tar does not support ZIP.

As @afoxman pointed out, Windows has been [shipping bsdtar](https://docs.microsoft.com/en-us/virtualization/community/team-blog/2017/20171219-tar-and-curl-come-to-windows) since build 17063.

### Test plan

1. Run `rnx-build --platform windows --project-root ../../packages/test-app` in Git Bash
2. Run `rnx-build --platform windows --project-root ../../packages/test-app` in Command Prompt or PowerShell