### PR TITLE
fix: contrast ratio on hyperlinks

### DIFF
--- a/docsite/src/css/custom.css
+++ b/docsite/src/css/custom.css
@@ -197,11 +197,13 @@ html[data-theme="dark"] .navbar {
  * Links
  */
 .markdown a {
-  background-color: rgba(187, 239, 253, 0.3);
+  background-color: rgba(187, 239, 253, 0.4);
   border-bottom: 1px solid var(--ifm-hr-border-color);
   color: var(--ifm-font-color-base);
   display: initial;
   line-height: calc(var(--ifm-font-size-base) + 4px);
+  text-decoration: underline;
+  text-underline-offset: 0.25em;
 }
 
 .markdown a:hover {
@@ -211,7 +213,7 @@ html[data-theme="dark"] .navbar {
 }
 
 html[data-theme="dark"] .markdown a {
-  background-color: rgba(var(--react-native-color-rgb), 0.12);
+  background-color: rgba(var(--react-native-color-rgb), 0.2);
   border-bottom-color: rgba(var(--react-native-color-rgb), 0.3);
 }
 


### PR DESCRIPTION
### Description

Fixed the poor contrast ratio on hyperlinks by adding `text-decoration: underline` and bumping the `background-color` a bit.

#### Before:

Light Mode:

![poor contrast of hyperlinks in light mode](https://user-images.githubusercontent.com/96492656/212063401-4d00fcf0-016b-4928-9b71-a3fbcc75d4e3.png)

Dark Mode:

![poor contrast of hyperlinks in dark mode](https://user-images.githubusercontent.com/96492656/212063567-4474c3c3-7f12-4764-a982-8603af3a63c4.png)

#### After:

Light Mode:

![good contrast of hyperlinks in light mode](https://user-images.githubusercontent.com/96492656/211524618-8ddafdc3-791c-468b-9efa-62a8a3632504.jpg)

Dark Mode:

![good contrast of hyperlinks in dark mode](https://user-images.githubusercontent.com/96492656/211524998-48b12aaa-a0a1-4e71-bb32-3d0a53d684f7.png)

Resolves #2089

### Test plan

n/a
