### PR TITLE
fix(build/ios): prompt user for device rather than failing

### DIFF
--- a/.changeset/angry-ways-double.md
+++ b/.changeset/angry-ways-double.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+iOS: Prompt user for device rather than failing

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -102,7 +102,7 @@ jobs:
           security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
 
           security import "${RUNNER_TEMP}/${CERTIFICATE_FILE}" -k "${RUNNER_TEMP}/${KEYCHAIN_FILE}" -t cert -f pkcs12 -P "${P12_PASSWORD}" -A -T '/usr/bin/codesign' -T '/usr/bin/security'
-          security set-key-partition-list -S apple-tool:,apple: -k ${KEYCHAIN_PASSWORD} "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
+          security set-key-partition-list -S apple-tool:,apple: -k ${KEYCHAIN_PASSWORD} "${RUNNER_TEMP}/${KEYCHAIN_FILE}" 1> /dev/null
           security list-keychain -d user -s "${RUNNER_TEMP}/${KEYCHAIN_FILE}" login.keychain
       - name: Build iOS app
         run: |

--- a/incubator/build/workflows/github.yml
+++ b/incubator/build/workflows/github.yml
@@ -102,7 +102,7 @@ jobs:
           security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
 
           security import "${RUNNER_TEMP}/${CERTIFICATE_FILE}" -k "${RUNNER_TEMP}/${KEYCHAIN_FILE}" -t cert -f pkcs12 -P "${P12_PASSWORD}" -A -T '/usr/bin/codesign' -T '/usr/bin/security'
-          security set-key-partition-list -S apple-tool:,apple: -k ${KEYCHAIN_PASSWORD} "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
+          security set-key-partition-list -S apple-tool:,apple: -k ${KEYCHAIN_PASSWORD} "${RUNNER_TEMP}/${KEYCHAIN_FILE}" 1> /dev/null
           security list-keychain -d user -s "${RUNNER_TEMP}/${KEYCHAIN_FILE}" login.keychain
       - name: Build iOS app
         run: |


### PR DESCRIPTION
### Description

Prompt the user for device until one is plugged in instead of failing.

### Test plan

Without a device plugged in, run `yarn rnx-build --platform ios --device-type device --project-root ../../packages/test-app`
