### PR TITLE
[TPN] Fix code to deal with nested node_modules

### DIFF
--- a/.changeset/four-bikes-learn.md
+++ b/.changeset/four-bikes-learn.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/third-party-notices": patch
+---
+
+Fix code to deal with nested node_module

--- a/packages/third-party-notices/src/write-third-party-notices.ts
+++ b/packages/third-party-notices/src/write-third-party-notices.ts
@@ -112,13 +112,14 @@ export function splitSourcePath(rootPath: string, p: string): string[] {
 
   const pnpmRegExp = /(.*?node_modules\/[.].+?\/node_modules\/)(.*)/;
   const pnpmPathComponents = pnpmRegExp.exec(p);
+
   if (pnpmPathComponents !== null) {
     nodeModulesPath = pnpmPathComponents[1];
     relativeSourcePath = pnpmPathComponents[2];
   } else {
     nodeModulesPath = p.substring(
       0,
-      p.indexOf(modulesRoot) + modulesRoot.length
+      p.lastIndexOf(modulesRoot) + modulesRoot.length
     );
     relativeSourcePath = p.substring(nodeModulesPath.length);
   }

--- a/packages/third-party-notices/test/normalizePaths.test.ts
+++ b/packages/third-party-notices/test/normalizePaths.test.ts
@@ -42,6 +42,12 @@ describe("normalizePath", () => {
     );
   });
 
+  test("webPackNestedNodeModelesByNoHoistOrNotYarn", () => {
+    const path =
+      "webpack://@ms/office-test-project-runtime/../../node_modules/@myframework/driver-utils/node_modules/@myframework/telemetry-utils/lib/config.js";
+    expect(normalizePath(path)).toBe(path);
+  });
+
   // Paths
   test("relativePath", () => {
     expect(normalizePath("folder/file")).toBe("folder/file");

--- a/packages/third-party-notices/test/splitSourcePath.test.ts
+++ b/packages/third-party-notices/test/splitSourcePath.test.ts
@@ -40,9 +40,24 @@ describe("splitSourcePath", () => {
       `${absolutePathRoot}src\\root`,
       `${absolutePathRoot}src/root/node_modules/myPackage/node_modules/nestedPackage/nestedFile.js`
     );
-    expect(moduleName).toBe("myPackage");
+    expect(moduleName).toBe("nestedPackage");
     expect(osSpecificPath(modulePath)).toBe(
-      osSpecificPath(`${absolutePathRoot}src\\root\\node_modules\\myPackage`)
+      osSpecificPath(
+        `${absolutePathRoot}src\\root\\node_modules\\myPackage\\node_modules\\nestedPackage`
+      )
+    );
+  });
+
+  test("packageFolderWithNestedNodeModulesFilesAndNamespaces", () => {
+    const [moduleName, modulePath] = splitSourcePath(
+      `${absolutePathRoot}src\\root`,
+      `${absolutePathRoot}src/root/node_modules/@myframework/driver-utils/node_modules/@myframework/telemetry-utils/lib/config.js`
+    );
+    expect(moduleName).toBe("@myframework/telemetry-utils");
+    expect(osSpecificPath(modulePath)).toBe(
+      osSpecificPath(
+        `${absolutePathRoot}src\\root\\node_modules\\@myframework\\driver-utils\\node_modules\\@myframework\\telemetry-utils`
+      )
     );
   });
 


### PR DESCRIPTION

### Description

Fix code in third_party-notices to properly deal with nested node_modules. It should always take the 'last' node_modules in a path rather than the first. 
There existed a test for it, but it was checking to actually take the first one.

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

Added local tests with customers paths and they pass