### PR TITLE
fix(metro-serializer-esbuild): use esbuild only for prod

### DIFF
--- a/.changeset/clean-terms-tap.md
+++ b/.changeset/clean-terms-tap.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Use esbuild only for production bundles

--- a/.changeset/clean-terms-tap.md
+++ b/.changeset/clean-terms-tap.md
@@ -1,4 +1,5 @@
 ---
+"@rnx-kit/babel-preset-metro-react-native": patch
 "@rnx-kit/metro-serializer-esbuild": patch
 ---
 

--- a/packages/babel-preset-metro-react-native/src/index.js
+++ b/packages/babel-preset-metro-react-native/src/index.js
@@ -59,7 +59,12 @@ function constEnumPlugin() {
  */
 function overridesFor(transformProfile) {
   // Use the `esbuild` transform profile if the serializer is being used.
-  if (!transformProfile && process.env["RNX_METRO_SERIALIZER_ESBUILD"]) {
+  const env = process.env.BABEL_ENV || process.env.NODE_ENV;
+  if (
+    !transformProfile &&
+    env === "production" &&
+    process.env["RNX_METRO_SERIALIZER_ESBUILD"]
+  ) {
     transformProfile = "esbuild";
   }
 

--- a/packages/metro-serializer-esbuild/README.md
+++ b/packages/metro-serializer-esbuild/README.md
@@ -197,12 +197,6 @@ basically on your own to fix any issues that might come up.
 
 ## Known Limitations
 
-- Dev server may not work with this serializer. To work around this limitation,
-  you can save the esbuild specific Metro config to a separate file and only
-  specify it when needed, e.g.:
-  ```sh
-  react-native bundle ... --config metro+esbuild.config.js
-  ```
 - esbuild does not properly tree-shake `export *`. This is a known limitation
   (see https://github.com/evanw/esbuild/issues/1420). It is also not recommended
   to use `export *` in your code as they may lead to duplicate exports. For more

--- a/packages/metro-serializer-esbuild/README.md
+++ b/packages/metro-serializer-esbuild/README.md
@@ -197,6 +197,8 @@ basically on your own to fix any issues that might come up.
 
 ## Known Limitations
 
+- Dev server does not play well with esbuild. It is therefore only used when
+  building production bundles.
 - esbuild does not properly tree-shake `export *`. This is a known limitation
   (see https://github.com/evanw/esbuild/issues/1420). It is also not recommended
   to use `export *` in your code as they may lead to duplicate exports. For more

--- a/packages/metro-serializer-esbuild/babel.config.js
+++ b/packages/metro-serializer-esbuild/babel.config.js
@@ -1,16 +1,9 @@
-if (process.env.NODE_ENV !== "test") {
-  module.exports = {
-    presets: [
-      [
-        "module:metro-react-native-babel-preset",
-        { disableImportExportTransform: true },
-      ],
+module.exports = {
+  presets: ["@rnx-kit/babel-preset-metro-react-native"],
+  plugins: [
+    [
+      "@rnx-kit/babel-plugin-import-path-remapper",
+      { test: (source) => source.startsWith("@rnx-kit/") },
     ],
-    plugins: [
-      [
-        "@rnx-kit/babel-plugin-import-path-remapper",
-        { test: (source) => source.startsWith("@rnx-kit/") },
-      ],
-    ],
-  };
-}
+  ],
+};

--- a/packages/metro-serializer-esbuild/metro.config.js
+++ b/packages/metro-serializer-esbuild/metro.config.js
@@ -13,7 +13,9 @@ module.exports = makeMetroConfig({
     blockList,
   },
   serializer: {
-    customSerializer: MetroSerializer(),
+    customSerializer: MetroSerializer([], {
+      minify: false,
+    }),
     getPolyfills: () => [],
   },
   transformer: esbuildTransformerConfig,

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@fluentui/utilities": "8.12.0",
     "@react-native-community/cli-plugin-metro": "^7.0.3",
+    "@rnx-kit/babel-preset-metro-react-native": "*",
     "@rnx-kit/metro-config": "*",
     "@rnx-kit/metro-serializer": "*",
     "@rnx-kit/scripts": "*",

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -145,6 +145,9 @@ export function MetroSerializer(
   // Signal to every plugin that we're using esbuild.
   process.env["RNX_METRO_SERIALIZER_ESBUILD"] = "true";
 
+  const baseJSBundle = require("metro/src/DeltaBundler/Serializers/baseJSBundle");
+  const bundleToString = require("metro/src/lib/bundleToString");
+
   return (
     entryPoint: string,
     preModules: ReadonlyArray<Module>,
@@ -154,6 +157,12 @@ export function MetroSerializer(
     metroPlugins.forEach((plugin) =>
       plugin(entryPoint, preModules, graph, options)
     );
+
+    if (options.dev) {
+      const bundle = baseJSBundle(entryPoint, preModules, graph, options);
+      const bundleCode = bundleToString(bundle).code;
+      return Promise.resolve(bundleCode);
+    }
 
     const { dependencies } = graph;
     const metroPlugin: Plugin = {


### PR DESCRIPTION
### Description

Use esbuild only for production bundles.

### Test plan

Tests were added.