### PR TITLE
fix(metro-config): cannot resolve react-native when using pnpm + GitHub URLs

### DIFF
--- a/.changeset/light-cameras-unite.md
+++ b/.changeset/light-cameras-unite.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Fixed react-native not being found when using pnpm and GitHub URLs

--- a/packages/metro-config/README.md
+++ b/packages/metro-config/README.md
@@ -27,7 +27,14 @@ module.exports = {
 const { makeMetroConfig } = require("@rnx-kit/metro-config");
 
 module.exports = makeMetroConfig({
-  projectRoot: __dirname,
+  transformer: {
+    getTransformOptions: async () => ({
+      transform: {
+        experimentalImportSupport: false,
+        inlineRequires: true,
+      },
+    }),
+  },
 });
 ```
 
@@ -152,7 +159,6 @@ const additionalExclusions = [msalExcludePattern];
 const blockList = exclusionList(additionalExclusions);
 
 module.exports = makeMetroConfig({
-  projectRoot: __dirname,
   resolver: {
     extraNodeModules: {
       "react-native-msal": msalPath,
@@ -214,7 +220,6 @@ const blockList = exclusionList([
 ]);
 
 module.exports = makeMetroConfig({
-  projectRoot: __dirname,
   resolver: {
     blacklistRE: blockList, // For Metro < 0.60
     blockList, // For Metro >= 0.60
@@ -240,7 +245,7 @@ const { makeMetroConfig } = require("@rnx-kit/metro-config");
 const fs = require("fs");
 const path = require("path");
 
-const config = makeMetroConfig({ projectRoot: __dirname });
+const config = makeMetroConfig();
 
 module.exports = {
   ...config,

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -85,10 +85,7 @@ function resolveUniqueModule(packageName, searchStartDir) {
   // - path/to/node_modules/@babel/runtime
   // - path/to/node_modules/prop-types
   const owningDir = path.dirname(result.slice(0, -packageName.length));
-  const escapedPath = owningDir
-    .replace(/\\/g, "\\\\")
-    .replace(/\+/g, "\\+")
-    .replace(/\./g, "\\.");
+  const escapedPath = owningDir.replace(/[+.\\]/g, "\\$&");
   const escapedPackageName = path.normalize(packageName).replace(/\\/g, "\\\\");
 
   const exclusionRE = new RegExp(

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -85,7 +85,10 @@ function resolveUniqueModule(packageName, searchStartDir) {
   // - path/to/node_modules/@babel/runtime
   // - path/to/node_modules/prop-types
   const owningDir = path.dirname(result.slice(0, -packageName.length));
-  const escapedPath = owningDir.replace(/\\/g, "\\\\");
+  const escapedPath = owningDir
+    .replace(/\\/g, "\\\\")
+    .replace(/\+/g, "\\+")
+    .replace(/\./g, "\\.");
   const escapedPackageName = path.normalize(packageName).replace(/\\/g, "\\\\");
 
   const exclusionRE = new RegExp(

--- a/packages/metro-config/test/__fixtures__/pnpm-repo/node_modules/.pnpm/github.com+facebook+react-native@72e1eda0736d34d027e4d4b1c3cace529ab5dcf3_react@17.0.2/node_modules/react-native/package.json
+++ b/packages/metro-config/test/__fixtures__/pnpm-repo/node_modules/.pnpm/github.com+facebook+react-native@72e1eda0736d34d027e4d4b1c3cace529ab5dcf3_react@17.0.2/node_modules/react-native/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "react-native",
+  "version": "1000.0.0",
+  "description": "A framework for building native apps using React",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:facebook/react-native.git"
+  }
+}

--- a/packages/metro-config/test/__fixtures__/pnpm-repo/node_modules/.pnpm/react@17.0.2/node_modules/react/package.json
+++ b/packages/metro-config/test/__fixtures__/pnpm-repo/node_modules/.pnpm/react@17.0.2/node_modules/react/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "react",
+  "version": "17.0.2",
+  "description": "React is a JavaScript library for building user interfaces.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/react.git",
+    "directory": "packages/react"
+  }
+}

--- a/packages/metro-config/test/__fixtures__/pnpm-repo/node_modules/react
+++ b/packages/metro-config/test/__fixtures__/pnpm-repo/node_modules/react
@@ -1,0 +1,1 @@
+.pnpm/react@17.0.2/node_modules/react

--- a/packages/metro-config/test/__fixtures__/pnpm-repo/node_modules/react-native
+++ b/packages/metro-config/test/__fixtures__/pnpm-repo/node_modules/react-native
@@ -1,0 +1,1 @@
+.pnpm/github.com+facebook+react-native@72e1eda0736d34d027e4d4b1c3cace529ab5dcf3_react@17.0.2/node_modules/react-native

--- a/packages/metro-config/test/__fixtures__/pnpm-repo/package.json
+++ b/packages/metro-config/test/__fixtures__/pnpm-repo/package.json
@@ -1,0 +1,7 @@
+{
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ]
+  }
+}

--- a/packages/metro-config/test/__fixtures__/pnpm-repo/pnpm-lock.yaml
+++ b/packages/metro-config/test/__fixtures__/pnpm-repo/pnpm-lock.yaml
@@ -1,0 +1,1 @@
+# `@rnx-kit/tools-workspaces` determines repo root by looking for a lock file

--- a/packages/metro-config/test/index.test.ts
+++ b/packages/metro-config/test/index.test.ts
@@ -154,6 +154,15 @@ describe("@rnx-kit/metro-config", () => {
     );
   });
 
+  test("resolveUniqueModule() escapes characters clashing with regex tokens", () => {
+    const repo = fixturePath("pnpm-repo");
+    const [rnPath, rnExclude] = resolveUniqueModule("react-native", repo);
+    expect(rnPath).toMatch(
+      /__fixtures__[/\\]pnpm-repo[/\\]node_modules[/\\]\.pnpm[/\\]github\.com\+facebook\+react-native@72e1eda0736d34d027e4d4b1c3cace529ab5dcf3_react@17\.0\.2[/\\]node_modules[/\\]react-native$/
+    );
+    expect(rnExclude.test(path.join(rnPath, "package.json"))).toBeFalsy();
+  });
+
   test("exclusionList() ignores extra copies of react and react-native", () => {
     const repo = fixturePath("awesome-repo");
     const reactCopy = path.join(repo, "node_modules", "react", "package.json");


### PR DESCRIPTION
### Description

Fixed react-native not being found when using pnpm and GitHub URLs.

Resolves #1744.

### Test plan

See repro steps in #1744.