### PR TITLE
fix(tools-workspaces): exclude packages that don't have a manifest

### DIFF
--- a/.changeset/five-lizards-compete.md
+++ b/.changeset/five-lizards-compete.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-workspaces": patch
+---
+
+Exclude packages that don't have a manifest

--- a/packages/tools-workspaces/test/__fixtures__/lerna-packages/packages/invalid-package/.gitignore
+++ b/packages/tools-workspaces/test/__fixtures__/lerna-packages/packages/invalid-package/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/tools-workspaces/test/__fixtures__/lerna-workspaces/packages/invalid-package/.gitignore
+++ b/packages/tools-workspaces/test/__fixtures__/lerna-workspaces/packages/invalid-package/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/tools-workspaces/test/__fixtures__/npm/packages/invalid-package/.gitignore
+++ b/packages/tools-workspaces/test/__fixtures__/npm/packages/invalid-package/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/tools-workspaces/test/__fixtures__/pnpm/packages/invalid-package/.gitignore
+++ b/packages/tools-workspaces/test/__fixtures__/pnpm/packages/invalid-package/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/tools-workspaces/test/__fixtures__/rush/packages/invalid-package/.gitignore
+++ b/packages/tools-workspaces/test/__fixtures__/rush/packages/invalid-package/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/tools-workspaces/test/__fixtures__/yarn/packages/invalid-package/.gitignore
+++ b/packages/tools-workspaces/test/__fixtures__/yarn/packages/invalid-package/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/tools-workspaces/test/lerna.test.ts
+++ b/packages/tools-workspaces/test/lerna.test.ts
@@ -49,22 +49,22 @@ describe("findWorkspacePackages", () => {
 
   test("returns packages for Lerna workspaces", async () => {
     setFixture("lerna-packages");
-    expect(await findWorkspacePackages()).toEqual(packagesPackages);
+    expect((await findWorkspacePackages()).sort()).toEqual(packagesPackages);
   });
 
   test("returns packages for Lerna workspaces (sync)", () => {
     setFixture("lerna-packages");
-    expect(findWorkspacePackagesSync()).toEqual(packagesPackages);
+    expect(findWorkspacePackagesSync().sort()).toEqual(packagesPackages);
   });
 
   test("returns packages for delegated workspaces", async () => {
     setFixture("lerna-workspaces");
-    expect(await findWorkspacePackages()).toEqual(workspacesPackages);
+    expect((await findWorkspacePackages()).sort()).toEqual(workspacesPackages);
   });
 
   test("returns packages for delegated workspaces (sync)", () => {
     setFixture("lerna-workspaces");
-    expect(findWorkspacePackagesSync()).toEqual(workspacesPackages);
+    expect(findWorkspacePackagesSync().sort()).toEqual(workspacesPackages);
   });
 });
 

--- a/packages/tools-workspaces/test/npm.test.ts
+++ b/packages/tools-workspaces/test/npm.test.ts
@@ -21,12 +21,12 @@ describe("findWorkspacePackages", () => {
 
   test("returns packages for npm workspaces", async () => {
     setFixture("npm");
-    expect(await findWorkspacePackages()).toEqual(packages);
+    expect((await findWorkspacePackages()).sort()).toEqual(packages);
   });
 
   test("returns packages for npm workspaces (sync)", () => {
     setFixture("npm");
-    expect(findWorkspacePackagesSync()).toEqual(packages);
+    expect(findWorkspacePackagesSync().sort()).toEqual(packages);
   });
 });
 

--- a/packages/tools-workspaces/test/pnpm.test.ts
+++ b/packages/tools-workspaces/test/pnpm.test.ts
@@ -21,12 +21,12 @@ describe("findWorkspacePackages", () => {
 
   test("returns packages for pnpm workspaces", async () => {
     setFixture("pnpm");
-    expect(await findWorkspacePackages()).toEqual(packages);
+    expect((await findWorkspacePackages()).sort()).toEqual(packages);
   });
 
   test("returns packages for pnpm workspaces (sync)", () => {
     setFixture("pnpm");
-    expect(findWorkspacePackagesSync()).toEqual(packages);
+    expect(findWorkspacePackagesSync().sort()).toEqual(packages);
   });
 });
 

--- a/packages/tools-workspaces/test/rush.test.ts
+++ b/packages/tools-workspaces/test/rush.test.ts
@@ -21,12 +21,12 @@ describe("findWorkspacePackages", () => {
 
   test("returns packages for Rush workspaces", async () => {
     setFixture("rush");
-    expect(await findWorkspacePackages()).toEqual(packages);
+    expect((await findWorkspacePackages()).sort()).toEqual(packages);
   });
 
   test("returns packages for Rush workspaces (sync)", () => {
     setFixture("rush");
-    expect(findWorkspacePackagesSync()).toEqual(packages);
+    expect(findWorkspacePackagesSync().sort()).toEqual(packages);
   });
 });
 

--- a/packages/tools-workspaces/test/yarn.test.ts
+++ b/packages/tools-workspaces/test/yarn.test.ts
@@ -21,12 +21,12 @@ describe("findWorkspacePackages", () => {
 
   test("returns packages for Yarn workspaces", async () => {
     setFixture("yarn");
-    expect(await findWorkspacePackages()).toEqual(packages);
+    expect((await findWorkspacePackages()).sort()).toEqual(packages);
   });
 
   test("returns packages for Yarn workspaces (sync)", () => {
     setFixture("yarn");
-    expect(findWorkspacePackagesSync()).toEqual(packages);
+    expect(findWorkspacePackagesSync().sort()).toEqual(packages);
   });
 });
 


### PR DESCRIPTION
### Description

Exclude packages that don't have a manifest.

### Test plan

Tests were added.