### PR TITLE
fix(metro-resolver-symlinks): also load `require` if `default` and `node` are missing

### DIFF
--- a/.changeset/brown-cats-chew.md
+++ b/.changeset/brown-cats-chew.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Handle packages that are missing the `default` exports conditional

--- a/packages/metro-resolver-symlinks/src/utils/enhancedResolve.ts
+++ b/packages/metro-resolver-symlinks/src/utils/enhancedResolve.ts
@@ -18,6 +18,10 @@ const getEnhancedResolver = (() => {
       const extensions = sourceExts.map((ext) => `.${ext}`);
       resolvers[platform] = require("enhanced-resolve").create.sync({
         aliasFields: ["browser"],
+        // Add `require` to handle packages that are missing `default`
+        // conditional. See
+        // https://github.com/webpack/enhanced-resolve/issues/313
+        conditionNames: ["require", "node"],
         extensions:
           platform === "common"
             ? extensions


### PR DESCRIPTION
### Description

Handle packages that are missing the `default` exports conditional

### Test plan

Tested internally.