### PR TITLE
fix(metro-serializer-esbuild): removing `"use strict";` breaks source maps

### DIFF
--- a/.changeset/rich-donkeys-design.md
+++ b/.changeset/rich-donkeys-design.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Stop removing `"use strict";` by default as it breaks source maps

--- a/packages/metro-serializer-esbuild/README.md
+++ b/packages/metro-serializer-esbuild/README.md
@@ -161,14 +161,19 @@ Values: `absolute` | `relative`
 
 Defaults to `relative`.
 
-### `stripUseStrict`
+### `strictMode`
 
-You can save some bytes by stripping out `"use strict";` from the bundle. Note
-that this breaks the source map.
+By default, the `"use strict";` directive is added by Babel and esbuild when
+lowering to ES5. You can save some bytes by telling this serializer to strip
+them from the bundle.
+
+Note that disabling `strictMode` here will definitely break source maps. It is
+recommended to try disabling strict mode in Babel or TypeScript first before
+considering this option. If you can target ES6, that is a better alternative.
 
 This flag only affects production environment.
 
-Defaults to `false`.
+Defaults to `true`.
 
 ### `analyze`
 

--- a/packages/metro-serializer-esbuild/README.md
+++ b/packages/metro-serializer-esbuild/README.md
@@ -126,6 +126,17 @@ parameter. For instance, to output ES6 compliant code, set the target option:
 
 Below are all the currently supported options.
 
+### `target`
+
+Sets the target environment for the transpiled JavaScript code.
+
+See the full documentation at https://esbuild.github.io/api/#target.
+
+Values: Any JS language version string such as `es6` or `esnext`. You can also
+use environment names. See the full documentation for a list of supported names.
+
+Defaults to `hermes0.7.0`.
+
 ### `fabric`
 
 When enabled, includes Fabric-enabled version of React. You can save some bytes
@@ -141,17 +152,6 @@ See the full documentation at https://esbuild.github.io/api/#minify.
 
 Defaults to `true` in production environment; `false` otherwise.
 
-### `target`
-
-Sets the target environment for the transpiled JavaScript code.
-
-See the full documentation at https://esbuild.github.io/api/#target.
-
-Values: Any JS language version string such as `es6` or `esnext`. You can also
-use environment names. See the full documentation for a list of supported names.
-
-Defaults to `hermes0.7.0`.
-
 ### `sourceMapPaths`
 
 Determines whether paths in the output source map are absolute or relative to
@@ -160,6 +160,15 @@ the directory containing the source map.
 Values: `absolute` | `relative`
 
 Defaults to `relative`.
+
+### `stripUseStrict`
+
+You can save some bytes by stripping out `"use strict";` from the bundle. Note
+that this breaks the source map.
+
+This flag only affects production environment.
+
+Defaults to `false`.
 
 ### `analyze`
 

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -49,6 +49,8 @@
   },
   "depcheck": {
     "ignoreMatches": [
+      "@fluentui/utilities",
+      "lodash-es",
       "metro-config",
       "metro-transform-worker"
     ]

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -15,7 +15,7 @@ export type Options = Pick<BuildOptions, "logLevel" | "minify" | "target"> & {
   analyze?: boolean | "verbose";
   fabric?: boolean;
   sourceMapPaths?: "absolute" | "relative";
-  stripUseStrict?: boolean;
+  strictMode?: boolean;
 };
 
 function assertVersion(requiredVersion: string): void {
@@ -143,7 +143,7 @@ export function MetroSerializer(
         // Metro does not inject `"use strict"`, but esbuild does. We can strip
         // them out like Metro does, but it'll break the source map. See also
         // https://github.com/facebook/metro/blob/0fe1253cc4f76aa2a7683cfb2ad0253d0a768c83/packages/metro-react-native-babel-preset/src/configs/main.js#L68
-        if (!options.dev && buildOptions?.stripUseStrict) {
+        if (!options.dev && buildOptions?.strictMode === false) {
           const encoder = new TextEncoder();
           build.onEnd(({ outputFiles }) => {
             outputFiles?.forEach(({ path, text }, index) => {

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -15,6 +15,7 @@ export type Options = Pick<BuildOptions, "logLevel" | "minify" | "target"> & {
   analyze?: boolean | "verbose";
   fabric?: boolean;
   sourceMapPaths?: "absolute" | "relative";
+  stripUseStrict?: boolean;
 };
 
 function assertVersion(requiredVersion: string): void {
@@ -139,10 +140,10 @@ export function MetroSerializer(
       setup: (build) => {
         const pluginOptions = { filter: /.*/ };
 
-        // Metro does not inject `"use strict"`, but esbuild does. We should
-        // strip them out like Metro does. See also
+        // Metro does not inject `"use strict"`, but esbuild does. We can strip
+        // them out like Metro does, but it'll break the source map. See also
         // https://github.com/facebook/metro/blob/0fe1253cc4f76aa2a7683cfb2ad0253d0a768c83/packages/metro-react-native-babel-preset/src/configs/main.js#L68
-        if (!options.dev) {
+        if (!options.dev && buildOptions?.stripUseStrict) {
           const encoder = new TextEncoder();
           build.onEnd(({ outputFiles }) => {
             outputFiles?.forEach(({ path, text }, index) => {

--- a/packages/metro-serializer-esbuild/test/index.test.ts
+++ b/packages/metro-serializer-esbuild/test/index.test.ts
@@ -9,9 +9,9 @@ describe("metro-serializer-esbuild", () => {
   async function bundle(
     entryFile: string,
     dev = true,
-    sourcemapOutput = undefined
+    sourcemapOutput: string | undefined = undefined
   ): Promise<string> {
-    let result: string | undefined = undefined;
+    let result = "";
     await buildBundle(
       {
         entryFile,
@@ -250,14 +250,6 @@ describe("metro-serializer-esbuild", () => {
         // test/__fixtures__/sideEffectsArray.ts
         warn(\\"this should _not_ be removed\\");
       })();
-      "
-    `);
-  });
-
-  test('strips out `"use strict"`', async () => {
-    const result = await bundle("test/__fixtures__/direct.ts", false);
-    expect(result).toMatchInlineSnapshot(`
-      "\\"use strict\\";(()=>{var e=new Function(\\"return this;\\")();})();
       "
     `);
   });

--- a/packages/metro-serializer-esbuild/test/index.test.ts
+++ b/packages/metro-serializer-esbuild/test/index.test.ts
@@ -257,7 +257,7 @@ describe("metro-serializer-esbuild", () => {
   test('strips out `"use strict"`', async () => {
     const result = await bundle("test/__fixtures__/direct.ts", false);
     expect(result).toMatchInlineSnapshot(`
-      "(()=>{var e=new Function(\\"return this;\\")();})();
+      "\\"use strict\\";(()=>{var e=new Function(\\"return this;\\")();})();
       "
     `);
   });
@@ -269,7 +269,7 @@ describe("metro-serializer-esbuild", () => {
       ".test-output.jsbundle.map"
     );
     expect(result).toMatchInlineSnapshot(`
-      "(()=>{var e=new Function(\\"return this;\\")();})();
+      "\\"use strict\\";(()=>{var e=new Function(\\"return this;\\")();})();
       //# sourceMappingURL=.test-output.jsbundle.map
       "
     `);


### PR DESCRIPTION
### Description

Stop removing `"use strict";` by default as it breaks source maps.

### Test plan

```
cd example/test-app
yarn build --dependencies
yarn bundle+esbuild --dev false --platform ios
```

Upload `dist/main+esbuild.ios.jsbundle` and `dist/main+esbuild.ios.jsbundle.map` to <https://evanw.github.io/source-map-visualization/>, and verify that that symbols are correctly remapped.

![source-map-visualization](https://user-images.githubusercontent.com/4123478/188456221-c1420487-7592-4004-9c51-89ede331712e.png)
