### PR TITLE
fix: depend on an explicit version of Kotlin Android plugin

### DIFF
--- a/.changeset/metal-years-pump.md
+++ b/.changeset/metal-years-pump.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/react-native-auth": patch
+"@rnx-kit/react-native-test-app-msal": patch
+---
+
+Depend on an explicit version of Kotlin Android plugin using the [plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block)

--- a/packages/react-native-auth/android/build.gradle
+++ b/packages/react-native-auth/android/build.gradle
@@ -34,14 +34,13 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:${getExtProp('androidPluginVersion', '4.2.2')}"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath("com.android.tools.build:gradle:${getExtProp('androidPluginVersion', '7.2.1')}")
     }
 }
 
 plugins {
-    id "com.android.library"
-    id "kotlin-android"
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android") version "${kotlinVersion}"
 }
 
 repositories {

--- a/packages/react-native-test-app-msal/android/build.gradle
+++ b/packages/react-native-test-app-msal/android/build.gradle
@@ -50,14 +50,13 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:${getExtProp('androidPluginVersion', '4.2.2')}"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath("com.android.tools.build:gradle:${getExtProp('androidPluginVersion', '7.2.1')}")
     }
 }
 
 plugins {
-    id "com.android.library"
-    id "kotlin-android"
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android") version "${kotlinVersion}"
 }
 
 repositories {

--- a/packages/test-app/android/build.gradle
+++ b/packages/test-app/android/build.gradle
@@ -8,7 +8,6 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:$androidPluginVersion"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath("com.android.tools.build:gradle:${androidPluginVersion}")
     }
 }

--- a/packages/test-app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/test-app/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -49,7 +49,7 @@
     "@types/react-native": "^0.68.0",
     "jest-cli": "^27.5.1",
     "metro-react-native-babel-preset": "^0.67.0",
-    "react-native-test-app": "^1.5.0",
+    "react-native-test-app": "^1.3.5",
     "react-test-renderer": "17.0.2",
     "typescript": "^4.0.0"
   },

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -49,7 +49,7 @@
     "@types/react-native": "^0.68.0",
     "jest-cli": "^27.5.1",
     "metro-react-native-babel-preset": "^0.67.0",
-    "react-native-test-app": "^1.3.5",
+    "react-native-test-app": "^1.5.0",
     "react-test-renderer": "17.0.2",
     "typescript": "^4.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13293,7 +13293,7 @@ react-native-screens@~3.11.1:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
 
-react-native-test-app@^1.5.0:
+react-native-test-app@^1.3.5:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.5.0.tgz#a504a71246555234a18c02cab454d2a57950e914"
   integrity sha512-Z+zJjnwnqE/H36aFRKLgjyjrCRanB2R5gN8j33VclBiw9tP6O3lC7iCEewJlKVyRkPzMDOdL0EM18hcx6snqsg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -13293,10 +13293,10 @@ react-native-screens@~3.11.1:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
 
-react-native-test-app@^1.3.5:
-  version "1.3.11"
-  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.3.11.tgz#73253fea7c9c7e5ce7f1cb5c1d616d2e6a341ee6"
-  integrity sha512-IpQDLbtgKKat1NQXJpWdSKxNloXJqFMU2WqlDHqqdc0xsRxk3xZ08Ia5dAQwJKUDTejky0lFX9QocRKl3IkU9Q==
+react-native-test-app@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.5.0.tgz#a504a71246555234a18c02cab454d2a57950e914"
+  integrity sha512-Z+zJjnwnqE/H36aFRKLgjyjrCRanB2R5gN8j33VclBiw9tP6O3lC7iCEewJlKVyRkPzMDOdL0EM18hcx6snqsg==
   dependencies:
     ajv "^8.0.0"
     chalk "^4.1.0"


### PR DESCRIPTION
### Description

- Depend on an explicit version of Kotlin Android plugin using the [plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block)
- Bumped `react-native-test-app` to 1.5.0 for full new architecture support

### Test plan

CI should pass.