### PR TITLE
Quick security and Windows-compatibility fix

### DIFF
--- a/.changeset/gentle-feet-brush.md
+++ b/.changeset/gentle-feet-brush.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Fix Windows compatability and a minor security issue.

--- a/packages/cli/src/copy-assets.ts
+++ b/packages/cli/src/copy-assets.ts
@@ -312,7 +312,7 @@ export async function assembleAarBundle(
 
     const settingsGradle = [
       `include(":${targetName}")`,
-      `project(":${targetName}").projectDir = file("${androidProject}")`,
+      `project(":${targetName}").projectDir = file(${JSON.stringify(androidProject)})`,
       "",
     ].join("\n");
 

--- a/packages/cli/src/copy-assets.ts
+++ b/packages/cli/src/copy-assets.ts
@@ -312,7 +312,9 @@ export async function assembleAarBundle(
 
     const settingsGradle = [
       `include(":${targetName}")`,
-      `project(":${targetName}").projectDir = file(${JSON.stringify(androidProject)})`,
+      `project(":${targetName}").projectDir = file(${JSON.stringify(
+        androidProject
+      )})`,
       "",
     ].join("\n");
 

--- a/packages/cli/test/copy-assets/assembleAarBundle.test.ts
+++ b/packages/cli/test/copy-assets/assembleAarBundle.test.ts
@@ -168,7 +168,7 @@ describe("assembleAarBundle", () => {
           /[/\\]node_modules[/\\].rnx-gradle-build[/\\]rnx-kit_react-native-auth[/\\]settings.gradle$/
         ),
         expect.stringMatching(
-          /include\(":rnx-kit_react-native-auth"\)\nproject\(":rnx-kit_react-native-auth"\).projectDir = file\(".*?[/\\\\]node_modules[/\\\\]@rnx-kit[/\\\\]react-native-auth[/\\\\]android"\)/
+          /include\(":rnx-kit_react-native-auth"\)\nproject\(":rnx-kit_react-native-auth"\).projectDir = file\(".*?(\/|\\\\)node_modules(\/|\\\\)@rnx-kit(\/|\\\\)react-native-auth(\/|\\\\)android"\)/
         ),
       ],
       [

--- a/packages/cli/test/copy-assets/assembleAarBundle.test.ts
+++ b/packages/cli/test/copy-assets/assembleAarBundle.test.ts
@@ -168,7 +168,7 @@ describe("assembleAarBundle", () => {
           /[/\\]node_modules[/\\].rnx-gradle-build[/\\]rnx-kit_react-native-auth[/\\]settings.gradle$/
         ),
         expect.stringMatching(
-          /include\(":rnx-kit_react-native-auth"\)\nproject\(":rnx-kit_react-native-auth"\).projectDir = file\(".*?[/\\]node_modules[/\\]@rnx-kit[/\\]react-native-auth[/\\]android"\)/
+          /include\(":rnx-kit_react-native-auth"\)\nproject\(":rnx-kit_react-native-auth"\).projectDir = file\(".*?[/\\\\]node_modules[/\\\\]@rnx-kit[/\\\\]react-native-auth[/\\\\]android"\)/
         ),
       ],
       [


### PR DESCRIPTION
This is a one-line quick fix for 2 issues:

1. The small issue is for **Windows compatibility**. Assuming `androidProject` is `D:\Projects\abc`. Notice that the path separator is backslash in Windows and slash in Linux/MacOS. The original code is write `file("D:\Projects\abc")` in the files which is not valid. After the fix it will write `file("D:\\Projects\\abc")` that the backslashes are correctly escaped.
2. The big issue is for **security**. Linux/MacOS allows a lot of special characters in file name. So hackers can potentially name there project `");doSomethingBad();("` and hack whoever uses it. This fix will correctly escape it and make sure it's just a string.

I don't have the knowledge to decide whether I should update `targetName` in the line as well so I'm not touching it and assuming it's safe.