### PR TITLE
fix(build/ios): add ability to launch on device

### DIFF
--- a/.changeset/little-mirrors-tell.md
+++ b/.changeset/little-mirrors-tell.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+iOS: Added ability to launch on device

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -55,6 +55,10 @@ jobs:
     name: "Build iOS"
     if: ${{ github.event.inputs.platform == 'ios' }}
     runs-on: macos-12
+    env:
+      CERTIFICATE_FILE: build-certificate.p12
+      KEYCHAIN_FILE: app-signing.keychain-db
+      PROVISION_PATH: 'Library/MobileDevice/Provisioning Profiles/Provisioning_Profile.mobileprovision'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -66,8 +70,7 @@ jobs:
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Pods
-        run: |
-          pod install --project-directory=ios
+        run: pod install --project-directory=ios
         working-directory: ${{ github.event.inputs.projectRoot }}
       - name: Disable Clang sanitizers
         run: |
@@ -79,16 +82,44 @@ jobs:
           sed -i '' 's/CLANG_UNDEFINED_BEHAVIOR_SANITIZER = YES/CLANG_UNDEFINED_BEHAVIOR_SANITIZER = NO/g' ${xcconfig}
           sed -i '' 's/-fsanitize=bounds//g' ${xcconfig}
         working-directory: ${{ github.event.inputs.projectRoot }}
+      - name: Install Apple signing certificate and provisioning profile
+        if: ${{ github.event.inputs.deviceType == 'device' }}
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+        run: |
+          # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
+          mkdir -p "$(dirname "${HOME}/${PROVISION_PATH}")"
+
+          echo -n "${BUILD_CERTIFICATE_BASE64}" | base64 --decode --output "${RUNNER_TEMP}/${CERTIFICATE_FILE}"
+          echo -n "${BUILD_PROVISION_PROFILE_BASE64}" | base64 --decode --output "${HOME}/${PROVISION_PATH}"
+
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
+          security set-keychain-settings -lut 21600 "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
+
+          security import "${RUNNER_TEMP}/${CERTIFICATE_FILE}" -k "${RUNNER_TEMP}/${KEYCHAIN_FILE}" -t cert -f pkcs12 -P "${P12_PASSWORD}" -A -T '/usr/bin/codesign' -T '/usr/bin/security'
+          security set-key-partition-list -S apple-tool:,apple: -k ${KEYCHAIN_PASSWORD} "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
+          security list-keychain -d user -s "${RUNNER_TEMP}/${KEYCHAIN_FILE}" login.keychain
       - name: Build iOS app
         run: |
           if [[ ${{ github.event.inputs.deviceType }} == 'device' ]]; then
             destination='generic/platform=iOS'
+            code_signing=''
           else
             destination='generic/platform=iOS Simulator'
+            code_signing='CODE_SIGNING_ALLOWED=NO'
           fi
           xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
-          xcodebuild -workspace ${xcworkspace} -scheme ReactTestApp -destination "${destination}" -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build
+          xcodebuild -workspace ${xcworkspace} -scheme ReactTestApp -destination "${destination}" -configuration Debug -derivedDataPath DerivedData ${code_signing} COMPILER_INDEX_STORE_ENABLE=NO build
         working-directory: ${{ github.event.inputs.projectRoot }}/ios
+      - name: Remove Apple signing certificate and provisioning profile
+        if: ${{ always() && github.event.inputs.deviceType == 'device' }}
+        run: |
+          security delete-keychain "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
+          rm -f "${RUNNER_TEMP}/${CERTIFICATE_FILE}" "${HOME}/${PROVISION_PATH}"
       - name: Prepare build artifact
         run: |
           output_path=DerivedData/Build/Products

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -58,7 +58,7 @@ jobs:
     env:
       CERTIFICATE_FILE: build-certificate.p12
       KEYCHAIN_FILE: app-signing.keychain-db
-      PROVISION_PATH: 'Library/MobileDevice/Provisioning Profiles/Provisioning_Profile.mobileprovision'
+      PROVISION_PATH: "Library/MobileDevice/Provisioning Profiles/Provisioning_Profile.mobileprovision"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -118,6 +118,8 @@ jobs:
       - name: Remove Apple signing certificate and provisioning profile
         if: ${{ always() && github.event.inputs.deviceType == 'device' }}
         run: |
+          # Always run this job step, even if previous ones fail. See also
+          # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development#required-clean-up-on-self-hosted-runners
           security delete-keychain "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
           rm -f "${RUNNER_TEMP}/${CERTIFICATE_FILE}" "${HOME}/${PROVISION_PATH}"
       - name: Prepare build artifact

--- a/incubator/build/README.md
+++ b/incubator/build/README.md
@@ -43,6 +43,14 @@ npm run rnx-build --platform <platform>
 | --device-type  | [Optional] Supported device types are `device`, `emulator`, `simulator` |
 | --project-root | [Optional] Path to the root of the project                              |
 
+### iOS: Install Signing Certificate and Provisioning Profile
+
+In order to launch the build artifact on device, you need to install Apple
+signing certificate and provisioning profile on your host of choice.
+
+For GitHub, please follow the steps to create the four secrets here:
+[Creating secrets for your certificate and provisioning profile](https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development#creating-secrets-for-your-certificate-and-provisioning-profile)
+
 ## Contributors' Notes
 
 ### TODO
@@ -56,11 +64,11 @@ npm run rnx-build --platform <platform>
   - [x] macOS
   - [x] Windows
 - [x] Figure out how to download artifacts
-- [ ] Figure out how to install artifacts
+- [x] Figure out how to install artifacts
   - [x] Android emulator
   - [x] Android device
   - [x] iOS simulator
-  - [ ] iOS device (need to figure out how to sign on CI)
+  - [x] iOS device (need to figure out how to sign on CI)
     - https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
   - [x] macOS
   - [x] Windows

--- a/incubator/build/src/remotes/github.ts
+++ b/incubator/build/src/remotes/github.ts
@@ -158,7 +158,7 @@ async function watchWorkflowRun(
           params
         );
         const job = result.data.jobs.find(
-          (job) => job.conclusion !== "skipped"
+          (job) => job && job.conclusion !== "skipped"
         );
         if (job) {
           const { status, conclusion, started_at, steps } = job;

--- a/incubator/build/workflows/github.yml
+++ b/incubator/build/workflows/github.yml
@@ -55,6 +55,10 @@ jobs:
     name: "Build iOS"
     if: ${{ github.event.inputs.platform == 'ios' }}
     runs-on: macos-12
+    env:
+      CERTIFICATE_FILE: build-certificate.p12
+      KEYCHAIN_FILE: app-signing.keychain-db
+      PROVISION_PATH: 'Library/MobileDevice/Provisioning Profiles/Provisioning_Profile.mobileprovision'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -66,8 +70,7 @@ jobs:
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Pods
-        run: |
-          pod install --project-directory=ios
+        run: pod install --project-directory=ios
         working-directory: ${{ github.event.inputs.projectRoot }}
       - name: Disable Clang sanitizers
         run: |
@@ -79,16 +82,44 @@ jobs:
           sed -i '' 's/CLANG_UNDEFINED_BEHAVIOR_SANITIZER = YES/CLANG_UNDEFINED_BEHAVIOR_SANITIZER = NO/g' ${xcconfig}
           sed -i '' 's/-fsanitize=bounds//g' ${xcconfig}
         working-directory: ${{ github.event.inputs.projectRoot }}
+      - name: Install Apple signing certificate and provisioning profile
+        if: ${{ github.event.inputs.deviceType == 'device' }}
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+        run: |
+          # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
+          mkdir -p "$(dirname "${HOME}/${PROVISION_PATH}")"
+
+          echo -n "${BUILD_CERTIFICATE_BASE64}" | base64 --decode --output "${RUNNER_TEMP}/${CERTIFICATE_FILE}"
+          echo -n "${BUILD_PROVISION_PROFILE_BASE64}" | base64 --decode --output "${HOME}/${PROVISION_PATH}"
+
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
+          security set-keychain-settings -lut 21600 "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
+
+          security import "${RUNNER_TEMP}/${CERTIFICATE_FILE}" -k "${RUNNER_TEMP}/${KEYCHAIN_FILE}" -t cert -f pkcs12 -P "${P12_PASSWORD}" -A -T '/usr/bin/codesign' -T '/usr/bin/security'
+          security set-key-partition-list -S apple-tool:,apple: -k ${KEYCHAIN_PASSWORD} "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
+          security list-keychain -d user -s "${RUNNER_TEMP}/${KEYCHAIN_FILE}" login.keychain
       - name: Build iOS app
         run: |
           if [[ ${{ github.event.inputs.deviceType }} == 'device' ]]; then
             destination='generic/platform=iOS'
+            code_signing=''
           else
             destination='generic/platform=iOS Simulator'
+            code_signing='CODE_SIGNING_ALLOWED=NO'
           fi
           xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
-          xcodebuild -workspace ${xcworkspace} -scheme ReactTestApp -destination "${destination}" -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build
+          xcodebuild -workspace ${xcworkspace} -scheme ReactTestApp -destination "${destination}" -configuration Debug -derivedDataPath DerivedData ${code_signing} COMPILER_INDEX_STORE_ENABLE=NO build
         working-directory: ${{ github.event.inputs.projectRoot }}/ios
+      - name: Remove Apple signing certificate and provisioning profile
+        if: ${{ always() && github.event.inputs.deviceType == 'device' }}
+        run: |
+          security delete-keychain "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
+          rm -f "${RUNNER_TEMP}/${CERTIFICATE_FILE}" "${HOME}/${PROVISION_PATH}"
       - name: Prepare build artifact
         run: |
           output_path=DerivedData/Build/Products

--- a/incubator/build/workflows/github.yml
+++ b/incubator/build/workflows/github.yml
@@ -58,7 +58,7 @@ jobs:
     env:
       CERTIFICATE_FILE: build-certificate.p12
       KEYCHAIN_FILE: app-signing.keychain-db
-      PROVISION_PATH: 'Library/MobileDevice/Provisioning Profiles/Provisioning_Profile.mobileprovision'
+      PROVISION_PATH: "Library/MobileDevice/Provisioning Profiles/Provisioning_Profile.mobileprovision"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/incubator/build/workflows/github.yml
+++ b/incubator/build/workflows/github.yml
@@ -118,6 +118,8 @@ jobs:
       - name: Remove Apple signing certificate and provisioning profile
         if: ${{ always() && github.event.inputs.deviceType == 'device' }}
         run: |
+          # Always run this job step, even if previous ones fail. See also
+          # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development#required-clean-up-on-self-hosted-runners
           security delete-keychain "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
           rm -f "${RUNNER_TEMP}/${CERTIFICATE_FILE}" "${HOME}/${PROVISION_PATH}"
       - name: Prepare build artifact


### PR DESCRIPTION
### Description

Added ability to launch on device.

### Test plan

1. Build for Simulator: `yarn rnx-build --platform ios --project-root ../../packages/test-app`
    - Example build: https://github.com/tido64/rnx-kit/runs/7094524653?check_suite_focus=true
2. Build for device: `yarn rnx-build --platform ios --device-type device --project-root ../../packages/test-app`
    - Example build: https://github.com/tido64/rnx-kit/runs/7094128933?check_suite_focus=true

For the device build, you might have to change the bundle identifier and development team to match your provisioning profile:

```diff
diff --git a/packages/test-app/app.json b/packages/test-app/app.json
index 2ca6bad8..7da48bdc 100644
--- a/packages/test-app/app.json
+++ b/packages/test-app/app.json
@@ -18,6 +18,10 @@
   "android": {
     "package": "com.msft.identity.client.sample.local"
   },
+  "ios": {
+    "bundleIdentifier": "<my unique app bundle id>",
+    "developmentTeam": "<my development team id>"
+  },
   "react-native-test-app-msal": {
     "clientId": "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
     "msaScopes": ["user.read"],
```
