### PR TITLE
fix(tools-node): allow aliases of the form `@alias`

### DIFF
--- a/.changeset/chatty-readers-do.md
+++ b/.changeset/chatty-readers-do.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-node": patch
+---
+
+Allow aliases of the form `@alias`

--- a/packages/tools-node/src/package.ts
+++ b/packages/tools-node/src/package.ts
@@ -22,17 +22,21 @@ export type PackageRef = {
  */
 export function parsePackageRef(r: string): PackageRef {
   if (r.startsWith("@")) {
+    // If `/` is not found, the reference could be a path alias.
     const indexSeparator = r.indexOf("/");
-    // The separator must start from position >= 2 to ensure that it is '@'
-    // and at least one other character. Further, the separator must have
-    // at least 1 character following it, before the end of the string.
-    if (indexSeparator < 2 || indexSeparator + 2 >= r.length) {
-      throw new Error(`Invalid package reference: "${r}"`);
+    if (indexSeparator >= 0) {
+      // The separator must start from position >= 2 to ensure that it is '@'
+      // and at least one other character. Further, the separator must have
+      // at least 1 character following it, before the end of the string.
+      if (indexSeparator < 2 || indexSeparator + 2 >= r.length) {
+        throw new Error(`Invalid package reference: "${r}"`);
+      }
+
+      return {
+        scope: r.substring(0, indexSeparator),
+        name: r.substring(indexSeparator + 1),
+      };
     }
-    return {
-      scope: r.substring(0, indexSeparator),
-      name: r.substring(indexSeparator + 1),
-    };
   }
 
   if (!r) {

--- a/packages/tools-node/test/package.test.ts
+++ b/packages/tools-node/test/package.test.ts
@@ -17,8 +17,8 @@ describe("Node > Package", () => {
   const fixtureDir = path.resolve(__dirname, "__fixtures__");
 
   beforeAll(() => {
-    expect(fs.existsSync(fixtureDir)).toBeTrue();
-    expect(fs.existsSync(tempDir)).toBeTrue();
+    expect(fs.existsSync(fixtureDir)).toBe(true);
+    expect(fs.existsSync(tempDir)).toBe(true);
   });
 
   let testTempDir: string;
@@ -44,12 +44,17 @@ describe("Node > Package", () => {
     });
   });
 
+  test("parsePackageRef(@alias) is allowed", () => {
+    expect(parsePackageRef("@alias")).toEqual({ name: "@alias" });
+  });
+
   test("parsePackageRef(undefined) throws an Error", () => {
+    // @ts-expect-error Argument of type 'undefined' is not assignable to parameter of type 'string'
     expect(() => parsePackageRef(undefined)).toThrowError();
   });
 
-  test("parsePackageRef(@babel) throws an Error", () => {
-    expect(() => parsePackageRef("@babel")).toThrowError();
+  test("parsePackageRef(@babel/) throws an Error", () => {
+    expect(() => parsePackageRef("@babel/")).toThrowError();
   });
 
   test("parsePackageRef(@/core) throws an Error", () => {
@@ -73,15 +78,15 @@ describe("Node > Package", () => {
       name: "package name",
       version: "1.0.0",
     };
-    expect(isPackageManifest(manifest)).toBeTrue();
+    expect(isPackageManifest(manifest)).toBe(true);
   });
 
   test("isPackageManifest() returns false when the object is not a PackageManifest", () => {
-    expect(isPackageManifest(undefined)).toBeFalse();
-    expect(isPackageManifest({})).toBeFalse();
-    expect(isPackageManifest("hello")).toBeFalse();
-    expect(isPackageManifest({ name: "name but no version" })).toBeFalse();
-    expect(isPackageManifest({ version: "version but no name" })).toBeFalse();
+    expect(isPackageManifest(undefined)).toBe(false);
+    expect(isPackageManifest({})).toBe(false);
+    expect(isPackageManifest("hello")).toBe(false);
+    expect(isPackageManifest({ name: "name but no version" })).toBe(false);
+    expect(isPackageManifest({ version: "version but no name" })).toBe(false);
   });
 
   test("readPackage() loads package.json when given its containing directory", () => {
@@ -102,9 +107,9 @@ describe("Node > Package", () => {
       name: "package name",
       version: "1.0.0",
     };
-    expect(fs.existsSync(pkgPath)).toBeFalse();
+    expect(fs.existsSync(pkgPath)).toBe(false);
     writePackage(testTempDir, manifest);
-    expect(fs.existsSync(pkgPath)).toBeTrue();
+    expect(fs.existsSync(pkgPath)).toBe(true);
   });
 
   test("writePackage() writes package.json when given a full path to it", () => {
@@ -113,9 +118,9 @@ describe("Node > Package", () => {
       name: "package name",
       version: "1.0.0",
     };
-    expect(fs.existsSync(pkgPath)).toBeFalse();
+    expect(fs.existsSync(pkgPath)).toBe(false);
     writePackage(pkgPath, manifest);
-    expect(fs.existsSync(pkgPath)).toBeTrue();
+    expect(fs.existsSync(pkgPath)).toBe(true);
   });
 
   test("findPackage() returns the nearest package.json file", () => {


### PR DESCRIPTION
### Description

Allow aliases of the form `@alias`.

Resolves #1946.

### Test plan

Tests were added.