### PR TITLE
feat(metro-resolver-symlinks): experimental option to retry resolving from disk

### DIFF
--- a/.changeset/wet-cheetahs-explain.md
+++ b/.changeset/wet-cheetahs-explain.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Add an experimental option for retrying module resolution from disk if not found in Haste map

--- a/packages/metro-resolver-symlinks/README.md
+++ b/packages/metro-resolver-symlinks/README.md
@@ -41,9 +41,10 @@ Import and assign the resolver to `resolver.resolveRequest` in your
 
 ## Options
 
-| Option      | Type                           | Description                                         |
-| :---------- | :----------------------------- | :-------------------------------------------------- |
-| remapModule | `(moduleId: string) => string` | A custom function for remapping additional modules. |
+| Option                                | Type                           | Description                                                                                                                                                                                                                                                                                          |
+| :------------------------------------ | :----------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `remapModule`                         | `(moduleId: string) => string` | A custom function for remapping additional modules.                                                                                                                                                                                                                                                  |
+| `experimental_retryResolvingFromDisk` | boolean                        | [Experimental] Whether to retry module resolution on disk if not found in Haste map. This option is useful for scenarios where you want to reduce the number of watched files (and thus the initial time spent on crawling). Note that enabling this will likely be slower than having a warm cache. |
 
 ### `remapModule`
 

--- a/packages/metro-resolver-symlinks/src/symlinkResolver.ts
+++ b/packages/metro-resolver-symlinks/src/symlinkResolver.ts
@@ -8,7 +8,10 @@ import { requireModuleFromMetro } from "./helper";
 import { remapReactNativeModule, resolveModulePath } from "./resolver";
 import type { MetroResolver, Options } from "./types";
 import { applyEnhancedResolver } from "./utils/enhancedResolve";
-import { patchMetro } from "./utils/patchMetro";
+import {
+  patchMetro,
+  shouldEnableRetryResolvingFromDisk,
+} from "./utils/patchMetro";
 import { remapImportPath } from "./utils/remapImportPath";
 
 function applyMetroResolver(
@@ -25,16 +28,16 @@ export function makeResolver(options: Options = {}): MetroResolver {
   const { resolve: metroResolver } =
     requireModuleFromMetro<typeof import("metro-resolver")>("metro-resolver");
 
-  const {
-    remapModule = (_, moduleName, __) => moduleName,
-    experimental_retryResolvingFromDisk,
-  } = options;
+  const { remapModule = (_, moduleName, __) => moduleName } = options;
 
-  const applyResolver = experimental_retryResolvingFromDisk
+  const enableRetryResolvingFromDisk =
+    shouldEnableRetryResolvingFromDisk(options);
+
+  const applyResolver = enableRetryResolvingFromDisk
     ? applyEnhancedResolver
     : applyMetroResolver;
 
-  if (experimental_retryResolvingFromDisk) {
+  if (enableRetryResolvingFromDisk) {
     patchMetro(options);
   }
 

--- a/packages/metro-resolver-symlinks/src/types.ts
+++ b/packages/metro-resolver-symlinks/src/types.ts
@@ -1,7 +1,7 @@
 import type { ResolutionContext as MetroResolutionContext } from "metro-resolver";
 
 type ExperimentalOptions = {
-  experimental_retryResolvingFromDisk?: boolean;
+  experimental_retryResolvingFromDisk?: boolean | "force";
 };
 
 export type MetroResolver = typeof import("metro-resolver").resolve;

--- a/packages/metro-resolver-symlinks/src/types.ts
+++ b/packages/metro-resolver-symlinks/src/types.ts
@@ -1,5 +1,9 @@
 import type { ResolutionContext as MetroResolutionContext } from "metro-resolver";
 
+type ExperimentalOptions = {
+  experimental_retryResolvingFromDisk?: boolean;
+};
+
 export type MetroResolver = typeof import("metro-resolver").resolve;
 
 export type ResolutionContext = Pick<
@@ -13,6 +17,6 @@ export type ModuleResolver = (
   platform: string
 ) => string;
 
-export type Options = {
+export type Options = ExperimentalOptions & {
   remapModule?: ModuleResolver;
 };

--- a/packages/metro-resolver-symlinks/src/utils/enhancedResolve.ts
+++ b/packages/metro-resolver-symlinks/src/utils/enhancedResolve.ts
@@ -15,12 +15,13 @@ const getEnhancedResolver = (() => {
     if (!resolvers[platform]) {
       // @ts-expect-error Property 'mainFields' does not exist on type 'ResolutionContext'
       const { mainFields, sourceExts } = context;
+      const extensions = sourceExts.map((ext) => `.${ext}`);
       resolvers[platform] = require("enhanced-resolve").create.sync({
         aliasFields: ["browser"],
-        extensions: expandPlatformExtensions(
-          platform,
-          sourceExts.map((ext) => `.${ext}`)
-        ),
+        extensions:
+          platform === "common"
+            ? extensions
+            : expandPlatformExtensions(platform, extensions),
         mainFields,
       });
     }

--- a/packages/metro-resolver-symlinks/src/utils/enhancedResolve.ts
+++ b/packages/metro-resolver-symlinks/src/utils/enhancedResolve.ts
@@ -1,0 +1,67 @@
+import { isPackageModuleRef, parseModuleRef } from "@rnx-kit/tools-node";
+import { expandPlatformExtensions } from "@rnx-kit/tools-react-native/platform";
+import type {
+  CustomResolver,
+  Resolution,
+  ResolutionContext,
+} from "metro-resolver";
+import * as path from "path";
+
+type Resolver = (fromDir: string, moduleId: string) => string | false;
+
+const getEnhancedResolver = (() => {
+  const resolvers: Record<string, Resolver> = {};
+  return (context: ResolutionContext, platform = "common") => {
+    if (!resolvers[platform]) {
+      // @ts-expect-error Property 'mainFields' does not exist on type 'ResolutionContext'
+      const { mainFields, sourceExts } = context;
+      resolvers[platform] = require("enhanced-resolve").create.sync({
+        aliasFields: ["browser"],
+        extensions: expandPlatformExtensions(
+          platform,
+          sourceExts.map((ext) => `.${ext}`)
+        ),
+        mainFields,
+      });
+    }
+    return resolvers[platform];
+  };
+})();
+
+function getFromDir(context: ResolutionContext, moduleName: string): string {
+  const { extraNodeModules, originModulePath } = context;
+  if (extraNodeModules) {
+    const ref = parseModuleRef(moduleName);
+    if (isPackageModuleRef(ref)) {
+      const pkgName = ref.scope ? `${ref.scope}/${ref.name}` : ref.name;
+      const dir = extraNodeModules[pkgName];
+      if (dir) {
+        return dir;
+      }
+    }
+  }
+
+  return originModulePath ? path.dirname(originModulePath) : process.cwd();
+}
+
+export function applyEnhancedResolver(
+  _resolve: CustomResolver,
+  context: ResolutionContext,
+  moduleName: string,
+  platform: string
+): Resolution {
+  if (!platform) {
+    return { type: "empty" };
+  }
+
+  const enhancedResolve = getEnhancedResolver(context, platform);
+  const filePath = enhancedResolve(getFromDir(context, moduleName), moduleName);
+  if (filePath === false) {
+    return { type: "empty" };
+  }
+
+  return {
+    type: "sourceFile",
+    filePath,
+  };
+}

--- a/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
+++ b/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
@@ -48,6 +48,11 @@ function getModuleResolver() {
  * cases, like on CI, we can even set `watchFolders` to an empty array to limit
  * watched files to the current package only.
  *
+ * Why didn't we use `hasteImplModulePath`? Contrary to the name, it doesn't
+ * let you replace HasteFS. As of 0.73, it is only used to retrieve the path of
+ * a module. The default implementation returns
+ * `path.relative(projectRoot, filePath)` if the entry is not found in the map.
+ *
  * @param options Options passed to Metro
  */
 export function patchMetro({

--- a/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
+++ b/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
@@ -97,7 +97,7 @@ export function patchMetro(options: Options): void {
     };
 
     this.orig__createModuleResolver();
-    if (!(typeof this._moduleResolver._options.resolveAsset === "function")) {
+    if (typeof this._moduleResolver._options.resolveAsset !== "function") {
       throw new Error("Could not find `resolveAsset` in `ModuleResolver`");
     }
 

--- a/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
+++ b/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
@@ -1,0 +1,122 @@
+import * as fs from "fs";
+import * as path from "path";
+import { ensureResolveFrom, getMetroSearchPath } from "../helper";
+import type { Options } from "../types";
+
+function fileExists(path: string): boolean {
+  const stat = fs.statSync(path, { throwIfNoEntry: false });
+  return Boolean(stat && stat.isFile());
+}
+
+function importMetroModule(path: string) {
+  const metroPath = ensureResolveFrom("metro", getMetroSearchPath());
+  const modulePath = metroPath + path;
+  try {
+    return require(modulePath);
+  } catch (_) {
+    throw new Error(
+      `Cannot find '${modulePath}'. This probably means that 'experimental_retryResolvingFromDisk' is not compatible with the version of 'metro' that you are currently using. Please update to the latest version and try again. If the issue still persists after the update, please file a bug at https://github.com/microsoft/rnx-kit/issues.`
+    );
+  }
+}
+
+function getDependencyGraph() {
+  return importMetroModule("/src/node-haste/DependencyGraph");
+}
+
+function getModuleResolver() {
+  return importMetroModule("/src/node-haste/DependencyGraph/ModuleResolution");
+}
+
+/**
+ * Monkey-patches Metro to not use HasteFS as the only source for module
+ * resolution.
+ *
+ * Practically every file system operation in Metro must go through HasteFS,
+ * most notably watching for file changes and resolving node modules. If Metro
+ * cannot find a file in the Haste map, it does not exist. This means that for
+ * Metro to find a file, all folders must be declared in `watchFolders`,
+ * including `node_modules` and any dependency storage folders (e.g. pnpm)
+ * regardless of whether we need to watch them. In big monorepos, this can
+ * easily overwhelm file watchers, even with Watchman installed.
+ *
+ * There's no way to avoid the initial crawling of the file system. However, we
+ * can drastically reduce the number of files that needs to be crawled/watched
+ * by not relying solely on Haste for module resolution. This requires patching
+ * Metro to use `fs.existsSync` instead of `HasteFS.exists`. With this change,
+ * we can list only the folders that we care about in `watchFolders`. In some
+ * cases, like on CI, we can even set `watchFolders` to an empty array to limit
+ * watched files to the current package only.
+ *
+ * @param options Options passed to Metro
+ */
+export function patchMetro({
+  experimental_retryResolvingFromDisk,
+}: Options): void {
+  if (!experimental_retryResolvingFromDisk) {
+    return;
+  }
+
+  const DependencyGraph = getDependencyGraph();
+  const { ModuleResolver } = getModuleResolver();
+
+  // Patch `_createModuleResolver` and `_doesFileExist` to use `fs.existsSync`.
+  DependencyGraph.prototype.orig__createModuleResolver =
+    DependencyGraph.prototype._createModuleResolver;
+  DependencyGraph.prototype._createModuleResolver = function (): void {
+    this._doesFileExist = (filePath: string): boolean => {
+      return this._hasteFS.exists(filePath) || fileExists(filePath);
+    };
+
+    this._moduleResolver = new ModuleResolver({
+      dirExists: (filePath: string) => {
+        try {
+          return fs.lstatSync(filePath).isDirectory();
+        } catch (_) {
+          return false;
+        }
+      },
+      disableHierarchicalLookup:
+        this._config.resolver.disableHierarchicalLookup,
+      doesFileExist: this._doesFileExist,
+      emptyModulePath: this._config.resolver.emptyModulePath,
+      extraNodeModules: this._config.resolver.extraNodeModules,
+      isAssetFile: (file: string) =>
+        this._assetExtensions.has(path.extname(file)),
+      mainFields: this._config.resolver.resolverMainFields,
+      moduleCache: this._moduleCache,
+      moduleMap: this._moduleMap,
+      nodeModulesPaths: this._config.resolver.nodeModulesPaths,
+      preferNativePlatform: true,
+      projectRoot: this._config.projectRoot,
+      resolveAsset: (dirPath: string, assetName: string, extension: string) => {
+        const basePath = dirPath + path.sep + assetName;
+        const assets = [
+          basePath + extension,
+          ...this._config.resolver.assetResolutions.map(
+            (resolution: string) =>
+              basePath + "@" + resolution + "x" + extension
+          ),
+        ].filter(this._doesFileExist);
+        return assets.length ? assets : null;
+      },
+      resolveRequest: this._config.resolver.resolveRequest,
+      sourceExts: this._config.resolver.sourceExts,
+    });
+  };
+
+  // Since we will be resolving files outside of `watchFolders`, their hashes
+  // will not be found. We'll return the `filePath` as they should be unique.
+  DependencyGraph.prototype.orig_getSha1 = DependencyGraph.prototype.getSha1;
+  DependencyGraph.prototype.getSha1 = function (filePath: string): string {
+    try {
+      return this.orig_getSha1(filePath);
+    } catch (e) {
+      if (e instanceof ReferenceError) {
+        return filePath;
+      }
+
+      throw e;
+    }
+  };
+}


### PR DESCRIPTION
### Description

Add an experimental option for retrying module resolution from disk if not found in Haste map.

A proper solution would be to implement lazy crawling upstream but that may take some time. In the meantime, this is a workaround that works and doesn't cause too much pollution.

### Test plan

This has been tested by a few teams internally.