### PR TITLE
feat(rn-changelog-generator): filter sync commits, simplify types

### DIFF
--- a/.changeset/tidy-turkeys-cry.md
+++ b/.changeset/tidy-turkeys-cry.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/rn-changelog-generator": patch
+---
+
+Add filter for the sync commits


### PR DESCRIPTION
### Description

This PR adds additional filter step to the `rn-changelog-generator` script, which purpose is to filter out OSS repository sync commits, like for example:
* https://github.com/facebook/react-native/commit/0a5481924c61723211472db9c1174811d14ac868

Additionally, I have extracted `run` options object to the separate type and simplified it a bit.

### Test plan

To test the changes I have build the package and run it locally via `node` (0.67 -> 0.68).

### Preview

<img width="560" alt="Screenshot 2022-07-02 194129" src="https://user-images.githubusercontent.com/719641/177011119-425c14b2-4b79-471c-b2e2-15887ec71531.png">
