### PR TITLE
fix(metro-config): add "react-native" to resolverMainFields

### DIFF
--- a/.changeset/proud-rice-bake.md
+++ b/.changeset/proud-rice-bake.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": minor
+---
+
+fix(metro-config): add react-native to main fields

--- a/.changeset/proud-rice-bake.md
+++ b/.changeset/proud-rice-bake.md
@@ -2,4 +2,4 @@
 "@rnx-kit/metro-config": minor
 ---
 
-fix(metro-config): add react-native to main fields
+Added `react-native` to main fields

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -196,7 +196,7 @@ module.exports = {
     return mergeConfig(
       {
         resolver: {
-          resolverMainFields: ["module", "browser", "main"],
+          resolverMainFields: ["react-native", "module", "browser", "main"],
           blacklistRE: blockList, // For Metro < 0.60
           blockList, // For Metro >= 0.60
         },


### PR DESCRIPTION
### Description

For packages that include both `react-dom` and `react-native` code and differentiate by using the `"react-native"` directive in `package.json`,  the current list of mainFields will pick the `react-dom` module.

Seen in the wild with projects using recoiljs: https://github.com/facebookexperimental/Recoil

This change adds "react-native" as the preferred main field.

### Test plan

Include recoiljs (or other package using split module declarations) in a project and build.