### PR TITLE
chore: bump Node requirement so we can target ES2019

### DIFF
--- a/.changeset/flat-moons-float.md
+++ b/.changeset/flat-moons-float.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-service": major
+---
+
+Drop support for Node 10

--- a/incubator/patcher-rnmacos/package.json
+++ b/incubator/patcher-rnmacos/package.json
@@ -21,7 +21,7 @@
     "directory": "incubator/patcher-rnmacos"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=14.15"
   },
   "scripts": {
     "prepare": "echo '⚠️ patcher-rnmacos is EXPERIMENTAL - USE WITH CAUTION  ⚠️'",

--- a/incubator/rn-changelog-generator/package.json
+++ b/incubator/rn-changelog-generator/package.json
@@ -18,7 +18,7 @@
     "directory": "incubator/rn-changelog-generator"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=14.15"
   },
   "scripts": {
     "prepare": "echo '⚠️ rn-changelog-generator is EXPERIMENTAL - USE WITH CAUTION  ⚠️'",

--- a/packages/dep-check/tsconfig.json
+++ b/packages/dep-check/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "compilerOptions": {
-    "lib": ["ES2019.Object"],
     "alwaysStrict": false
   },
   "include": ["src"]

--- a/packages/golang/package.json
+++ b/packages/golang/package.json
@@ -15,7 +15,7 @@
     "directory": "packages/golang"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=14.15"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/metro-serializer-esbuild/tsconfig.json
+++ b/packages/metro-serializer-esbuild/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "@rnx-kit/scripts/tsconfig-shared.json",
-  "compilerOptions": {
-    "target": "ES2017"
-  },
   "include": ["src"]
 }

--- a/packages/metro-service/package.json
+++ b/packages/metro-service/package.json
@@ -21,7 +21,7 @@
     "test": "rnx-kit-scripts test"
   },
   "engines": {
-    "node": ">=10.12"
+    "node": ">=12.13"
   },
   "dependencies": {
     "@rnx-kit/tools-language": "^1.2.6",

--- a/scripts/tsconfig-shared.json
+++ b/scripts/tsconfig-shared.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "ES2019",
     "module": "commonjs",
     "moduleResolution": "node",
     "declaration": true,


### PR DESCRIPTION
### Description

According to https://kangax.github.io/compat-table/es2016plus/, we can target ES2019 with Node 12+.

### Test plan

CI should pass.