### PR TITLE
fix(dep-check): `@types/react-native` won't be needed from 0.71 on

### DIFF
--- a/.changeset/kind-forks-lie.md
+++ b/.changeset/kind-forks-lie.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/dep-check": patch
+---
+
+`@types/react-native` won't be needed from 0.71 on

--- a/packages/dep-check/src/presets/banned.ts
+++ b/packages/dep-check/src/presets/banned.ts
@@ -14,6 +14,12 @@ const bannedPackages: ExcludedPackage[] = [
       "This package was renamed to '@react-native-masked-view/masked-view' in 0.2.0. Please remove the old package and start using the new one.",
   },
   {
+    name: "@types/react-native",
+    version: ">=0.71.0-0",
+    reason:
+      "Types are included in react-native starting with 0.71.0. '@types/react-native' will be deprecated from 0.72 onwards.",
+  },
+  {
     name: "react-native-linear-gradient",
     version: "<2.6.0",
     reason:


### PR DESCRIPTION
### Description

Resolves #1899.

### Test plan

n/a