### PR TITLE
fix(dep-check): allow specifying multiple packages

### DIFF
--- a/.changeset/ninety-rivers-design.md
+++ b/.changeset/ninety-rivers-design.md
@@ -1,4 +1,5 @@
 ---
+"@rnx-kit/cli": patch
 "@rnx-kit/dep-check": patch
 ---
 

--- a/.changeset/ninety-rivers-design.md
+++ b/.changeset/ninety-rivers-design.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/dep-check": patch
+---
+
+Allow specifying multiple packages on command line

--- a/packages/cli/src/dep-check.ts
+++ b/packages/cli/src/dep-check.ts
@@ -23,7 +23,7 @@ export function rnxDepCheck(
     ),
     loose: Boolean(args.loose),
     write: Boolean(args.write),
-    "package-json": argv[0],
+    packages: argv,
   });
 }
 

--- a/packages/dep-check/README.md
+++ b/packages/dep-check/README.md
@@ -30,11 +30,11 @@ npm add --save-dev @rnx-kit/dep-check
 ## Usage
 
 ```sh
-yarn rnx-dep-check [options] [/path/to/package.json]
+yarn rnx-dep-check [options] [packages...]
 ```
 
-Providing a path to `package.json` is optional. If omitted, it will look for one
-using Node module resolution.
+Specifying packages is optional. If omitted, dep-check will look for the closest
+`package.json` using Node module resolution.
 
 Examples:
 

--- a/packages/dep-check/README.md
+++ b/packages/dep-check/README.md
@@ -33,8 +33,10 @@ npm add --save-dev @rnx-kit/dep-check
 yarn rnx-dep-check [options] [packages...]
 ```
 
-Specifying packages is optional. If omitted, dep-check will look for the closest
-`package.json` using Node module resolution.
+Listing paths to packages that should be checked is optional. If omitted,
+dep-check will look for the closest `package.json` using Node module resolution.
+If the target package is a root package defining workspaces, they will all be
+included.
 
 Examples:
 

--- a/packages/dep-check/src/types.ts
+++ b/packages/dep-check/src/types.ts
@@ -11,9 +11,9 @@ type Options = {
 export type Args = Options & {
   "custom-profiles"?: string | number;
   "exclude-packages"?: string | number;
-  "package-json"?: string | number;
   "set-version"?: string | number;
   init?: string;
+  packages?: (string | number)[];
   vigilant?: string | number;
 };
 


### PR DESCRIPTION
### Description

Allow specifying multiple packages on command line.

Resolves #1862.

### Test plan

Make a change that would fail dep-check, e.g.:

```diff
diff --git a/packages/test-app/package.json b/packages/test-app/package.json
index fa7a9e76..84d0dfee 100644
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -24,7 +24,7 @@
     "start": "react-native rnx-start"
   },
   "dependencies": {
-    "react": "17.0.2",
+    "react": "18.0.0",
     "react-native": "^0.68.0",
     "react-native-macos": "^0.68.0",
     "react-native-windows": "^0.68.0"
```

Build and run:

```sh
cd packages/dep-check
yarn build --dependencies

# Check the current package
node lib/cli.js

# Check test app
node lib/cli.js ../test-app

# Check both test apps
node lib/cli.js ../test-app ../expo-app
```