### PR TITLE
fix(jest-preset): `@office-iss/react-native-win32` needs to be transformed

### DIFF
--- a/.changeset/fresh-owls-reflect.md
+++ b/.changeset/fresh-owls-reflect.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/jest-preset": patch
+---
+
+`@office-iss/react-native-win32` needs to be transformed because it contains Flow typed files

--- a/.changeset/fresh-owls-reflect.md
+++ b/.changeset/fresh-owls-reflect.md
@@ -2,4 +2,4 @@
 "@rnx-kit/jest-preset": patch
 ---
 
-`@office-iss/react-native-win32` needs to be transformed because it contains Flow typed files
+`@office-iss/react-native-win32` and `react-native-macos` need to be transformed because they contain Flow typed files

--- a/packages/jest-preset/src/index.js
+++ b/packages/jest-preset/src/index.js
@@ -209,7 +209,7 @@ module.exports = (
       ...userTransform,
     },
     transformIgnorePatterns: [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)/)",
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?|@office-iss/react-native-win32)/)",
       ...(userTransformIgnorePatterns || []),
     ],
     ...userOptions,

--- a/packages/jest-preset/src/index.js
+++ b/packages/jest-preset/src/index.js
@@ -209,7 +209,7 @@ module.exports = (
       ...userTransform,
     },
     transformIgnorePatterns: [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?|@office-iss/react-native-win32)/)",
+      "node_modules/(?!((jest-)?react-native(-macos)?|@react-native(-community)?|@office-iss/react-native-win32)/)",
       ...(userTransformIgnorePatterns || []),
     ],
     ...userOptions,

--- a/packages/jest-preset/test/index.test.ts
+++ b/packages/jest-preset/test/index.test.ts
@@ -241,6 +241,7 @@ describe("jest-preset", () => {
       "node_modules/@react-native-windows/virtualized-list/src/VirtualizedList.js":
         true,
       "node_modules/@react-native/polyfills/index.js": false,
+      "node_modules/react-native-macos/index.js": false,
       "node_modules/react-native/index.js": false,
       "node_modules/react/index.js": true,
       "packages/react-native/index.js": false,

--- a/packages/jest-preset/test/index.test.ts
+++ b/packages/jest-preset/test/index.test.ts
@@ -247,7 +247,6 @@ describe("jest-preset", () => {
     };
 
     const regex = new RegExp(transformIgnorePatterns[0]);
-    console.log(regex);
     for (const [path, ignored] of Object.entries(paths)) {
       expect(regex.test(path)).toBe(ignored);
     }

--- a/packages/jest-preset/test/index.test.ts
+++ b/packages/jest-preset/test/index.test.ts
@@ -226,4 +226,30 @@ describe("jest-preset", () => {
       expect.objectContaining(jestMacOSPreset(path.sep + "react-native-macos"))
     );
   });
+
+  test("ignores 'node_modules' with a few exceptions", () => {
+    const { transformIgnorePatterns } = jestPreset();
+    if (!transformIgnorePatterns || transformIgnorePatterns.length === 0) {
+      fail();
+    }
+
+    const paths = {
+      "node_modules/@babel/runtime/regenerator": true,
+      "node_modules/@office-iss/react-native-win32/index.js": false,
+      "node_modules/@office-iss/rex-win32/rex-win32.js": true,
+      "node_modules/@react-native-community/cli/index.js": false,
+      "node_modules/@react-native-windows/virtualized-list/src/VirtualizedList.js":
+        true,
+      "node_modules/@react-native/polyfills/index.js": false,
+      "node_modules/react-native/index.js": false,
+      "node_modules/react/index.js": true,
+      "packages/react-native/index.js": false,
+    };
+
+    const regex = new RegExp(transformIgnorePatterns[0]);
+    console.log(regex);
+    for (const [path, ignored] of Object.entries(paths)) {
+      expect(regex.test(path)).toBe(ignored);
+    }
+  });
 });


### PR DESCRIPTION
### Description

`@office-iss/react-native-win32` and `react-native-macos` need to be transformed because they contain Flow typed files

### Test plan

Tested in https://github.com/microsoft/fluentui-react-native/pull/2242