### PR TITLE
fix(react-native-auth): add TurboModule spec

### DIFF
--- a/.changeset/purple-dots-travel.md
+++ b/.changeset/purple-dots-travel.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-auth": patch
+---
+
+Add TurboModule spec

--- a/packages/react-native-auth/README.md
+++ b/packages/react-native-auth/README.md
@@ -7,7 +7,7 @@
 
 <!--remove-block end-->
 
-@rnx-kit/react-native-auth provides a cross-app uniform API for user
+`@rnx-kit/react-native-auth` provides a cross-app uniform API for user
 authentication.
 
 ## Install
@@ -24,16 +24,23 @@ choice.
 ## Usage
 
 ```typescript
-import { acquireToken } from "@rnx-kit/react-native-auth";
+import {
+  acquireTokenWithScopes,
+  isAvailable,
+} from "@rnx-kit/react-native-auth";
 
-const scopes = ["user.read"];
-const userPrincipalName = "arnold@contoso.com";
+if (isAvailable()) {
+  const scopes = ["user.read"];
+  const userPrincipalName = "arnold@contoso.com";
 
-const result = await acquireToken(
-  scopes,
-  userPrincipalName,
-  "MicrosoftAccount"
-);
+  const result = await acquireTokenWithScopes(
+    scopes,
+    userPrincipalName,
+    "MicrosoftAccount"
+  );
+} else {
+  // Use an alternate authentication method
+}
 ```
 
 ## Motivation

--- a/packages/react-native-auth/README.md
+++ b/packages/react-native-auth/README.md
@@ -29,10 +29,10 @@ import {
   isAvailable,
 } from "@rnx-kit/react-native-auth";
 
-if (isAvailable()) {
-  const scopes = ["user.read"];
-  const userPrincipalName = "arnold@contoso.com";
+const scopes = ["user.read"];
+const userPrincipalName = "arnold@contoso.com";
 
+if (isAvailable()) {
   const result = await acquireTokenWithScopes(
     scopes,
     userPrincipalName,
@@ -42,6 +42,27 @@ if (isAvailable()) {
   // Use an alternate authentication method
 }
 ```
+
+<!-- The following table can be updated by running `yarn update-readme` -->
+<!-- @rnx-kit/api start -->
+
+| Category | Type Name         | Description                                                                                                                                                            |
+| -------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| types    | AccountType       | Account types. Current valid types are Microsoft accounts (or MSA) and organizational (M365), but can be extended to support other types, e.g. Apple, Google, etc.     |
+| types    | AuthErrorAndroid  | The authentication error object contains a stack trace on Android.                                                                                                     |
+| types    | AuthErrorIOS      | The authentication error object contains a stack trace on iOS.                                                                                                         |
+| types    | AuthErrorNative   | The authentication error object. May contain a native stack trace.                                                                                                     |
+| types    | AuthErrorType     | The type of error that occurred during authentication.                                                                                                                 |
+| types    | AuthErrorUserInfo | Authentication error details provided by the underlying implementation. This object can be used to provide the inner exception, or a more user friendly error message. |
+| types    | AuthResult        | Authentication result returned on success.                                                                                                                             |
+
+| Category | Function                                                             | Description                               |
+| -------- | -------------------------------------------------------------------- | ----------------------------------------- |
+| -        | `acquireTokenWithResource(resource, userPrincipalName, accountType)` | Acquires a token for a resource.          |
+| -        | `acquireTokenWithScopes(scopes, userPrincipalName, accountType)`     | Acquires a token with specified scopes.   |
+| -        | `isAvailable()`                                                      | Returns whether this module is available. |
+
+<!-- @rnx-kit/api end -->
 
 ## Motivation
 

--- a/packages/react-native-auth/package.json
+++ b/packages/react-native-auth/package.json
@@ -26,7 +26,8 @@
     "format": "rnx-kit-scripts format",
     "format:c": "clang-format -i $(git ls-files '*.h' '*.m')",
     "lint": "rnx-kit-scripts lint",
-    "lint:kt": "ktlint --relative --verbose 'android/src/**/*.kt'"
+    "lint:kt": "ktlint --relative --verbose 'android/src/**/*.kt'",
+    "update-readme": "rnx-kit-scripts update-api-readme"
   },
   "peerDependencies": {
     "react": "16.11.0 || 16.13.1 || 17.0.1 || 17.0.2 || 18.0.0 || 18.1.0",

--- a/packages/react-native-auth/src/NativeAuth.ts
+++ b/packages/react-native-auth/src/NativeAuth.ts
@@ -45,6 +45,9 @@ import type { AuthResult } from "./types";
  */
 type AccountType = string;
 
+/**
+ * Specification for the native auth module.
+ */
 export interface Spec extends TurboModule {
   acquireTokenWithResource(
     resource: string,
@@ -61,7 +64,12 @@ export interface Spec extends TurboModule {
 
 const AuthModule = TurboModuleRegistry.get<Spec>("RNXAuth");
 
-export function getEnforcing() {
+/**
+ * Returns the native auth module.
+ * @protected
+ * @throws If the native module is not found
+ */
+export function getEnforcing(): Spec {
   if (!AuthModule) {
     throw new Error(
       "TurboModuleRegistry: 'RNXAuth' could not be found. Verify that a" +

--- a/packages/react-native-auth/src/NativeAuth.ts
+++ b/packages/react-native-auth/src/NativeAuth.ts
@@ -1,0 +1,74 @@
+import type { TurboModule } from "react-native";
+import { TurboModuleRegistry } from "react-native";
+import type { AuthResult } from "./types";
+
+/**
+ * We re-declare `AccountType` here as a `string` because codegen currently does
+ * not understand string literal unions. The workaround is to use string enums,
+ * but that has a runtime cost and bloats the bundle size. The following:
+ *
+ *     ```ts
+ *     export enum AccountTypeOption {
+ *       MicrosoftAccount = 'MicrosoftAccount',
+ *       Organizational = 'Organizational',
+ *     }
+ *     ```
+ *
+ * is transpiled to:
+ *
+ *     ```js
+ *     exports.AccountTypeOption = void 0;
+ *     var AccountTypeOption;
+ *     (function (AccountTypeOption) {
+ *         AccountTypeOption["MicrosoftAccount"] = "MicrosoftAccount";
+ *         AccountTypeOption["Organizational"] = "Organizational";
+ *     })(AccountTypeOption = exports.AccountTypeOption || (exports.AccountTypeOption = {}));
+ *     ```
+ *
+ * With a string literal union, no code is generated. Additionally, when this
+ * runs through codegen, we get:
+ *
+ *     ```objc
+ *     - (void)acquireTokenWithResource:(NSString *)resource
+ *                    userPrincipalName:(NSString *)userPrincipalName
+ *                          accountType:(NSString *)accountType
+ *                              resolve:(RCTPromiseResolveBlock)resolve
+ *                               reject:(RCTPromiseRejectBlock)reject;
+ *     - (void)acquireTokenWithScopes:(NSArray *)scopes
+ *                  userPrincipalName:(NSString *)userPrincipalName
+ *                        accountType:(NSString *)accountType
+ *                            resolve:(RCTPromiseResolveBlock)resolve
+ *                             reject:(RCTPromiseRejectBlock)reject;
+ *     ```
+ *
+ * So we might as well use `string` here.
+ */
+type AccountType = string;
+
+export interface Spec extends TurboModule {
+  acquireTokenWithResource(
+    resource: string,
+    userPrincipalName: string,
+    accountType: AccountType
+  ): Promise<AuthResult>;
+
+  acquireTokenWithScopes(
+    scopes: string[],
+    userPrincipalName: string,
+    accountType: AccountType
+  ): Promise<AuthResult>;
+}
+
+const AuthModule = TurboModuleRegistry.get<Spec>("RNXAuth");
+
+export function getEnforcing() {
+  if (!AuthModule) {
+    throw new Error(
+      "TurboModuleRegistry: 'RNXAuth' could not be found. Verify that a" +
+        "module by this name is registered in the native binary."
+    );
+  }
+  return AuthModule;
+}
+
+export default AuthModule;

--- a/packages/react-native-auth/src/NativeAuth.ts
+++ b/packages/react-native-auth/src/NativeAuth.ts
@@ -66,7 +66,6 @@ const AuthModule = TurboModuleRegistry.get<Spec>("RNXAuth");
 
 /**
  * Returns the native auth module.
- * @protected
  * @throws If the native module is not found
  */
 export function getEnforcing(): Spec {

--- a/packages/react-native-auth/src/index.ts
+++ b/packages/react-native-auth/src/index.ts
@@ -58,6 +58,9 @@ export function acquireTokenWithScopes(
   );
 }
 
+/**
+ * Returns whether this module is available.
+ */
 export function isAvailable(): boolean {
   return Boolean(NativeAuth);
 }

--- a/packages/react-native-auth/src/index.ts
+++ b/packages/react-native-auth/src/index.ts
@@ -1,105 +1,16 @@
-import { NativeModules } from "react-native";
+import NativeAuth, { getEnforcing } from "./NativeAuth";
+import type { AccountType, AuthResult } from "./types";
 
-if (!NativeModules.RNXAuth) {
-  throw new Error(
-    "`RNXAuth` native module is missing. Please make sure it was correctly linked."
-  );
-}
-
-/**
- * Account types. Current valid types are Microsoft accounts (or MSA) and
- * organizational (M365), but can be extended to support other types, e.g.
- * Apple, Google, etc.
- */
-export type AccountType = "MicrosoftAccount" | "Organizational";
-
-/**
- * The type of error that occurred during authentication.
- */
-export type AuthErrorType =
-  | "Unknown"
-  | "BadRefreshToken"
-  | "ConditionalAccessBlocked"
-  | "InteractionRequired"
-  | "NoResponse"
-  | "PreconditionViolated"
-  | "ServerDeclinedScopes"
-  | "ServerProtectionPoliciesRequired"
-  | "Timeout"
-  | "UserCanceled"
-  | "WorkplaceJoinRequired";
-
-/**
- * Authentication error details provided by the underlying implementation. This
- * object can be used to provide the inner exception, or a more user friendly
- * error message.
- *
- * @property type The type of error that occurred during authentication
- * @property correlationId The unique id for identifying the authentication attempt
- * @property message The error message
- */
-export type AuthErrorUserInfo = {
-  type: AuthErrorType;
-  correlationId: string;
-  message?: string;
-};
-
-/**
- * Authentication error object thrown by {@link acquireTokenWithResource} or {@link acquireTokenWithScopes}.
- *
- * @note This object is populated by React Native when the underlying
- *       implementation returns an `Exception` (Android) or `NSError`
- *       (iOS/macOS).
- *
- * @property code The type of error that occurred during authentication
- * @property message The error message
- * @property userInfo Error details provided by the underlying implementation
- */
-export type AuthErrorBase = {
-  code: AuthErrorType;
-  message?: string;
-  userInfo: AuthErrorUserInfo;
-};
-
-/**
- * The authentication error object contains a stack trace on Android.
- *
- * @note This object is populated by React Native when the underlying
- *       implementation returns an `Exception`.
- *
- * @property nativeStackAndroid Android stack trace
- */
-export type AuthErrorAndroid = AuthErrorBase & {
-  nativeStackAndroid?: string[];
-};
-
-/**
- * The authentication error object contains a stack trace on iOS.
- *
- * @note This object is populated by React Native when the underlying
- *       implementation returns an `NSError`.
- *
- * @property nativeStackIOS iOS stack trace
- */
-export type AuthErrorIOS = AuthErrorBase & {
-  domain: "RNX_AUTH";
-  nativeStackIOS?: string[];
-};
-
-export type AuthErrorNative = AuthErrorAndroid | AuthErrorIOS;
-
-/**
- * Authentication result returned on success.
- *
- * @property accessToken The access token
- * @property expirationTime The time at which the access token expires
- * @property redirectUri The redirect URI that should be used if the access token is forwarded to a second service
- */
-export type AuthResult = {
-  accessToken: string;
-  expirationTime: number;
-  redirectUri?: string;
-};
+export type {
+  AccountType,
+  AuthErrorAndroid,
+  AuthErrorBase,
+  AuthErrorIOS,
+  AuthErrorNative,
+  AuthErrorType,
+  AuthErrorUserInfo,
+  AuthResult,
+} from "./types";
 
 /**
  * Acquires a token for a resource.
@@ -117,7 +28,7 @@ export function acquireTokenWithResource(
   userPrincipalName: string,
   accountType: AccountType
 ): Promise<AuthResult> {
-  return NativeModules.RNXAuth.acquireTokenWithResource(
+  return getEnforcing().acquireTokenWithResource(
     resource,
     userPrincipalName,
     accountType
@@ -140,9 +51,13 @@ export function acquireTokenWithScopes(
   userPrincipalName: string,
   accountType: AccountType
 ): Promise<AuthResult> {
-  return NativeModules.RNXAuth.acquireTokenWithScopes(
+  return getEnforcing().acquireTokenWithScopes(
     scopes,
     userPrincipalName,
     accountType
   );
+}
+
+export function isAvailable(): boolean {
+  return Boolean(NativeAuth);
 }

--- a/packages/react-native-auth/src/types.ts
+++ b/packages/react-native-auth/src/types.ts
@@ -37,11 +37,14 @@ export type AuthErrorUserInfo = {
 };
 
 /**
- * Authentication error object thrown by {@link acquireTokenWithResource} or {@link acquireTokenWithScopes}.
+ * Authentication error object thrown by {@link acquireTokenWithResource} or
+ * {@link acquireTokenWithScopes}.
  *
  * @note This object is populated by React Native when the underlying
  *       implementation returns an `Exception` (Android) or `NSError`
  *       (iOS/macOS).
+ *
+ * @internal
  *
  * @property code The type of error that occurred during authentication
  * @property message The error message
@@ -78,6 +81,9 @@ export type AuthErrorIOS = AuthErrorBase & {
   nativeStackIOS?: string[];
 };
 
+/**
+ * The authentication error object. May contain a native stack trace.
+ */
 export type AuthErrorNative = AuthErrorAndroid | AuthErrorIOS;
 
 /**

--- a/packages/react-native-auth/src/types.ts
+++ b/packages/react-native-auth/src/types.ts
@@ -1,0 +1,94 @@
+/**
+ * Account types. Current valid types are Microsoft accounts (or MSA) and
+ * organizational (M365), but can be extended to support other types, e.g.
+ * Apple, Google, etc.
+ */
+export type AccountType = "MicrosoftAccount" | "Organizational";
+
+/**
+ * The type of error that occurred during authentication.
+ */
+export type AuthErrorType =
+  | "Unknown"
+  | "BadRefreshToken"
+  | "ConditionalAccessBlocked"
+  | "InteractionRequired"
+  | "NoResponse"
+  | "PreconditionViolated"
+  | "ServerDeclinedScopes"
+  | "ServerProtectionPoliciesRequired"
+  | "Timeout"
+  | "UserCanceled"
+  | "WorkplaceJoinRequired";
+
+/**
+ * Authentication error details provided by the underlying implementation. This
+ * object can be used to provide the inner exception, or a more user friendly
+ * error message.
+ *
+ * @property type The type of error that occurred during authentication
+ * @property correlationId The unique id for identifying the authentication attempt
+ * @property message The error message
+ */
+export type AuthErrorUserInfo = {
+  type: AuthErrorType;
+  correlationId: string;
+  message?: string;
+};
+
+/**
+ * Authentication error object thrown by {@link acquireTokenWithResource} or {@link acquireTokenWithScopes}.
+ *
+ * @note This object is populated by React Native when the underlying
+ *       implementation returns an `Exception` (Android) or `NSError`
+ *       (iOS/macOS).
+ *
+ * @property code The type of error that occurred during authentication
+ * @property message The error message
+ * @property userInfo Error details provided by the underlying implementation
+ */
+export type AuthErrorBase = {
+  code: AuthErrorType;
+  message?: string;
+  userInfo: AuthErrorUserInfo;
+};
+
+/**
+ * The authentication error object contains a stack trace on Android.
+ *
+ * @note This object is populated by React Native when the underlying
+ *       implementation returns an `Exception`.
+ *
+ * @property nativeStackAndroid Android stack trace
+ */
+export type AuthErrorAndroid = AuthErrorBase & {
+  nativeStackAndroid?: string[];
+};
+
+/**
+ * The authentication error object contains a stack trace on iOS.
+ *
+ * @note This object is populated by React Native when the underlying
+ *       implementation returns an `NSError`.
+ *
+ * @property nativeStackIOS iOS stack trace
+ */
+export type AuthErrorIOS = AuthErrorBase & {
+  domain: "RNX_AUTH";
+  nativeStackIOS?: string[];
+};
+
+export type AuthErrorNative = AuthErrorAndroid | AuthErrorIOS;
+
+/**
+ * Authentication result returned on success.
+ *
+ * @property accessToken The access token
+ * @property expirationTime The time at which the access token expires
+ * @property redirectUri The redirect URI that should be used if the access token is forwarded to a second service
+ */
+export type AuthResult = {
+  accessToken: string;
+  expirationTime: number;
+  redirectUri?: string;
+};

--- a/packages/test-app/ios/Podfile.lock
+++ b/packages/test-app/ios/Podfile.lock
@@ -289,7 +289,7 @@ PODS:
   - ReactTestApp-DevSupport (2.0.2):
     - React-Core
     - React-jsi
-  - ReactTestApp-MSAL (2.0.0):
+  - ReactTestApp-MSAL (2.0.1):
     - MSAL
     - RNXAuth
   - ReactTestApp-Resources (1.0.0-dev)
@@ -448,7 +448,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: b1f1995089b90696dbc2a7ffe0059a80db5c8eb1
   ReactCommon: 149e2c0acab9bac61378da0db5b2880a1b5ff59b
   ReactTestApp-DevSupport: 93a3ec4d2affbd491128b89e922d7f1a359f547a
-  ReactTestApp-MSAL: 3f96be79ebe2abeacaa237cf0b2f8372c0b4e074
+  ReactTestApp-MSAL: 8d785756a554aa97d4e0549061accece850ba82d
   ReactTestApp-Resources: 74a1cf509f4e7962b16361ea4e73cba3648fff5d
   RNXAuth: 12ce1f1087d1c8367b34e5680cd4b4edb6532cd7
   Yoga: c4d61225a466f250c35c1ee78d2d0b3d41fe661c


### PR DESCRIPTION
### Description

Adds TurboModule spec. Implementing TurboModule (including backwards compatiblity) will be left for a separate PR.

### Test plan

- [x] Test that this still works with 0.64 (or whatever minimum version we support)
  - Support goes back to at least 0.62: https://github.com/facebook/react-native/blob/0.62-stable/Libraries/TurboModule/TurboModuleRegistry.js
- [x] ~~Figure out why `WithDefault` breaks codegen~~
  - `WithDefault` is only supported on components. Modules do not have defaults.

```
cd packages/test-app
yarn build --dependencies
yarn ios
```

Tap on "Acquire Token".