### PR TITLE
fix(rnx-build): increase timeout waiting for Android emulator

### DIFF
--- a/.changeset/odd-hounds-brush.md
+++ b/.changeset/odd-hounds-brush.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+Increased timeout waiting for Android emulator to boot

--- a/incubator/build/src/platforms/android.ts
+++ b/incubator/build/src/platforms/android.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import type { Ora } from "ora";
 import { idle, retry } from "../async";
 import { ensure, makeCommand, makeCommandSync } from "../command";
+import { MAX_ATTEMPTS } from "../constants";
 import type { BuildParams } from "../types";
 import { latestVersion } from "../version";
 
@@ -130,7 +131,7 @@ async function launchEmulator(
   const result = await retry(async () => {
     const devices = await getDevices();
     return devices.find((device) => device.state === "device") || null;
-  }, 4);
+  }, MAX_ATTEMPTS);
   return result || new Error("Timed out waiting for the emulator");
 }
 


### PR DESCRIPTION
### Description

Increased timeout waiting for Android emulator to boot. Android emulators can take very long to boot, especially if they're cold-booting i.e. not from a snapshot.

### Test plan

CI should pass.