### PR TITLE
docs: replace tsdoc with typedoc

### DIFF
--- a/.changeset/funny-hairs-bow.md
+++ b/.changeset/funny-hairs-bow.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-language": patch
+---
+
+Also export `isNonEmptyArray`, `keysOf` from index

--- a/packages/tools-language/src/index.ts
+++ b/packages/tools-language/src/index.ts
@@ -1,10 +1,11 @@
-export { toIndex, addRange } from "./array";
+export { addRange, isNonEmptyArray, toIndex } from "./array";
 export { tryInvoke } from "./function";
 export { isApproximatelyEqual } from "./math";
 export {
   extendObject,
   extendObjectArray,
   hasProperty,
+  keysOf,
   pickValue,
   pickValues,
 } from "./properties";

--- a/packages/tools-react-native/src/platform.ts
+++ b/packages/tools-react-native/src/platform.ts
@@ -31,7 +31,6 @@ export function expandPlatformExtensions(
 
 /**
  * Returns a map of available React Native platforms. The result is cached.
- * @privateRemarks is-arrow-function
  * @param startDir The directory to look for react-native platforms from
  * @returns A platform-to-npm-package map, excluding "core" platforms.
  */

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -14,24 +14,19 @@
     "lint": "rnx-kit-scripts lint"
   },
   "dependencies": {
-    "@babel/core": "^7.0.0",
-    "@babel/parser": "^7.0.0",
-    "@babel/types": "^7.0.0",
-    "@microsoft/tsdoc": "^0.14.0",
     "@rnx-kit/golang": "^0.2.1",
     "depcheck": "^1.0.0",
     "esbuild": "^0.15.0",
     "fs-extra": "^10.0.0",
-    "glob": "^7.0.0",
     "jest": "^27.0.0",
     "markdown-table": "^2.0.0",
     "midgard-yarn": "^1.23.24",
+    "typedoc": "^0.23.21",
     "typescript": "^4.0.0",
     "yargs": "^16.0.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.0",
-    "@types/glob": "^7.0.0",
     "@types/jest": "^27.0.0"
   },
   "depcheck": {

--- a/scripts/src/commands/updateApiReadme.js
+++ b/scripts/src/commands/updateApiReadme.js
@@ -1,161 +1,96 @@
 // @ts-check
 
-const {
-  isExportNamedDeclaration,
-  isFunctionDeclaration,
-  isIdentifier,
-} = require("@babel/types");
-const { DocExcerpt, TSDocParser } = require("@microsoft/tsdoc");
-const fs = require("fs");
-
 const README = "README.md";
 const TOKEN_START = "<!-- @rnx-kit/api start -->";
 const TOKEN_END = "<!-- @rnx-kit/api end -->";
 
-/**
- * @param {string} summary
- * @returns {string}
- */
-function extractBrief(summary) {
-  const newParagraph = summary.indexOf("\n\n");
-  return (newParagraph > 0 ? summary.substring(0, newParagraph) : summary)
-    .trim()
-    .replace(/\n/g, " ");
-}
+const path = require("path");
 
 /**
- * @param {readonly import("@babel/types").Comment[] | null | undefined} comments
- * @returns {import("@babel/types").Comment | null}
+ * @typedef {import("typedoc/dist/lib/serialization/schema").Comment} Comment
+ * @typedef {import("typedoc/dist/lib/serialization/schema").CommentDisplayPart} CommentDisplayPart
+ * @typedef {import("typedoc/dist/lib/serialization/schema").SourceReference} SourceReference
  */
-function findLastBlockComment(comments) {
-  if (comments) {
-    for (let i = comments.length - 1; i >= 0; --i) {
-      if (comments[i].type === "CommentBlock") {
-        return comments[i];
-      }
+const typedoc = require("typedoc");
+
+/**
+ * @param {SourceReference[] | undefined} sources
+ */
+function getBaseName(sources) {
+  if (Array.isArray(sources)) {
+    const filename = sources[0].fileName;
+    const ext = path.extname(filename);
+    const base = path.basename(filename, ext);
+    if (base !== "index") {
+      return base;
     }
   }
-  return null;
+  return "-";
 }
 
 /**
- * @returns {string[]}
+ * @param {string} source
+ * @param {string} identifier
+ * @param {Comment | undefined} comment
+ * @returns {comment is Comment}
  */
-function findSourceFiles() {
-  try {
-    const tsconfig = require.resolve("./tsconfig.json", {
-      paths: [process.cwd()],
-    });
-    const { include } = require(tsconfig);
-    if (Array.isArray(include)) {
-      const glob = require("glob");
-      return include.reduce((result, pattern) => {
-        if (fs.existsSync(pattern)) {
-          if (fs.statSync(pattern).isDirectory()) {
-            result.push(...glob.sync(`${pattern}/**/*.ts`));
-          } else {
-            result.push(pattern);
-          }
-        } else {
-          result.push(...glob.sync(pattern));
+function isCommented(source, identifier, comment) {
+  if (!comment) {
+    console.warn(
+      "WARN",
+      `${source}:`,
+      `${identifier} is exported but undocumented`
+    );
+    return false;
+  }
+
+  return true;
+}
+
+function parse() {
+  const app = new typedoc.Application();
+  app.options.addReader(new typedoc.TypeDocReader());
+  app.options.addReader(new typedoc.TSConfigReader());
+
+  app.bootstrap({
+    entryPoints: ["src/index.ts"],
+    excludeInternal: true,
+  });
+
+  return app.serializer.toObject(app.convert());
+}
+
+/**
+ * @param {CommentDisplayPart[]} parts
+ */
+function renderSummary(parts) {
+  const result = [];
+
+  for (const part of parts) {
+    switch (part.kind) {
+      case "text":
+      case "code":
+        result.push(part.text);
+        break;
+      case "inline-tag":
+        switch (part.tag) {
+          case "@label":
+          case "@inheritdoc": // Shouldn't happen
+            break; // Not rendered.
+          case "@link":
+          case "@linkcode":
+          case "@linkplain":
+            result.push("`" + part.text + "`");
+            break;
         }
-        return result;
-      }, /** @type {string[]} */ ([]));
+        break;
     }
-  } catch (_) {
-    /* ignore */
   }
-  return [];
-}
 
-/**
- * @param {import("@babel/types").ExportNamedDeclaration} node
- * @returns {string}
- */
-function getExportedName(node) {
-  const declaration = node.declaration;
-  switch (declaration?.type) {
-    case "FunctionDeclaration":
-    case "TSInterfaceDeclaration":
-    case "TSTypeAliasDeclaration":
-      if (!isIdentifier(declaration.id)) {
-        // TODO: Unnamed functions are currently unsupported
-        return "";
-      }
-      return declaration.id.name;
-
-    case "VariableDeclaration": {
-      if (isArrowFunction(node)) {
-        const decl = declaration.declarations[0];
-        if (isIdentifier(decl.id)) {
-          return decl.id.name;
-        }
-      }
-      return "";
-    }
-
-    default:
-      return "";
-  }
-}
-
-/**
- * Returns whether the node represents a memoized function.
- * @param {import("@babel/types").ExportNamedDeclaration} node
- * @returns {boolean}
- */
-function isArrowFunction(node) {
-  return Boolean(
-    node.declaration?.type === "VariableDeclaration" &&
-      findLastBlockComment(node.leadingComments)?.value?.includes(
-        "@privateRemarks is-arrow-function"
-      )
-  );
-}
-
-/**
- * @param {import("@microsoft/tsdoc").DocNode} docNode
- * @returns {string}
- */
-function renderDocNode(docNode) {
-  /** @type {string[]} */
-  const content = [];
-  if (docNode) {
-    if (docNode instanceof DocExcerpt) {
-      content.push(docNode.content.toString());
-    }
-    docNode.getChildNodes().forEach((childNode) => {
-      content.push(renderDocNode(childNode));
-    });
-  }
-  return content.join("");
-}
-
-/**
- * @param {import("@babel/types").LVal} node
- * @returns {string}
- */
-function renderParamNode(node) {
-  switch (node.type) {
-    case "ArrayPattern":
-      return "[]";
-    case "AssignmentPattern":
-      return renderParamNode(node.left);
-    case "Identifier":
-      return node.name;
-    case "MemberExpression":
-      throw new Error(`Unsupported parameter type: ${node.type}`);
-    case "ObjectPattern":
-      return "{}";
-    case "RestElement":
-      return `...${renderParamNode(node.argument)}`;
-    case "TSAsExpression":
-    case "TSNonNullExpression":
-    case "TSParameterProperty":
-    case "TSSatisfiesExpression":
-    case "TSTypeAssertion":
-      throw new Error(`Unsupported parameter type: ${node.type}`);
-  }
+  const comment = result.join("");
+  const paragraph = comment.indexOf("\n\n");
+  const summary = paragraph > 0 ? comment.substring(0, paragraph) : comment;
+  return summary.replace(/\n/g, " ");
 }
 
 /**
@@ -172,7 +107,7 @@ function updateReadme(exportedTypes, exportedFunctions) {
   };
 
   /** @type {(table: string[][], options?: {}) => string} */
-  // @ts-expect-error
+  // @ts-expect-error no declaration file for markdown-table
   const markdownTable = require("markdown-table");
 
   const types =
@@ -191,6 +126,8 @@ function updateReadme(exportedTypes, exportedFunctions) {
           ...exportedFunctions.sort(sortByCategory),
         ]);
 
+  const fs = require("fs");
+
   const readme = fs.readFileSync(README, { encoding: "utf-8" });
   const updatedReadme = readme.replace(
     new RegExp(`${TOKEN_START}([^]+)${TOKEN_END}`),
@@ -205,11 +142,12 @@ function updateReadme(exportedTypes, exportedFunctions) {
 }
 
 function updateApiReadme() {
-  return new Promise((resolve) => {
-    const babelParser = require("@babel/parser");
-    const path = require("path");
-
-    const tsdocParser = new TSDocParser();
+  return new Promise((resolve, reject) => {
+    const project = parse();
+    const children = project?.children;
+    if (!children) {
+      return reject();
+    }
 
     /** @type {[string, string, string][]} */
     const exportedFunctions = [];
@@ -217,69 +155,36 @@ function updateApiReadme() {
     /** @type {[string, string, string][]} */
     const exportedTypes = [];
 
-    findSourceFiles().forEach((file) => {
-      const filename = path.basename(file, ".ts");
-      const category = filename === "index" ? "-" : filename;
-      const content = fs.readFileSync(file, { encoding: "utf-8" });
-      babelParser
-        .parse(content, {
-          plugins: ["typescript"],
-          sourceType: "module",
-          sourceFilename: file,
-        })
-        .program.body.forEach((node) => {
-          if (!isExportNamedDeclaration(node)) {
-            return;
+    for (const { name, kind, comment, sources, signatures } of children) {
+      switch (kind) {
+        case typedoc.ReflectionKind.TypeAlias: {
+          const source = getBaseName(sources);
+          if (isCommented(source, name, comment)) {
+            exportedTypes.push([source, name, renderSummary(comment.summary)]);
           }
-
-          const name = getExportedName(node);
-          if (!name) {
-            return;
-          }
-
-          const identifier = (() => {
-            if (isFunctionDeclaration(node.declaration)) {
-              return `\`${name}(${node.declaration.params
-                .map(renderParamNode)
-                .join(", ")})\``;
+          break;
+        }
+        case typedoc.ReflectionKind.Function: {
+          const source = getBaseName(sources);
+          signatures?.forEach(({ name, comment, parameters }) => {
+            if (isCommented(source, name, comment)) {
+              exportedFunctions.push([
+                source,
+                Array.isArray(parameters)
+                  ? `\`${name}(${parameters
+                      .map((p) => (p.flags.isRest ? `...${p.name}` : p.name))
+                      .join(", ")})\``
+                  : `\`${name}()\``,
+                renderSummary(comment.summary),
+              ]);
             }
-            if (isArrowFunction(node)) {
-              const comment = findLastBlockComment(node.leadingComments);
-              return `\`${name}(${comment?.value
-                ?.split("@param ")
-                ?.map((part) => part.substring(0, part.indexOf(" ")))
-                ?.slice(1)
-                ?.join(", ")})\``;
-            }
-            return name;
-          })();
-
-          const commentBlock = findLastBlockComment(node.leadingComments);
-          if (!commentBlock) {
-            console.warn(
-              "WARN",
-              `${file}:`,
-              `${identifier} is exported but undocumented`
-            );
-            return;
-          }
-
-          const result = tsdocParser.parseString(
-            "/*" + commentBlock.value + "*/"
-          );
-          const summary = renderDocNode(result.docComment.summarySection);
-          const description = extractBrief(summary);
-
-          if (
-            isFunctionDeclaration(node.declaration) ||
-            isArrowFunction(node)
-          ) {
-            exportedFunctions.push([category, identifier, description]);
-          } else {
-            exportedTypes.push([category, identifier, description]);
-          }
-        });
-    });
+          });
+          break;
+        }
+        default:
+          console.warn("Unknown kind:", name);
+      }
+    }
 
     updateReadme(exportedTypes, exportedFunctions);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2105,11 +2105,6 @@
     eslint-plugin-react "7.24.0"
     eslint-plugin-security "1.4.0"
 
-"@microsoft/tsdoc@^0.14.0":
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz#c3ec604a0b54b9a9b87e9735dfc59e1a5da6a5fb"
-  integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -2891,14 +2886,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/glob@^7.0.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
-  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
-  dependencies:
-    "@types/minimatch" "*"
-    "@types/node" "*"
-
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -3035,7 +3022,7 @@
     "@types/metro-source-map" "*"
     "@types/metro-transform-worker" "*"
 
-"@types/minimatch@*", "@types/minimatch@^3.0.3":
+"@types/minimatch@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
@@ -4115,6 +4102,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
@@ -7911,7 +7905,7 @@ json5@^2.1.0, json5@^2.1.3, json5@^2.2.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
-jsonc-parser@3.2.0:
+jsonc-parser@3.2.0, jsonc-parser@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
   integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
@@ -8174,6 +8168,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lunr@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
+  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
+
 magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -8270,6 +8269,11 @@ markdown-table@^2.0.0:
   integrity sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==
   dependencies:
     repeat-string "^1.0.0"
+
+marked@^4.0.19:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.2.3.tgz#bd76a5eb510ff1d8421bc6c3b2f0b93488c15bea"
+  integrity sha512-slWRdJkbTZ+PjkyJnE30Uid64eHwbwa1Q25INCAYfZlK4o6ylagBy/Le9eWntqJFoFT93ikUKMv47GZ4gTwHkw==
 
 md5-file@^3.2.3:
   version "3.2.3"
@@ -8687,6 +8691,13 @@ min-indent@^1.0.0:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
+  integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist-options@^4.0.2:
   version "4.1.0"
@@ -10785,6 +10796,15 @@ shelljs@^0.8.4:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
+shiki@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.11.1.tgz#df0f719e7ab592c484d8b73ec10e215a503ab8cc"
+  integrity sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==
+  dependencies:
+    jsonc-parser "^3.0.0"
+    vscode-oniguruma "^1.6.1"
+    vscode-textmate "^6.0.0"
+
 shimmer@^1.1.0, shimmer@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
@@ -11604,6 +11624,16 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typedoc@^0.23.21:
+  version "0.23.21"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.23.21.tgz#2a6b0e155f91ffa9689086706ad7e3e4bc11d241"
+  integrity sha512-VNE9Jv7BgclvyH9moi2mluneSviD43dCE9pY8RWkO88/DrEgJZk9KpUk7WO468c9WWs/+aG6dOnoH7ccjnErhg==
+  dependencies:
+    lunr "^2.3.9"
+    marked "^4.0.19"
+    minimatch "^5.1.0"
+    shiki "^0.11.1"
+
 typescript@^4.0.0:
   version "4.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
@@ -11824,6 +11854,16 @@ vlq@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-1.0.1.tgz#c003f6e7c0b4c1edd623fd6ee50bbc0d6a1de468"
   integrity sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==
+
+vscode-oniguruma@^1.6.1:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz#aeb9771a2f1dbfc9083c8a7fdd9cccaa3f386607"
+  integrity sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==
+
+vscode-textmate@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-6.0.0.tgz#a3777197235036814ac9a92451492f2748589210"
+  integrity sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Description

Replace tsdoc with typedoc to avoid having to parse TypeScript ourselves.

### Test plan

`yarn update-readme` should not change any `README` files.