### PR TITLE
fix: use `esbuild` transform profile when `metro-serializer-esbuild` is used

### DIFF
--- a/.changeset/eleven-elephants-give.md
+++ b/.changeset/eleven-elephants-give.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/babel-preset-metro-react-native": patch
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Use `esbuild` transform profile when `metro-serializer-esbuild` is used

--- a/packages/babel-preset-metro-react-native/src/index.js
+++ b/packages/babel-preset-metro-react-native/src/index.js
@@ -59,10 +59,7 @@ function constEnumPlugin() {
  */
 function overridesFor(transformProfile) {
   // Use the `esbuild` transform profile if the serializer is being used.
-  if (
-    !transformProfile &&
-    process.env[`RNX_METRO_SERIALIZER_ESBUILD_${process.ppid}`]
-  ) {
+  if (!transformProfile && process.env["RNX_METRO_SERIALIZER_ESBUILD"]) {
     transformProfile = "esbuild";
   }
 

--- a/packages/babel-preset-metro-react-native/src/index.js
+++ b/packages/babel-preset-metro-react-native/src/index.js
@@ -59,7 +59,10 @@ function constEnumPlugin() {
  */
 function overridesFor(transformProfile) {
   // Use the `esbuild` transform profile if the serializer is being used.
-  if (!transformProfile && process.env["RNX_METRO_SERIALIZER_ESBUILD"]) {
+  if (
+    !transformProfile &&
+    process.env[`RNX_METRO_SERIALIZER_ESBUILD_${process.ppid}`]
+  ) {
     transformProfile = "esbuild";
   }
 

--- a/packages/babel-preset-metro-react-native/src/index.js
+++ b/packages/babel-preset-metro-react-native/src/index.js
@@ -58,6 +58,11 @@ function constEnumPlugin() {
  * @returns {MetroPresetOptions | undefined}
  */
 function overridesFor(transformProfile) {
+  // Use the `esbuild` transform profile if the serializer is being used.
+  if (!transformProfile && process.env["RNX_METRO_SERIALIZER_ESBUILD"]) {
+    transformProfile = "esbuild";
+  }
+
   switch (transformProfile) {
     case "esbuild":
       return {
@@ -124,8 +129,8 @@ module.exports = (
     ...(options.withDevTools == null
       ? { dev: env !== "production" }
       : undefined),
-    ...options,
     ...overridesFor(unstable_transformProfile),
+    ...options,
   });
   const overrides = metroPreset.overrides;
 

--- a/packages/metro-serializer-esbuild/README.md
+++ b/packages/metro-serializer-esbuild/README.md
@@ -57,19 +57,8 @@ in `babel.config.js`:
  };
 ```
 
-If you're using `@rnx-kit/babel-preset-metro-react-native`, you can instead set
-`esbuild` as transform profile:
-
-```diff
- module.exports = {
-   presets: [
-     [
-       "@rnx-kit/babel-preset-metro-react-native",
-+      { unstable_transformProfile: "esbuild" },
-     ],
-   ],
- };
-```
+If you're using `@rnx-kit/babel-preset-metro-react-native`, you don't need to
+make any changes.
 
 > Note that Hermes currently does not fully implement the
 > [ES6 spec](https://kangax.github.io/compat-table/es6/). esbuild, on the other

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -123,6 +123,9 @@ export function MetroSerializer(
 ): SerializerConfigT["customSerializer"] {
   assertVersion(">=0.66.1");
 
+  // Signal to every plugin that we're using esbuild.
+  process.env["RNX_METRO_SERIALIZER_ESBUILD"] = "true";
+
   return (
     entryPoint: string,
     preModules: ReadonlyArray<Module>,

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -124,7 +124,7 @@ export function MetroSerializer(
   assertVersion(">=0.66.1");
 
   // Signal to every plugin that we're using esbuild.
-  process.env[`RNX_METRO_SERIALIZER_ESBUILD_${process.pid}`] = "true";
+  process.env["RNX_METRO_SERIALIZER_ESBUILD"] = "true";
 
   return (
     entryPoint: string,

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -124,7 +124,7 @@ export function MetroSerializer(
   assertVersion(">=0.66.1");
 
   // Signal to every plugin that we're using esbuild.
-  process.env["RNX_METRO_SERIALIZER_ESBUILD"] = "true";
+  process.env[`RNX_METRO_SERIALIZER_ESBUILD_${process.pid}`] = "true";
 
   return (
     entryPoint: string,


### PR DESCRIPTION
### Description

Use `esbuild` transform profile when `metro-serializer-esbuild` is used.

Resolves #142.

### Test plan

```
cd packages/test-app
yarn build --dependencies
yarn bundle+esbuild --dev false --platform ios --reset-cache
```

| Before | After |
| :- | :- |
| 684314 | 585154 |