### PR TITLE
Update tree shaking docs

### DIFF
--- a/docsite/docs/guides/bundling.mdx
+++ b/docsite/docs/guides/bundling.mdx
@@ -261,36 +261,6 @@ Tree shaking is _off_ by default. You can control it with the
 }
 ```
 
-To make tree shaking to work properly, you'll also need to set
-`disableImportExportTransform` in your Babel config:
-
-```js title="babel.config.js"
-module.exports = {
-  presets: [
-    [
-      "@rnx-kit/babel-preset-metro-react-native",
-      { disableImportExportTransform: true },
-    ],
-  ],
-};
-```
-
-You'll also need to set `experimentalImportSupport` and `inlineRequires` in your
-Metro config:
-
-```js title="metro.config.js"
-module.exports = {
-  transformer: {
-    getTransformOptions: async () => ({
-      transform: {
-        experimentalImportSupport: true,
-        inlineRequires: true,
-      },
-    }),
-  },
-};
-```
-
 ### Duplicate Dependencies
 
 Did you know that your app bundle can have multiple copies of a single package

--- a/docsite/docs/guides/bundling.mdx
+++ b/docsite/docs/guides/bundling.mdx
@@ -98,8 +98,8 @@ iOS developer bundle:
       --sourcemap-output ios/main.jsbundle.map \
       --assets-dest ios
 
-If you're curious about the rest of the command-line parameters, you can find the
-complete list in the
+If you're curious about the rest of the command-line parameters, you can find
+the complete list in the
 [CLI bundle documentation](/docs/tools/cli#command-line-overrides).
 
 Now is a good time to try out your `rnx-bundle` command.
@@ -272,6 +272,22 @@ module.exports = {
       { disableImportExportTransform: true },
     ],
   ],
+};
+```
+
+You'll also need to set `experimentalImportSupport` and `inlineRequires` in your
+Metro config:
+
+```js title="metro.config.js"
+module.exports = {
+  transformer: {
+    getTransformOptions: async () => ({
+      transform: {
+        experimentalImportSupport: true,
+        inlineRequires: true,
+      },
+    }),
+  },
 };
 ```
 

--- a/docsite/docs/guides/bundling.mdx
+++ b/docsite/docs/guides/bundling.mdx
@@ -98,8 +98,8 @@ iOS developer bundle:
       --sourcemap-output ios/main.jsbundle.map \
       --assets-dest ios
 
-If you're curious about the rest of the command-line parameters, you can find
-the complete list in the
+If you're curious about the rest of the command-line parameters, you can find the
+complete list in the
 [CLI bundle documentation](/docs/tools/cli#command-line-overrides).
 
 Now is a good time to try out your `rnx-bundle` command.
@@ -272,22 +272,6 @@ module.exports = {
       { disableImportExportTransform: true },
     ],
   ],
-};
-```
-
-You'll also need to set `experimentalImportSupport` and `inlineRequires` in your
-Metro config:
-
-```js title="metro.config.js"
-module.exports = {
-  transformer: {
-    getTransformOptions: async () => ({
-      transform: {
-        experimentalImportSupport: true,
-        inlineRequires: true,
-      },
-    }),
-  },
 };
 ```
 


### PR DESCRIPTION
### Description

The tree shaking section of the `Bundling` guide omits an important setup step -- setting `experimentalImportSupport` in metro.config.js. This is called out in #142 as something we should do automatically, but we don't have a fix for that yet.

> Note: bug #142 calls out `experimentalImportSupport` but also sets `inlineRequires` to `true`, so I called out the need for both. If that's wrong, please let me know in a PR comment.

Thank you to @denissb for pointing this out (and sorry it caused you so much trouble).

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

Manually verify the docsite using a local server.

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
