### PR TITLE
chore: bump esbuild to 0.17.0

### DIFF
--- a/.changeset/slow-colts-invite.md
+++ b/.changeset/slow-colts-invite.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/esbuild-plugin-import-path-remapper": major
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Bumped esbuild to 0.17.0

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 .expo/
 .gradle/
 .idea/
-.xcode.env.local
+.xcode.env*
 /incubator/*/bin/
 /incubator/*/dist/
 /incubator/*/lib/

--- a/packages/esbuild-plugin-import-path-remapper/package.json
+++ b/packages/esbuild-plugin-import-path-remapper/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@rnx-kit/scripts": "*",
-    "esbuild": "^0.15.0",
+    "esbuild": "^0.17.0",
     "prettier": "^2.0.0"
   },
   "depcheck": {

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@rnx-kit/console": "^1.0.11",
     "@rnx-kit/tools-node": "^1.3.0",
-    "esbuild": "^0.15.0",
+    "esbuild": "^0.17.0",
     "esbuild-plugin-lodash": "^1.2.0",
     "fast-glob": "^3.2.7",
     "semver": "^7.0.0"

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -164,6 +164,8 @@ export function MetroSerializer(
       return Promise.resolve(bundleCode);
     }
 
+    const prelude = "__rnx_prelude__";
+
     const { dependencies } = graph;
     const metroPlugin: Plugin = {
       name: require("../package.json").name,
@@ -210,7 +212,7 @@ export function MetroSerializer(
           }
 
           if (
-            args.path === __filename ||
+            args.path === prelude ||
             preModules.find(({ path }) => path === args.path)
           ) {
             return {
@@ -252,7 +254,7 @@ export function MetroSerializer(
             };
           }
 
-          if (args.path === __filename) {
+          if (args.path === prelude) {
             return {
               /**
                * Add all the polyfills in this file. See the `inject` option
@@ -340,7 +342,7 @@ export function MetroSerializer(
            * to medium sized app. We can work around this issue by adding all
            * the polyfills in a single file that we inject here.
            */
-          __filename,
+          prelude,
         ],
         legalComments: "none",
         logLevel: buildOptions?.logLevel ?? "error",

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -209,7 +209,10 @@ export function MetroSerializer(
             };
           }
 
-          if (preModules.find(({ path }) => path === args.path)) {
+          if (
+            args.path === __filename ||
+            preModules.find(({ path }) => path === args.path)
+          ) {
             return {
               namespace,
               path: args.path,

--- a/packages/metro-serializer-esbuild/test/index.test.ts
+++ b/packages/metro-serializer-esbuild/test/index.test.ts
@@ -74,7 +74,7 @@ describe("metro-serializer-esbuild", () => {
     expect(result).toMatchInlineSnapshot(`
       "\\"use strict\\";
       (() => {
-        // virtual:metro:/~/metro-serializer-esbuild/lib/index.js
+        // virtual:metro:__rnx_prelude__
         var global = new Function(\\"return this;\\")();
 
         // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts
@@ -94,7 +94,7 @@ describe("metro-serializer-esbuild", () => {
     expect(result).toMatchInlineSnapshot(`
       "\\"use strict\\";
       (() => {
-        // virtual:metro:/~/metro-serializer-esbuild/lib/index.js
+        // virtual:metro:__rnx_prelude__
         var global = new Function(\\"return this;\\")();
 
         // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts
@@ -114,7 +114,7 @@ describe("metro-serializer-esbuild", () => {
     expect(result).toMatchInlineSnapshot(`
       "\\"use strict\\";
       (() => {
-        // virtual:metro:/~/metro-serializer-esbuild/lib/index.js
+        // virtual:metro:__rnx_prelude__
         var global = new Function(\\"return this;\\")();
 
         // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts
@@ -134,7 +134,7 @@ describe("metro-serializer-esbuild", () => {
     expect(result).toMatchInlineSnapshot(`
       "\\"use strict\\";
       (() => {
-        // virtual:metro:/~/metro-serializer-esbuild/lib/index.js
+        // virtual:metro:__rnx_prelude__
         var global = new Function(\\"return this;\\")();
 
         // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts
@@ -154,7 +154,7 @@ describe("metro-serializer-esbuild", () => {
     expect(result).toMatchInlineSnapshot(`
       "\\"use strict\\";
       (() => {
-        // virtual:metro:/~/metro-serializer-esbuild/lib/index.js
+        // virtual:metro:__rnx_prelude__
         var global = new Function(\\"return this;\\")();
 
         // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts
@@ -174,7 +174,7 @@ describe("metro-serializer-esbuild", () => {
     expect(result).toMatchInlineSnapshot(`
       "\\"use strict\\";
       (() => {
-        // virtual:metro:/~/metro-serializer-esbuild/lib/index.js
+        // virtual:metro:__rnx_prelude__
         var global = new Function(\\"return this;\\")();
 
         // virtual:metro:/~/node_modules/lodash-es/head.js
@@ -200,25 +200,25 @@ describe("metro-serializer-esbuild", () => {
           return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
         };
 
-        // virtual:metro:/~/metro-serializer-esbuild/lib/index.js
+        // virtual:metro:__rnx_prelude__
         var global;
-        var init_lib = __esm({
-          \\"virtual:metro:/~/metro-serializer-esbuild/lib/index.js\\"() {
+        var init_rnx_prelude = __esm({
+          \\"virtual:metro:__rnx_prelude__\\"() {
             global = new Function(\\"return this;\\")();
           }
         });
 
         // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/sideEffectsArray.ts
-        init_lib();
+        init_rnx_prelude();
 
         // virtual:metro:/~/node_modules/@fluentui/utilities/lib/index.js
-        init_lib();
+        init_rnx_prelude();
 
         // virtual:metro:/~/node_modules/@fluentui/set-version/lib/index.js
-        init_lib();
+        init_rnx_prelude();
 
         // virtual:metro:/~/node_modules/@fluentui/set-version/lib/setVersion.js
-        init_lib();
+        init_rnx_prelude();
         var packagesCache = {};
         var _win = void 0;
         try {
@@ -240,7 +240,7 @@ describe("metro-serializer-esbuild", () => {
         setVersion(\\"@fluentui/set-version\\", \\"6.0.0\\");
 
         // virtual:metro:/~/node_modules/@fluentui/utilities/lib/warn/warn.js
-        init_lib();
+        init_rnx_prelude();
         var _warningCallback = void 0;
         function warn(message) {
           if (_warningCallback && false) {
@@ -251,10 +251,10 @@ describe("metro-serializer-esbuild", () => {
         }
 
         // virtual:metro:/~/node_modules/@fluentui/utilities/lib/warn.js
-        init_lib();
+        init_rnx_prelude();
 
         // virtual:metro:/~/node_modules/@fluentui/utilities/lib/version.js
-        init_lib();
+        init_rnx_prelude();
         setVersion(\\"@fluentui/utilities\\", \\"8.12.0\\");
 
         // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/sideEffectsArray.ts
@@ -273,7 +273,7 @@ describe("metro-serializer-esbuild", () => {
     expect(result).toMatchInlineSnapshot(`
       "\\"use strict\\";
       (() => {
-        // virtual:metro:/~/metro-serializer-esbuild/lib/index.js
+        // virtual:metro:__rnx_prelude__
         var global = new Function(\\"return this;\\")();
 
         // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts

--- a/packages/metro-serializer-esbuild/test/index.test.ts
+++ b/packages/metro-serializer-esbuild/test/index.test.ts
@@ -74,7 +74,7 @@ describe("metro-serializer-esbuild", () => {
     expect(result).toMatchInlineSnapshot(`
       "\\"use strict\\";
       (() => {
-        // lib/index.js
+        // virtual:metro:/~/metro-serializer-esbuild/lib/index.js
         var global = new Function(\\"return this;\\")();
 
         // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts
@@ -94,7 +94,7 @@ describe("metro-serializer-esbuild", () => {
     expect(result).toMatchInlineSnapshot(`
       "\\"use strict\\";
       (() => {
-        // lib/index.js
+        // virtual:metro:/~/metro-serializer-esbuild/lib/index.js
         var global = new Function(\\"return this;\\")();
 
         // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts
@@ -114,7 +114,7 @@ describe("metro-serializer-esbuild", () => {
     expect(result).toMatchInlineSnapshot(`
       "\\"use strict\\";
       (() => {
-        // lib/index.js
+        // virtual:metro:/~/metro-serializer-esbuild/lib/index.js
         var global = new Function(\\"return this;\\")();
 
         // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts
@@ -134,7 +134,7 @@ describe("metro-serializer-esbuild", () => {
     expect(result).toMatchInlineSnapshot(`
       "\\"use strict\\";
       (() => {
-        // lib/index.js
+        // virtual:metro:/~/metro-serializer-esbuild/lib/index.js
         var global = new Function(\\"return this;\\")();
 
         // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts
@@ -154,7 +154,7 @@ describe("metro-serializer-esbuild", () => {
     expect(result).toMatchInlineSnapshot(`
       "\\"use strict\\";
       (() => {
-        // lib/index.js
+        // virtual:metro:/~/metro-serializer-esbuild/lib/index.js
         var global = new Function(\\"return this;\\")();
 
         // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts
@@ -174,7 +174,7 @@ describe("metro-serializer-esbuild", () => {
     expect(result).toMatchInlineSnapshot(`
       "\\"use strict\\";
       (() => {
-        // lib/index.js
+        // virtual:metro:/~/metro-serializer-esbuild/lib/index.js
         var global = new Function(\\"return this;\\")();
 
         // virtual:metro:/~/node_modules/lodash-es/head.js
@@ -200,11 +200,10 @@ describe("metro-serializer-esbuild", () => {
           return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
         };
 
-        // lib/index.js
+        // virtual:metro:/~/metro-serializer-esbuild/lib/index.js
         var global;
         var init_lib = __esm({
-          \\"lib/index.js\\"() {
-            \\"use strict\\";
+          \\"virtual:metro:/~/metro-serializer-esbuild/lib/index.js\\"() {
             global = new Function(\\"return this;\\")();
           }
         });
@@ -274,7 +273,7 @@ describe("metro-serializer-esbuild", () => {
     expect(result).toMatchInlineSnapshot(`
       "\\"use strict\\";
       (() => {
-        // lib/index.js
+        // virtual:metro:/~/metro-serializer-esbuild/lib/index.js
         var global = new Function(\\"return this;\\")();
 
         // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts

--- a/packages/test-app/ios/Podfile.lock
+++ b/packages/test-app/ios/Podfile.lock
@@ -286,14 +286,14 @@ PODS:
     - React-jsi (= 0.68.5)
     - React-logger (= 0.68.5)
     - React-perflogger (= 0.68.5)
-  - ReactTestApp-DevSupport (2.0.2):
+  - ReactTestApp-DevSupport (2.0.3):
     - React-Core
     - React-jsi
   - ReactTestApp-MSAL (2.0.1):
     - MSAL
     - RNXAuth
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNXAuth (0.2.0):
+  - RNXAuth (0.2.1):
     - React-Core
   - Yoga (1.14.0)
 
@@ -447,10 +447,10 @@ SPEC CHECKSUMS:
   React-RCTVibration: 9819a3bf6230e4b2a99877c21268b0b2416157a1
   React-runtimeexecutor: b1f1995089b90696dbc2a7ffe0059a80db5c8eb1
   ReactCommon: 149e2c0acab9bac61378da0db5b2880a1b5ff59b
-  ReactTestApp-DevSupport: 93a3ec4d2affbd491128b89e922d7f1a359f547a
+  ReactTestApp-DevSupport: 13f0b1ee9ff539bd7c8976eb5cf99c6cd0e00def
   ReactTestApp-MSAL: 8d785756a554aa97d4e0549061accece850ba82d
   ReactTestApp-Resources: 74a1cf509f4e7962b16361ea4e73cba3648fff5d
-  RNXAuth: 12ce1f1087d1c8367b34e5680cd4b4edb6532cd7
+  RNXAuth: d37ae710b2ce38b5e0221015bd56ce710673c704
   Yoga: c4d61225a466f250c35c1ee78d2d0b3d41fe661c
 
 PODFILE CHECKSUM: df600ab6f7e85a7573cb1b256a65b13294140cbd

--- a/scripts/align-deps-preset.js
+++ b/scripts/align-deps-preset.js
@@ -27,7 +27,7 @@ const profile = {
   },
   esbuild: {
     name: "esbuild",
-    version: "^0.15.0",
+    version: "^0.17.0",
   },
   eslint: {
     name: "eslint",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@rnx-kit/golang": "^0.2.1",
     "depcheck": "^1.0.0",
-    "esbuild": "^0.15.0",
+    "esbuild": "^0.17.0",
     "fs-extra": "^10.0.0",
     "jest": "^27.0.0",
     "markdown-table": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1320,15 +1320,115 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@esbuild/android-arm@0.15.16":
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.15.16.tgz#0642926178b15e3d1545efae6eee05c4f3451d15"
-  integrity sha512-nyB6CH++2mSgx3GbnrJsZSxzne5K0HMyNIWafDHqYy7IwxFc4fd/CgHVZXr8Eh+Q3KbIAcAe3vGyqIPhGblvMQ==
+"@esbuild/android-arm64@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.17.0.tgz#dd4c28274f08a16be95430d19fc0dab835fd2eae"
+  integrity sha512-77GVyD7ToESy/7+9eI8z62GGBdS/hsqsrpM+JA4kascky86wHbN29EEFpkVvxajPL7k6mbLJ5VBQABdj7n9FhQ==
 
-"@esbuild/linux-loong64@0.15.16":
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.15.16.tgz#284522de76abe951e4ed2bd24a467e8d49c67933"
-  integrity sha512-SDLfP1uoB0HZ14CdVYgagllgrG7Mdxhkt4jDJOKl/MldKrkQ6vDJMZKl2+5XsEY/Lzz37fjgLQoJBGuAw/x8kQ==
+"@esbuild/android-arm@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.17.0.tgz#10d289617902f877a28f9f7913f4f54a4e699875"
+  integrity sha512-hlbX5ym1V5kIKvnwFhm6rhar7MNqfJrZyYTNfk6+WS1uQfQmszFgXeyPH2beP3lSCumZyqX0zMBfOqftOpZ7GA==
+
+"@esbuild/android-x64@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.17.0.tgz#b0c124e434cec1a6551b400850458c860a30ecb4"
+  integrity sha512-TroxZdZhtAz0JyD0yahtjcbKuIXrBEAoAazaYSeR2e2tUtp9uXrcbpwFJF6oxxOiOOne6y7l4hx4YVnMW/tdFw==
+
+"@esbuild/darwin-arm64@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.17.0.tgz#4a1b65e756cc29e8d68a5ace0a2eb1c63614a767"
+  integrity sha512-wP/v4cgdWt1m8TS/WmbaBc3NZON10eCbm6XepdVc3zJuqruHCzCKcC9dTSTEk50zX04REcRcbIbdhTMciQoFIg==
+
+"@esbuild/darwin-x64@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.17.0.tgz#9a59890391f17cd3998d2c7959ea70a1aad28c93"
+  integrity sha512-R4WB6D6V9KGO/3LVTT8UlwRJO26IBFatOdo/bRXksfJR0vyOi2/lgmAAMBSpgcnnwvts9QsWiyM++mTTlwRseA==
+
+"@esbuild/freebsd-arm64@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.0.tgz#3412ffa1703c991b4d562176881fb43a9ee6f7e3"
+  integrity sha512-FO7+UEZv79gen2df8StFYFHZPI9ADozpFepLZCxY+O8sYLDa1rirvenmLwJiOHmeQRJ5orYedFeLk1PFlZ6t8Q==
+
+"@esbuild/freebsd-x64@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.17.0.tgz#427f2a07c997fb30f1a8906b070e28959f38f1e2"
+  integrity sha512-qCsNRsVTaC3ekwZcb2sa7l1gwCtJK3EqCWyDgpoQocYf3lRpbAzaCvqZSF2+NOO64cV+JbedXPsFiXU1aaVcIg==
+
+"@esbuild/linux-arm64@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.17.0.tgz#0e32c6a6b290406b1203854c2d594987570dd66c"
+  integrity sha512-js4Vlch5XJQYISbDVJd2hsI/MsfVUz6d/FrclCE73WkQmniH37vFpuQI42ntWAeBghDIfaPZ6f9GilhwGzVFUg==
+
+"@esbuild/linux-arm@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.17.0.tgz#5a70a95bf336035884dee123b5453aeab9c608f3"
+  integrity sha512-Y2G2NU6155gcfNKvrakVmZV5xUAEhXjsN/uKtbKKRnvee0mHUuaT3OdQJDJKjHVGr6B0898pc3slRpI1PqspoQ==
+
+"@esbuild/linux-ia32@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.17.0.tgz#47baca8e733405a81952bcc475da1b8e5682915f"
+  integrity sha512-7tl/jSPkF59R3zeFDB2/09zLGhcM7DM+tCoOqjJbQjuL6qbMWomGT2RglCqRFpCSdzBx0hukmPPgUAMlmdj0sQ==
+
+"@esbuild/linux-loong64@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.17.0.tgz#809398ca125ba3b57d4d12d261f2471ac32b1edb"
+  integrity sha512-OG356F7dIVVF+EXJx5UfzFr1I5l6ES53GlMNSr3U1MhlaVyrP9um5PnrSJ+7TSDAzUC7YGjxb2GQWqHLd5XFoA==
+
+"@esbuild/linux-mips64el@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.17.0.tgz#94b50097a3421ff538eb6a41cd4fb5db4c4993ff"
+  integrity sha512-LWQJgGpxrjh2x08UYf6G5R+Km7zhkpCvKXtFQ6SX0fimDvy1C8kslgFHGxLS0wjGV8C4BNnENW/HNy57+RB7iA==
+
+"@esbuild/linux-ppc64@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.17.0.tgz#3a580bc8b494d3b273cf08a3bb0d893b31b786ae"
+  integrity sha512-f40N8fKiTQslUcUuhof2/syOQ+DC9Mqdnm9d063pew+Ptv9r6dBNLQCz4300MOfCLAbb0SdnrcMSzHbMehXWLw==
+
+"@esbuild/linux-riscv64@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.17.0.tgz#bf75f769e5fa35d143bc5759520e4277b3a95bcc"
+  integrity sha512-sc/pvLexRvxgEbmeq7LfLGnzUBFi/E2MGbnQj3CG8tnQ90tWPTi+9CbZEgIADhj6CAlCCmqxpUclIV1CRVUOTw==
+
+"@esbuild/linux-s390x@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.17.0.tgz#ad6569476d6751cc9255fe059a5e074a08dd3e27"
+  integrity sha512-7xq9/kY0vunCL2vjHKdHGI+660pCdeEC6K6TWBVvbTGXvT8s/qacfxMgr8PCeQRbNUZLOA13G6/G1+c0lYXO1A==
+
+"@esbuild/linux-x64@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.17.0.tgz#7e38c248b8c9f39240c0914872f93893bde7182a"
+  integrity sha512-o7FhBLONk1mLT2ytlj/j/WuJcPdhWcVpysSJn1s9+zRdLwLKveipbPi5SIasJIqMq0T4CkQW76pxJYMqz9HrQA==
+
+"@esbuild/netbsd-x64@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.17.0.tgz#46e770aa6a14dad73d2cdf6a9521585eca1005ef"
+  integrity sha512-V6xXsv71b8vwFCW/ky82Rs//SbyA+ORty6A7Mzkg33/4NbYZ/1Vcbk7qAN5oi0i/gS4Q0+7dYT7NqaiVZ7+Xjw==
+
+"@esbuild/openbsd-x64@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.17.0.tgz#5d4070663448db20d3de42f7a44a2c2dd0cac847"
+  integrity sha512-StlQor6A0Y9SSDxraytr46Qbz25zsSDmsG3MCaNkBnABKHP3QsngOCfdBikqHVVrXeK0KOTmtX92/ncTGULYgQ==
+
+"@esbuild/sunos-x64@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.17.0.tgz#4a77dbf1691ce2fd9aba69f58248d46f3e28f98b"
+  integrity sha512-K64Wqw57j8KrwjR3QjsuzN/qDGK6Cno6QYtIlWAmGab5iYPBZCWz7HFtF2a86/130LmUsdXqOID7J0SmjjRFIQ==
+
+"@esbuild/win32-arm64@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.17.0.tgz#9b7cb6839240cd4408fbca6565c6a08e277d73bb"
+  integrity sha512-hly6iSWAf0hf3aHD18/qW7iFQbg9KAQ0RFGG9plcxkhL4uGw43O+lETGcSO/PylNleFowP/UztpF6U4oCYgpPw==
+
+"@esbuild/win32-ia32@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.17.0.tgz#059a1651b830bfc188920487badd12a8e1b8f050"
+  integrity sha512-aL4EWPh0nyC5uYRfn+CHkTgawd4DjtmwquthNDmGf6Ht6+mUc+bQXyZNH1QIw8x20hSqFc4Tf36aLLWP/TPR3g==
+
+"@esbuild/win32-x64@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.17.0.tgz#d2253fef7e7cd11f010f688fa4f5ebb2875f34c1"
+  integrity sha512-W6IIQ9Rt43I/GqfXeBFLk0TvowKBoirs9sw2LPfhHax6ayMlW5PhFzSJ76I1ac9Pk/aRcSMrHWvVyZs8ZPK2wA==
 
 "@eslint/eslintrc@^1.3.3":
   version "1.3.3"
@@ -4381,138 +4481,38 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esbuild-android-64@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.15.16.tgz#0d6a16fa1bea441d5183976f1633183c25a764d5"
-  integrity sha512-Vwkv/sT0zMSgPSVO3Jlt1pUbnZuOgtOQJkJkyyJFAlLe7BiT8e9ESzo0zQSx4c3wW4T6kGChmKDPMbWTgtliQA==
-
-esbuild-android-arm64@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.15.16.tgz#78643bbbf396d26d20ba1f2fcdff3618c7c033e9"
-  integrity sha512-lqfKuofMExL5niNV3gnhMUYacSXfsvzTa/58sDlBET/hCOG99Zmeh+lz6kvdgvGOsImeo6J9SW21rFCogNPLxg==
-
-esbuild-darwin-64@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.15.16.tgz#de3e91809dcd1ffb64409e2f990bb86e33e4ffd8"
-  integrity sha512-wo2VWk/n/9V2TmqUZ/KpzRjCEcr00n7yahEdmtzlrfQ3lfMCf3Wa+0sqHAbjk3C6CKkR3WKK/whkMq5Gj4Da9g==
-
-esbuild-darwin-arm64@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.16.tgz#bc9cc8d51109d8e9db4ffe2c064dd53d1eb5a2a6"
-  integrity sha512-fMXaUr5ou0M4WnewBKsspMtX++C1yIa3nJ5R2LSbLCfJT3uFdcRoU/NZjoM4kOMKyOD9Sa/2vlgN8G07K3SJnw==
-
-esbuild-freebsd-64@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.16.tgz#f8c54c679c16e9b20a1bf860ca91ba700d6c9c5d"
-  integrity sha512-UzIc0xlRx5x9kRuMr+E3+hlSOxa/aRqfuMfiYBXu2jJ8Mzej4lGL7+o6F5hzhLqWfWm1GWHNakIdlqg1ayaTNQ==
-
-esbuild-freebsd-arm64@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.16.tgz#dd28a55df0f062e2c1628266008434c32ddc7adf"
-  integrity sha512-8xyiYuGc0DLZphFQIiYaLHlfoP+hAN9RHbE+Ibh8EUcDNHAqbQgUrQg7pE7Bo00rXmQ5Ap6KFgcR0b4ALZls1g==
-
-esbuild-linux-32@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.15.16.tgz#41eb0b9b49b3430b9cc4577f1ad3d414ef70f806"
-  integrity sha512-iGijUTV+0kIMyUVoynK0v+32Oi8yyp0xwMzX69GX+5+AniNy/C/AL1MjFTsozRp/3xQPl7jVux/PLe2ds10/2w==
-
-esbuild-linux-64@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.15.16.tgz#b2fb0c7d49b7a579b2de26fbf4c7afb1835f2073"
-  integrity sha512-tuSOjXdLw7VzaUj89fIdAaQT7zFGbKBcz4YxbWrOiXkwscYgE7HtTxUavreBbnRkGxKwr9iT/gmeJWNm4djy/g==
-
-esbuild-linux-arm64@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.16.tgz#78fed3745b20251fc3bdc8db35ea0781e9b0e7c6"
-  integrity sha512-mPYksnfHnemNrvjrDhZyixL/AfbJN0Xn9S34ZOHYdh6/jJcNd8iTsv3JwJoEvTJqjMggjMhGUPJAdjnFBHoH8A==
-
-esbuild-linux-arm@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.15.16.tgz#6963f061a2b778aad7df2bfb6fa32d1904313f7f"
-  integrity sha512-XKcrxCEXDTOuoRj5l12tJnkvuxXBMKwEC5j0JISw3ziLf0j4zIwXbKbTmUrKFWbo6ZgvNpa7Y5dnbsjVvH39bQ==
-
-esbuild-linux-mips64le@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.16.tgz#e2aed3527e551f8182c6b0fc8a045726fd98ad87"
-  integrity sha512-kSJO2PXaxfm0pWY39+YX+QtpFqyyrcp0ZeI8QPTrcFVQoWEPiPVtOfTZeS3ZKedfH+Ga38c4DSzmKMQJocQv6A==
-
-esbuild-linux-ppc64le@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.16.tgz#fa3095b24950f63408f46f34b6d9a073ed88d53f"
-  integrity sha512-NimPikwkBY0yGABw6SlhKrtT35sU4O23xkhlrTT/O6lSxv3Pm5iSc6OYaqVAHWkLdVf31bF4UDVFO+D990WpAA==
-
-esbuild-linux-riscv64@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.16.tgz#19c012dcc55c9d6d2a3855aa77c2c5217182cd1e"
-  integrity sha512-ty2YUHZlwFOwp7pR+J87M4CVrXJIf5ZZtU/umpxgVJBXvWjhziSLEQxvl30SYfUPq0nzeWKBGw5i/DieiHeKfw==
-
-esbuild-linux-s390x@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.16.tgz#aa61f64740e5b983cc3ebb4183a03df4b435a873"
-  integrity sha512-VkZaGssvPDQtx4fvVdZ9czezmyWyzpQhEbSNsHZZN0BHvxRLOYAQ7sjay8nMQwYswP6O2KlZluRMNPYefFRs+w==
-
-esbuild-netbsd-64@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.16.tgz#dffdc104c1f2bafc42be3faa21376c0a092f5702"
-  integrity sha512-ElQ9rhdY51et6MJTWrCPbqOd/YuPowD7Cxx3ee8wlmXQQVW7UvQI6nSprJ9uVFQISqSF5e5EWpwWqXZsECLvXg==
-
-esbuild-openbsd-64@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.16.tgz#e5987f8eda55ea5f6ef6258afb1a838158f890bb"
-  integrity sha512-KgxMHyxMCT+NdLQE1zVJEsLSt2QQBAvJfmUGDmgEq8Fvjrf6vSKB00dVHUEDKcJwMID6CdgCpvYNt999tIYhqA==
-
 esbuild-plugin-lodash@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/esbuild-plugin-lodash/-/esbuild-plugin-lodash-1.2.0.tgz#6395b64cbb9b23a1bee3e37fbbdd98c50bd0b53a"
   integrity sha512-8CyR67Z/VMvcJ4ABYYSaR2hhioeuoFVII1IsyPb6AwAKN57VQW8jFXyY27OwH4FGU3h3OVwwQ/GVNbo+RgpTGA==
 
-esbuild-sunos-64@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.15.16.tgz#60a085aa4b74d900e4de8c00a9fce207937320a2"
-  integrity sha512-exSAx8Phj7QylXHlMfIyEfNrmqnLxFqLxdQF6MBHPdHAjT7fsKaX6XIJn+aQEFiOcE4X8e7VvdMCJ+WDZxjSRQ==
-
-esbuild-windows-32@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.15.16.tgz#24f94e5fb243d211c7db9a12985fd2880ba98ca3"
-  integrity sha512-zQgWpY5pUCSTOwqKQ6/vOCJfRssTvxFuEkpB4f2VUGPBpdddZfdj8hbZuFRdZRPIVHvN7juGcpgCA/XCF37mAQ==
-
-esbuild-windows-64@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.15.16.tgz#71d24d68d8b652bf5a93a6c7453c334584fa2211"
-  integrity sha512-HjW1hHRLSncnM3MBCP7iquatHVJq9l0S2xxsHHj4yzf4nm9TU4Z7k4NkeMlD/dHQ4jPlQQhwcMvwbJiOefSuZw==
-
-esbuild-windows-arm64@0.15.16:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.16.tgz#77e804d60dec0390fe8f21401e39b435d5d1b863"
-  integrity sha512-oCcUKrJaMn04Vxy9Ekd8x23O8LoU01+4NOkQ2iBToKgnGj5eo1vU9i27NQZ9qC8NFZgnQQZg5oZWAejmbsppNA==
-
-esbuild@^0.15.0:
-  version "0.15.16"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.15.16.tgz#59324e5667985bf6aee8a91ea576baef6872cf21"
-  integrity sha512-o6iS9zxdHrrojjlj6pNGC2NAg86ECZqIETswTM5KmJitq+R1YmahhWtMumeQp9lHqJaROGnsBi2RLawGnfo5ZQ==
+esbuild@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.17.0.tgz#fcf19373d1d546bdbec1557276284c0e6350380b"
+  integrity sha512-4yGk3rD95iS/wGzrx0Ji5czZcx1j2wvfF1iAJaX2FIYLB6sU6wYkDeplpZHzfwQw2yXGXsAoxmO6LnMQkl04Kg==
   optionalDependencies:
-    "@esbuild/android-arm" "0.15.16"
-    "@esbuild/linux-loong64" "0.15.16"
-    esbuild-android-64 "0.15.16"
-    esbuild-android-arm64 "0.15.16"
-    esbuild-darwin-64 "0.15.16"
-    esbuild-darwin-arm64 "0.15.16"
-    esbuild-freebsd-64 "0.15.16"
-    esbuild-freebsd-arm64 "0.15.16"
-    esbuild-linux-32 "0.15.16"
-    esbuild-linux-64 "0.15.16"
-    esbuild-linux-arm "0.15.16"
-    esbuild-linux-arm64 "0.15.16"
-    esbuild-linux-mips64le "0.15.16"
-    esbuild-linux-ppc64le "0.15.16"
-    esbuild-linux-riscv64 "0.15.16"
-    esbuild-linux-s390x "0.15.16"
-    esbuild-netbsd-64 "0.15.16"
-    esbuild-openbsd-64 "0.15.16"
-    esbuild-sunos-64 "0.15.16"
-    esbuild-windows-32 "0.15.16"
-    esbuild-windows-64 "0.15.16"
-    esbuild-windows-arm64 "0.15.16"
+    "@esbuild/android-arm" "0.17.0"
+    "@esbuild/android-arm64" "0.17.0"
+    "@esbuild/android-x64" "0.17.0"
+    "@esbuild/darwin-arm64" "0.17.0"
+    "@esbuild/darwin-x64" "0.17.0"
+    "@esbuild/freebsd-arm64" "0.17.0"
+    "@esbuild/freebsd-x64" "0.17.0"
+    "@esbuild/linux-arm" "0.17.0"
+    "@esbuild/linux-arm64" "0.17.0"
+    "@esbuild/linux-ia32" "0.17.0"
+    "@esbuild/linux-loong64" "0.17.0"
+    "@esbuild/linux-mips64el" "0.17.0"
+    "@esbuild/linux-ppc64" "0.17.0"
+    "@esbuild/linux-riscv64" "0.17.0"
+    "@esbuild/linux-s390x" "0.17.0"
+    "@esbuild/linux-x64" "0.17.0"
+    "@esbuild/netbsd-x64" "0.17.0"
+    "@esbuild/openbsd-x64" "0.17.0"
+    "@esbuild/sunos-x64" "0.17.0"
+    "@esbuild/win32-arm64" "0.17.0"
+    "@esbuild/win32-ia32" "0.17.0"
+    "@esbuild/win32-x64" "0.17.0"
 
 escalade@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
### Description

Bumps esbuild to latest 0.17.0

### Test plan

```
cd packages/test-app
yarn build --dependencies

yarn bundle+esbuild --platform ios --dev false
cp dist/main+esbuild.ios.jsbundle dist/main.ios.jsbundle

pod install --project-directory=ios
yarn ios
```

Note: Don't start the dev server.