### PR TITLE
fix: bump `@rnx-kit/tools-workspaces` to 0.1.2

### DIFF
--- a/.changeset/shy-countries-lick.md
+++ b/.changeset/shy-countries-lick.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/metro-config": patch
+"@rnx-kit/dep-check": patch
+---
+
+Bump `@rnx-kit/tools-workspaces` to 0.1.2

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -23,7 +23,7 @@
     "@rnx-kit/babel-preset-metro-react-native": "^1.0.17",
     "@rnx-kit/console": "^1.0.0",
     "@rnx-kit/tools-node": "^1.3.0",
-    "@rnx-kit/tools-workspaces": "^0.1.0"
+    "@rnx-kit/tools-workspaces": "^0.1.2"
   },
   "peerDependencies": {
     "metro-config": ">=0.58.0",


### PR DESCRIPTION
### Description

Bump `@rnx-kit/dep-check` and `@rnx-kit/metro-config` to get latest `@rnx-kit/tools-workspaces`.

### Test plan

CI should pass.