### PR TITLE
chore: bump @types/react and dedupe babel-plugin-polyfill-regenerator

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3051,9 +3051,9 @@
     "@types/react" "^17"
 
 "@types/react@^17", "@types/react@^17.0.2", "@types/react@~17.0.21":
-  version "17.0.47"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.47.tgz#4ee71aaf4c5a9e290e03aa4d0d313c5d666b3b78"
-  integrity sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==
+  version "17.0.48"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.48.tgz#a4532a8b91d7b27b8768b6fc0c3bccb760d15a6c"
+  integrity sha512-zJ6IYlJ8cYYxiJfUaZOQee4lh99mFihBoqkOSEGV+dFi9leROW6+PgstzQ+w3gWTnUfskALtQPGHK6dYmPj+2A==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
### Description

Fixes the `@types/react` bump in #1800, ~~and dedupes `babel-plugin-polyfill-regenerator` introduced in #1802~~.

The dupe was resolved in #1797.

### Test plan

CI should pass.