### PR TITLE
fix(build): move some build scripts to a separate file

### DIFF
--- a/.changeset/strong-drinks-raise.md
+++ b/.changeset/strong-drinks-raise.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+Move some build scripts to a separate file so they can be shared

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Pods
-        run: pod install --project-directory=ios
+        run: pod install --project-directory=ios --verbose
         working-directory: ${{ github.event.inputs.projectRoot }}
       - name: Install Apple signing certificate and provisioning profile
         if: ${{ github.event.inputs.deviceType == 'device' }}
@@ -87,54 +87,21 @@ jobs:
           BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-        run: |
-          # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
-          mkdir -p "$(dirname "${HOME}/${PROVISION_PATH}")"
-
-          echo -n "${BUILD_CERTIFICATE_BASE64}" | base64 --decode --output "${RUNNER_TEMP}/${CERTIFICATE_FILE}"
-          echo -n "${BUILD_PROVISION_PROFILE_BASE64}" | base64 --decode --output "${HOME}/${PROVISION_PATH}"
-
-          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
-          security set-keychain-settings -lut 21600 "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
-          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
-
-          security import "${RUNNER_TEMP}/${CERTIFICATE_FILE}" -k "${RUNNER_TEMP}/${KEYCHAIN_FILE}" -t cert -f pkcs12 -P "${P12_PASSWORD}" -A -T '/usr/bin/codesign' -T '/usr/bin/security'
-          security set-key-partition-list -S apple-tool:,apple: -k ${KEYCHAIN_PASSWORD} "${RUNNER_TEMP}/${KEYCHAIN_FILE}" 1> /dev/null
-          security list-keychain -d user -s "${RUNNER_TEMP}/${KEYCHAIN_FILE}" login.keychain
+        run: npx --prefix . rnx-build-apple install-certificate
       - name: Build iOS app
-        run: |
-          if [[ ${{ github.event.inputs.deviceType }} == 'device' ]]; then
-            destination='generic/platform=iOS'
-            code_signing=''
-          else
-            destination='generic/platform=iOS Simulator'
-            archs='ARCHS=${{ github.event.inputs.architecture }}'
-            code_signing='CODE_SIGNING_ALLOWED=NO'
-          fi
-          # We need to disable Clang sanitizers otherwise the app will crash on
-          # startup trying to load Clang sanitizer libraries that would only
-          # exist if Xcode was attached.
-          xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
-          xcodebuild -workspace ${xcworkspace} -scheme ${{ github.event.inputs.scheme }} -destination "${destination}" -configuration Debug -derivedDataPath DerivedData -archivePath ${XCARCHIVE_FILE} ${archs} ${code_signing} CLANG_ADDRESS_SANITIZER=NO CLANG_UNDEFINED_BEHAVIOR_SANITIZER=NO OTHER_CFLAGS='$(inherited) -fstack-protector-strong' OTHER_LDFLAGS='$(inherited) -fstack-protector-strong' COMPILER_INDEX_STORE_ENABLE=NO archive
+        run: npx --prefix . rnx-build-apple build-ios --scheme ${{ github.event.inputs.scheme }} --device-type ${{ github.event.inputs.deviceType }} --archs ${{ github.event.inputs.architecture }}
         working-directory: ${{ github.event.inputs.projectRoot }}/ios
       - name: Remove Apple signing certificate and provisioning profile
+        # Always run this job step, even if previous ones fail. See also
+        # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development#required-clean-up-on-self-hosted-runners
         if: ${{ always() && github.event.inputs.deviceType == 'device' }}
-        run: |
-          # Always run this job step, even if previous ones fail. See also
-          # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development#required-clean-up-on-self-hosted-runners
-          security delete-keychain "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
-          rm -f "${RUNNER_TEMP}/${CERTIFICATE_FILE}" "${HOME}/${PROVISION_PATH}"
+        run: npx --prefix . rnx-build-apple uninstall-certificate
       - name: Prepare build artifact
         id: prepare-build-artifact
         run: |
           if [[ ${{ github.event.inputs.distribution }} == 'local' ]]; then
             app=$(find ${XCARCHIVE_FILE}/Products/Applications -maxdepth 1 -name '*.app' -type d | head -1)
-            # bsdtar corrupts files when archiving due to APFS sparse files. A
-            # workaround is to use GNU Tar instead. See also:
-            #   - https://github.com/actions/cache/issues/403
-            #   - https://github.com/actions/virtual-environments/issues/2619
-            gtar -cvf ios-artifact.tar -C "$(dirname ${app})" "$(basename ${app})"
-            shasum --algorithm 256 ios-artifact.tar
+            npx --prefix . rnx-build-apple archive ios-artifact.tar "${app}"
             echo "::set-output name=filename::ios-artifact.tar"
           else
             xcodebuild -exportArchive -archivePath ${XCARCHIVE_FILE} -exportPath export -exportOptionsPlist ExportOptions.plist 2>&1
@@ -163,26 +130,16 @@ jobs:
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Pods
-        run: pod install --project-directory=macos
+        run: pod install --project-directory=macos --verbose
         working-directory: ${{ github.event.inputs.projectRoot }}
       - name: Build macOS app
-        run: |
-          # We need to disable Clang sanitizers otherwise the app will crash on
-          # startup trying to load Clang sanitizer libraries that would only
-          # exist if Xcode was attached.
-          xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
-          xcodebuild -workspace ${xcworkspace} -scheme ${{ github.event.inputs.scheme }} -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO CLANG_ADDRESS_SANITIZER=NO CLANG_UNDEFINED_BEHAVIOR_SANITIZER=NO OTHER_CFLAGS='$(inherited) -fstack-protector-strong' OTHER_LDFLAGS='$(inherited) -fstack-protector-strong' COMPILER_INDEX_STORE_ENABLE=NO build
+        run: npx --prefix . rnx-build-apple build-macos --scheme ${{ github.event.inputs.scheme }}
         working-directory: ${{ github.event.inputs.projectRoot }}/macos
       - name: Prepare build artifact
         run: |
           output_path=DerivedData/Build/Products
           app=$(find ${output_path} -maxdepth 2 -name '*.app' -type d | head -1)
-          # bsdtar corrupts files when archiving due to APFS sparse files. A
-          # workaround is to use GNU Tar instead. See also:
-          #   - https://github.com/actions/cache/issues/403
-          #   - https://github.com/actions/virtual-environments/issues/2619
-          gtar -cvf macos-artifact.tar -C "$(dirname ${app})" "$(basename ${app})"
-          shasum --algorithm 256 macos-artifact.tar
+          npx --prefix . rnx-build-apple archive macos-artifact.tar "${app}"
         working-directory: ${{ github.event.inputs.projectRoot }}/macos
       - name: Upload build artifact
         uses: actions/upload-artifact@v3

--- a/incubator/build/package.json
+++ b/incubator/build/package.json
@@ -11,12 +11,14 @@
   },
   "files": [
     "lib/**/*.{d.ts,js}",
+    "scripts/*",
     "workflows/*"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "bin": {
-    "rnx-build": "lib/cli.js"
+    "rnx-build": "lib/cli.js",
+    "rnx-build-apple": "scripts/build-apple.sh"
   },
   "repository": {
     "type": "git",

--- a/incubator/build/scripts/build-apple.sh
+++ b/incubator/build/scripts/build-apple.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -eox pipefail
 
 case ${1-} in
   archive)
@@ -30,7 +30,7 @@ case ${1-} in
           ;;
         *)
           echo "Unknown option: $1"
-          shift
+          exit 1
           ;;
       esac
     done
@@ -71,7 +71,7 @@ case ${1-} in
           ;;
         *)
           echo "Unknown option: $1"
-          shift
+          exit 1
           ;;
       esac
     done

--- a/incubator/build/scripts/build-apple.sh
+++ b/incubator/build/scripts/build-apple.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+set -eo pipefail
+
+case ${1-} in
+  archive)
+    archive=$2
+    file=$3
+    # bsdtar corrupts files when archiving due to APFS sparse files. A
+    # workaround is to use GNU Tar instead. See also:
+    #   - https://github.com/actions/cache/issues/403
+    #   - https://github.com/actions/virtual-environments/issues/2619
+    gtar -cvf ${archive} -C "$(dirname ${file})" "$(basename ${file})"
+    shasum --algorithm 256 ${archive}
+    ;;
+  build-ios)
+    shift
+    while [[ "$#" -gt 0 ]]; do
+      case $1 in
+        --archs)
+          archs="ARCHS=$2"
+          shift 2
+          ;;
+        --device-type)
+          device_type="$2"
+          shift 2
+          ;;
+        --scheme)
+          scheme="$2"
+          shift 2
+          ;;
+        *)
+          echo "Unknown option: $1"
+          shift
+          ;;
+      esac
+    done
+    if [[ "${device_type}" == 'device' ]]; then
+      destination='generic/platform=iOS'
+      archs=''
+      code_signing=''
+    else
+      destination='generic/platform=iOS Simulator'
+      code_signing='CODE_SIGNING_ALLOWED=NO'
+    fi
+    xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
+    # We need to disable Clang sanitizers otherwise the app will crash on
+    # startup trying to load Clang sanitizer libraries that would only
+    # exist if Xcode was attached.
+    xcodebuild -workspace "${xcworkspace}" \
+               -scheme ${scheme} \
+               -destination "${destination}" \
+               -configuration Debug \
+               -derivedDataPath DerivedData \
+               -archivePath ${XCARCHIVE_FILE} \
+               ${archs} \
+               ${code_signing} \
+               CLANG_ADDRESS_SANITIZER=NO \
+               CLANG_UNDEFINED_BEHAVIOR_SANITIZER=NO \
+               OTHER_CFLAGS='$(inherited) -fstack-protector-strong' \
+               OTHER_LDFLAGS='$(inherited) -fstack-protector-strong' \
+               COMPILER_INDEX_STORE_ENABLE=NO \
+               archive
+    ;;
+  build-macos)
+    shift
+    while [[ "$#" -gt 0 ]]; do
+      case $1 in
+        --scheme)
+          scheme="$2"
+          shift 2
+          ;;
+        *)
+          echo "Unknown option: $1"
+          shift
+          ;;
+      esac
+    done
+    xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
+    # We need to disable Clang sanitizers otherwise the app will crash on
+    # startup trying to load Clang sanitizer libraries that would only
+    # exist if Xcode was attached.
+    xcodebuild -workspace "${xcworkspace}" \
+               -scheme ${scheme} \
+               -configuration Debug \
+               -derivedDataPath DerivedData \
+               CODE_SIGNING_ALLOWED=NO \
+               CLANG_ADDRESS_SANITIZER=NO \
+               CLANG_UNDEFINED_BEHAVIOR_SANITIZER=NO \
+               OTHER_CFLAGS='$(inherited) -fstack-protector-strong' \
+               OTHER_LDFLAGS='$(inherited) -fstack-protector-strong' \
+               COMPILER_INDEX_STORE_ENABLE=NO \
+               build
+    ;;
+  install-certificate)
+    # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
+    mkdir -p "$(dirname "${HOME}/${PROVISION_PATH}")"
+
+    echo -n "${BUILD_CERTIFICATE_BASE64}" | base64 --decode --output "${RUNNER_TEMP}/${CERTIFICATE_FILE}"
+    echo -n "${BUILD_PROVISION_PROFILE_BASE64}" | base64 --decode --output "${HOME}/${PROVISION_PATH}"
+
+    security create-keychain -p "${KEYCHAIN_PASSWORD}" "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
+    security set-keychain-settings -lut 21600 "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
+    security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
+
+    security import "${RUNNER_TEMP}/${CERTIFICATE_FILE}" -k "${RUNNER_TEMP}/${KEYCHAIN_FILE}" -t cert -f pkcs12 -P "${P12_PASSWORD}" -A -T '/usr/bin/codesign' -T '/usr/bin/security'
+    security set-key-partition-list -S apple-tool:,apple: -k ${KEYCHAIN_PASSWORD} "${RUNNER_TEMP}/${KEYCHAIN_FILE}" 1> /dev/null
+    security list-keychain -d user -s "${RUNNER_TEMP}/${KEYCHAIN_FILE}" login.keychain
+    ;;
+  uninstall-certificate)
+    # Always run this job step, even if previous ones fail. See also
+    # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development#required-clean-up-on-self-hosted-runners
+    security delete-keychain "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
+    rm -f "${RUNNER_TEMP}/${CERTIFICATE_FILE}" "${HOME}/${PROVISION_PATH}"
+    ;;
+esac

--- a/incubator/build/src/cli.ts
+++ b/incubator/build/src/cli.ts
@@ -4,7 +4,12 @@ import type { Options } from "yargs";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { startBuild } from "./build";
-import { DEPLOYMENT, DEVICE_TYPES, PLATFORMS } from "./constants";
+import {
+  DEPLOYMENT,
+  DEVICE_TYPES,
+  PLATFORMS,
+  USER_CONFIG_FILE,
+} from "./constants";
 import { getDistribution } from "./distribution";
 import { getRepositoryRoot } from "./git";
 import { detectPackageManager } from "./packageManager";
@@ -104,4 +109,8 @@ async function main(): Promise<void> {
   });
 }
 
-main();
+main().catch((e) => {
+  process.exitCode = 1;
+  console.error(e);
+  console.log("User config:", USER_CONFIG_FILE);
+});

--- a/incubator/build/workflows/github.yml
+++ b/incubator/build/workflows/github.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Pods
-        run: pod install --project-directory=ios
+        run: pod install --project-directory=ios --verbose
         working-directory: ${{ github.event.inputs.projectRoot }}
       - name: Install Apple signing certificate and provisioning profile
         if: ${{ github.event.inputs.deviceType == 'device' }}
@@ -87,54 +87,21 @@ jobs:
           BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-        run: |
-          # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
-          mkdir -p "$(dirname "${HOME}/${PROVISION_PATH}")"
-
-          echo -n "${BUILD_CERTIFICATE_BASE64}" | base64 --decode --output "${RUNNER_TEMP}/${CERTIFICATE_FILE}"
-          echo -n "${BUILD_PROVISION_PROFILE_BASE64}" | base64 --decode --output "${HOME}/${PROVISION_PATH}"
-
-          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
-          security set-keychain-settings -lut 21600 "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
-          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
-
-          security import "${RUNNER_TEMP}/${CERTIFICATE_FILE}" -k "${RUNNER_TEMP}/${KEYCHAIN_FILE}" -t cert -f pkcs12 -P "${P12_PASSWORD}" -A -T '/usr/bin/codesign' -T '/usr/bin/security'
-          security set-key-partition-list -S apple-tool:,apple: -k ${KEYCHAIN_PASSWORD} "${RUNNER_TEMP}/${KEYCHAIN_FILE}" 1> /dev/null
-          security list-keychain -d user -s "${RUNNER_TEMP}/${KEYCHAIN_FILE}" login.keychain
+        run: npx --prefix . rnx-build-apple install-certificate
       - name: Build iOS app
-        run: |
-          if [[ ${{ github.event.inputs.deviceType }} == 'device' ]]; then
-            destination='generic/platform=iOS'
-            code_signing=''
-          else
-            destination='generic/platform=iOS Simulator'
-            archs='ARCHS=${{ github.event.inputs.architecture }}'
-            code_signing='CODE_SIGNING_ALLOWED=NO'
-          fi
-          # We need to disable Clang sanitizers otherwise the app will crash on
-          # startup trying to load Clang sanitizer libraries that would only
-          # exist if Xcode was attached.
-          xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
-          xcodebuild -workspace ${xcworkspace} -scheme ${{ github.event.inputs.scheme }} -destination "${destination}" -configuration Debug -derivedDataPath DerivedData -archivePath ${XCARCHIVE_FILE} ${archs} ${code_signing} CLANG_ADDRESS_SANITIZER=NO CLANG_UNDEFINED_BEHAVIOR_SANITIZER=NO OTHER_CFLAGS='$(inherited) -fstack-protector-strong' OTHER_LDFLAGS='$(inherited) -fstack-protector-strong' COMPILER_INDEX_STORE_ENABLE=NO archive
+        run: npx --prefix . rnx-build-apple build-ios --scheme ${{ github.event.inputs.scheme }} --device-type ${{ github.event.inputs.deviceType }} --archs ${{ github.event.inputs.architecture }}
         working-directory: ${{ github.event.inputs.projectRoot }}/ios
       - name: Remove Apple signing certificate and provisioning profile
+        # Always run this job step, even if previous ones fail. See also
+        # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development#required-clean-up-on-self-hosted-runners
         if: ${{ always() && github.event.inputs.deviceType == 'device' }}
-        run: |
-          # Always run this job step, even if previous ones fail. See also
-          # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development#required-clean-up-on-self-hosted-runners
-          security delete-keychain "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
-          rm -f "${RUNNER_TEMP}/${CERTIFICATE_FILE}" "${HOME}/${PROVISION_PATH}"
+        run: npx --prefix . rnx-build-apple uninstall-certificate
       - name: Prepare build artifact
         id: prepare-build-artifact
         run: |
           if [[ ${{ github.event.inputs.distribution }} == 'local' ]]; then
             app=$(find ${XCARCHIVE_FILE}/Products/Applications -maxdepth 1 -name '*.app' -type d | head -1)
-            # bsdtar corrupts files when archiving due to APFS sparse files. A
-            # workaround is to use GNU Tar instead. See also:
-            #   - https://github.com/actions/cache/issues/403
-            #   - https://github.com/actions/virtual-environments/issues/2619
-            gtar -cvf ios-artifact.tar -C "$(dirname ${app})" "$(basename ${app})"
-            shasum --algorithm 256 ios-artifact.tar
+            npx --prefix . rnx-build-apple archive ios-artifact.tar "${app}"
             echo "::set-output name=filename::ios-artifact.tar"
           else
             xcodebuild -exportArchive -archivePath ${XCARCHIVE_FILE} -exportPath export -exportOptionsPlist ExportOptions.plist 2>&1
@@ -163,26 +130,16 @@ jobs:
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Pods
-        run: pod install --project-directory=macos
+        run: pod install --project-directory=macos --verbose
         working-directory: ${{ github.event.inputs.projectRoot }}
       - name: Build macOS app
-        run: |
-          # We need to disable Clang sanitizers otherwise the app will crash on
-          # startup trying to load Clang sanitizer libraries that would only
-          # exist if Xcode was attached.
-          xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
-          xcodebuild -workspace ${xcworkspace} -scheme ${{ github.event.inputs.scheme }} -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO CLANG_ADDRESS_SANITIZER=NO CLANG_UNDEFINED_BEHAVIOR_SANITIZER=NO OTHER_CFLAGS='$(inherited) -fstack-protector-strong' OTHER_LDFLAGS='$(inherited) -fstack-protector-strong' COMPILER_INDEX_STORE_ENABLE=NO build
+        run: npx --prefix . rnx-build-apple build-macos --scheme ${{ github.event.inputs.scheme }}
         working-directory: ${{ github.event.inputs.projectRoot }}/macos
       - name: Prepare build artifact
         run: |
           output_path=DerivedData/Build/Products
           app=$(find ${output_path} -maxdepth 2 -name '*.app' -type d | head -1)
-          # bsdtar corrupts files when archiving due to APFS sparse files. A
-          # workaround is to use GNU Tar instead. See also:
-          #   - https://github.com/actions/cache/issues/403
-          #   - https://github.com/actions/virtual-environments/issues/2619
-          gtar -cvf macos-artifact.tar -C "$(dirname ${app})" "$(basename ${app})"
-          shasum --algorithm 256 macos-artifact.tar
+          npx --prefix . rnx-build-apple archive macos-artifact.tar "${app}"
         working-directory: ${{ github.event.inputs.projectRoot }}/macos
       - name: Upload build artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### Description

Move some build scripts to a separate file so they can be shared.

### Test plan

```
cd incubator/build
yarn build --dependencies

# macOS
yarn rnx-build -p macos ../../packages/test-app

# iOS simulator
yarn rnx-build -p ios ../../packages/test-app

# iOS device
yarn rnx-build -p ios --deploy local-only --device-type device ../../packages/test-app