### PR TITLE
fix(golang): replace `workspace-tools` with a call to `find-up`

### DIFF
--- a/.changeset/thick-mugs-cough.md
+++ b/.changeset/thick-mugs-cough.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/golang": patch
+---
+
+Replace `workspace-tools` with a call to `find-up`

--- a/packages/golang/package.json
+++ b/packages/golang/package.json
@@ -25,8 +25,7 @@
   "dependencies": {
     "find-up": "^5.0.0",
     "got": "^11.8.2",
-    "hasha": "^5.2.2",
-    "workspace-tools": "^0.18.3"
+    "hasha": "^5.2.2"
   },
   "devDependencies": {
     "@types/node": "^16.0.0",


### PR DESCRIPTION
### Description

Replace `workspace-tools` dependency with a single call to `find-up`.

### Test plan

Existing tests should pass.