### PR TITLE
fix(build): authenticating with `--token` is deprecated

### DIFF
--- a/.changeset/eight-waves-search.md
+++ b/.changeset/eight-waves-search.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": minor
+---
+
+Firebase: Authenticating with `--token` is deprecated. A service account is now required for authentication.

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -17,13 +17,13 @@ runs:
   using: composite
   steps:
     - name: Set up Node.js
-      uses: actions/setup-node@v3.4.1
+      uses: actions/setup-node@v3.5.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: yarn
     - name: Set up JDK
       if: ${{ inputs.jdk-version != 0 }}
-      uses: actions/setup-java@v3.4.1
+      uses: actions/setup-java@v3.5.1
       with:
         distribution: temurin
         java-version: ${{ inputs.jdk-version }}

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -36,18 +36,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v3.4.1
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: temurin
           java-version: 11
       - name: Set up Node 16
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.5.0
         with:
           node-version: 16
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Build Android app
-        uses: gradle/gradle-build-action@v2.3.0
+        uses: gradle/gradle-build-action@v2.3.2
         with:
           gradle-version: wrapper
           arguments: --no-daemon clean assembleDebug
@@ -72,7 +72,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Node 16
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.5.0
         with:
           node-version: 16
       - name: Install npm dependencies
@@ -124,7 +124,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Node 16
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.5.0
         with:
           node-version: 16
       - name: Install npm dependencies
@@ -158,7 +158,7 @@ jobs:
       - name: Set up MSBuild
         uses: microsoft/setup-msbuild@v1.1
       - name: Set up Node 16
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.5.0
         with:
           node-version: 16
       - name: Install npm dependencies
@@ -207,7 +207,8 @@ jobs:
         if: ${{ startsWith(github.event.inputs.distribution, 'firebase:') }}
         env:
           FIREBASE_APP_ID: ${{ github.event.inputs.distribution }}
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          GOOGLE_APPLICATION_CREDENTIALS: credentials.json
         run: |
           artifact=$(find . -maxdepth 1 -type f | head -1)
-          npx --package firebase-tools@11 firebase appdistribution:distribute "${artifact}" --app ${FIREBASE_APP_ID:9} --release-notes "${{ github.ref_name }}" --token "${FIREBASE_TOKEN}"
+          echo -n "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}" | base64 --decode > ${GOOGLE_APPLICATION_CREDENTIALS}
+          npx --package firebase-tools@11 firebase appdistribution:distribute "${artifact}" --app ${FIREBASE_APP_ID:9} --release-notes "${{ github.ref_name }}"

--- a/incubator/build-plugin-firebase/README.md
+++ b/incubator/build-plugin-firebase/README.md
@@ -47,11 +47,13 @@ section in `package.json` like in the following example:
 }
 ```
 
-Next, you need to
-[generate a token for Firebase CLI](https://firebase.google.com/docs/cli/#cli-ci-systems),
-and store it as a secret, `FIREBASE_TOKEN`, on your project host.
+Next, you need to create a
+[service account](https://firebase.google.com/docs/app-distribution/authenticate-service-account)
+with the **Firebase App Distribution Admin** role, and create a private JSON
+key. Once a key is created and downloaded, base64 it and store it as a secret,
+`GOOGLE_APPLICATION_CREDENTIALS_BASE64`, on your project host.
 
-If you're using GitHub, you should store it as an encrypted secret:
+If you're using GitHub, store it as an encrypted secret:
 https://docs.github.com/en/actions/security-guides/encrypted-secrets
 
 ## Contributors' Notes

--- a/incubator/build/workflows/github.yml
+++ b/incubator/build/workflows/github.yml
@@ -36,18 +36,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v3.4.1
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: temurin
           java-version: 11
       - name: Set up Node 16
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.5.0
         with:
           node-version: 16
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Build Android app
-        uses: gradle/gradle-build-action@v2.3.0
+        uses: gradle/gradle-build-action@v2.3.2
         with:
           gradle-version: wrapper
           arguments: --no-daemon clean assembleDebug
@@ -72,7 +72,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Node 16
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.5.0
         with:
           node-version: 16
       - name: Install npm dependencies
@@ -124,7 +124,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Node 16
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.5.0
         with:
           node-version: 16
       - name: Install npm dependencies
@@ -158,7 +158,7 @@ jobs:
       - name: Set up MSBuild
         uses: microsoft/setup-msbuild@v1.1
       - name: Set up Node 16
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.5.0
         with:
           node-version: 16
       - name: Install npm dependencies
@@ -207,7 +207,8 @@ jobs:
         if: ${{ startsWith(github.event.inputs.distribution, 'firebase:') }}
         env:
           FIREBASE_APP_ID: ${{ github.event.inputs.distribution }}
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          GOOGLE_APPLICATION_CREDENTIALS: credentials.json
         run: |
           artifact=$(find . -maxdepth 1 -type f | head -1)
-          npx --package firebase-tools@11 firebase appdistribution:distribute "${artifact}" --app ${FIREBASE_APP_ID:9} --release-notes "${{ github.ref_name }}" --token "${FIREBASE_TOKEN}"
+          echo -n "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}" | base64 --decode > ${GOOGLE_APPLICATION_CREDENTIALS}
+          npx --package firebase-tools@11 firebase appdistribution:distribute "${artifact}" --app ${FIREBASE_APP_ID:9} --release-notes "${{ github.ref_name }}"


### PR DESCRIPTION
### Description

Firebase: Authenticating with `--token` is deprecated. A service account is now required for authentication.

### Test plan

Follow README instructions for creating a Firebase Distribution service account.

```
cd incubator/build
yarn build --dependencies
yarn rnx-build -p android --device-type device ../../packages/test-app
```

Build log of a successful build: https://github.com/tido64/rnx-kit/actions/runs/3197388647/jobs/5220603030