### PR TITLE
fix(metro-config): remove `module` from `resolverMainFields`

### DIFF
--- a/.changeset/swift-laws-turn.md
+++ b/.changeset/swift-laws-turn.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Remove `module` from `resolverMainFields` as Metro currently does not support it and causes confusion when bundling fails.

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -196,7 +196,7 @@ module.exports = {
     return mergeConfig(
       {
         resolver: {
-          resolverMainFields: ["react-native", "module", "browser", "main"],
+          resolverMainFields: ["react-native", "browser", "main"],
           blacklistRE: blockList, // For Metro < 0.60
           blockList, // For Metro >= 0.60
         },

--- a/packages/metro-serializer-esbuild/metro.config.js
+++ b/packages/metro-serializer-esbuild/metro.config.js
@@ -8,6 +8,7 @@ module.exports = makeMetroConfig({
   reporter: { update: () => undefined },
   resetCache: true,
   resolver: {
+    resolverMainFields: ["react-native", "module", "browser", "main"],
     blacklistRE: blockList,
     blockList,
   },


### PR DESCRIPTION
### Description

Remove `module` from `resolverMainFields` as Metro currently does not support it and causes confusion when bundling fails.

Adding `module` to `resolverMainFields` does work, but it may also require adding `.mjs` (depending on the code base), which comes with its own set of issues that need to be resolved separately. Removing it is the only correct choice. For advanced users, they can still add `module` manually.

Resolves #1752.

### Test plan

n/a