### PR TITLE
fix: Remove broken link in CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,6 @@ As a contributor, you're expected to follow the
 <!--remove-block start-->
 
 - [Contributor License Agreement](#Contributor-License-Agreement)
-- [Code of Conduct](#Code-of-Conduct)
 - [Requirements](#Requirements)
 - [Build](#Build)
 - [Change Logs](#Change-Logs)


### PR DESCRIPTION
### Description

In the CONTRIBUTING.md file, removed the broken link that directs to nowhere.

![screenshot showing the broken link](https://user-images.githubusercontent.com/96492656/211296641-fbf03669-059b-4ee9-83d3-e161e5d6dc36.png)

Resolves #2090 

### Test plan

n/a
