### PR TITLE
fix(metro-config): ensure `server.enhanceMiddleware` is consistent with `transformer.assetPlugins`

### DIFF
--- a/.changeset/rotten-crabs-try.md
+++ b/.changeset/rotten-crabs-try.md
@@ -2,4 +2,4 @@
 "@rnx-kit/metro-config": patch
 ---
 
-Ensure `server.enhanceMiddleware` is only set if `transformer.assetPlugins` includes the asset plugin.
+Verify `server.enhanceMiddleware` is only set if `transformer.assetPlugins` includes the asset plugin.

--- a/.changeset/rotten-crabs-try.md
+++ b/.changeset/rotten-crabs-try.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Ensure `server.enhanceMiddleware` is only set if `transformer.assetPlugins` includes the asset plugin.

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@rnx-kit/babel-preset-metro-react-native": "^1.0.17",
+    "@rnx-kit/console": "^1.0.0",
     "@rnx-kit/tools-node": "^1.3.0",
     "@rnx-kit/tools-workspaces": "^0.1.0"
   },

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -37,10 +37,8 @@
     "@types/metro-config": "^0.66.0",
     "metro-config": "^0.67.0",
     "metro-react-native-babel-preset": "^0.67.0",
-    "prettier": "^2.0.0",
     "react-native": "^0.68.0",
-    "type-fest": "^2.1.0",
-    "typescript": "^4.0.0"
+    "type-fest": "^2.1.0"
   },
   "depcheck": {
     "ignoreMatches": [

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -20,10 +20,12 @@ const UNIQUE_PACKAGES = ["react", "react-native"];
  */
 function verifyMiddlewareConsistency(config) {
   if (!config.server || !config.server.enhanceMiddleware) {
-    // If our middleware was removed, we should also remove the corresponding
-    // asset plugin. Note that we can only check whether `enhanceMiddleware` is
-    // unset as we cannot guarantee that our middleware isn't embedded
-    // somewhere.
+    // If our middleware was removed, the corresponding asset plugin should also
+    // be removed to avoid issues. We should notify the user of this so they can
+    // handle it accordingly.
+    //
+    // Note that we can only check whether `enhanceMiddleware` is unset as we
+    // cannot guarantee that our middleware isn't embedded somewhere.
     const monorepoPluginIndex =
       config.transformer &&
       config.transformer.assetPlugins &&

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -21,12 +21,15 @@ const UNIQUE_PACKAGES = ["react", "react-native"];
 function ensureMiddlewareConsistency(config) {
   const { enhanceMiddleware } = require("./assetPluginForMonorepos");
 
-  const assetPlugins = config.transformer?.assetPlugins;
+  const assetPlugins = config.transformer && config.transformer.assetPlugins;
   const monorepoPluginIndex = assetPlugins
     ? assetPlugins.indexOf(require.resolve("./assetPluginForMonorepos"))
     : -1;
 
-  if (config.server?.enhanceMiddleware !== enhanceMiddleware) {
+  if (
+    !config.server ||
+    (config.server && config.server.enhanceMiddleware !== enhanceMiddleware)
+  ) {
     // If our middleware was removed, we should also remove the corresponding
     // asset plugin.
     if (monorepoPluginIndex >= 0) {

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -33,7 +33,7 @@ function ensureMiddlewareConsistency(config) {
     // If our middleware was removed, we should also remove the corresponding
     // asset plugin.
     if (monorepoPluginIndex >= 0) {
-      // @ts-ignore `assetPlugins` is read-only
+      // @ts-expect-error `assetPlugins` is read-only
       assetPlugins.splice(monorepoPluginIndex, 1);
     }
   } else if (monorepoPluginIndex < 0) {

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -19,26 +19,21 @@ const UNIQUE_PACKAGES = ["react", "react-native"];
  * @returns {MetroConfig}
  */
 function ensureMiddlewareConsistency(config) {
-  const { enhanceMiddleware } = require("./assetPluginForMonorepos");
-
-  const assetPlugins = config.transformer && config.transformer.assetPlugins;
-  const monorepoPluginIndex = assetPlugins
-    ? assetPlugins.indexOf(require.resolve("./assetPluginForMonorepos"))
-    : -1;
-
-  if (
-    !config.server ||
-    (config.server && config.server.enhanceMiddleware !== enhanceMiddleware)
-  ) {
+  if (!config.server || !config.server.enhanceMiddleware) {
     // If our middleware was removed, we should also remove the corresponding
-    // asset plugin.
-    if (monorepoPluginIndex >= 0) {
-      // @ts-expect-error `assetPlugins` is read-only
-      assetPlugins.splice(monorepoPluginIndex, 1);
+    // asset plugin. Note that we can only check whether `enhanceMiddleware` is
+    // unset as we cannot guarantee that our middleware isn't embedded
+    // somewhere.
+    const assetPlugins = config.transformer && config.transformer.assetPlugins;
+    if (assetPlugins) {
+      const monorepoPluginIndex = assetPlugins.indexOf(
+        require.resolve("./assetPluginForMonorepos")
+      );
+      if (monorepoPluginIndex >= 0) {
+        // @ts-expect-error `assetPlugins` is read-only
+        assetPlugins.splice(monorepoPluginIndex, 1);
+      }
     }
-  } else if (monorepoPluginIndex < 0) {
-    // If our asset plugin was removed, we should also remove our middleware.
-    delete config.server["enhanceMiddleware"];
   }
 
   return config;

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -13,26 +13,28 @@ const path = require("path");
 const UNIQUE_PACKAGES = ["react", "react-native"];
 
 /**
- * Ensures `server.enhanceMiddleware` is only set if
+ * Verifies `server.enhanceMiddleware` is only set if
  * `transformer.assetPlugins` includes the asset plugin.
  * @param {MetroConfig} config
  * @returns {MetroConfig}
  */
-function ensureMiddlewareConsistency(config) {
+function verifyMiddlewareConsistency(config) {
   if (!config.server || !config.server.enhanceMiddleware) {
     // If our middleware was removed, we should also remove the corresponding
     // asset plugin. Note that we can only check whether `enhanceMiddleware` is
     // unset as we cannot guarantee that our middleware isn't embedded
     // somewhere.
-    const assetPlugins = config.transformer && config.transformer.assetPlugins;
-    if (assetPlugins) {
-      const monorepoPluginIndex = assetPlugins.indexOf(
+    const monorepoPluginIndex =
+      config.transformer &&
+      config.transformer.assetPlugins &&
+      config.transformer.assetPlugins.indexOf(
         require.resolve("./assetPluginForMonorepos")
       );
-      if (monorepoPluginIndex >= 0) {
-        // @ts-expect-error `assetPlugins` is read-only
-        assetPlugins.splice(monorepoPluginIndex, 1);
-      }
+    if (typeof monorepoPluginIndex === "number" && monorepoPluginIndex >= 0) {
+      const console = require("@rnx-kit/console");
+      console.warn(
+        `@rnx-kit/metro-config's middleware for assets in a monorepo was removed, but the accompanying plugin was not. If you intended to remove the middleware, you should also remove the plugin to avoid issues. The middleware was set in 'server.enhanceMiddleware' and the plugin can be found in 'transformer.assetPlugins'.`
+      );
     }
   }
 
@@ -275,6 +277,6 @@ module.exports = {
       }
     );
 
-    return ensureMiddlewareConsistency(mergedConfig);
+    return verifyMiddlewareConsistency(mergedConfig);
   },
 };

--- a/packages/metro-config/test/index.test.ts
+++ b/packages/metro-config/test/index.test.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { enhanceMiddleware } from "../src/assetPluginForMonorepos";
 import {
   defaultWatchFolders,
   exclusionList,
@@ -252,6 +253,8 @@ describe("@rnx-kit/metro-config", () => {
       fail("Expected `config.resolver.blacklistRE` to be a RegExp");
     } else if (!(config.resolver.blockList instanceof RegExp)) {
       fail("Expected `config.resolver.blockList` to be a RegExp");
+    } else if (!config.server) {
+      fail("Expected `config.server` to be defined");
     } else if (!config.transformer) {
       fail("Expected `config.transformer` to be defined");
     } else if (!config.transformer.getTransformOptions) {
@@ -267,6 +270,11 @@ describe("@rnx-kit/metro-config", () => {
     const blockList = exclusionList().source;
     expect(config.resolver.blacklistRE.source).toBe(blockList);
     expect(config.resolver.blockList.source).toBe(blockList);
+
+    expect(config.server.enhanceMiddleware).toBe(enhanceMiddleware);
+    expect(config.transformer.assetPlugins).toContain(
+      require.resolve("../src/assetPluginForMonorepos")
+    );
 
     const opts = { dev: false, hot: false };
     const transformerOptions = await config.transformer.getTransformOptions(
@@ -303,6 +311,8 @@ describe("@rnx-kit/metro-config", () => {
       fail("Expected `config.resolver.blacklistRE` to be a RegExp");
     } else if (!(config.resolver.blockList instanceof RegExp)) {
       fail("Expected `config.resolver.blockList` to be a RegExp");
+    } else if (!config.server) {
+      fail("Expected `config.server` to be defined");
     } else if (!config.transformer) {
       fail("Expected `config.transformer` to be defined");
     } else if (!config.transformer.getTransformOptions) {
@@ -318,6 +328,11 @@ describe("@rnx-kit/metro-config", () => {
     const blockList = exclusionList().source;
     expect(config.resolver.blacklistRE.source).toBe(blockList);
     expect(config.resolver.blockList.source).toBe(blockList);
+
+    expect(config.server.enhanceMiddleware).toBe(enhanceMiddleware);
+    expect(config.transformer.assetPlugins).toContain(
+      require.resolve("../src/assetPluginForMonorepos")
+    );
 
     const opts = { dev: false, hot: false };
     const transformerOptions = await config.transformer.getTransformOptions(
@@ -379,5 +394,29 @@ describe("@rnx-kit/metro-config", () => {
 
     expect(blockList).not.toBeUndefined();
     expect(blockList).toBe(configWithBlockList.resolver?.blacklistRE);
+  });
+
+  test("makeMetroConfig() removes the asset plugin if the middleware is removed", () => {
+    const config = makeMetroConfig({
+      // @ts-ignore
+      server: { enhanceMiddleware: null },
+    });
+
+    expect(config.server?.enhanceMiddleware).toBeNull();
+    expect(config.transformer?.assetPlugins).not.toContain(
+      require.resolve("../src/assetPluginForMonorepos")
+    );
+  });
+
+  test("makeMetroConfig() removes the middleware if the asset plugin is removed", () => {
+    const config = makeMetroConfig({
+      transformer: {
+        // @ts-ignore
+        assetPlugins: null
+      }
+    });
+
+    expect(config.server?.enhanceMiddleware).toBeUndefined();
+    expect(config.transformer?.assetPlugins).toBeNull();
   });
 });

--- a/packages/metro-config/test/index.test.ts
+++ b/packages/metro-config/test/index.test.ts
@@ -412,8 +412,8 @@ describe("@rnx-kit/metro-config", () => {
     const config = makeMetroConfig({
       transformer: {
         // @ts-ignore
-        assetPlugins: null
-      }
+        assetPlugins: null,
+      },
     });
 
     expect(config.server?.enhanceMiddleware).toBeUndefined();

--- a/packages/metro-config/test/index.test.ts
+++ b/packages/metro-config/test/index.test.ts
@@ -10,16 +10,6 @@ import {
 } from "../src/index";
 
 describe("@rnx-kit/metro-config", () => {
-  const metroConfigKeys = [
-    "cacheStores",
-    "resolver",
-    "serializer",
-    "server",
-    "symbolicator",
-    "transformer",
-    "watchFolders",
-  ];
-
   const currentWorkingDir = process.cwd();
 
   /**
@@ -240,8 +230,20 @@ describe("@rnx-kit/metro-config", () => {
     ).toBeTruthy();
     expect(conanExclude.test("Test.ProjectImports.zip")).toBeTruthy();
   });
+});
 
-  test("makeMetroConfig() returns a default Metro config", async () => {
+describe("makeMetroConfig", () => {
+  const metroConfigKeys = [
+    "cacheStores",
+    "resolver",
+    "serializer",
+    "server",
+    "symbolicator",
+    "transformer",
+    "watchFolders",
+  ];
+
+  test("returns a default Metro config", async () => {
     const config = makeMetroConfig();
     expect(Object.keys(config).sort()).toEqual(metroConfigKeys);
 
@@ -290,7 +292,7 @@ describe("@rnx-kit/metro-config", () => {
     expect(config.watchFolders.length).toBeGreaterThan(0);
   });
 
-  test("makeMetroConfig() merges Metro configs", async () => {
+  test("merges Metro configs", async () => {
     const config = makeMetroConfig({
       projectRoot: __dirname,
       resetCache: true,
@@ -348,7 +350,7 @@ describe("@rnx-kit/metro-config", () => {
     expect(config.watchFolders.length).toBeGreaterThan(0);
   });
 
-  test("makeMetroConfig() merges `extraNodeModules`", () => {
+  test("merges `extraNodeModules`", () => {
     const config = makeMetroConfig({
       projectRoot: __dirname,
       resolver: {
@@ -374,7 +376,7 @@ describe("@rnx-kit/metro-config", () => {
     expect(extraNodeModules["react-native"]).toBe("/skynet");
   });
 
-  test("makeMetroConfig() sets both `blacklistRE` and `blockList`", () => {
+  test("sets both `blacklistRE` and `blockList`", () => {
     const configWithBlacklist = makeMetroConfig({
       resolver: {
         blacklistRE: /.*/,
@@ -396,9 +398,9 @@ describe("@rnx-kit/metro-config", () => {
     expect(blockList).toBe(configWithBlockList.resolver?.blacklistRE);
   });
 
-  test("makeMetroConfig() removes the asset plugin if the middleware is removed", () => {
+  test("deletes the asset plugin if the middleware is deleted", () => {
     const config = makeMetroConfig({
-      // @ts-ignore
+      // @ts-expect-error intentionally setting `enhanceMiddleware` to `null`
       server: { enhanceMiddleware: null },
     });
 
@@ -408,15 +410,14 @@ describe("@rnx-kit/metro-config", () => {
     );
   });
 
-  test("makeMetroConfig() removes the middleware if the asset plugin is removed", () => {
+  test("does not delete the asset plugin if the middleware is replaced", () => {
     const config = makeMetroConfig({
-      transformer: {
-        // @ts-ignore
-        assetPlugins: null,
-      },
+      server: { enhanceMiddleware: (middleware) => middleware },
     });
 
-    expect(config.server?.enhanceMiddleware).toBeUndefined();
-    expect(config.transformer?.assetPlugins).toBeNull();
+    expect(config.server?.enhanceMiddleware).not.toBeUndefined();
+    expect(config.transformer?.assetPlugins).toEqual([
+      require.resolve("../src/assetPluginForMonorepos"),
+    ]);
   });
 });


### PR DESCRIPTION
### Description

Ensure `server.enhanceMiddleware` is only set if `transformer.assetPlugins` includes the asset plugin.

### Test plan

Tests were added.