### PR TITLE
docs(changeset): Bump for a build with latest @rnx-kit dependencies

### DIFF
--- a/.changeset/clean-shirts-whisper.md
+++ b/.changeset/clean-shirts-whisper.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/dep-check": patch
+---
+
+Bump for a build with latest @rnx-kit dependencies


### PR DESCRIPTION
### Description

Bumping dep-check so we can get a build with the fix for `node:` prefixes.

### Test plan

n/a