### PR TITLE
fix(tools-workspaces): remove `node:` prefix to support Node <14.18

### DIFF
--- a/.changeset/warm-balloons-remain.md
+++ b/.changeset/warm-balloons-remain.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-workspaces": patch
+---
+
+Remove `node:` prefix to support Node <14.18

--- a/incubator/build/package.json
+++ b/incubator/build/package.json
@@ -46,7 +46,7 @@
     "memfs": "^3.4.1"
   },
   "engines": {
-    "node": ">=14.15"
+    "node": ">=14.18"
   },
   "eslintConfig": {
     "extends": "@rnx-kit/eslint-config"

--- a/incubator/patcher-rnmacos/package.json
+++ b/incubator/patcher-rnmacos/package.json
@@ -21,7 +21,7 @@
     "directory": "incubator/patcher-rnmacos"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">=14"
   },
   "scripts": {
     "prepare": "echo '⚠️ patcher-rnmacos is EXPERIMENTAL - USE WITH CAUTION  ⚠️'",

--- a/incubator/rn-changelog-generator/package.json
+++ b/incubator/rn-changelog-generator/package.json
@@ -18,7 +18,7 @@
     "directory": "incubator/rn-changelog-generator"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">=14"
   },
   "scripts": {
     "prepare": "echo '⚠️ rn-changelog-generator is EXPERIMENTAL - USE WITH CAUTION  ⚠️'",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prettier": "^2.3.0"
   },
   "engines": {
-    "node": ">=14.15"
+    "node": ">=14.18"
   },
   "resolutions": {
     "eslint-plugin-react": "^7.26.0",

--- a/packages/golang/package.json
+++ b/packages/golang/package.json
@@ -15,7 +15,7 @@
     "directory": "packages/golang"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">=14"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/metro-service/package.json
+++ b/packages/metro-service/package.json
@@ -21,7 +21,7 @@
     "test": "rnx-kit-scripts test"
   },
   "engines": {
-    "node": ">= 10.12"
+    "node": ">=10.12"
   },
   "dependencies": {
     "@rnx-kit/tools-language": "^1.2.6",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -20,7 +20,7 @@
     "directory": "packages/template"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">=14.18"
   },
   "scripts": {
     "build": "rnx-kit-scripts build",

--- a/packages/tools-workspaces/package.json
+++ b/packages/tools-workspaces/package.json
@@ -34,7 +34,7 @@
     "@rnx-kit/scripts": "*"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">=14.15"
   },
   "eslintConfig": {
     "extends": "@rnx-kit/eslint-config"

--- a/packages/tools-workspaces/src/common.ts
+++ b/packages/tools-workspaces/src/common.ts
@@ -1,7 +1,7 @@
 import type { Options } from "fast-glob";
 import fg from "fast-glob";
 import findUp from "find-up";
-import * as path from "node:path";
+import * as path from "path";
 
 type PackageManager = {
   findWorkspacePackages: (sentinel: string) => Promise<string[]>;

--- a/packages/tools-workspaces/src/index.ts
+++ b/packages/tools-workspaces/src/index.ts
@@ -1,4 +1,4 @@
-import * as path from "node:path";
+import * as path from "path";
 import {
   findSentinel,
   findSentinelSync,

--- a/packages/tools-workspaces/src/lerna.ts
+++ b/packages/tools-workspaces/src/lerna.ts
@@ -1,6 +1,6 @@
-import { existsSync as fileExists, readFileSync } from "node:fs";
-import { readFile } from "node:fs/promises";
-import * as path from "node:path";
+import { existsSync as fileExists, readFileSync } from "fs";
+import { readFile } from "fs/promises";
+import * as path from "path";
 import {
   findPackages,
   findPackagesSync,

--- a/packages/tools-workspaces/src/pnpm.ts
+++ b/packages/tools-workspaces/src/pnpm.ts
@@ -1,4 +1,4 @@
-import * as path from "node:path";
+import * as path from "path";
 import {
   default as readYamlFile,
   sync as readYamlFileSync,

--- a/packages/tools-workspaces/src/rush.ts
+++ b/packages/tools-workspaces/src/rush.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from "node:fs";
-import { readFile } from "node:fs/promises";
-import * as path from "node:path";
+import { readFileSync } from "fs";
+import { readFile } from "fs/promises";
+import * as path from "path";
 
 type RushProject = {
   packageName: string;

--- a/packages/tools-workspaces/src/yarn.ts
+++ b/packages/tools-workspaces/src/yarn.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from "node:fs";
-import { readFile } from "node:fs/promises";
-import * as path from "node:path";
+import { readFileSync } from "fs";
+import { readFile } from "fs/promises";
+import * as path from "path";
 import { findPackages, findPackagesSync } from "./common";
 
 type Manifest = {


### PR DESCRIPTION
### Description

`node:` prefix was first introduced in [14.18](https://nodejs.org/en/blog/release/v14.18.0/), but our support goes back to the first LTS version, [14.15](https://nodejs.org/en/blog/release/v14.15.0/).

Resolves #1731.

### Test plan

Logically, nothing has changed. All tests should pass.