### PR TITLE
fix(metro-serializer-esbuild): fix missing `sourceMappingURL` comment

### DIFF
--- a/.changeset/fluffy-cycles-unite.md
+++ b/.changeset/fluffy-cycles-unite.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Fix missing `sourceMappingURL` comment

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -258,8 +258,9 @@ export function MetroSerializer(
     // the sourcemap and insert it into `BuildResult["outputFiles"]`. We've
     // disabled writing to disk by setting `write: false`. Metro will handle
     // the rest after we return code + sourcemap.
-    const outfile = "main.jsbundle";
-    const sourcemapfile = outfile + ".map";
+    const outfile =
+      options.sourceMapUrl?.replace(/\.map$/, "") ?? "main.jsbundle";
+    const sourcemapfile = options.sourceMapUrl ?? outfile + ".map";
 
     const plugins = [metroPlugin];
     if (isImporting("lodash", dependencies)) {
@@ -301,7 +302,7 @@ export function MetroSerializer(
         minify: buildOptions?.minify ?? !options.dev,
         outfile,
         plugins,
-        sourcemap: "external",
+        sourcemap: Boolean(options.sourceMapUrl) && "linked",
         target,
         supported: (() => {
           if (typeof target !== "string" || !target.startsWith("hermes")) {

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -254,10 +254,11 @@ export function MetroSerializer(
       },
     };
 
-    // `outfile` is only meant to give esbuild a name it can use to generate
-    // the sourcemap and insert it into `BuildResult["outputFiles"]`. We've
-    // disabled writing to disk by setting `write: false`. Metro will handle
-    // the rest after we return code + sourcemap.
+    // `outfile` is required by esbuild to generate the sourcemap and insert it
+    // into `BuildResult["outputFiles"]`. It is also used to generate the
+    // `//# sourceMappingURL=` comment at the end of bundle. We've disabled
+    // writing to disk by setting `write: false`. Metro will handle the rest
+    // after we return code + sourcemap.
     const outfile =
       options.sourceMapUrl?.replace(/\.map$/, "") ?? "main.jsbundle";
     const sourcemapfile = options.sourceMapUrl ?? outfile + ".map";

--- a/packages/metro-serializer-esbuild/test/index.test.ts
+++ b/packages/metro-serializer-esbuild/test/index.test.ts
@@ -6,7 +6,11 @@ describe("metro-serializer-esbuild", () => {
 
   const consoleWarnSpy = jest.spyOn(global.console, "warn");
 
-  async function bundle(entryFile: string, dev = true): Promise<string> {
+  async function bundle(
+    entryFile: string,
+    dev = true,
+    sourcemapOutput = undefined
+  ): Promise<string> {
     let result: string | undefined = undefined;
     await buildBundle(
       {
@@ -17,6 +21,7 @@ describe("metro-serializer-esbuild", () => {
         platform: "native",
         resetCache: false,
         resetGlobalCache: false,
+        sourcemapOutput,
         sourcemapUseAbsolutePath: true,
         verbose: false,
       },
@@ -253,6 +258,19 @@ describe("metro-serializer-esbuild", () => {
     const result = await bundle("test/__fixtures__/direct.ts", false);
     expect(result).toMatchInlineSnapshot(`
       "(()=>{var e=new Function(\\"return this;\\")();})();
+      "
+    `);
+  });
+
+  test("adds sourceMappingURL comment", async () => {
+    const result = await bundle(
+      "test/__fixtures__/direct.ts",
+      false,
+      ".test-output.jsbundle.map"
+    );
+    expect(result).toMatchInlineSnapshot(`
+      "(()=>{var e=new Function(\\"return this;\\")();})();
+      //# sourceMappingURL=.test-output.jsbundle.map
       "
     `);
   });


### PR DESCRIPTION
### Description

`sourceMappingURL` comment is missing when `--sourcemap-output` is specified.

### Test plan

```
cd packages/test-app
yarn build --dependencies
yarn bundle+esbuild --platform android

tail -1 dist/main+esbuild.android.bundle
```

Verify that the last line of the bundle is `//# sourceMappingURL=main+esbuild.android.bundle.map`.