### PR TITLE
fix(align-deps): fix not being able to load `microsoft/react-native`

### DIFF
--- a/.changeset/poor-experts-glow.md
+++ b/.changeset/poor-experts-glow.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": patch
+---
+
+Fix not being able to load `microsoft/react-native`

--- a/packages/align-deps/src/preset.ts
+++ b/packages/align-deps/src/preset.ts
@@ -3,6 +3,7 @@ import semverCoerce from "semver/functions/coerce";
 import semverSatisfies from "semver/functions/satisfies";
 import semverValidRange from "semver/ranges/valid";
 import { gatherRequirements } from "./dependencies";
+import { preset as reactNativePreset } from "./presets/microsoft/react-native";
 import type { AlignDepsConfig, Options, Preset } from "./types";
 
 type Resolution = {
@@ -24,10 +25,11 @@ function loadPreset(
   projectRoot: string,
   resolve = require.resolve
 ): Preset {
-  try {
-    return require("./presets/" + preset).default;
-  } catch (_) {
-    return require(resolve(preset, { paths: [projectRoot] }));
+  switch (preset) {
+    case "microsoft/react-native":
+      return reactNativePreset;
+    default:
+      return require(resolve(preset, { paths: [projectRoot] }));
   }
 }
 


### PR DESCRIPTION
### Description

Fix not being able to load `microsoft/react-native`. We can't dynamically load the preset because we ship a bundled JS.

### Test plan

Tested internally.