### PR TITLE
fix(align-deps): fix `--exclude-packages` not working with plain check

### DIFF
--- a/.changeset/eleven-ducks-suffer.md
+++ b/.changeset/eleven-ducks-suffer.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": patch
+---
+
+Fix `--exclude-packages` not working with plain check

--- a/packages/align-deps/src/cli.ts
+++ b/packages/align-deps/src/cli.ts
@@ -201,7 +201,7 @@ export async function cli({ packages, ...args }: Args): Promise<void> {
   const errors = manifests.reduce((errors, manifest) => {
     try {
       const result = command(manifest);
-      if (result !== "success") {
+      if (result !== "success" && result !== "excluded") {
         printError(manifest, result);
         return errors + 1;
       }

--- a/packages/align-deps/src/commands/check.ts
+++ b/packages/align-deps/src/commands/check.ts
@@ -51,7 +51,7 @@ function stringify(manifest: PackageManifest): string {
 export function checkPackageManifest(
   manifestPath: string,
   options: Options,
-  inputConfig = loadConfig(manifestPath)
+  inputConfig = loadConfig(manifestPath, options)
 ): ErrorCode {
   if (isError(inputConfig)) {
     return inputConfig;
@@ -146,7 +146,7 @@ export function makeCheckCommand(options: Options): Command {
   }
 
   return (manifest: string) => {
-    const inputConfig = loadConfig(manifest);
+    const inputConfig = loadConfig(manifest, options);
     const config = isError(inputConfig)
       ? inputConfig
       : migrateConfig(inputConfig, manifest, options);

--- a/packages/align-deps/src/commands/setVersion.ts
+++ b/packages/align-deps/src/commands/setVersion.ts
@@ -170,7 +170,7 @@ export async function makeSetVersionCommand(
   const write = { ...options, loose: false, write: true };
 
   return (manifestPath: string) => {
-    const config = loadConfig(manifestPath);
+    const config = loadConfig(manifestPath, options);
     if (isError(config)) {
       return config;
     }

--- a/packages/align-deps/src/config.ts
+++ b/packages/align-deps/src/config.ts
@@ -4,7 +4,12 @@ import { error, warn } from "@rnx-kit/console";
 import { isPackageManifest, readPackage } from "@rnx-kit/tools-node/package";
 import * as path from "path";
 import { findBadPackages } from "./findBadPackages";
-import type { AlignDepsConfig, ErrorCode, LegacyCheckConfig } from "./types";
+import type {
+  AlignDepsConfig,
+  ErrorCode,
+  LegacyCheckConfig,
+  Options,
+} from "./types";
 
 type ConfigResult = AlignDepsConfig | LegacyCheckConfig | ErrorCode;
 
@@ -39,12 +44,20 @@ export function containsValidRequirements(
 /**
  * Loads configuration from the specified package manifest.
  * @param manifestPath The path to the package manifest to load configuration from
+ * @param options Command line options
  * @returns The configuration; otherwise an error code
  */
-export function loadConfig(manifestPath: string): ConfigResult {
+export function loadConfig(
+  manifestPath: string,
+  { excludePackages }: Pick<Options, "excludePackages">
+): ConfigResult {
   const manifest = readPackage(manifestPath);
   if (!isPackageManifest(manifest)) {
     return "invalid-manifest";
+  }
+
+  if (excludePackages?.includes(manifest.name)) {
+    return "excluded";
   }
 
   const badPackages = findBadPackages(manifest);

--- a/packages/align-deps/src/errors.ts
+++ b/packages/align-deps/src/errors.ts
@@ -9,6 +9,7 @@ export function isError<T>(config: T | ErrorCode): config is ErrorCode {
 export function printError(manifestPath: string, code: ErrorCode): void {
   switch (code) {
     case "success":
+    case "excluded":
       break;
 
     case "invalid-app-requirements":

--- a/packages/align-deps/src/types.ts
+++ b/packages/align-deps/src/types.ts
@@ -31,6 +31,7 @@ export type DependencyType = "direct" | "development" | "peer";
 
 export type ErrorCode =
   | "success"
+  | "excluded"
   | "invalid-app-requirements"
   | "invalid-configuration"
   | "invalid-manifest"

--- a/packages/align-deps/test/check.test.ts
+++ b/packages/align-deps/test/check.test.ts
@@ -267,6 +267,25 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(consoleWarnSpy).not.toBeCalled();
   });
 
+  test("returns appropriate error code if package is excluded", () => {
+    fs.__setMockContent(mockManifest);
+    rnxKitConfig.__setMockConfig({
+      alignDeps: {
+        requirements: ["react-native@0.70"],
+        capabilities: ["core-ios"],
+      },
+    });
+
+    const result = checkPackageManifest("package.json", {
+      ...defaultOptions,
+      excludePackages: ["@rnx-kit/align-deps"],
+    });
+
+    expect(result).toBe("excluded");
+    expect(consoleLogSpy).not.toBeCalled();
+    expect(consoleWarnSpy).not.toBeCalled();
+  });
+
   test("uses minimum supported version as development version", () => {
     fs.__setMockContent({
       ...mockManifest,


### PR DESCRIPTION
### Description

Fix `--exclude-packages` not working with plain check. We return `not-configured` when trying to load the config, which is then treated as an error. Introducing an `excluded` state allows us to keep the "laziness", i.e. loading the config only when a package is being inspected. The alternative would be to read all `package.json` up front, filter out the excluded packages, and only inspect the remaining ones. This would require significantly more changes and I'm not sure it's worth it.

Resolves #2074.

### Test plan

```
cd packages/align-deps
yarn build --dependencies

# This should fail
node lib/cli.js

# This should succeed
node lib/cli.js --exclude-packages @rnx-kit/align-deps
```