### PR TITLE
fix(dep-check): update react-native-svg package for RN 0.69+

### DIFF
--- a/packages/dep-check/src/presets/microsoft/profile-0.69.ts
+++ b/packages/dep-check/src/presets/microsoft/profile-0.69.ts
@@ -109,6 +109,10 @@ const profile: Profile = {
     name: "@react-native-async-storage/async-storage",
     version: "^1.17.7",
   },
+  svg: {
+    name: "react-native-svg",
+    version: "^13.5.0",
+  },
   "test-app": {
     name: "react-native-test-app",
     version: "^1.3.10",


### PR DESCRIPTION
### Description

react-native-svg@^13.5.0 support react native 0.69+ new architecture build (Fabric).
See: https://github.com/software-mansion/react-native-svg/releases/tag/v13.0.0