### PR TITLE
fix(rnx-build): add support for Apple M1

### DIFF
--- a/.changeset/five-deers-doubt.md
+++ b/.changeset/five-deers-doubt.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+Added support for Apple M1

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -120,10 +120,11 @@ jobs:
             code_signing=''
           else
             destination='generic/platform=iOS Simulator'
+            archs='ARCHS=${{ github.event.inputs.architecture }}'
             code_signing='CODE_SIGNING_ALLOWED=NO'
           fi
           xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
-          xcodebuild -workspace ${xcworkspace} -scheme ${{ github.event.inputs.scheme }} -destination "${destination}" -configuration Debug -derivedDataPath DerivedData -archivePath ${XCARCHIVE_FILE} ${code_signing} COMPILER_INDEX_STORE_ENABLE=NO archive
+          xcodebuild -workspace ${xcworkspace} -scheme ${{ github.event.inputs.scheme }} -destination "${destination}" -configuration Debug -derivedDataPath DerivedData -archivePath ${XCARCHIVE_FILE} ${archs} ${code_signing} COMPILER_INDEX_STORE_ENABLE=NO archive
         working-directory: ${{ github.event.inputs.projectRoot }}/ios
       - name: Remove Apple signing certificate and provisioning profile
         if: ${{ always() && github.event.inputs.deviceType == 'device' }}

--- a/incubator/build/src/cli.ts
+++ b/incubator/build/src/cli.ts
@@ -41,6 +41,11 @@ async function main(): Promise<void> {
       choices: PLATFORMS,
       required: true,
     })
+    .option("architecture", {
+      type: "string",
+      description: "CPU architecture of the machine running the app",
+      default: process.arch,
+    })
     .option("deploy", {
       type: "string",
       description: "Where builds should be deployed from",
@@ -70,6 +75,7 @@ async function main(): Promise<void> {
     .strict().argv;
 
   const {
+    architecture,
     deploy,
     "device-type": deviceType,
     "package-manager": packageManager,
@@ -84,6 +90,7 @@ async function main(): Promise<void> {
   );
 
   process.exitCode = await startBuild(remote, distribution, repoInfo, {
+    architecture,
     deviceType,
     distribution: await distribution.getConfigString(platform),
     packageManager: packageManager || "npm",

--- a/incubator/build/src/types.ts
+++ b/incubator/build/src/types.ts
@@ -12,6 +12,7 @@ export type DeviceType = typeof DEVICE_TYPES[number];
 export type Platform = typeof PLATFORMS[number];
 
 export type BuildParams = {
+  architecture: string;
   platform: Platform;
   deviceType: DeviceType;
   distribution: string;

--- a/incubator/build/workflows/github.yml
+++ b/incubator/build/workflows/github.yml
@@ -120,10 +120,11 @@ jobs:
             code_signing=''
           else
             destination='generic/platform=iOS Simulator'
+            archs='ARCHS=${{ github.event.inputs.architecture }}'
             code_signing='CODE_SIGNING_ALLOWED=NO'
           fi
           xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
-          xcodebuild -workspace ${xcworkspace} -scheme ${{ github.event.inputs.scheme }} -destination "${destination}" -configuration Debug -derivedDataPath DerivedData -archivePath ${XCARCHIVE_FILE} ${code_signing} COMPILER_INDEX_STORE_ENABLE=NO archive
+          xcodebuild -workspace ${xcworkspace} -scheme ${{ github.event.inputs.scheme }} -destination "${destination}" -configuration Debug -derivedDataPath DerivedData -archivePath ${XCARCHIVE_FILE} ${archs} ${code_signing} COMPILER_INDEX_STORE_ENABLE=NO archive
         working-directory: ${{ github.event.inputs.projectRoot }}/ios
       - name: Remove Apple signing certificate and provisioning profile
         if: ${{ always() && github.event.inputs.deviceType == 'device' }}


### PR DESCRIPTION
### Description

Added support for Apple M1.

### Test plan

```
cd incubator/build
yarn build --dependencies
yarn rnx-build --platform ios ../../packages/test-app
```

Successful build: https://github.com/tido64/rnx-kit/runs/7495451857?check_suite_focus=true