### PR TITLE
fix(metro-config): fix invalid regular expression on Windows

### DIFF
--- a/.changeset/wet-tigers-sparkle.md
+++ b/.changeset/wet-tigers-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Fixed invalid regular expression on Windows

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -89,7 +89,7 @@ function resolveUniqueModule(packageName, searchStartDir) {
   const escapedPackageName = path.normalize(packageName).replace(/\\/g, "\\\\");
 
   const exclusionRE = new RegExp(
-    `(?<!${escapedPath})[/\\\\]node_modules[/\\\\]${escapedPackageName}[/\\\\].*`
+    `(?<!${escapedPath})\\${path.sep}node_modules\\${path.sep}${escapedPackageName}\\${path.sep}.*`
   );
   return [result, exclusionRE];
 }


### PR DESCRIPTION
### Description

The regular expression `[/\\]` is clashing with path separator escaping in upstream `metro-config`: https://github.com/facebook/metro/blob/v0.71.3/packages/metro-config/src/defaults/exclusionList.js#L25

Replacing it with OS specific separators since it's what Metro wants anyway.

Resolves #1694.

### Test plan

See repro steps in #1694. This was tested on both macOS and Windows.