### PR TITLE
fix(metro-resolver-symlinks): use `extraNodeModules` if present

### DIFF
--- a/.changeset/big-ladybugs-laugh.md
+++ b/.changeset/big-ladybugs-laugh.md
@@ -1,6 +1,5 @@
 ---
 "@rnx-kit/metro-resolver-symlinks": patch
-"@rnx-kit/tools-react-native": patch
 ---
 
 Respect `extraNodeModules` (and some refactoring)

--- a/.changeset/big-ladybugs-laugh.md
+++ b/.changeset/big-ladybugs-laugh.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+"@rnx-kit/tools-react-native": patch
+---
+
+Respect `extraNodeModules` (and some refactoring)

--- a/.changeset/big-ladybugs-laugh.md
+++ b/.changeset/big-ladybugs-laugh.md
@@ -2,4 +2,4 @@
 "@rnx-kit/metro-resolver-symlinks": patch
 ---
 
-Respect `extraNodeModules` (and some refactoring)
+Use `extraNodeModules` if it is defined (and some refactoring)

--- a/.changeset/thin-insects-tan.md
+++ b/.changeset/thin-insects-tan.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-react-native": patch
+---
+
+`extensions` argument of `expandPlatformExtensions` should be readonly

--- a/packages/metro-resolver-symlinks/src/helper.ts
+++ b/packages/metro-resolver-symlinks/src/helper.ts
@@ -1,0 +1,58 @@
+import { findPackageDependencyDir, readPackage } from "@rnx-kit/tools-node";
+
+export function resolveFrom(
+  moduleName: string,
+  startDir: string
+): string | undefined {
+  return findPackageDependencyDir(moduleName, {
+    startDir,
+    resolveSymlinks: true,
+  });
+}
+
+export function ensureResolveFrom(
+  moduleName: string,
+  startDir: string
+): string {
+  const p = resolveFrom(moduleName, startDir);
+  if (!p) {
+    throw new Error(`Cannot find module '${moduleName}'`);
+  }
+  return p;
+}
+
+/**
+ * Returns the directory in which `metro` and its dependencies were installed.
+ * @param fromDir The directory to start searching from
+ */
+export function getMetroSearchPath(fromDir = process.cwd()): string {
+  const rnPath = ensureResolveFrom("react-native", fromDir);
+  const rncliPath = ensureResolveFrom("@react-native-community/cli", rnPath);
+
+  const { dependencies = {} } = readPackage(rncliPath);
+  return "@react-native-community/cli-plugin-metro" in dependencies
+    ? ensureResolveFrom("@react-native-community/cli-plugin-metro", rncliPath)
+    : rncliPath;
+}
+
+/**
+ * Imports specified module starting from the installation directory of the
+ * currently used `metro` version.
+ *
+ * @todo Currently not possible to do `R = type import(Module)`:
+ *       https://github.com/microsoft/TypeScript/issues/44636
+ */
+export function requireModuleFromMetro<R = unknown>(
+  moduleName: string,
+  fromDir = process.cwd()
+): R {
+  try {
+    const startDir = getMetroSearchPath(fromDir);
+    const metroModulePath = ensureResolveFrom(moduleName, startDir);
+    return require(metroModulePath);
+  } catch (_) {
+    throw new Error(
+      `Cannot find module '${moduleName}'. This probably means that '@rnx-kit/metro-resolver-symlinks' is not compatible with the version of 'metro' that you are currently using. Please update to the latest version and try again. If the issue still persists after the update, please file a bug at https://github.com/microsoft/rnx-kit/issues.`
+    );
+  }
+}

--- a/packages/metro-resolver-symlinks/src/symlinkResolver.ts
+++ b/packages/metro-resolver-symlinks/src/symlinkResolver.ts
@@ -1,19 +1,17 @@
 import { normalizePath } from "@rnx-kit/tools-node";
 import type { CustomResolver, ResolutionContext } from "metro-resolver";
-import {
-  getMetroResolver,
-  remapReactNativeModule,
-  resolveModulePath,
-} from "./resolver";
+import { requireModuleFromMetro } from "./helper";
+import { remapReactNativeModule, resolveModulePath } from "./resolver";
 import type { MetroResolver, Options } from "./types";
 import { remapImportPath } from "./utils/remapImportPath";
 
-export function makeResolver({
-  remapModule = (_, moduleName, __) => moduleName,
-}: Options = {}): MetroResolver {
-  const metroResolver = getMetroResolver();
-  const remappers = [remapModule, remapReactNativeModule, resolveModulePath];
+export function makeResolver(options: Options = {}): MetroResolver {
+  const { resolve: metroResolver } =
+    requireModuleFromMetro<typeof import("metro-resolver")>("metro-resolver");
 
+  const { remapModule = (_, moduleName, __) => moduleName } = options;
+
+  const remappers = [remapModule, remapReactNativeModule, resolveModulePath];
   const symlinkResolver = (
     context: ResolutionContext,
     moduleName: string,

--- a/packages/metro-resolver-symlinks/src/types.ts
+++ b/packages/metro-resolver-symlinks/src/types.ts
@@ -4,7 +4,7 @@ export type MetroResolver = typeof import("metro-resolver").resolve;
 
 export type ResolutionContext = Pick<
   MetroResolutionContext,
-  "originModulePath"
+  "extraNodeModules" | "originModulePath"
 >;
 
 export type ModuleResolver = (

--- a/packages/metro-resolver-symlinks/test/remapImportPath.test.ts
+++ b/packages/metro-resolver-symlinks/test/remapImportPath.test.ts
@@ -21,7 +21,7 @@ describe("remap-import-path", () => {
   });
 
   test("throws if test function is missing", () => {
-    // @ts-ignore
+    // @ts-expect-error Intentionally missing test function
     expect(() => remapImportPath()).toThrow(
       "A test function is required for this plugin"
     );

--- a/packages/metro-resolver-symlinks/test/resolver.test.ts
+++ b/packages/metro-resolver-symlinks/test/resolver.test.ts
@@ -1,10 +1,7 @@
 import * as os from "os";
 import * as path from "path";
-import {
-  getMetroResolver,
-  remapReactNativeModule,
-  resolveModulePath,
-} from "../src/resolver";
+import { requireModuleFromMetro } from "../src/helper";
+import { remapReactNativeModule, resolveModulePath } from "../src/resolver";
 import { useFixture } from "./fixtures";
 
 const AVAILABLE_PLATFORMS = {
@@ -14,6 +11,13 @@ const AVAILABLE_PLATFORMS = {
 };
 
 const nixOnlyTest = os.platform() === "win32" ? test.skip : test;
+
+function getMetroResolver(fromDir: string) {
+  return requireModuleFromMetro<typeof import("metro-resolver")>(
+    "metro-resolver",
+    fromDir
+  ).resolve;
+}
 
 describe("getMetroResolver", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/tools-react-native/src/platform.ts
+++ b/packages/tools-react-native/src/platform.ts
@@ -16,7 +16,7 @@ export type AllPlatforms = "ios" | "android" | "windows" | "win32" | "macos";
  */
 export function expandPlatformExtensions(
   platform: string,
-  extensions: string[]
+  extensions: readonly string[]
 ): string[] {
   const platforms = platformExtensions(platform);
 


### PR DESCRIPTION
### Description

Use `extraNodeModules` if present.

### Test plan

n/a