### PR TITLE
Allow rnx bundle config to add custom serialization plugins

### DIFF
--- a/.changeset/ninety-items-worry.md
+++ b/.changeset/ninety-items-worry.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/cli": patch
+"@rnx-kit/config": patch
+---
+
+Allow rnx bundle config to add custom serialization plugins

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -70,6 +70,7 @@
       "@react-native-community/cli-clean",
       "metro",
       "metro-babel-transformer",
+      "my-custom-metro-serialization-plugin",
       "readline"
     ]
   },

--- a/packages/cli/src/bundle/defaultPlugins.ts
+++ b/packages/cli/src/bundle/defaultPlugins.ts
@@ -2,6 +2,7 @@ import type { BundlerPlugins } from "@rnx-kit/config";
 
 export function getDefaultBundlerPlugins(): Required<BundlerPlugins> {
   return {
+    customSerializationPlugins: [],
     detectCyclicDependencies: true,
     detectDuplicateDependencies: true,
     typescriptValidation: true,

--- a/packages/cli/src/bundle/defaultPlugins.ts
+++ b/packages/cli/src/bundle/defaultPlugins.ts
@@ -2,7 +2,7 @@ import type { BundlerPlugins } from "@rnx-kit/config";
 
 export function getDefaultBundlerPlugins(): Required<BundlerPlugins> {
   return {
-    customSerializationPlugins: [],
+    extraSerializationPlugins: [],
     detectCyclicDependencies: true,
     detectDuplicateDependencies: true,
     typescriptValidation: true,

--- a/packages/cli/src/metro-config.ts
+++ b/packages/cli/src/metro-config.ts
@@ -118,6 +118,7 @@ const emptySerializerHook = (_graph: Graph, _delta: DeltaResult): void => {
 export function customizeMetroConfig(
   metroConfigReadonly: InputConfigT,
   {
+    customSerializationPlugins,
     detectCyclicDependencies,
     detectDuplicateDependencies,
     treeShake,
@@ -130,6 +131,13 @@ export function customizeMetroConfig(
   const metroConfig = metroConfigReadonly as InputConfigT;
 
   const plugins: MetroPlugin[] = [];
+  if (customSerializationPlugins) {
+    customSerializationPlugins.forEach((plugin) => {
+      const implPath = require.resolve(plugin.path, { paths: [process.cwd()] });
+      const impl = require(implPath);
+      plugins.push(impl(plugin.options));
+    });
+  }
   if (typeof detectDuplicateDependencies === "object") {
     plugins.push(DuplicateDependencies(detectDuplicateDependencies));
   } else if (detectDuplicateDependencies !== false) {

--- a/packages/cli/src/metro-config.ts
+++ b/packages/cli/src/metro-config.ts
@@ -131,16 +131,14 @@ export function customizeMetroConfig(
   const metroConfig = metroConfigReadonly as InputConfigT;
 
   const plugins: MetroPlugin[] = [];
-  if (extraSerializationPlugins) {
-    if (Array.isArray(extraSerializationPlugins))
-      extraSerializationPlugins.forEach((plugin) => {
-        const implPath = require.resolve(plugin.path, {
-          paths: [metroConfig.projectRoot],
-        });
-        const impl = require(implPath);
-        plugins.push(impl(plugin.options));
+  if (Array.isArray(extraSerializationPlugins))
+    extraSerializationPlugins.forEach((plugin) => {
+      const implPath = require.resolve(plugin.path, {
+        paths: [metroConfig.projectRoot],
       });
-  }
+      const impl = require(implPath);
+      plugins.push(impl(plugin.options));
+    });
   if (typeof detectDuplicateDependencies === "object") {
     plugins.push(DuplicateDependencies(detectDuplicateDependencies));
   } else if (detectDuplicateDependencies !== false) {

--- a/packages/cli/src/metro-config.ts
+++ b/packages/cli/src/metro-config.ts
@@ -118,7 +118,7 @@ const emptySerializerHook = (_graph: Graph, _delta: DeltaResult): void => {
 export function customizeMetroConfig(
   metroConfigReadonly: InputConfigT,
   {
-    customSerializationPlugins,
+    extraSerializationPlugins,
     detectCyclicDependencies,
     detectDuplicateDependencies,
     treeShake,
@@ -131,12 +131,15 @@ export function customizeMetroConfig(
   const metroConfig = metroConfigReadonly as InputConfigT;
 
   const plugins: MetroPlugin[] = [];
-  if (customSerializationPlugins) {
-    customSerializationPlugins.forEach((plugin) => {
-      const implPath = require.resolve(plugin.path, { paths: [process.cwd()] });
-      const impl = require(implPath);
-      plugins.push(impl(plugin.options));
-    });
+  if (extraSerializationPlugins) {
+    if (Array.isArray(extraSerializationPlugins))
+      extraSerializationPlugins.forEach((plugin) => {
+        const implPath = require.resolve(plugin.path, {
+          paths: [metroConfig.projectRoot],
+        });
+        const impl = require(implPath);
+        plugins.push(impl(plugin.options));
+      });
   }
   if (typeof detectDuplicateDependencies === "object") {
     plugins.push(DuplicateDependencies(detectDuplicateDependencies));

--- a/packages/cli/test/bundle/kit-config.test.ts
+++ b/packages/cli/test/bundle/kit-config.test.ts
@@ -32,6 +32,7 @@ describe("CLI > Bundle > Kit Config > getCliPlatformBundleConfigs", () => {
   const defaultConfig = {
     entryFile: "index.js",
     sourcemapUseAbsolutePath: false,
+    customSerializationPlugins: [],
     detectCyclicDependencies: true,
     detectDuplicateDependencies: true,
     typescriptValidation: true,

--- a/packages/cli/test/bundle/kit-config.test.ts
+++ b/packages/cli/test/bundle/kit-config.test.ts
@@ -32,7 +32,7 @@ describe("CLI > Bundle > Kit Config > getCliPlatformBundleConfigs", () => {
   const defaultConfig = {
     entryFile: "index.js",
     sourcemapUseAbsolutePath: false,
-    customSerializationPlugins: [],
+    extraSerializationPlugins: [],
     detectCyclicDependencies: true,
     detectDuplicateDependencies: true,
     typescriptValidation: true,

--- a/packages/cli/test/metro-config.test.ts
+++ b/packages/cli/test/metro-config.test.ts
@@ -20,6 +20,7 @@ jest.mock("@rnx-kit/metro-plugin-duplicates-checker", () => {
 // Always use a new mock since `customizeMetroConfig()` modifies the object.
 function makeMockConfig(): InputConfigT {
   return {
+    projectRoot: __dirname,
     serializer: {
       customSerializer: false,
       experimentalSerializerHook: false,
@@ -40,6 +41,7 @@ describe("cli/metro-config/customizeMetroConfig", () => {
     customizeMetroConfig(inputConfig, {});
 
     expect(inputConfig).toEqual({
+      projectRoot: expect.stringContaining("test"),
       serializer: {
         customSerializer: expect.anything(),
         experimentalSerializerHook: expect.anything(),
@@ -62,6 +64,7 @@ describe("cli/metro-config/customizeMetroConfig", () => {
     });
 
     expect(inputConfig).toEqual({
+      projectRoot: expect.stringContaining("test"),
       serializer: {
         experimentalSerializerHook: expect.anything(),
       },
@@ -82,6 +85,7 @@ describe("cli/metro-config/customizeMetroConfig", () => {
     });
 
     expect(inputConfig).toEqual({
+      projectRoot: expect.stringContaining("test"),
       serializer: {
         customSerializer: expect.anything(),
         experimentalSerializerHook: expect.anything(),
@@ -103,6 +107,7 @@ describe("cli/metro-config/customizeMetroConfig", () => {
     });
 
     expect(inputConfig).toEqual({
+      projectRoot: expect.stringContaining("test"),
       serializer: {
         customSerializer: expect.anything(),
         experimentalSerializerHook: expect.anything(),
@@ -127,6 +132,7 @@ describe("cli/metro-config/customizeMetroConfig", () => {
     });
 
     expect(inputConfig).toEqual({
+      projectRoot: expect.stringContaining("test"),
       serializer: {
         customSerializer: expect.anything(),
         experimentalSerializerHook: expect.anything(),
@@ -149,13 +155,14 @@ describe("cli/metro-config/customizeMetroConfig", () => {
     customizeMetroConfig(inputConfig, {
       extraSerializationPlugins: [
         {
-          path: "./test/my-custom-metro-serialization-plugin",
+          path: "./my-custom-metro-serialization-plugin",
           options: myCustomPluginOptions,
         },
       ],
     });
 
     expect(inputConfig).toEqual({
+      projectRoot: expect.stringContaining("test"),
       serializer: {
         customSerializer: expect.anything(),
         experimentalSerializerHook: expect.anything(),
@@ -180,6 +187,7 @@ describe("cli/metro-config/customizeMetroConfig", () => {
     });
 
     expect(inputConfig).toEqual({
+      projectRoot: expect.stringContaining("test"),
       serializer: {
         customSerializer: expect.anything(),
         experimentalSerializerHook: expect.anything(),

--- a/packages/cli/test/metro-config.test.ts
+++ b/packages/cli/test/metro-config.test.ts
@@ -147,7 +147,7 @@ describe("cli/metro-config/customizeMetroConfig", () => {
     const inputConfig = makeMockConfig();
     const myCustomPluginOptions = { param1: "foo" };
     customizeMetroConfig(inputConfig, {
-      customSerializationPlugins: [
+      extraSerializationPlugins: [
         {
           path: "./test/my-custom-metro-serialization-plugin",
           options: myCustomPluginOptions,

--- a/packages/cli/test/my-custom-metro-serialization-plugin.js
+++ b/packages/cli/test/my-custom-metro-serialization-plugin.js
@@ -1,0 +1,2 @@
+const mockMyCustomMetroSerializationPlugin = jest.fn();
+module.exports = mockMyCustomMetroSerializationPlugin;

--- a/packages/config/src/bundleConfig.ts
+++ b/packages/config/src/bundleConfig.ts
@@ -10,7 +10,7 @@ export type TypeScriptValidationOptions = {
   throwOnError?: boolean;
 };
 
-export type CustomSerializationPluginOption = {
+export type ExtraSerializationPluginOption = {
   path: string;
   options?: object;
 };
@@ -22,7 +22,7 @@ export type BundlerPlugins = {
   /**
    * Specify additional custom metro serializer plugins
    */
-  customSerializationPlugins?: CustomSerializationPluginOption[];
+  extraSerializationPlugins?: ExtraSerializationPluginOption[];
 
   /**
    * Choose whether to detect cycles in the dependency graph. `true` uses defaults,

--- a/packages/config/src/bundleConfig.ts
+++ b/packages/config/src/bundleConfig.ts
@@ -10,10 +10,20 @@ export type TypeScriptValidationOptions = {
   throwOnError?: boolean;
 };
 
+export type CustomSerializationPluginOption = {
+  path: string;
+  options?: object;
+};
+
 /**
  * Parameters controlling bundler plugins.
  */
 export type BundlerPlugins = {
+  /**
+   * Specify additional custom metro serializer plugins
+   */
+  customSerializationPlugins?: CustomSerializationPluginOption[];
+
   /**
    * Choose whether to detect cycles in the dependency graph. `true` uses defaults,
    * while `CyclicDetectorOptions` lets you control the detection process.


### PR DESCRIPTION
### Description

Want to be able to specify custom serialization plugins in the rnx bundle config:

```json
  "rnx-kit": {
    "bundle": {
      "entryFile": "src/index.tsx",
      "customSerializationPlugins": [{"path": "<moduleNameOrPathToCustomPlugin>"}],
      "detectCyclicDependencies": true,
      "detectDuplicateDependencies": true,
      "typescriptValidation": true,
      "targets": [
        "android"
      ],
      "treeShake": false,
      "outputBundle": "dist/dev/android/index.bundle",
      "dev": true,
    },
  
```

This will add the additional plugins to the list of plugins passed into the serializer. 