### PR TITLE
fix(rnx-build): move config file into OS-specific path

### DIFF
--- a/.changeset/proud-birds-wonder.md
+++ b/.changeset/proud-birds-wonder.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": minor
+---
+
+Moved config file into OS-specific path for config files

--- a/incubator/build/package.json
+++ b/incubator/build/package.json
@@ -34,6 +34,7 @@
     "@octokit/core": "^3.6.0",
     "@octokit/plugin-rest-endpoint-methods": "^5.14.0",
     "@octokit/request-error": "^2.0.5",
+    "env-paths": "^2.2.1",
     "fast-xml-parser": "^4.0.8",
     "find-up": "^5.0.0",
     "ora": "^5.4.1",

--- a/incubator/build/src/constants.ts
+++ b/incubator/build/src/constants.ts
@@ -1,9 +1,10 @@
-import * as os from "node:os";
+import envPaths from "env-paths";
 import * as path from "node:path";
 
 export const MAX_ATTEMPTS = 8;
 export const MAX_DOWNLOAD_ATTEMPTS = 3;
 
 export const BUILD_ID = "rnx-build";
-export const USER_CONFIG_FILE = path.join(os.homedir(), `.${BUILD_ID}.json`);
+export const CONFIG_DIR = envPaths(BUILD_ID).config;
+export const USER_CONFIG_FILE = path.join(CONFIG_DIR, "config.json");
 export const WORKFLOW_ID = BUILD_ID + ".yml";

--- a/incubator/build/src/remotes/github.ts
+++ b/incubator/build/src/remotes/github.ts
@@ -90,8 +90,8 @@ function getPersonalAccessToken(): string | undefined {
   }
 
   const content = fileReadSync(USER_CONFIG_FILE, { encoding: "utf-8" });
-  const config: Partial<UserConfig> = JSON.parse(content);
-  return config?.tokens?.github;
+  const config: UserConfig = JSON.parse(content);
+  return config?.github?.token;
 }
 
 async function getWorkflowRunId(
@@ -248,16 +248,11 @@ export async function install(): Promise<number> {
 
   if (!getPersonalAccessToken()) {
     const exampleConfig: UserConfig = {
-      tokens: {
-        github: "token",
-      },
+      github: { token: "ghp_0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ" },
     };
     const example = JSON.stringify(exampleConfig);
     console.error(
-      `Missing personal access token for GitHub. Please create one, and put it in \`${USER_CONFIG_FILE}\`, e.g.: \`${example}\`.`
-    );
-    console.error(
-      "For how to create a personal access token, see: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"
+      `Missing personal access token for GitHub.\n\nPlease create one, and save it in '${USER_CONFIG_FILE}' like below:\n\n\t${example}\n\nFor how to create a personal access token, see: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token`
     );
     return 1;
   }

--- a/incubator/build/src/types.ts
+++ b/incubator/build/src/types.ts
@@ -16,8 +16,8 @@ export type RepositoryInfo = {
 };
 
 export type UserConfig = {
-  tokens: {
-    github?: string;
+  github?: {
+    token: string;
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6982,7 +6982,7 @@ env-editor@^0.4.1:
   resolved "https://registry.yarnpkg.com/env-editor/-/env-editor-0.4.2.tgz#4e76568d0bd8f5c2b6d314a9412c8fe9aa3ae861"
   integrity sha512-ObFo8v4rQJAE59M69QzwloxPZtd33TpYEIjtKD1rrFDcM1Gd7IkDxEBU+HriziN6HSHQnBJi8Dmy+JWkav5HKA==
 
-env-paths@^2.2.0:
+env-paths@^2.2.0, env-paths@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==


### PR DESCRIPTION
### Description

Moves config file into OS-specific path for config files.

### Test plan

```
cd incubator/build
yarn build
yarn rnx-build
```

Example output:

```
Missing personal access token for GitHub.

Please create one, and save it in '~/Library/Preferences/rnx-build-nodejs/config.json' like below:

	{"github":{"token":"ghp_0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"}}

For how to create a personal access token, see: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
```