### PR TITLE
feat: @expo/config-plugins support module for react-native-test-app

### DIFF
--- a/.changeset/tame-horses-heal.md
+++ b/.changeset/tame-horses-heal.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-test-app-config-plugins": minor
+---
+
+`@expo/config-plugins` support module for `react-native-test-app`

--- a/incubator/react-native-test-app-config-plugins/README.md
+++ b/incubator/react-native-test-app-config-plugins/README.md
@@ -1,0 +1,60 @@
+# @rnx-kit/react-native-test-app-config-plugins
+
+[![Build](https://github.com/microsoft/rnx-kit/actions/workflows/build.yml/badge.svg)](https://github.com/microsoft/rnx-kit/actions/workflows/build.yml)
+[![npm version](https://img.shields.io/npm/v/@rnx-kit/react-native-test-app-config-plugins)](https://www.npmjs.com/package/@rnx-kit/react-native-test-app-config-plugins)
+
+🚧🚧🚧🚧🚧🚧🚧🚧🚧🚧🚧
+
+### This tool is EXPERIMENTAL - USE WITH CAUTION
+
+🚧🚧🚧🚧🚧🚧🚧🚧🚧🚧🚧
+
+[@expo/config-plugins](https://docs.expo.dev/guides/config-plugins/) support
+module for
+[react-native-test-app](https://github.com/microsoft/react-native-test-app).
+
+Most Expo config plugins should work out of box. You should check out
+[Expo's documentation](https://docs.expo.dev/guides/config-plugins/) for how to
+use plugins, as well as writing your own.
+
+## Installation
+
+```sh
+yarn add @rnx-kit/react-native-test-app-config-plugins --dev
+```
+
+or if you're using npm
+
+```sh
+npm add --save-dev @rnx-kit/react-native-test-app-config-plugins
+```
+
+## Using a Plugin in Your App
+
+In your app's config (`app.json`), you can add plugins to the `plugins` section:
+
+```diff
+ {
+   "name": "Example",
++  "plugins": ["module-with-config-plugin"]
+ }
+```
+
+You can also pass options to the plugin by wrapping both in an array:
+
+```diff
+ {
+   "name": "Example",
++  "plugins": [
++    ["module-with-config-plugin", { "myOption": "value" }]
++  ]
+ }
+```
+
+For more details, please refer to
+[Expo Config Plugins](https://docs.expo.dev/guides/config-plugins/#using-a-plugin-in-your-app).
+
+Note that Expo specific mods are not implemented. These include:
+
+- `mods.ios.expoPlist`
+- `mods.ios.podfileProperties`

--- a/incubator/react-native-test-app-config-plugins/package.json
+++ b/incubator/react-native-test-app-config-plugins/package.json
@@ -1,0 +1,54 @@
+{
+  "private": true,
+  "name": "@rnx-kit/react-native-test-app-config-plugins",
+  "version": "0.0.1",
+  "description": "EXPERIMENTAL - USE WITH CAUTION - `@expo/config-plugins` support module for `react-native-test-app`",
+  "homepage": "https://github.com/microsoft/rnx-kit/tree/main/incubator/react-native-test-app-config-plugins#readme",
+  "license": "MIT",
+  "author": {
+    "name": "Microsoft Open Source",
+    "email": "microsoftopensource@users.noreply.github.com"
+  },
+  "files": [
+    "lib/**/*.{d.ts,js}"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/rnx-kit",
+    "directory": "incubator/react-native-test-app-config-plugins"
+  },
+  "scripts": {
+    "build": "rnx-kit-scripts build",
+    "format": "rnx-kit-scripts format",
+    "lint": "rnx-kit-scripts lint",
+    "test": "rnx-kit-scripts test"
+  },
+  "dependencies": {
+    "find-up": "^5.0.0"
+  },
+  "peerDependencies": {
+    "@expo/config-plugins": "^4.0.0 || ^5.0.0"
+  },
+  "devDependencies": {
+    "@expo/config-plugins": "^4.0.0",
+    "@rnx-kit/scripts": "*",
+    "@types/node": "^16.0.0"
+  },
+  "engines": {
+    "node": ">=14.15"
+  },
+  "depcheck": {
+    "ignoreMatches": [
+      "find-up"
+    ]
+  },
+  "eslintConfig": {
+    "extends": "@rnx-kit/eslint-config"
+  },
+  "jest": {
+    "preset": "@rnx-kit/scripts"
+  },
+  "experimental": true
+}

--- a/incubator/react-native-test-app-config-plugins/package.json
+++ b/incubator/react-native-test-app-config-plugins/package.json
@@ -22,8 +22,7 @@
   "scripts": {
     "build": "rnx-kit-scripts build",
     "format": "rnx-kit-scripts format",
-    "lint": "rnx-kit-scripts lint",
-    "test": "rnx-kit-scripts test"
+    "lint": "rnx-kit-scripts lint"
   },
   "dependencies": {
     "find-up": "^5.0.0"

--- a/incubator/react-native-test-app-config-plugins/src/apply.ts
+++ b/incubator/react-native-test-app-config-plugins/src/apply.ts
@@ -1,0 +1,25 @@
+import { withPlugins } from "@expo/config-plugins";
+import * as fs from "fs/promises";
+import { compileModsAsync } from "./plugins/mod-compiler";
+import { withInternal } from "./plugins/withInternal";
+import type { ProjectInfo } from "./types";
+
+export async function applyConfigPlugins({
+  appJsonPath,
+  ...info
+}: ProjectInfo) {
+  if (!appJsonPath) {
+    return;
+  }
+
+  const content = await fs.readFile(appJsonPath, { encoding: "utf-8" });
+  const { plugins, ...config } = JSON.parse(content);
+  if (!Array.isArray(plugins) || plugins.length === 0) {
+    return;
+  }
+
+  return compileModsAsync(
+    withPlugins(withInternal(config, info), plugins),
+    info
+  );
+}

--- a/incubator/react-native-test-app-config-plugins/src/index.ts
+++ b/incubator/react-native-test-app-config-plugins/src/index.ts
@@ -1,0 +1,11 @@
+import { getAndroidModFileProviders } from "./plugins/withAndroidBaseMods";
+import { getIosModFileProviders } from "./plugins/withIosBaseMods";
+
+export { applyConfigPlugins } from "./apply";
+export { compileModsAsync, withDefaultBaseMods } from "./plugins/mod-compiler";
+export { withInternal } from "./plugins/withInternal";
+
+export const BaseMods = {
+  getAndroidModFileProviders,
+  getIosModFileProviders,
+};

--- a/incubator/react-native-test-app-config-plugins/src/plugins/mod-compiler.ts
+++ b/incubator/react-native-test-app-config-plugins/src/plugins/mod-compiler.ts
@@ -1,0 +1,31 @@
+import type {
+  compileModsAsync as compileExpoModsAsync,
+  withDefaultBaseMods as withExpoBaseMods,
+} from "@expo/config-plugins";
+import { BaseMods, evalModsAsync } from "@expo/config-plugins";
+import { getAndroidModFileProviders } from "./withAndroidBaseMods";
+import { getIosModFileProviders } from "./withIosBaseMods";
+
+export const withDefaultBaseMods: typeof withExpoBaseMods = (config, props) => {
+  config = BaseMods.withIosBaseMods(config, {
+    ...props,
+    providers: getIosModFileProviders(),
+  });
+  config = BaseMods.withAndroidBaseMods(config, {
+    ...props,
+    providers: getAndroidModFileProviders(),
+  });
+  return config;
+};
+
+export const compileModsAsync: typeof compileExpoModsAsync = (
+  config,
+  props
+) => {
+  if (props.introspect === true) {
+    console.warn("`introspect` is not supported by react-native-test-app");
+  }
+
+  config = withDefaultBaseMods(config);
+  return evalModsAsync(config, props);
+};

--- a/incubator/react-native-test-app-config-plugins/src/plugins/withAndroidBaseMods.ts
+++ b/incubator/react-native-test-app-config-plugins/src/plugins/withAndroidBaseMods.ts
@@ -1,0 +1,49 @@
+import { BaseMods } from "@expo/config-plugins";
+import { makeFilePathModifier } from "../provider";
+
+const modifyFilePath = makeFilePathModifier(
+  "node_modules/react-native-test-app/android"
+);
+
+// https://github.com/expo/expo/blob/93cd0503117d5a25f8b80ed7b30ec5bed3a67c24/packages/@expo/config-plugins/src/plugins/withAndroidBaseMods.ts
+const expoProviders = BaseMods.getAndroidModFileProviders();
+
+const defaultProviders: typeof expoProviders = {
+  dangerous: expoProviders.dangerous,
+  manifest: modifyFilePath(
+    expoProviders.manifest,
+    "app/src/main/AndroidManifest.xml"
+  ),
+  gradleProperties: expoProviders.gradleProperties,
+  strings: modifyFilePath(
+    expoProviders.strings,
+    "app/src/main/res/values/strings.xml"
+  ),
+  colors: modifyFilePath(
+    expoProviders.colors,
+    "app/src/main/res/values/colors.xml"
+  ),
+  colorsNight: modifyFilePath(
+    expoProviders.colors,
+    "app/src/main/res/values-night/colors.xml"
+  ),
+  styles: modifyFilePath(
+    expoProviders.styles,
+    "app/src/main/res/values/styles.xml"
+  ),
+  projectBuildGradle: expoProviders.projectBuildGradle,
+  settingsGradle: expoProviders.settingsGradle,
+  appBuildGradle: expoProviders.appBuildGradle,
+  mainActivity: modifyFilePath(
+    expoProviders.mainActivity,
+    "app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt"
+  ),
+  mainApplication: modifyFilePath(
+    expoProviders.mainApplication,
+    "app/src/main/java/com/microsoft/reacttestapp/TestApp.kt"
+  ),
+};
+
+export function getAndroidModFileProviders() {
+  return defaultProviders;
+}

--- a/incubator/react-native-test-app-config-plugins/src/plugins/withInternal.ts
+++ b/incubator/react-native-test-app-config-plugins/src/plugins/withInternal.ts
@@ -1,0 +1,13 @@
+import type { ConfigPlugin } from "@expo/config-plugins";
+import type { ProjectInfo } from "../types";
+
+type Internals = Omit<ProjectInfo, "appJsonPath">;
+
+export const withInternal: ConfigPlugin<Internals> = (config, internals) => {
+  config._internal = {
+    isDebug: false,
+    ...config._internal,
+    ...internals,
+  };
+  return config;
+};

--- a/incubator/react-native-test-app-config-plugins/src/plugins/withIosBaseMods.ts
+++ b/incubator/react-native-test-app-config-plugins/src/plugins/withIosBaseMods.ts
@@ -1,0 +1,32 @@
+import { BaseMods } from "@expo/config-plugins";
+import { makeFilePathModifier, makeNullProvider } from "../provider";
+
+const modifyFilePath = makeFilePathModifier("node_modules/.generated/ios");
+
+const nullProvider = makeNullProvider();
+
+// https://github.com/expo/expo/blob/93cd0503117d5a25f8b80ed7b30ec5bed3a67c24/packages/@expo/config-plugins/src/plugins/withIosBaseMods.ts
+const expoProviders = BaseMods.getIosModFileProviders();
+
+const defaultProviders: typeof expoProviders = {
+  dangerous: expoProviders.dangerous,
+  appDelegate: modifyFilePath(
+    expoProviders.appDelegate,
+    "ReactTestApp/AppDelegate.swift"
+  ),
+  expoPlist: nullProvider,
+  xcodeproj: modifyFilePath(
+    expoProviders.xcodeproj,
+    "ReactTestApp.xcodeproj/project.pbxproj"
+  ),
+  infoPlist: modifyFilePath(expoProviders.infoPlist, "ReactTestApp/Info.plist"),
+  entitlements: modifyFilePath(
+    expoProviders.entitlements,
+    "ReactTestApp/ReactTestApp.entitlements"
+  ),
+  podfileProperties: nullProvider,
+};
+
+export function getIosModFileProviders() {
+  return defaultProviders;
+}

--- a/incubator/react-native-test-app-config-plugins/src/provider.ts
+++ b/incubator/react-native-test-app-config-plugins/src/provider.ts
@@ -1,0 +1,31 @@
+import { BaseMods } from "@expo/config-plugins";
+import findUp from "find-up";
+import * as path from "path";
+
+type BaseModProviderMethods<ModType, Props> = ReturnType<
+  typeof BaseMods.provider<ModType, Props>
+>;
+
+export function makeNullProvider(defaultRead = {}) {
+  return BaseMods.provider({
+    getFilePath: () => "",
+    read: () => Promise.resolve(defaultRead),
+    write: () => Promise.resolve(),
+  });
+}
+
+export function makeFilePathModifier(actualProjectDir: string) {
+  return function <ModType, Props>(
+    original: BaseModProviderMethods<ModType, Props>,
+    file: string
+  ): BaseModProviderMethods<ModType, Props> {
+    return BaseMods.provider({
+      ...original,
+      getFilePath: async ({ modRequest: { projectRoot } }) => {
+        const name = path.posix.join(actualProjectDir, file);
+        const result = await findUp(name, { cwd: projectRoot });
+        return result || name;
+      },
+    });
+  };
+}

--- a/incubator/react-native-test-app-config-plugins/src/types.ts
+++ b/incubator/react-native-test-app-config-plugins/src/types.ts
@@ -1,0 +1,5 @@
+export type ProjectInfo = {
+  projectRoot: string;
+  packageJsonPath: string;
+  appJsonPath: string;
+};

--- a/incubator/react-native-test-app-config-plugins/tsconfig.json
+++ b/incubator/react-native-test-app-config-plugins/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
+  "compilerOptions": {
+    "target": "ES2020"
+  },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2048,7 +2048,7 @@
     node-forge "^1.2.1"
     nullthrows "^1.1.1"
 
-"@expo/config-plugins@4.1.5", "@expo/config-plugins@^4.0.14", "@expo/config-plugins@~4.1.4":
+"@expo/config-plugins@4.1.5", "@expo/config-plugins@^4.0.0", "@expo/config-plugins@^4.0.14", "@expo/config-plugins@~4.1.4":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-4.1.5.tgz#9d357d2cda9c095e511b51583ede8a3b76174068"
   integrity sha512-RVvU40RtZt12HavuDAe+LDIq9lHj7sheOfMEHdmpJ/uTA8pgvkbc56XF6JHQD+yRr6+uhhb+JnAasGq49dsQbw==


### PR DESCRIPTION
### Description

Adds `@expo/config-plugins` support module for `react-native-test-app`.

### Test plan

See https://github.com/microsoft/react-native-test-app/pull/1033.