### PR TITLE
feat(cli): add new `plugins` option

### DIFF
--- a/.changeset/afraid-dingos-pretend.md
+++ b/.changeset/afraid-dingos-pretend.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/cli": minor
+"@rnx-kit/config": minor
+---
+
+Add new `plugins` option

--- a/.changeset/lovely-snails-heal.md
+++ b/.changeset/lovely-snails-heal.md
@@ -1,0 +1,7 @@
+---
+"@rnx-kit/metro-plugin-cyclic-dependencies-detector": minor
+"@rnx-kit/metro-plugin-duplicates-checker": minor
+"@rnx-kit/metro-plugin-typescript": minor
+---
+
+Support new `plugins` option in CLI

--- a/docsite/docs/guides/bundling.mdx
+++ b/docsite/docs/guides/bundling.mdx
@@ -229,18 +229,22 @@ you're used to, right in the Metro output:
   width="700"
 />
 
-TypeScript validation is **on** by default. You can control it with the
-[typescriptValidation](/docs/tools/config#bundlerplugins) configuration
-property.
+TypeScript validation is **on** by default. You can configure it by passing
+options with the `@rnx-kit/metro-plugin-typescript` entry in
+[plugins](/docs/tools/config#bundlerplugins) configuration property.
 
-```json title=package.json
-{
-  "rnx-kit": {
-    "bundle": {
-      "typescriptValidation": true
-    }
-  }
-}
+```diff title=package.json
+ {
+   "rnx-kit": {
+     "bundle": {
+       "plugins": [
+         "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+         "@rnx-kit/metro-plugin-duplicates-checker",
++        ["@rnx-kit/metro-plugin-typescript", { options: {} }]
+       ]
+     }
+   }
+ }
 ```
 
 ### Tree Shaking
@@ -277,18 +281,22 @@ the duplicated package has global state.
   width="700"
 />
 
-Duplicate detection is **on** by default. You can control it with the
-[detectDuplicateDependencies](/docs/tools/config#bundlerplugins) configuration
-property.
+Duplicate detection is **on** by default. You can configure it by passing
+options with the `@rnx-kit/metro-plugin-duplicates-checker` entry in
+[plugins](/docs/tools/config#bundlerplugins) configuration property.
 
-```json title=package.json
-{
-  "rnx-kit": {
-    "bundle": {
-      "detectDuplicateDependencies": true
-    }
-  }
-}
+```diff title=package.json
+ {
+   "rnx-kit": {
+     "bundle": {
+       "plugins": [
+         "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
++        ["@rnx-kit/metro-plugin-duplicates-checker", { "options": {} }],
+         "@rnx-kit/metro-plugin-typescript"
+       ]
+     }
+   }
+ }
 ```
 
 ### Cyclic Dependencies
@@ -305,18 +313,26 @@ A cycle in your dependency graph will look somthing like this: `logger` requires
   width="650"
 />
 
-Cycles can be bad news. Detecting them is **on** by default. You can control it
-with the [detectCyclicDependencies](/docs/tools/config#bundlerplugins)
-configuration property.
+Cycles can be bad news. Detecting them is **on** by default. You can configure
+it by passing options with the
+`@rnx-kit/metro-plugin-cyclic-dependencies-detector` entry in
+[plugins](/docs/tools/config#bundlerplugins) configuration property.
 
-```json title=package.json
-{
-  "rnx-kit": {
-    "bundle": {
-      "detectCyclicDependencies": true
-    }
-  }
-}
+```diff title=package.json
+ {
+   "rnx-kit": {
+     "bundle": {
+       "plugins": [
++        [
++          "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
++          { "options": {} }
++        ],
+         "@rnx-kit/metro-plugin-duplicates-checker",
+         "@rnx-kit/metro-plugin-typescript"
+       ]
+     }
+   }
+ }
 ```
 
 ## Running the Bundler
@@ -344,11 +360,25 @@ find flaws, see patterns, and do automated transformations.
 
 You should fix these now, or plan on fixing them soon. To defer until later,
 configure the bundler so it reports the errors without failing. Set
-`throwOnError` to `false` in the `typescriptValidation`
-[configuration object](/docs/tools/config#bundlerplugins). It's also a good idea
-to open a new issue for tracking the type errors, and to remind you to re-enable
-`throwOnError`. In the meantime, keeping the errors visible in the Metro output
-helps everyone be aware of danger-areas in the app.
+`throwOnError` to `false`:
+
+```diff title=package.json
+ {
+   "rnx-kit": {
+     "bundle": {
+       "plugins": [
+         "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+         "@rnx-kit/metro-plugin-duplicates-checker",
++        ["@rnx-kit/metro-plugin-typescript", { "throwOnError": false }]
+       ]
+     }
+   }
+ }
+```
+
+It's also a good idea to open a new issue for tracking the type errors, and to
+remind you to re-enable `throwOnError`. In the meantime, keeping the errors
+visible in the Metro output helps everyone be aware of danger-areas in the app.
 
 **Are you running into duplicate package errors?**
 
@@ -387,8 +417,24 @@ Below are some helpful tricks you can try:
 
 If you can't get rid of the duplicate package, and your app seems to be working,
 you can choose to live with it. Add the duplicate package name to the
-`ignoredModules` list in the `detectDuplicateDependencies`
-[configuration object](/docs/tools/config#bundlerplugins).
+`ignoredModules` option, e.g. to ignore duplicates of `react-is`:
+
+```diff title=package.json
+ {
+   "rnx-kit": {
+     "bundle": {
+       "plugins": [
+         "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
++        [
++          "@rnx-kit/metro-plugin-duplicates-checker",
++          { "ignoredModules": ["react-is"] }
++        ],
+         "@rnx-kit/metro-plugin-typescript"
+       ]
+     }
+   }
+ }
+```
 
 **Are you seeing cyclic dependency errors?**
 
@@ -410,8 +456,24 @@ Here are some approaches you can use to fix a cycle:
 If none of this is appealing, you can take a closer look at the code involved to
 understand if and how an infinite loop might occur. If you can avoid triggering
 it, then document that in your code, and live with the cycle. Set `throwOnError`
-to `false` in the `detectCyclicDependencies`
-[configuration object](/docs/tools/config#bundlerplugins).
+to `false`:
+
+```diff title=package.json
+ {
+   "rnx-kit": {
+     "bundle": {
+       "plugins": [
++        [
++          "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
++          { "throwOnError": false }
++        ],
+         "@rnx-kit/metro-plugin-duplicates-checker",
+         "@rnx-kit/metro-plugin-typescript"
+       ]
+     }
+   }
+ }
+```
 
 ## Integrating with PRs and Builds
 

--- a/docsite/docs/guides/bundling.mdx
+++ b/docsite/docs/guides/bundling.mdx
@@ -240,7 +240,7 @@ options with the `@rnx-kit/metro-plugin-typescript` entry in
        "plugins": [
          "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
          "@rnx-kit/metro-plugin-duplicates-checker",
-+        ["@rnx-kit/metro-plugin-typescript", { options: {} }]
++        ["@rnx-kit/metro-plugin-typescript", { "throwOnError": true }]
        ]
      }
    }
@@ -291,7 +291,7 @@ options with the `@rnx-kit/metro-plugin-duplicates-checker` entry in
      "bundle": {
        "plugins": [
          "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
-+        ["@rnx-kit/metro-plugin-duplicates-checker", { "options": {} }],
++        ["@rnx-kit/metro-plugin-duplicates-checker", { "throwOnError": true }],
          "@rnx-kit/metro-plugin-typescript"
        ]
      }
@@ -325,7 +325,7 @@ it by passing options with the
        "plugins": [
 +        [
 +          "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
-+          { "options": {} }
++          { "throwOnError": true }
 +        ],
          "@rnx-kit/metro-plugin-duplicates-checker",
          "@rnx-kit/metro-plugin-typescript"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -49,12 +49,15 @@ yarn react-native rnx-bundle --entry-file src/index.ts --bundle-output main.jsbu
     "bundle": {
       "entryFile": "entry.js",
       "assetsDest": "dist",
-      "detectCyclicDependencies": true,
-      "detectDuplicateDependencies": {
-        "ignoredModules": ["react-is"]
-      },
-      "typescriptValidation": true,
       "targets": ["ios", "android", "windows", "macos"],
+      "plugins": [
+        "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+        [
+          "@rnx-kit/metro-plugin-duplicates-checker",
+          { "ignoredModules": ["react-is"] }
+        ],
+        "@rnx-kit/metro-plugin-typescript"
+      ],
       "platforms": {
         "android": {
           "assetsDest": "dist/res"
@@ -73,14 +76,12 @@ yarn react-native rnx-bundle --entry-file src/index.ts --bundle-output main.jsbu
 When certain parameters aren't specified in configuration or on the
 command-line, they are explicitly set to default values.
 
-| Parameter                   | Default Value                                                                                 |
-| --------------------------- | --------------------------------------------------------------------------------------------- |
-| entryFile                   | "index.js"                                                                                    |
-| bundleOutput                | "index.<`platform`>.bundle" (Windows, Android), or "index.<`platform`>.jsbundle" (iOS, MacOS) |
-| detectCyclicDependencies    | `true`                                                                                        |
-| detectDuplicateDependencies | `true`                                                                                        |
-| typescriptValidation        | `true`                                                                                        |
-| treeShake                   | `false`                                                                                       |
+| Parameter    | Default Value                                                                                                                            |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| entryFile    | "index.js"                                                                                                                               |
+| bundleOutput | "index.<`platform`>.bundle" (Windows, Android), or "index.<`platform`>.jsbundle" (iOS, MacOS)                                            |
+| treeShake    | `false`                                                                                                                                  |
+| plugins      | `["@rnx-kit/metro-plugin-cyclic-dependencies-detector", "@rnx-kit/metro-plugin-duplicates-checker", "@rnx-kit/metro-plugin-typescript"]` |
 
 Other parameters have implicit defaults, buried deep in Metro or its
 dependencies.
@@ -134,12 +135,17 @@ yarn react-native rnx-start --host localhost --port 8812
   "rnx-kit": {
     "server": {
       "projectRoot": "src",
-      "detectCyclicDependencies": true,
-      "detectDuplicateDependencies": {
-        "ignoredModules": ["react-is"],
-        "throwOnError": false
-      },
-      "typescriptValidation": true
+      "plugins": [
+        "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+        [
+          "@rnx-kit/metro-plugin-duplicates-checker",
+          {
+            "ignoredModules": ["react-is"],
+            "throwOnError": false
+          }
+        ],
+        "@rnx-kit/metro-plugin-typescript"
+      ]
     }
   }
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -49,7 +49,6 @@ yarn react-native rnx-bundle --entry-file src/index.ts --bundle-output main.jsbu
     "bundle": {
       "entryFile": "entry.js",
       "assetsDest": "dist",
-      "targets": ["ios", "android", "windows", "macos"],
       "plugins": [
         "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
         [
@@ -58,6 +57,7 @@ yarn react-native rnx-bundle --entry-file src/index.ts --bundle-output main.jsbu
         ],
         "@rnx-kit/metro-plugin-typescript"
       ],
+      "targets": ["ios", "android", "windows", "macos"],
       "platforms": {
         "android": {
           "assetsDest": "dist/res"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -63,7 +63,13 @@ yarn react-native rnx-bundle --entry-file src/index.ts --bundle-output main.jsbu
           "assetsDest": "dist/res"
         },
         "macos": {
-          "typescriptValidation": false
+          "plugins": [
+            "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+            [
+              "@rnx-kit/metro-plugin-duplicates-checker",
+              { "ignoredModules": ["react-is"] }
+            ]
+          ]
         }
       }
     }

--- a/packages/cli/src/bundle/defaultPlugins.ts
+++ b/packages/cli/src/bundle/defaultPlugins.ts
@@ -1,10 +1,16 @@
 import type { BundlerPlugins } from "@rnx-kit/config";
 
-export function getDefaultBundlerPlugins(): Required<BundlerPlugins> {
-  return {
-    detectCyclicDependencies: true,
-    detectDuplicateDependencies: true,
-    typescriptValidation: true,
-    treeShake: false,
-  };
+const defaultPlugins = {
+  plugins: [
+    "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+    "@rnx-kit/metro-plugin-duplicates-checker",
+    "@rnx-kit/metro-plugin-typescript",
+  ],
+  treeShake: false,
+};
+
+export function getDefaultBundlerPlugins(): Required<
+  Pick<BundlerPlugins, "plugins" | "treeShake">
+> {
+  return defaultPlugins;
 }

--- a/packages/cli/src/bundle/defaultPlugins.ts
+++ b/packages/cli/src/bundle/defaultPlugins.ts
@@ -1,6 +1,8 @@
 import type { BundleParameters } from "@rnx-kit/config";
 
-const defaultPlugins = {
+type DefaultPlugins = Pick<Required<BundleParameters>, "plugins" | "treeShake">;
+
+const defaultPlugins: DefaultPlugins = {
   plugins: [
     "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
     "@rnx-kit/metro-plugin-duplicates-checker",
@@ -9,8 +11,6 @@ const defaultPlugins = {
   treeShake: false,
 };
 
-export function getDefaultBundlerPlugins(): Required<
-  Pick<BundleParameters, "plugins" | "treeShake">
-> {
+export function getDefaultBundlerPlugins(): DefaultPlugins {
   return defaultPlugins;
 }

--- a/packages/cli/src/bundle/defaultPlugins.ts
+++ b/packages/cli/src/bundle/defaultPlugins.ts
@@ -1,4 +1,4 @@
-import type { BundlerPlugins } from "@rnx-kit/config";
+import type { BundleParameters } from "@rnx-kit/config";
 
 const defaultPlugins = {
   plugins: [
@@ -10,7 +10,7 @@ const defaultPlugins = {
 };
 
 export function getDefaultBundlerPlugins(): Required<
-  Pick<BundlerPlugins, "plugins" | "treeShake">
+  Pick<BundleParameters, "plugins" | "treeShake">
 > {
   return defaultPlugins;
 }

--- a/packages/cli/src/bundle/types.ts
+++ b/packages/cli/src/bundle/types.ts
@@ -28,10 +28,8 @@ export type CliPlatformBundleConfig = BundleParameters &
       | "entryFile"
       | "bundleOutput"
       | "sourcemapUseAbsolutePath"
-      | "detectCyclicDependencies"
-      | "detectDuplicateDependencies"
-      | "typescriptValidation"
       | "treeShake"
+      | "plugins"
     >
   > & {
     unstableTransformProfile?: TransformProfile;

--- a/packages/cli/src/metro-config.ts
+++ b/packages/cli/src/metro-config.ts
@@ -1,4 +1,4 @@
-import type { BundleParameters, BundlerPlugins } from "@rnx-kit/config";
+import type { BundleParameters } from "@rnx-kit/config";
 import { warn } from "@rnx-kit/console";
 import { CyclicDependencies } from "@rnx-kit/metro-plugin-cyclic-dependencies-detector";
 import { DuplicateDependencies } from "@rnx-kit/metro-plugin-duplicates-checker";
@@ -38,7 +38,7 @@ function readLegacyOptions({
   detectCyclicDependencies,
   detectDuplicateDependencies,
   typescriptValidation,
-}: BundlerPlugins): string | undefined {
+}: MetroExtraParams): string | undefined {
   const oldOptions = [];
   const deprecatedOptions: Record<string, Record<string, unknown> | true> = {};
 

--- a/packages/cli/src/serve/kit-config.ts
+++ b/packages/cli/src/serve/kit-config.ts
@@ -9,7 +9,8 @@ export type ServerConfigOverrides = {
   sourceExts?: string[];
 };
 
-export type CliServerConfig = ServerConfig & Required<BundlerPlugins>;
+export type CliServerConfig = ServerConfig &
+  Required<Pick<BundlerPlugins, "plugins" | "treeShake">>;
 
 /**
  * Get the server configuration from the rnx-kit configuration. Apply any overrides.
@@ -30,6 +31,7 @@ export function getKitServerConfig(
         "detectDuplicateDependencies",
         "typescriptValidation",
         //"treeShake",  // don't pull in treeShake yet, since it doesn't work with the server
+        "plugins",
       ]);
     }
   }

--- a/packages/cli/src/serve/kit-config.ts
+++ b/packages/cli/src/serve/kit-config.ts
@@ -1,16 +1,18 @@
-import type { ServerConfig, BundlerPlugins } from "@rnx-kit/config";
-import { getKitConfig, getBundleConfig } from "@rnx-kit/config";
+import type { ServerConfig } from "@rnx-kit/config";
+import { getBundleConfig, getKitConfig } from "@rnx-kit/config";
 import { pickValues } from "@rnx-kit/tools-language/properties";
 import { getDefaultBundlerPlugins } from "../bundle/defaultPlugins";
 
-export type ServerConfigOverrides = {
+type ServerConfigOverrides = {
   projectRoot?: string;
   assetPlugins?: string[];
   sourceExts?: string[];
 };
 
-export type CliServerConfig = ServerConfig &
-  Required<Pick<BundlerPlugins, "plugins" | "treeShake">>;
+type CliServerConfig = ServerConfig & {
+  plugins: Required<ServerConfig>["plugins"];
+  treeShake: false;
+};
 
 /**
  * Get the server configuration from the rnx-kit configuration. Apply any overrides.
@@ -30,7 +32,6 @@ export function getKitServerConfig(
         "detectCyclicDependencies",
         "detectDuplicateDependencies",
         "typescriptValidation",
-        //"treeShake",  // don't pull in treeShake yet, since it doesn't work with the server
         "plugins",
       ]);
     }

--- a/packages/cli/test/bundle/kit-config.test.ts
+++ b/packages/cli/test/bundle/kit-config.test.ts
@@ -32,10 +32,12 @@ describe("CLI > Bundle > Kit Config > getCliPlatformBundleConfigs", () => {
   const defaultConfig = {
     entryFile: "index.js",
     sourcemapUseAbsolutePath: false,
-    detectCyclicDependencies: true,
-    detectDuplicateDependencies: true,
-    typescriptValidation: true,
     treeShake: false,
+    plugins: [
+      "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+      "@rnx-kit/metro-plugin-duplicates-checker",
+      "@rnx-kit/metro-plugin-typescript",
+    ],
   };
 
   const defaultConfigIOS = {

--- a/packages/cli/test/bundle/metro.test.ts
+++ b/packages/cli/test/bundle/metro.test.ts
@@ -19,10 +19,8 @@ describe("CLI > Bundle > Metro > metroBundle", () => {
   const bundleConfigNoPlugins: CliPlatformBundleConfig = {
     entryFile: "out/entry.js",
     bundleOutput: "src/main.jsbundle",
-    detectCyclicDependencies: false,
-    detectDuplicateDependencies: false,
-    typescriptValidation: false,
     treeShake: false,
+    plugins: [],
     platform: "ios",
     sourcemapOutput: "map/main.map",
     sourcemapSourcesRoot: "root-path-for-source-maps",
@@ -32,10 +30,12 @@ describe("CLI > Bundle > Metro > metroBundle", () => {
 
   const bundleConfig: CliPlatformBundleConfig = {
     ...bundleConfigNoPlugins,
-    detectCyclicDependencies: true,
-    detectDuplicateDependencies: true,
-    typescriptValidation: true,
     treeShake: true,
+    plugins: [
+      "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+      "@rnx-kit/metro-plugin-duplicates-checker",
+      "@rnx-kit/metro-plugin-typescript",
+    ],
   };
 
   const dev = true;

--- a/packages/cli/test/bundle/overrides.test.ts
+++ b/packages/cli/test/bundle/overrides.test.ts
@@ -10,10 +10,12 @@ describe("CLI > Bundle > Overrides > applyBundleConfigOverrides", () => {
     entryFile: "src/index.js",
     bundleOutput: "main.jsbundle",
     sourcemapUseAbsolutePath: false,
-    detectCyclicDependencies: true,
-    detectDuplicateDependencies: true,
-    typescriptValidation: true,
     treeShake: true,
+    plugins: [
+      "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+      "@rnx-kit/metro-plugin-duplicates-checker",
+      "@rnx-kit/metro-plugin-typescript",
+    ],
     indexedRamBundle: false,
     platform: "ios",
   };

--- a/packages/cli/test/metro-config.test.ts
+++ b/packages/cli/test/metro-config.test.ts
@@ -1,18 +1,36 @@
-import { CyclicDependencies } from "@rnx-kit/metro-plugin-cyclic-dependencies-detector";
-import { DuplicateDependencies } from "@rnx-kit/metro-plugin-duplicates-checker";
+import CyclicDependencies from "@rnx-kit/metro-plugin-cyclic-dependencies-detector";
+import DuplicateDependencies from "@rnx-kit/metro-plugin-duplicates-checker";
 import type { InputConfigT } from "metro-config";
 import { customizeMetroConfig } from "../src/metro-config";
 
-jest.mock("@rnx-kit/metro-plugin-cyclic-dependencies-detector", () => {
-  return {
-    CyclicDependencies: jest.fn(),
+function mockPlugin(moduleName: string) {
+  const state: { timesCalled: number; options?: Record<string, unknown> } = {
+    timesCalled: 0,
   };
+
+  function PluginMock(options: Record<string, unknown>) {
+    state.timesCalled = state.timesCalled + 1;
+    state.options = options;
+    return () => ({});
+  }
+
+  const Plugin = jest.requireActual(moduleName);
+  PluginMock.type = Plugin.default.type;
+  PluginMock.__context = state;
+  PluginMock.mockClear = () => {
+    state.timesCalled = 0;
+    state.options = undefined;
+  };
+
+  return PluginMock;
+}
+
+jest.mock("@rnx-kit/metro-plugin-cyclic-dependencies-detector", () => {
+  return mockPlugin("@rnx-kit/metro-plugin-cyclic-dependencies-detector");
 });
 
 jest.mock("@rnx-kit/metro-plugin-duplicates-checker", () => {
-  return {
-    DuplicateDependencies: jest.fn(),
-  };
+  return mockPlugin("@rnx-kit/metro-plugin-duplicates-checker");
 });
 
 // Always use a new mock since `customizeMetroConfig()` modifies the object.
@@ -26,10 +44,14 @@ function makeMockConfig(): InputConfigT {
   } as unknown as InputConfigT;
 }
 
+function toMock(module: unknown): ReturnType<typeof mockPlugin> {
+  return module as ReturnType<typeof mockPlugin>;
+}
+
 describe("cli/metro-config/customizeMetroConfig", () => {
   afterEach(() => {
-    (CyclicDependencies as any).mockClear();
-    (DuplicateDependencies as any).mockClear();
+    toMock(CyclicDependencies).mockClear();
+    toMock(DuplicateDependencies).mockClear();
   });
 
   test("returns a config with plugins by default", () => {
@@ -47,15 +69,14 @@ describe("cli/metro-config/customizeMetroConfig", () => {
     expect(typeof inputConfig.serializer.experimentalSerializerHook).toBe(
       "function"
     );
-    expect(CyclicDependencies).toHaveBeenCalledWith();
-    expect(DuplicateDependencies).toHaveBeenCalledWith();
+    expect(toMock(CyclicDependencies).__context).toEqual({ timesCalled: 1 });
+    expect(toMock(DuplicateDependencies).__context).toEqual({ timesCalled: 1 });
   });
 
   test("returns a config without a custom serializer when there are no plugins", () => {
     const inputConfig = makeMockConfig();
     customizeMetroConfig(inputConfig, {
-      detectCyclicDependencies: false,
-      detectDuplicateDependencies: false,
+      plugins: ["@rnx-kit/metro-plugin-typescript"],
     });
 
     expect(inputConfig).toEqual({
@@ -68,14 +89,17 @@ describe("cli/metro-config/customizeMetroConfig", () => {
     expect(typeof inputConfig.serializer.experimentalSerializerHook).toBe(
       "function"
     );
-    expect(CyclicDependencies).not.toHaveBeenCalled();
-    expect(DuplicateDependencies).not.toHaveBeenCalled();
+    expect(toMock(CyclicDependencies).__context).toEqual({ timesCalled: 0 });
+    expect(toMock(DuplicateDependencies).__context).toEqual({ timesCalled: 0 });
   });
 
   test("returns a config with only duplicates plugin", () => {
     const inputConfig = makeMockConfig();
     customizeMetroConfig(inputConfig, {
-      detectCyclicDependencies: false,
+      plugins: [
+        "@rnx-kit/metro-plugin-duplicates-checker",
+        "@rnx-kit/metro-plugin-typescript",
+      ],
     });
 
     expect(inputConfig).toEqual({
@@ -89,14 +113,17 @@ describe("cli/metro-config/customizeMetroConfig", () => {
     expect(typeof inputConfig.serializer.experimentalSerializerHook).toBe(
       "function"
     );
-    expect(CyclicDependencies).not.toHaveBeenCalled();
-    expect(DuplicateDependencies).toHaveBeenCalledWith();
+    expect(toMock(CyclicDependencies).__context).toEqual({ timesCalled: 0 });
+    expect(toMock(DuplicateDependencies).__context).toEqual({ timesCalled: 1 });
   });
 
   test("returns a config with only cyclic dependencies plugin", () => {
     const inputConfig = makeMockConfig();
     customizeMetroConfig(inputConfig, {
-      detectDuplicateDependencies: false,
+      plugins: [
+        "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+        "@rnx-kit/metro-plugin-typescript",
+      ],
     });
 
     expect(inputConfig).toEqual({
@@ -110,8 +137,8 @@ describe("cli/metro-config/customizeMetroConfig", () => {
     expect(typeof inputConfig.serializer.experimentalSerializerHook).toBe(
       "function"
     );
-    expect(CyclicDependencies).toHaveBeenCalledWith();
-    expect(DuplicateDependencies).not.toHaveBeenCalled();
+    expect(toMock(CyclicDependencies).__context).toEqual({ timesCalled: 1 });
+    expect(toMock(DuplicateDependencies).__context).toEqual({ timesCalled: 0 });
   });
 
   test("forwards plugin options", () => {
@@ -119,8 +146,17 @@ describe("cli/metro-config/customizeMetroConfig", () => {
     const cyclicDependenciesOptions = { cyclicDependencies: true } as any;
     const duplicateDependencesOptions = { duplicateDependencies: true } as any;
     customizeMetroConfig(inputConfig, {
-      detectCyclicDependencies: cyclicDependenciesOptions,
-      detectDuplicateDependencies: duplicateDependencesOptions,
+      plugins: [
+        [
+          "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+          cyclicDependenciesOptions,
+        ],
+        [
+          "@rnx-kit/metro-plugin-duplicates-checker",
+          duplicateDependencesOptions,
+        ],
+        "@rnx-kit/metro-plugin-typescript",
+      ],
     });
 
     expect(inputConfig).toEqual({
@@ -134,18 +170,21 @@ describe("cli/metro-config/customizeMetroConfig", () => {
     expect(typeof inputConfig.serializer.experimentalSerializerHook).toBe(
       "function"
     );
-    expect(CyclicDependencies).toHaveBeenCalledWith(cyclicDependenciesOptions);
-    expect(DuplicateDependencies).toHaveBeenCalledWith(
-      duplicateDependencesOptions
-    );
+    expect(toMock(CyclicDependencies).__context).toEqual({
+      timesCalled: 1,
+      options: cyclicDependenciesOptions,
+    });
+    expect(toMock(DuplicateDependencies).__context).toEqual({
+      timesCalled: 1,
+      options: duplicateDependencesOptions,
+    });
   });
 
   test("returns a config with a custom serializer when tree shaking is enabled", () => {
     const inputConfig = makeMockConfig();
     customizeMetroConfig(inputConfig, {
-      detectCyclicDependencies: false,
-      detectDuplicateDependencies: false,
       treeShake: true,
+      plugins: ["@rnx-kit/metro-plugin-typescript"],
     });
 
     expect(inputConfig).toEqual({
@@ -161,7 +200,7 @@ describe("cli/metro-config/customizeMetroConfig", () => {
     expect(typeof inputConfig.serializer.experimentalSerializerHook).toBe(
       "function"
     );
-    expect(CyclicDependencies).not.toHaveBeenCalled();
-    expect(DuplicateDependencies).not.toHaveBeenCalled();
+    expect(toMock(CyclicDependencies).__context).toEqual({ timesCalled: 0 });
+    expect(toMock(DuplicateDependencies).__context).toEqual({ timesCalled: 0 });
   });
 });

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -48,29 +48,22 @@ platform-specific overrides.
 
 Union of: "ios", "android", "windows", "win32", "macos"
 
-### `BundleParameters` inherits `BundlerPlugins`
+### `BundleParameters`
 
 Parameters controlling how a bundle is constructed.
 
-| Name                     | Type               | Description                                                                                                                                                                                            |
-| ------------------------ | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| entryFile                | string, undefined  | Path to the .js file which is the entry-point for building the bundle. Either absolute, or relative to the package.                                                                                    |
-| bundleOutput             | string, undefined  | Path to the output bundle file. Either absolute or relative to the package.                                                                                                                            |
-| bundleEncoding           | string, undefined  | [Encoding scheme](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings) to use when writing the bundle file. Currently limited to UTF-8, UTF-16 (little endian), and 7-bit ASCII. |
-| sourcemapOutput          | string, undefined  | Path to use when creating the bundle source map file. Either absolute, or relative to the package.                                                                                                     |
-| sourcemapSourcesRoot     | string, undefined  | Path to the package's source files. Used to make source-map paths relative and therefore portable.                                                                                                     |
-| sourcemapUseAbsolutePath | boolean, undefined | Controls whether or not SourceMapURL is reported as a full path or just a file name.                                                                                                                   |
-| assetsDest               | string, undefined  | Path where all bundle assets (strings, images, fonts, sounds, ...) are written. Either absolute, or relative to the package.                                                                           |
-| indexedBundleFormat      | boolean, undefined | Force the "Indexed RAM" bundle file format, even when targeting Android. Only applies to the `rnx-ram-bundle` command.                                                                                 |
-
-### `BundlerPlugins`
-
-Parameters controlling bundler plugins.
-
-| Name      | Type                          | Description                                                                                                                                                                                    |
-| --------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| plugins   | `(string \| [string, any])[]` | List of plugins to apply. If unset, it falls back to `["@rnx-kit/metro-plugin-cyclic-dependencies-detector", "@rnx-kit/metro-plugin-duplicates-checker", "@rnx-kit/metro-plugin-typescript"]`. |
-| treeShake | boolean, undefined            | Choose whether to enable tree shaking.                                                                                                                                                         |
+| Name                     | Type                          | Description                                                                                                                                                                                            |
+| ------------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| entryFile                | string, undefined             | Path to the .js file which is the entry-point for building the bundle. Either absolute, or relative to the package.                                                                                    |
+| bundleOutput             | string, undefined             | Path to the output bundle file. Either absolute or relative to the package.                                                                                                                            |
+| bundleEncoding           | string, undefined             | [Encoding scheme](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings) to use when writing the bundle file. Currently limited to UTF-8, UTF-16 (little endian), and 7-bit ASCII. |
+| sourcemapOutput          | string, undefined             | Path to use when creating the bundle source map file. Either absolute, or relative to the package.                                                                                                     |
+| sourcemapSourcesRoot     | string, undefined             | Path to the package's source files. Used to make source-map paths relative and therefore portable.                                                                                                     |
+| sourcemapUseAbsolutePath | boolean, undefined            | Controls whether or not SourceMapURL is reported as a full path or just a file name.                                                                                                                   |
+| assetsDest               | string, undefined             | Path where all bundle assets (strings, images, fonts, sounds, ...) are written. Either absolute, or relative to the package.                                                                           |
+| indexedBundleFormat      | boolean, undefined            | Force the "Indexed RAM" bundle file format, even when targeting Android. Only applies to the `rnx-ram-bundle` command.                                                                                 |
+| plugins                  | `(string \| [string, any])[]` | List of plugins to apply. If unset, it falls back to `["@rnx-kit/metro-plugin-cyclic-dependencies-detector", "@rnx-kit/metro-plugin-duplicates-checker", "@rnx-kit/metro-plugin-typescript"]`.         |
+| treeShake                | boolean, undefined            | Choose whether to enable tree shaking.                                                                                                                                                                 |
 
 ### `CyclicDetectorOptions`
 
@@ -94,13 +87,14 @@ Parameters controlling bundler plugins.
 | ------------ | ------------------ | ------- | --------------------------------------------------------------- |
 | throwOnError | boolean, undefined | true    | Controls whether an error is thrown when type-validation fails. |
 
-### `ServerConfig` inherits `BundlerPlugins`
+### `ServerConfig`
 
-| Name         | Type                | Description                                                                                                                                                                                                                                                  |
-| ------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| projectRoot  | string, undefined   | Path to the root of your react-native application. The bundle server uses this root path to resolve all web requests. The root path should contain your Babel config, otherwise Metro won't be able to find it. Either absolute, or relative to the package. |
-| assetPlugins | string[], undefined | Additional asset plugins to be used by the Metro Babel transformer. Comma-separated list containing plugin modules and/or absolute paths to plugin packages.                                                                                                 |
-| sourceExts   | string[], undefined | Additional source-file extensions to include when generating bundles. Comma-separated list, excluding the leading dot.                                                                                                                                       |
+| Name         | Type                          | Description                                                                                                                                                                                                                                                  |
+| ------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| projectRoot  | string, undefined             | Path to the root of your react-native application. The bundle server uses this root path to resolve all web requests. The root path should contain your Babel config, otherwise Metro won't be able to find it. Either absolute, or relative to the package. |
+| assetPlugins | string[], undefined           | Additional asset plugins to be used by the Metro Babel transformer. Comma-separated list containing plugin modules and/or absolute paths to plugin packages.                                                                                                 |
+| sourceExts   | string[], undefined           | Additional source-file extensions to include when generating bundles. Comma-separated list, excluding the leading dot.                                                                                                                                       |
+| plugins      | `(string \| [string, any])[]` | List of plugins to apply. If unset, it falls back to `["@rnx-kit/metro-plugin-cyclic-dependencies-detector", "@rnx-kit/metro-plugin-duplicates-checker", "@rnx-kit/metro-plugin-typescript"]`.                                                               |
 
 ## API
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -67,12 +67,10 @@ Parameters controlling how a bundle is constructed.
 
 Parameters controlling bundler plugins.
 
-| Name                        | Type                                              | Description                                                                                                                                                         |
-| --------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| detectCyclicDependencies    | boolean, `CyclicDetectorOptions`, undefined       | Choose whether to detect cycles in the dependency graph. `true` uses defaults, while `CyclicDetectorOptions` lets you control the detection process.                |
-| detectDuplicateDependencies | boolean, `DuplicateDetectorOptions`, undefined    | Choose whether to detect duplicate packages in the dependency graph. `true` uses defaults, while `DuplicateDetectorOptions` lets you control the detection process. |
-| typescriptValidation        | boolean, `TypeScriptValidationOptions`, undefined | Choose whether to type-check source files using TypeScript. `true` uses defaults, while `TypeScriptValidationOptions` lets you control the validation process.      |
-| treeShake                   | boolean, undefined                                | Choose whether to enable tree shaking.                                                                                                                              |
+| Name      | Type                          | Description                                                                                                                                                                                    |
+| --------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| plugins   | `(string \| [string, any])[]` | List of plugins to apply. If unset, it falls back to `["@rnx-kit/metro-plugin-cyclic-dependencies-detector", "@rnx-kit/metro-plugin-duplicates-checker", "@rnx-kit/metro-plugin-typescript"]`. |
+| treeShake | boolean, undefined            | Choose whether to enable tree shaking.                                                                                                                                                         |
 
 ### `CyclicDetectorOptions`
 

--- a/packages/config/schema.json
+++ b/packages/config/schema.json
@@ -40,46 +40,21 @@
     "bundlerRuntimeParameters": {
       "type": "object",
       "properties": {
-        "detectCyclicDependencies": {
-          "description": "Choose whether to detect cycles in the dependency graph. If true, then a default set of options will be used. Otherwise the object allows for fine-grained control over the detection process.",
-          "oneOf": [
-            { "type": "boolean" },
-            {
-              "type": "object",
-              "properties": {
-                "includeNodeModules": { "type": "boolean" },
-                "linesOfContext": { "type": "number" },
-                "throwOnError": { "type": "boolean" }
+        "plugins": {
+          "description": "Plugins passed to the Metro config.",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "type": "string" },
+              {
+                "type": "array",
+                "items": {
+                  "oneOf": [{ "type": "string" }, { "type": "object" }]
+                }
               }
-            }
-          ],
-          "default": true
-        },
-        "detectDuplicateDependencies": {
-          "description": "Choose whether to detect duplicate packages in the dependency graph.",
-          "oneOf": [
-            { "type": "boolean" },
-            {
-              "type": "object",
-              "properties": {
-                "ignoredModules": {
-                  "type": "array",
-                  "items": { "type": "string" }
-                },
-                "bannedModules": {
-                  "type": "array",
-                  "items": { "type": "string" }
-                },
-                "throwOnError": { "type": "boolean" }
-              }
-            }
-          ],
-          "default": true
-        },
-        "typescriptValidation": {
-          "description": "Choose whether to type-check source files using TypeScript.",
-          "type": "boolean",
-          "default": true
+            ]
+          },
+          "uniqueItems": true
         },
         "treeShake": {
           "description": "Choose whether to enable tree shaking.",

--- a/packages/config/src/bundleConfig.ts
+++ b/packages/config/src/bundleConfig.ts
@@ -39,27 +39,6 @@ export type BundlerPlugins = {
    * @deprecated Replaced by `plugins`
    */
   typescriptValidation?: boolean | TypeScriptValidationOptions;
-
-  /**
-   * Choose whether to enable tree shaking.
-   *
-   * Note that Metro ignores custom serializers (which this feature depends on)
-   * when outputting RAM bundle format.
-   *
-   * Only applies to `rnx-bundle` command.
-   */
-  treeShake?: boolean;
-
-  /**
-   * List of plugins to add to the bundling process.
-   *
-   * @default [
-   *   "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
-   *   "@rnx-kit/metro-plugin-duplicates-checker",
-   *   "@rnx-kit/metro-plugin-typescript"
-   * ]
-   */
-  plugins?: Plugin[];
 };
 
 /**
@@ -114,6 +93,27 @@ export type BundleParameters = BundlerPlugins & {
    * Only applies to the `rnx-ram-bundle` command.
    */
   indexedRamBundle?: boolean;
+
+  /**
+   * Choose whether to enable tree shaking.
+   *
+   * Note that Metro ignores custom serializers (which this feature depends on)
+   * when outputting RAM bundle format.
+   *
+   * Only applies to `rnx-bundle` command.
+   */
+  treeShake?: boolean;
+
+  /**
+   * List of plugins to add to the bundling process.
+   *
+   * @default [
+   *   "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+   *   "@rnx-kit/metro-plugin-duplicates-checker",
+   *   "@rnx-kit/metro-plugin-typescript"
+   * ]
+   */
+  plugins?: Plugin[];
 };
 
 /**

--- a/packages/config/src/bundleConfig.ts
+++ b/packages/config/src/bundleConfig.ts
@@ -10,6 +10,8 @@ export type TypeScriptValidationOptions = {
   throwOnError?: boolean;
 };
 
+export type Plugin = string | [string, Record<string, unknown>];
+
 /**
  * Parameters controlling bundler plugins.
  */
@@ -17,18 +19,24 @@ export type BundlerPlugins = {
   /**
    * Choose whether to detect cycles in the dependency graph. `true` uses defaults,
    * while `CyclicDetectorOptions` lets you control the detection process.
+   *
+   * @deprecated Replaced by `plugins`
    */
   detectCyclicDependencies?: boolean | CyclicDetectorOptions;
 
   /**
    * Choose whether to detect duplicate packages in the dependency graph. `true` uses defaults,
    * while `DuplicateDetectorOptions` lets you control the detection process.
+   *
+   * @deprecated Replaced by `plugins`
    */
   detectDuplicateDependencies?: boolean | DuplicateDetectorOptions;
 
   /**
    * Choose whether to type-check source files using TypeScript. `true` uses defaults,
    * while `TypeScriptValidationOptions` lets you control the validation process.
+   *
+   * @deprecated Replaced by `plugins`
    */
   typescriptValidation?: boolean | TypeScriptValidationOptions;
 
@@ -41,6 +49,17 @@ export type BundlerPlugins = {
    * Only applies to `rnx-bundle` command.
    */
   treeShake?: boolean;
+
+  /**
+   * List of plugins to add to the bundling process.
+   *
+   * @default [
+   *   "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+   *   "@rnx-kit/metro-plugin-duplicates-checker",
+   *   "@rnx-kit/metro-plugin-typescript"
+   * ]
+   */
+  plugins?: Plugin[];
 };
 
 /**

--- a/packages/config/src/serverConfig.ts
+++ b/packages/config/src/serverConfig.ts
@@ -1,4 +1,4 @@
-import type { BundlerPlugins } from "./bundleConfig";
+import type { BundlerPlugins, Plugin } from "./bundleConfig";
 
 export type ServerConfig = BundlerPlugins & {
   /**
@@ -23,4 +23,15 @@ export type ServerConfig = BundlerPlugins & {
    * list, excluding the leading dot.
    */
   sourceExts?: string[];
+
+  /**
+   * List of plugins to add to the bundling process.
+   *
+   * @default [
+   *   "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+   *   "@rnx-kit/metro-plugin-duplicates-checker",
+   *   "@rnx-kit/metro-plugin-typescript"
+   * ]
+   */
+  plugins?: Plugin[];
 };

--- a/packages/metro-plugin-cyclic-dependencies-detector/package.json
+++ b/packages/metro-plugin-cyclic-dependencies-detector/package.json
@@ -29,9 +29,7 @@
     "@rnx-kit/scripts": "*",
     "@types/jest": "^27.0.0",
     "@types/metro": "^0.66.0",
-    "@types/node": "^16.0.0",
-    "prettier": "^2.0.0",
-    "typescript": "^4.0.0"
+    "@types/node": "^16.0.0"
   },
   "depcheck": {
     "ignoreMatches": [

--- a/packages/metro-plugin-cyclic-dependencies-detector/src/index.ts
+++ b/packages/metro-plugin-cyclic-dependencies-detector/src/index.ts
@@ -17,6 +17,6 @@ export function CyclicDependencies(
   };
 }
 
-CyclicDependencies.type = "analyzer";
+CyclicDependencies.type = "serializer";
 
 export default CyclicDependencies;

--- a/packages/metro-plugin-cyclic-dependencies-detector/src/index.ts
+++ b/packages/metro-plugin-cyclic-dependencies-detector/src/index.ts
@@ -16,3 +16,7 @@ export function CyclicDependencies(
     detectCycles(entryPoint, graph, pluginOptions);
   };
 }
+
+CyclicDependencies.type = "analyzer";
+
+export default CyclicDependencies;

--- a/packages/metro-plugin-duplicates-checker/package.json
+++ b/packages/metro-plugin-duplicates-checker/package.json
@@ -33,9 +33,7 @@
     "@types/jest": "^27.0.0",
     "@types/metro": "^0.66.0",
     "@types/metro-source-map": "^0.66.0",
-    "@types/node": "^16.0.0",
-    "prettier": "^2.0.0",
-    "typescript": "^4.0.0"
+    "@types/node": "^16.0.0"
   },
   "depcheck": {
     "ignoreMatches": [

--- a/packages/metro-plugin-duplicates-checker/src/index.ts
+++ b/packages/metro-plugin-duplicates-checker/src/index.ts
@@ -79,6 +79,8 @@ export function DuplicateDependencies(
   };
 }
 
+DuplicateDependencies.type = "analyzer";
+
 if (require.main === module) {
   checkForDuplicatePackagesInFile(process.argv[2]).catch((error) => {
     if (error) {
@@ -87,3 +89,5 @@ if (require.main === module) {
     }
   });
 }
+
+export default DuplicateDependencies;

--- a/packages/metro-plugin-duplicates-checker/src/index.ts
+++ b/packages/metro-plugin-duplicates-checker/src/index.ts
@@ -79,7 +79,7 @@ export function DuplicateDependencies(
   };
 }
 
-DuplicateDependencies.type = "analyzer";
+DuplicateDependencies.type = "serializer";
 
 if (require.main === module) {
   checkForDuplicatePackagesInFile(process.argv[2]).catch((error) => {

--- a/packages/metro-plugin-typescript/src/index.ts
+++ b/packages/metro-plugin-typescript/src/index.ts
@@ -1,1 +1,4 @@
-export { TypeScriptPlugin } from "./serializerHook";
+import { TypeScriptPlugin } from "./serializerHook";
+
+export { TypeScriptPlugin };
+export default TypeScriptPlugin;

--- a/packages/metro-plugin-typescript/src/serializerHook.ts
+++ b/packages/metro-plugin-typescript/src/serializerHook.ts
@@ -95,3 +95,5 @@ export function TypeScriptPlugin(
     }
   };
 }
+
+TypeScriptPlugin.type = "serializerHook";

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -78,14 +78,19 @@
         "id": "main",
         "entryFile": "src/index.ts",
         "assetsDest": "dist",
-        "detectCyclicDependencies": true,
-        "detectDuplicateDependencies": {
-          "ignoredModules": [
-            "react-is"
-          ]
-        },
-        "typescriptValidation": true,
         "treeShake": false,
+        "plugins": [
+          "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+          [
+            "@rnx-kit/metro-plugin-duplicates-checker",
+            {
+              "ignoredModules": [
+                "react-is"
+              ]
+            }
+          ],
+          "@rnx-kit/metro-plugin-typescript"
+        ],
         "targets": [
           "android",
           "ios",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -116,14 +116,19 @@
         "id": "esbuild",
         "entryFile": "src/index.ts",
         "assetsDest": "dist",
-        "detectCyclicDependencies": true,
-        "detectDuplicateDependencies": {
-          "ignoredModules": [
-            "react-is"
-          ]
-        },
-        "typescriptValidation": true,
         "treeShake": true,
+        "plugins": [
+          "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+          [
+            "@rnx-kit/metro-plugin-duplicates-checker",
+            {
+              "ignoredModules": [
+                "react-is"
+              ]
+            }
+          ],
+          "@rnx-kit/metro-plugin-typescript"
+        ],
         "targets": [
           "android",
           "ios",
@@ -148,11 +153,18 @@
     ],
     "server": {
       "projectRoot": "src",
-      "detectDuplicateDependencies": {
-        "ignoredModules": [
-          "react-is"
-        ]
-      }
+      "plugins": [
+        "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
+        [
+          "@rnx-kit/metro-plugin-duplicates-checker",
+          {
+            "ignoredModules": [
+              "react-is"
+            ]
+          }
+        ],
+        "@rnx-kit/metro-plugin-typescript"
+      ]
     },
     "alignDeps": {
       "presets": [


### PR DESCRIPTION
### Description

Generalized CLI's plugins configuration.

This is an alternative implementation of #2029.

### Remaining work

- [x] Update website

### Test plan

Build:

```
cd packages/test-app
yarn build --dependencies
```

Run `yarn build:ios` with random legacy options:

```diff
diff --git a/packages/test-app/package.json b/packages/test-app/package.json
index c651e9ae..69779731 100644
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -79,6 +79,8 @@
         "entryFile": "src/index.ts",
         "assetsDest": "dist",
         "treeShake": false,
+        "detectCyclicDependencies": true,
+        "typescriptValidation": true,
         "plugins": [
           "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
           [
```

or:

```diff
diff --git a/packages/test-app/package.json b/packages/test-app/package.json
index c651e9ae..f2534eca 100644
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -79,6 +79,13 @@
         "entryFile": "src/index.ts",
         "assetsDest": "dist",
         "treeShake": false,
+        "detectCyclicDependencies": true,
+        "detectDuplicateDependencies": {
+          "ignoredModules": [
+            "react-is"
+          ]
+        },
+        "typescriptValidation": true,
         "plugins": [
           "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
           [
```

Example output:

```
test-app % yarn bundle:ios
yarn run v1.22.19
$ react-native rnx-bundle --platform ios
info Bundling ios...
warn 'detectCyclicDependencies', 'detectDuplicateDependencies', 'typescriptValidation' have been replaced by a new 'plugins' option. Below is an equivalent config:

    "plugins": [
      "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
      ["@rnx-kit/metro-plugin-duplicates-checker", {
        "ignoredModules": [
          "react-is"
        ]
      }],
      "@rnx-kit/metro-plugin-typescript"
    ]

For more details, see https://github.com/microsoft/rnx-kit/tree/main/packages/cli#readme
                    Welcome to Metro!
              Fast - Scalable - Integrated


info Writing bundle output to:, dist/main.ios.jsbundle
info Writing sourcemap output to:, dist/main.ios.jsbundle.map
info Done writing bundle output
info Done writing sourcemap output
info Copying 6 asset files
info Done copying assets
✨  Done in 3.61s.
```