### PR TITLE
Change file not found error to warning

### DIFF
--- a/.changeset/olive-waves-sin.md
+++ b/.changeset/olive-waves-sin.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/dep-check": patch
+---
+
+change file not found error to warning

--- a/packages/dep-check/src/cli.ts
+++ b/packages/dep-check/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import type { KitType } from "@rnx-kit/config";
-import { error } from "@rnx-kit/console";
+import { error, warn } from "@rnx-kit/console";
 import { hasProperty } from "@rnx-kit/tools-language/properties";
 import { findPackageDir } from "@rnx-kit/tools-node/package";
 import {
@@ -168,6 +168,12 @@ export async function cli({
     } catch (e) {
       if (hasProperty(e, "message")) {
         const currentPackageJson = path.relative(process.cwd(), manifest);
+
+        if (hasProperty(e, "code") && e.code === "ENOENT") {
+          warn(`${currentPackageJson}: ${e.message}`);
+          return exitCode;
+        }
+
         error(`${currentPackageJson}: ${e.message}`);
         return exitCode || 1;
       }


### PR DESCRIPTION
### Description
Currently when aligning dependencies and rnx-kit/dep-check finds a package without a package.json it exits with an error, blocking subsequent steps.
Changing this error to a warning to alert the user of missing file but still complete the runs.

### Test plan
Align dependencies for packages that has a missing package.json file.
This should show a warning and not error out
