### PR TITLE
fix(cli): fix CLI not parsing numbers correctly

### DIFF
--- a/.changeset/tough-actors-own.md
+++ b/.changeset/tough-actors-own.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Fixed CLI not parsing numbers correctly

--- a/packages/cli/react-native.config.js
+++ b/packages/cli/react-native.config.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const {
   parseBoolean,
+  parseInt,
   rnxBundleCommand,
   rnxCopyAssetsCommand,
   rnxStart,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@ export { rnxBundle, rnxBundleCommand } from "./bundle";
 export { rnxClean } from "./clean";
 export { copyProjectAssets, rnxCopyAssetsCommand } from "./copy-assets";
 export { rnxDepCheck, rnxDepCheckCommand } from "./dep-check";
-export { parseBoolean, parseTransformProfile } from "./parsers";
+export { parseBoolean, parseInt, parseTransformProfile } from "./parsers";
 export { rnxRamBundle, rnxRamBundleCommand } from "./ram-bundle";
 export { rnxStart } from "./start";
 export { rnxTest, rnxTestCommand } from "./test";

--- a/packages/cli/src/parsers.ts
+++ b/packages/cli/src/parsers.ts
@@ -12,6 +12,10 @@ export function parseBoolean(val: string): boolean {
   );
 }
 
+export function parseInt(value: string): number {
+  return global.parseInt(value, 10);
+}
+
 export function parseTransformProfile(val: string): TransformProfile {
   const allowedProfiles: TransformProfile[] = [
     "hermes-stable",


### PR DESCRIPTION
### Description

CLI passes the default value as the second argument to value parsers which `parseInt` misinterprets as the radix. This causes any options with default values to return `NaN`.

### Test plan

```
cd packages/test-app
yarn build --dependencies
yarn start --port 8090
```