### PR TITLE
fix(build): error on unknown arguments

### DIFF
--- a/.changeset/small-files-remain.md
+++ b/.changeset/small-files-remain.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+Error on unknown arguments

--- a/incubator/build/README.md
+++ b/incubator/build/README.md
@@ -36,11 +36,11 @@ An experimental tool for building your apps in the cloud.
 npm run rnx-build --platform <platform>
 ```
 
-| Flag               | Description                                                             |
-| :----------------- | :---------------------------------------------------------------------- |
-| `-p`, `--platform` | Supported platforms are `android`, `ios`, `macos`, `windows`            |
-| `--device-type`    | [Optional] Supported device types are `device`, `emulator`, `simulator` |
-| `--project-root`   | [Optional] Path to the root of the project                              |
+| Flag               | Description                                                                                                                                                       |
+| :----------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-p`, `--platform` | Target platform to build for. Supported platforms are `android`, `ios`, `macos`, `windows`.                                                                       |
+| `--device-type`    | [Optional] Target device type. This is currently only implemented for iOS. Supported device types are `device`, `emulator`, `simulator`. Defaults to `simulator`. |
+| `--project-root`   | [Optional] Path to the root of the project. Defaults to current working directory.                                                                                |
 
 ### Android: Install Android Studio
 

--- a/incubator/build/src/index.ts
+++ b/incubator/build/src/index.ts
@@ -27,15 +27,13 @@ async function main(): Promise<void> {
     .option("platform", {
       alias: "p",
       type: "string",
-      description:
-        "Supported platforms are `android`, `ios`, `macos`, `windows`",
+      description: "Target platform to build for",
       choices: ["android", "ios", "macos", "windows"] as const,
       required: true,
     })
     .option("device-type", {
       type: "string",
-      description:
-        "Supported device types are `device`, `emulator`, `simulator`",
+      description: "Target device type",
       choices: ["device", "emulator", "simulator"] as const,
       default: "simulator" as const,
     })
@@ -48,7 +46,8 @@ async function main(): Promise<void> {
         const repoRoot = getRepositoryRoot();
         return path.relative(repoRoot, path.resolve(process.cwd(), value));
       },
-    }).argv;
+    })
+    .strict().argv;
 
   process.exitCode = await startBuild(remote, repoInfo, {
     deviceType: argv["device-type"],


### PR DESCRIPTION
### Description

Fail if unknown args are passed to rnx-build.

### Test plan

```
% yarn rnx-build --platform ios --package-root fail
yarn run v1.22.19
$ node lib/index.js --platform ios --package-root fail
Options:
      --help          Show help                                        [boolean]
      --version       Show version number                              [boolean]
  -p, --platform      Target platform
             [string] [required] [choices: "android", "ios", "macos", "windows"]
      --device-type   Target device type
    [string] [choices: "device", "emulator", "simulator"] [default: "simulator"]
      --project-root  Root of project
                [string] [default: "/Users/tido/Source/rnx-kit/incubator/build"]

Unknown arguments: package-root, packageRoot
error Command failed with exit code 1.
```