### PR TITLE
fix(react-native-auth): `redirectURI` should be nullable

### DIFF
--- a/.changeset/cyan-bobcats-cover.md
+++ b/.changeset/cyan-bobcats-cover.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-auth": patch
+---
+
+Make `redirectURI` optional as their JS counterpart

--- a/packages/react-native-auth/android/src/main/java/com/microsoft/reactnativesdk/auth/AuthError.kt
+++ b/packages/react-native-auth/android/src/main/java/com/microsoft/reactnativesdk/auth/AuthError.kt
@@ -11,19 +11,17 @@ import com.facebook.react.bridge.WritableMap
 data class AuthError(
     val type: AuthErrorType,
     val correlationId: String,
-    val message: String?
+    val message: String? = null
 ) {
     companion object {
         fun unknown() = AuthError(
             AuthErrorType.UNKNOWN,
-            "00000000-0000-0000-0000-000000000000",
-            null
+            "00000000-0000-0000-0000-000000000000"
         )
 
         fun userCanceled() = AuthError(
             AuthErrorType.USER_CANCELED,
-            "00000000-0000-0000-0000-000000000000",
-            null
+            "00000000-0000-0000-0000-000000000000"
         )
     }
 

--- a/packages/react-native-auth/android/src/main/java/com/microsoft/reactnativesdk/auth/AuthResult.kt
+++ b/packages/react-native-auth/android/src/main/java/com/microsoft/reactnativesdk/auth/AuthResult.kt
@@ -11,13 +11,15 @@ import com.facebook.react.bridge.WritableMap
 data class AuthResult(
     val accessToken: String,
     val expirationTime: Int,
-    val redirectUri: String
+    val redirectUri: String? = null
 ) {
     fun toWritableMap(): WritableMap {
         return Arguments.createMap().also { map ->
             map.putString("accessToken", accessToken)
             map.putInt("expirationTime", expirationTime)
-            map.putString("redirectUri", redirectUri)
+            redirectUri?.let {
+              map.putString("redirectUri", redirectUri)
+            }
         }
     }
 }

--- a/packages/react-native-auth/ios/RNXAuthError.h
+++ b/packages/react-native-auth/ios/RNXAuthError.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) RNXAuthErrorType type;
 @property (nonatomic, readonly) NSString *correlationID;
-@property (nonatomic, nullable, readonly) NSString *message;
+@property (nonatomic, readonly, nullable) NSString *message;
 
 + (instancetype)errorWithType:(RNXAuthErrorType)type
                 correlationID:(NSString *)correlationID

--- a/packages/react-native-auth/ios/RNXAuthResult.h
+++ b/packages/react-native-auth/ios/RNXAuthResult.h
@@ -11,11 +11,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) NSString *accessToken;
 @property (nonatomic, readonly) NSInteger expirationTime;
-@property (nonatomic, readonly) NSString *redirectURI;
+@property (nonatomic, readonly, nullable) NSString *redirectURI;
+
++ (instancetype)resultWithAccessToken:(NSString *)accessToken
+                       expirationTime:(NSInteger)expirationTime;
 
 + (instancetype)resultWithAccessToken:(NSString *)accessToken
                        expirationTime:(NSInteger)expirationTime
-                          redirectURI:(NSString *)redirectURI;
+                          redirectURI:(nullable NSString *)redirectURI;
 
 - (NSDictionary *)dictionary;
 

--- a/packages/react-native-auth/ios/RNXAuthResult.m
+++ b/packages/react-native-auth/ios/RNXAuthResult.m
@@ -4,6 +4,14 @@
 
 + (instancetype)resultWithAccessToken:(NSString *)accessToken
                        expirationTime:(NSInteger)expirationTime
+{
+    return [[RNXAuthResult alloc] initWithAccessToken:accessToken
+                                       expirationTime:expirationTime
+                                          redirectURI:NULL];
+}
+
++ (instancetype)resultWithAccessToken:(NSString *)accessToken
+                       expirationTime:(NSInteger)expirationTime
                           redirectURI:(NSString *)redirectURI
 {
     return [[RNXAuthResult alloc] initWithAccessToken:accessToken
@@ -28,7 +36,7 @@
     return @{
         @"accessToken": _accessToken,
         @"expirationTime": @(_expirationTime),
-        @"redirectUri": _redirectURI,
+        @"redirectUri": _redirectURI == NULL ? [NSNull null] : _redirectURI,
     };
 }
 

--- a/packages/test-app/ios/Podfile.lock
+++ b/packages/test-app/ios/Podfile.lock
@@ -286,7 +286,7 @@ PODS:
     - React-jsi (= 0.68.3)
     - React-logger (= 0.68.3)
     - React-perflogger (= 0.68.3)
-  - ReactTestApp-DevSupport (1.6.8):
+  - ReactTestApp-DevSupport (1.6.11):
     - React-Core
     - React-jsi
   - ReactTestApp-MSAL (1.0.5):
@@ -447,12 +447,12 @@ SPEC CHECKSUMS:
   React-RCTVibration: f41f116aad644973f24653effb3db3de64fa0314
   React-runtimeexecutor: 8cdd80915ed6dabf2221a689f1f7ddb50ea5e9f3
   ReactCommon: 5b1b43a7d81a1ac4eec85f7c4db3283a14a3b13d
-  ReactTestApp-DevSupport: 477807a2c223e21ea8567c0c0a5880d561e11534
+  ReactTestApp-DevSupport: 0164207f1b24b6c43f26f1e9d324e2ddc3193261
   ReactTestApp-MSAL: 803fb430f3d9bf6bc022964c64ac3b64fea88f73
   ReactTestApp-Resources: 74a1cf509f4e7962b16361ea4e73cba3648fff5d
   RNXAuth: 1f5001db635f153c400b657b91e06e9b997620e8
   Yoga: 2f6a78c58dcc2963bd8e34d96a4246d9dff2e3a7
 
-PODFILE CHECKSUM: 438d9afb225dc2a99c6750449d7231544f5ad6f3
+PODFILE CHECKSUM: df600ab6f7e85a7573cb1b256a65b13294140cbd
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
### Description

`redirectUri` is already optional in TS, but not in the native projections.

### Test plan

CI should pass.