### PR TITLE
feat(tools-language): add `keysOf` as a type-safe alt to `Object.keys`

### DIFF
--- a/.changeset/nine-terms-marry.md
+++ b/.changeset/nine-terms-marry.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/tools-language": minor
+"@rnx-kit/cli": patch
+---
+
+Add `keysOf` to `@rnx-kit/tools-language`, a type-safe wrapper around `Object.keys`

--- a/packages/align-deps/src/capabilities.ts
+++ b/packages/align-deps/src/capabilities.ts
@@ -1,7 +1,7 @@
 import type { Capability } from "@rnx-kit/config";
 import { warn } from "@rnx-kit/console";
+import { keysOf } from "@rnx-kit/tools-language/properties";
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
-import { keysOf } from "./helpers";
 import type { MetaPackage, Package, Preset, Profile } from "./types";
 
 /**

--- a/packages/align-deps/src/commands/setVersion.ts
+++ b/packages/align-deps/src/commands/setVersion.ts
@@ -1,3 +1,4 @@
+import { keysOf } from "@rnx-kit/tools-language/properties";
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
 import isString from "lodash/isString";
 import prompts from "prompts";
@@ -5,7 +6,7 @@ import semverCoerce from "semver/functions/coerce";
 import { transformConfig } from "../compatibility/config";
 import { defaultConfig, loadConfig } from "../config";
 import { isError } from "../errors";
-import { keysOf, modifyManifest } from "../helpers";
+import { modifyManifest } from "../helpers";
 import defaultPreset from "../presets/microsoft/react-native";
 import type {
   AlignDepsConfig,

--- a/packages/align-deps/src/commands/vigilant.ts
+++ b/packages/align-deps/src/commands/vigilant.ts
@@ -1,10 +1,11 @@
 import type { Capability } from "@rnx-kit/config";
 import { error } from "@rnx-kit/console";
+import { keysOf } from "@rnx-kit/tools-language/properties";
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
 import * as path from "path";
 import semverSubset from "semver/ranges/subset";
 import { resolveCapabilities } from "../capabilities";
-import { keysOf, modifyManifest } from "../helpers";
+import { modifyManifest } from "../helpers";
 import { updateDependencies } from "../manifest";
 import { filterPreset, mergePresets } from "../preset";
 import type {

--- a/packages/align-deps/src/helpers.ts
+++ b/packages/align-deps/src/helpers.ts
@@ -45,10 +45,6 @@ export function dropPatchFromVersion(version: string): string {
     .join(" || ");
 }
 
-export function keysOf<T extends Record<string, unknown>>(obj: T): (keyof T)[] {
-  return Object.keys(obj);
-}
-
 export function modifyManifest(
   pkgPath: string,
   manifest: PackageManifest

--- a/packages/cli/src/copy-assets.ts
+++ b/packages/cli/src/copy-assets.ts
@@ -1,6 +1,7 @@
 import type { Config as CLIConfig } from "@react-native-community/cli-types";
 import { error, info, warn } from "@rnx-kit/console";
 import { isNonEmptyArray } from "@rnx-kit/tools-language/array";
+import { keysOf } from "@rnx-kit/tools-language/properties";
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
 import {
   findPackageDependencyDir,
@@ -91,10 +92,6 @@ function gradleTargetName(packageName: string): string {
 
 function isAssetsConfig(config: unknown): config is AssetsConfig {
   return typeof config === "object" && config !== null && "getAssets" in config;
-}
-
-function keysOf(record: Record<string, unknown> | undefined): string[] {
-  return record ? Object.keys(record) : [];
 }
 
 export function versionOf(pkgName: string): string {

--- a/packages/tools-language/README.md
+++ b/packages/tools-language/README.md
@@ -34,6 +34,7 @@ import * from "@rnx-kit/tools-language/properties";
 | properties | `extendObject(obj, extendedProps)`        | Add properties to an object, changing it from its current type to an extended type.                                                                         |
 | properties | `extendObjectArray(arr, extendedProps)`   | Add properties to each object in an array, changing the object from its current type to an extended type.                                                   |
 | properties | `hasProperty(obj, property)`              | Returns whether `property` exists in `obj`.                                                                                                                 |
+| properties | `keysOf(obj)`                             | Returns the names of the enumerable string properties of an object. Equivalent to calling `Object.keys()`, but type safe.                                   |
 | properties | `pickValue(obj, key, name)`               | Pick the value for property `key` from `obj` and return it in a new object. If `name` is given, use it in the new object, instead of `key`.                 |
 | properties | `pickValues(obj, keys, names)`            | Pick the value for each `key` property from `obj` and return each one in a new object. If `names` are given, use them in the new object, instead of `keys`. |
 

--- a/packages/tools-language/src/properties.ts
+++ b/packages/tools-language/src/properties.ts
@@ -95,3 +95,15 @@ export function hasProperty<Property extends string>(
 ): obj is Record<Property, unknown> {
   return typeof obj === "object" && obj !== null && property in obj;
 }
+
+/**
+ * Returns the names of the enumerable string properties of an object.
+ * Equivalent to calling `Object.keys()`, but type safe.
+ * @param obj Object that contains the properties
+ * @returns Type-safe array of properties of the specified object
+ */
+export function keysOf<T extends Record<string, unknown>>(
+  obj: T | undefined
+): (keyof T)[] {
+  return obj ? Object.keys(obj) : [];
+}


### PR DESCRIPTION
### Description

Moves `keysOf` to `@rnx-kit/tools-language`.

### Test plan

n/a