### PR TITLE
Add support for react-native-windows to jest-preset

### DIFF
--- a/.changeset/breezy-oranges-matter.md
+++ b/.changeset/breezy-oranges-matter.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/jest-preset": patch
+---
+
+Add support for react-native-windows

--- a/packages/jest-preset/src/index.js
+++ b/packages/jest-preset/src/index.js
@@ -209,7 +209,7 @@ module.exports = (
       ...userTransform,
     },
     transformIgnorePatterns: [
-      "node_modules/(?!((jest-)?react-native(-macos)?|@react-native(-community)?|@office-iss/react-native-win32)/)",
+      "node_modules/(?!((jest-)?react-native(-macos)?|@react-native(-community)?|@office-iss/react-native-win32|@?react-native-windows)/)",
       ...(userTransformIgnorePatterns || []),
     ],
     ...userOptions,

--- a/packages/jest-preset/test/index.test.ts
+++ b/packages/jest-preset/test/index.test.ts
@@ -239,9 +239,10 @@ describe("jest-preset", () => {
       "node_modules/@office-iss/rex-win32/rex-win32.js": true,
       "node_modules/@react-native-community/cli/index.js": false,
       "node_modules/@react-native-windows/virtualized-list/src/VirtualizedList.js":
-        true,
+        false,
       "node_modules/@react-native/polyfills/index.js": false,
       "node_modules/react-native-macos/index.js": false,
+      "node_modules/react-native-windows/index.js": false,
       "node_modules/react-native/index.js": false,
       "node_modules/react/index.js": true,
       "packages/react-native/index.js": false,


### PR DESCRIPTION
### Description
jest-preset should apply transforms to the react-native-windows packages to support react-native-windows out of the box.