### PR TITLE
fix(cli): fail gracefully if `jest-cli` is missing (part 2)

### DIFF
--- a/.changeset/nice-ties-shave.md
+++ b/.changeset/nice-ties-shave.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Fail gracefully if `jest-cli` is not installed (part 2)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,9 @@
   "peerDependenciesMeta": {
     "@react-native-community/cli-server-api": {
       "optional": true
+    },
+    "jest-cli": {
+      "optional": true
     }
   },
   "devDependencies": {

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -65,16 +65,19 @@ function jestOptions(): Options[] {
   // To work around this, resolve `jest-cli` first, then use the resolved path
   // to import `./build/cli/args`.
   const jestPath = findPackageDependencyDir("jest-cli") || "jest-cli";
-  const { options } = require(`${jestPath}/build/cli/args`);
-
-  return Object.keys(options).map((option) => {
-    const { default: defaultValue, description, type } = options[option];
-    return {
-      name: `--${option} [${type}]`,
-      description,
-      default: defaultValue,
-    };
-  });
+  try {
+    const { options } = require(`${jestPath}/build/cli/args`);
+    return Object.keys(options).map((option) => {
+      const { default: defaultValue, description, type } = options[option];
+      return {
+        name: `--${option} [${type}]`,
+        description,
+        default: defaultValue,
+      };
+    });
+  } catch (_) {
+    return [];
+  }
 }
 
 export const rnxTestCommand = {


### PR DESCRIPTION
### Description

The fix in #1908 was incomplete. We were also pulling in `jest-cli` for options.

### Test plan

Remove `jest-cli` from test-app:

```diff
diff --git a/packages/test-app/package.json b/packages/test-app/package.json
index 9a744fe5..9cdf11b9 100644
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -48,7 +48,6 @@
     "@rnx-kit/scripts": "*",
     "@types/react": "^17.0.2",
     "@types/react-native": "^0.68.0",
-    "jest-cli": "^27.5.1",
     "metro-react-native-babel-preset": "^0.67.0",
     "react-native-test-app": "^2.0.2",
     "react-test-renderer": "17.0.2",
```

Run:

```
yarn

# Ensure jest-cli doesn't exist
rm -fr node_modules/jest-cli

# Build
cd packages/test-app
yarn build --dependencies

# Help should display `rnx-test`
yarn react-native --help

# Running `rnx-test` should fail
yarn react-native rnx-test
```