### PR TITLE
fix(rnx-build): properly handle multiple GitHub jobs

### DIFF
--- a/.changeset/metal-flies-shop.md
+++ b/.changeset/metal-flies-shop.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+Properly handle multiple GitHub jobs

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -235,3 +235,15 @@ jobs:
           name: windows-artifact
           path: ${{ github.event.inputs.projectRoot }}/windows/AppPackages/${{ steps.prepare-build-artifact.outputs.app-name }}
           if-no-files-found: error
+  distribute:
+    name: "Distribute build"
+    needs: [build-android, build-ios, build-macos, build-windows]
+    runs-on: ubuntu-20.04
+    if: ${{ !cancelled() && !failure() }}  # `success()` excludes skipped jobs
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ github.event.inputs.platform }}-artifact
+      - name: Display structure of build artifact
+        run: ls -R

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -239,7 +239,7 @@ jobs:
     name: "Distribute build"
     needs: [build-android, build-ios, build-macos, build-windows]
     runs-on: ubuntu-20.04
-    if: ${{ !cancelled() && !failure() }}  # `success()` excludes skipped jobs
+    if: ${{ !cancelled() && !failure() }} # `success()` excludes skipped jobs
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v3

--- a/incubator/build/workflows/github.yml
+++ b/incubator/build/workflows/github.yml
@@ -235,3 +235,15 @@ jobs:
           name: windows-artifact
           path: ${{ github.event.inputs.projectRoot }}/windows/AppPackages/${{ steps.prepare-build-artifact.outputs.app-name }}
           if-no-files-found: error
+  distribute:
+    name: "Distribute build"
+    needs: [build-android, build-ios, build-macos, build-windows]
+    runs-on: ubuntu-20.04
+    if: ${{ !cancelled() && !failure() }}  # `success()` excludes skipped jobs
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ github.event.inputs.platform }}-artifact
+      - name: Display structure of build artifact
+        run: ls -R

--- a/incubator/build/workflows/github.yml
+++ b/incubator/build/workflows/github.yml
@@ -239,7 +239,7 @@ jobs:
     name: "Distribute build"
     needs: [build-android, build-ios, build-macos, build-windows]
     runs-on: ubuntu-20.04
-    if: ${{ !cancelled() && !failure() }}  # `success()` excludes skipped jobs
+    if: ${{ !cancelled() && !failure() }} # `success()` excludes skipped jobs
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v3


### PR DESCRIPTION
### Description

Properly handle multiple GitHub jobs, e.g. `Build Android app` + `Distribute build`

### Test plan

```sh
yarn
cd incubator/build
yarn build
yarn rnx-build --platform android --project-root ../../packages/test-app
```

Example output:

```
✔ Created build branch rnx-build/tido/rnx-build-qr-code/20220607-151732.407-671facbe
✔ Build queued: https://github.com/tido64/rnx-kit/actions/runs/2630567411
✔ Build Android succeeded (4m 45s)
✔ Distribute build succeeded (5s)
✔ Build artifact saved to /~/packages/test-app/android/rnx-build/android-artifact.zip
✔ Extracted /~/packages/test-app/android/rnx-build/app-debug.apk
ℹ An Android emulator is already attached
✔ Started com.msft.identity.client.sample.local
✔ Deleted rnx-build/tido/rnx-build-qr-code/20220607-151732.407-671facbe
```