### PR TITLE
fix(metro-config): fix asset plugin breaking bundling

### DIFF
--- a/.changeset/dull-eggs-mate.md
+++ b/.changeset/dull-eggs-mate.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Fix monorepo asset plugin breaking bundling

--- a/packages/metro-config/src/assetPluginForMonorepos.js
+++ b/packages/metro-config/src/assetPluginForMonorepos.js
@@ -1,6 +1,11 @@
 /**
  * @typedef {import("metro").AssetData} AssetData;
+ * @typedef {import("metro-config").ConfigT} ConfigT;
  * @typedef {import("metro-config").Middleware} Middleware;
+ *
+ * @typedef {import("metro/src/Server") & {
+ *   _config?: ConfigT;
+ * }} Server;
  */
 
 /**
@@ -25,12 +30,39 @@ function assetPlugin(assetData) {
 }
 
 /**
+ * Injects {@link assetPlugin} into server asset plugins.
+ *
+ * This should only be called from {@link enhanceMiddleware} to ensure that the
+ * asset plugin is only applied when we are serving. This has the nice
+ * side-effect that the plugin doesn't get included if the middleware is
+ * unused (during bundling) or removed.
+ *
+ * @param {Server} server
+ */
+function injectAssetPlugin(server) {
+  const config = server._config;
+  if (!config || !Array.isArray(config.transformer.assetPlugins)) {
+    console.warn(
+      "'@rnx-kit/metro-config' was unable to install the asset plugin for " +
+        "monorepos. Please try again with the latest version. If this " +
+        "warning still persists, you can file an issue at " +
+        "https://github.com/microsoft/rnx-kit/issues/new?assignees=&labels=bug&template=bug_report.yml"
+    );
+    return;
+  }
+
+  config.transformer.assetPlugins.push(__filename);
+}
+
+/**
  * This middleware restores `..` in asset URLs.
  *
  * @param {Middleware} middleware
+ * @param {Server} server
  * @returns {Middleware}
  */
-function enhanceMiddleware(middleware) {
+function enhanceMiddleware(middleware, server) {
+  injectAssetPlugin(server);
   return (req, res, next) => {
     const { url } = req;
     if (url && url.startsWith("/assets/")) {

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -13,37 +13,6 @@ const path = require("path");
 const UNIQUE_PACKAGES = ["react", "react-native"];
 
 /**
- * Verifies `server.enhanceMiddleware` is only set if
- * `transformer.assetPlugins` includes the asset plugin.
- * @param {MetroConfig} config
- * @returns {MetroConfig}
- */
-function verifyMiddlewareConsistency(config) {
-  if (!config.server || !config.server.enhanceMiddleware) {
-    // If our middleware was removed, the corresponding asset plugin should also
-    // be removed to avoid issues. We should notify the user of this so they can
-    // handle it accordingly.
-    //
-    // Note that we can only check whether `enhanceMiddleware` is unset as we
-    // cannot guarantee that our middleware isn't embedded somewhere.
-    const monorepoPluginIndex =
-      config.transformer &&
-      config.transformer.assetPlugins &&
-      config.transformer.assetPlugins.indexOf(
-        require.resolve("./assetPluginForMonorepos")
-      );
-    if (typeof monorepoPluginIndex === "number" && monorepoPluginIndex >= 0) {
-      const console = require("@rnx-kit/console");
-      console.warn(
-        `@rnx-kit/metro-config's middleware for assets in a monorepo was removed, but the accompanying plugin was not. If you intended to remove the middleware, you should also remove the plugin to avoid issues. The middleware was set in 'server.enhanceMiddleware' and the plugin can be found in 'transformer.assetPlugins'.`
-      );
-    }
-  }
-
-  return config;
-}
-
-/**
  * A minimum list of folders that should be watched by Metro.
  * @returns {string[]}
  */
@@ -224,7 +193,7 @@ module.exports = {
     const customBlockList =
       customConfig.resolver &&
       (customConfig.resolver.blockList || customConfig.resolver.blacklistRE);
-    const mergedConfig = mergeConfig(
+    return mergeConfig(
       {
         resolver: {
           resolverMainFields: ["module", "browser", "main"],
@@ -235,7 +204,6 @@ module.exports = {
           enhanceMiddleware,
         },
         transformer: {
-          assetPlugins: [require.resolve("./assetPluginForMonorepos")],
           getTransformOptions: async () => ({
             transform: {
               experimentalImportSupport: false,
@@ -278,7 +246,5 @@ module.exports = {
         },
       }
     );
-
-    return verifyMiddlewareConsistency(mergedConfig);
   },
 };

--- a/packages/metro-config/test/assetPluginForMonorepos.test.ts
+++ b/packages/metro-config/test/assetPluginForMonorepos.test.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "http";
 import type { AssetData } from "metro";
 import type { Middleware } from "metro-config";
+import type Server from "metro/src/Server";
 
 describe("@rnx-kit/metro-config/assetPluginForMonorepos", () => {
   const assetPlugin = require("../src/assetPluginForMonorepos");
@@ -31,9 +32,18 @@ describe("@rnx-kit/metro-config/assetPluginForMonorepos", () => {
         expect(req).toEqual(expect.objectContaining({ url: output }));
         return middleware;
       };
+      const server = {
+        _config: { transformer: { assetPlugins: [] } },
+      } as unknown as Server;
+
       const incoming = { url: input } as IncomingMessage;
       const response = {} as ServerResponse;
-      enhanceMiddleware(middleware)(incoming, response, () => undefined);
+
+      enhanceMiddleware(middleware, server)(
+        incoming,
+        response,
+        () => undefined
+      );
     });
   });
 });

--- a/packages/metro-config/test/index.test.ts
+++ b/packages/metro-config/test/index.test.ts
@@ -280,9 +280,7 @@ describe("makeMetroConfig", () => {
     expect(config.resolver.blockList.source).toBe(blockList);
 
     expect(config.server.enhanceMiddleware).toBe(enhanceMiddleware);
-    expect(config.transformer.assetPlugins).toContain(
-      require.resolve("../src/assetPluginForMonorepos")
-    );
+    expect(config.transformer.assetPlugins).toBeUndefined();
 
     const opts = { dev: false, hot: false };
     const transformerOptions = await config.transformer.getTransformOptions(
@@ -338,9 +336,7 @@ describe("makeMetroConfig", () => {
     expect(config.resolver.blockList.source).toBe(blockList);
 
     expect(config.server.enhanceMiddleware).toBe(enhanceMiddleware);
-    expect(config.transformer.assetPlugins).toContain(
-      require.resolve("../src/assetPluginForMonorepos")
-    );
+    expect(config.transformer.assetPlugins).toBeUndefined();
 
     const opts = { dev: false, hot: false };
     const transformerOptions = await config.transformer.getTransformOptions(
@@ -402,22 +398,5 @@ describe("makeMetroConfig", () => {
 
     expect(blockList).not.toBeUndefined();
     expect(blockList).toBe(configWithBlockList.resolver?.blacklistRE);
-  });
-
-  test("warns about the asset plugin if the middleware is deleted", () => {
-    const config = makeMetroConfig({
-      // @ts-expect-error intentionally setting `enhanceMiddleware` to `null`
-      server: { enhanceMiddleware: null },
-    });
-
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "@rnx-kit/metro-config's middleware for assets in a monorepo was removed"
-      )
-    );
-    expect(config.server?.enhanceMiddleware).toBeNull();
-    expect(config.transformer?.assetPlugins).toContain(
-      require.resolve("../src/assetPluginForMonorepos")
-    );
   });
 });


### PR DESCRIPTION
### Description

The asset plugin breaks bundling because it replace `..` in paths with `@@`. This plugin is only intended as a workaround for a Metro issue with serving assets from relative paths, and should not be used when bundling.

Resolves #1879.

### Test plan

Tested in an internal app.

To test this locally, you can modify the plugin to output something, e.g.:

```diff
diff --git a/packages/metro-config/src/assetPluginForMonorepos.js b/packages/metro-config/src/assetPluginForMonorepos.js
index b6186449..c1808e3c 100644
--- a/packages/metro-config/src/assetPluginForMonorepos.js
+++ b/packages/metro-config/src/assetPluginForMonorepos.js
@@ -8,6 +8,8 @@
  * }} Server;
  */

+let didCallAssetPlugin = false;
+
 /**
  * Metro doesn't support assets in a monorepo setup. When the app requests
  * assets at URLs such as `/assets/../../../node_modules/react-native/<...>`,
@@ -22,6 +24,10 @@
  * @returns {AssetData}
  */
 function assetPlugin(assetData) {
+  if (!didCallAssetPlugin) {
+    didCallAssetPlugin = true;
+    console.log("Asset plugin used in worker", process.pid);
+  }
   assetData.httpServerLocation = assetData.httpServerLocation.replace(
     /\.\.\//g,
     "@@/"
```

Then try comparing `yarn bundle --platform ios --reset-cache` with `yarn start` in `packages/test-app`. Only the latter should hit the added lines.