### PR TITLE
fix(react-native-test-app-msal): bump dependencies

### DIFF
--- a/.changeset/brave-bikes-compare.md
+++ b/.changeset/brave-bikes-compare.md
@@ -1,0 +1,9 @@
+---
+"@rnx-kit/react-native-test-app-msal": patch
+---
+
+Bump dependencies:
+
+- `androidx.activity:activity-ktx` 1.5.1 -> 1.6.1
+- `com.google.android.material:material` 1.6.1 -> 1.7.0
+- `com.microsoft.identity.client:msal` 4.0.4 -> 4.1.3

--- a/packages/react-native-test-app-msal/android/build.gradle
+++ b/packages/react-native-test-app-msal/android/build.gradle
@@ -161,9 +161,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 
-    implementation "androidx.activity:activity-ktx:1.5.1"
-    implementation "com.google.android.material:material:1.6.1"
-    implementation "com.microsoft.identity.client:msal:4.0.4"
+    implementation "androidx.activity:activity-ktx:1.6.1"
+    implementation "com.google.android.material:material:1.7.0"
+    implementation "com.microsoft.identity.client:msal:4.1.3"
 
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"


### PR DESCRIPTION
### Description

- `androidx.activity:activity-ktx` 1.5.1 -> 1.6.1
- `com.google.android.material:material` 1.6.1 -> 1.7.0
- `com.microsoft.identity.client:msal` 4.0.4 -> 4.1.3

### Test plan

n/a