### PR TITLE
Add metro plugin support for @rnx-kit/third-party-notices

### DIFF
--- a/.changeset/clever-dancers-itch.md
+++ b/.changeset/clever-dancers-itch.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/third-party-notices": minor
+---
+
+Add metro plugin support for @rnx-kit/third-party-notices

--- a/.changeset/clever-dancers-itch.md
+++ b/.changeset/clever-dancers-itch.md
@@ -2,4 +2,4 @@
 "@rnx-kit/third-party-notices": minor
 ---
 
-Add metro plugin support for @rnx-kit/third-party-notices
+Add Metro plugin support

--- a/packages/third-party-notices/README.md
+++ b/packages/third-party-notices/README.md
@@ -61,3 +61,22 @@ writeThirdPartyNotices({
   sourceMapFile: "./dist/myPackage.js.map",
 });
 ```
+### As a plugin
+Import and add the plugin to `ThirdPartyNotices` in your `metro.config.js`, and
+optionally configure it to your liking:
+
+```diff
+ const { makeMetroConfig } = require("@rnx-kit/metro-config");
++const { ThirdPartyNotices } = require("@rnx-kit/third-party-notices");
++const { MetroSerializer } = require("@rnx-kit/metro-serializer");
+
+ module.exports = makeMetroConfig({
+   serializer: {
++    customSerializer: MetroSerializer([
++      ThirdPartyNotices({
++        rootPath: ".",
++        sourceMapFile: "./dist/myPackage.js.map",
++      }),
++    ]),
+   },
+ });

--- a/packages/third-party-notices/README.md
+++ b/packages/third-party-notices/README.md
@@ -61,25 +61,3 @@ writeThirdPartyNotices({
   sourceMapFile: "./dist/myPackage.js.map",
 });
 ```
-
-### As a plugin
-
-Import and add the plugin to `ThirdPartyNotices` in your `metro.config.js`, and
-optionally configure it to your liking:
-
-```diff
- const { makeMetroConfig } = require("@rnx-kit/metro-config");
-+const { ThirdPartyNotices } = require("@rnx-kit/third-party-notices");
-+const { MetroSerializer } = require("@rnx-kit/metro-serializer");
-
- module.exports = makeMetroConfig({
-   serializer: {
-+    customSerializer: MetroSerializer([
-+      ThirdPartyNotices({
-+        rootPath: ".",
-+        sourceMapFile: "./dist/myPackage.js.map",
-+      }),
-+    ]),
-   },
- });
-```

--- a/packages/third-party-notices/README.md
+++ b/packages/third-party-notices/README.md
@@ -61,7 +61,9 @@ writeThirdPartyNotices({
   sourceMapFile: "./dist/myPackage.js.map",
 });
 ```
+
 ### As a plugin
+
 Import and add the plugin to `ThirdPartyNotices` in your `metro.config.js`, and
 optionally configure it to your liking:
 
@@ -80,3 +82,4 @@ optionally configure it to your liking:
 +    ]),
    },
  });
+```

--- a/packages/third-party-notices/README.md
+++ b/packages/third-party-notices/README.md
@@ -61,3 +61,22 @@ writeThirdPartyNotices({
   sourceMapFile: "./dist/myPackage.js.map",
 });
 ```
+
+### As a plugin
+
+Import and add the plugin to `ThirdPartyNotices` in your `metro.config.js`, and
+optionally configure it to your liking:
+
+```diff
+ const { makeMetroConfig } = require("@rnx-kit/metro-config");
++const { ThirdPartyNotices } = require("@rnx-kit/third-party-notices");
++const { MetroSerializer } = require("@rnx-kit/metro-serializer");
+
+ module.exports = makeMetroConfig({
+   serializer: {
++    customSerializer: MetroSerializer([
++      ThirdPartyNotices(),
++    ]),
+   },
+ });
+```

--- a/packages/third-party-notices/package.json
+++ b/packages/third-party-notices/package.json
@@ -32,9 +32,15 @@
   },
   "devDependencies": {
     "@rnx-kit/eslint-config": "*",
+    "@rnx-kit/metro-serializer": "*",
     "@rnx-kit/scripts": "*",
     "@types/jest": "^27.0.0",
     "@types/yargs": "^16.0.0"
+  },
+  "depcheck": {
+    "ignoreMatches": [
+      "metro"
+    ]
   },
   "eslintConfig": {
     "extends": "@rnx-kit/eslint-config"

--- a/packages/third-party-notices/package.json
+++ b/packages/third-party-notices/package.json
@@ -39,7 +39,8 @@
   },
   "depcheck": {
     "ignoreMatches": [
-      "metro"
+      "metro",
+      "metro-source-map"
     ]
   },
   "eslintConfig": {

--- a/packages/third-party-notices/package.json
+++ b/packages/third-party-notices/package.json
@@ -35,6 +35,8 @@
     "@rnx-kit/metro-serializer": "*",
     "@rnx-kit/scripts": "*",
     "@types/jest": "^27.0.0",
+    "@types/metro": "^0.66.0",
+    "@types/metro-source-map": "^0.66.0",
     "@types/yargs": "^16.0.0"
   },
   "depcheck": {

--- a/packages/third-party-notices/src/index.ts
+++ b/packages/third-party-notices/src/index.ts
@@ -21,6 +21,14 @@ export function ThirdPartyNotices(
       return;
     }
 
+    if (!options) {
+      options = {
+        rootPath: serializerOptions.projectRoot,
+        sourceMapFile: serializerOptions.sourceMapUrl || "",
+        json: false,
+      };
+    }
+
     const sources = Array.from(graph.dependencies.keys());
     const moduleNameToPath = gatherModulesFromSources(sources, options);
     writeThirdPartyNoticesFromMap(options, moduleNameToPath);

--- a/packages/third-party-notices/src/index.ts
+++ b/packages/third-party-notices/src/index.ts
@@ -1,7 +1,10 @@
 import { Graph, Module, SerializerOptions } from "metro";
 import { WriteThirdPartyNoticesOptions } from "./types";
 import type { MetroPlugin } from "@rnx-kit/metro-serializer";
-import { writeThirdPartyNotices } from "./write-third-party-notices";
+import {
+  gatherModulesFromSources,
+  writeThirdPartyNoticesFromMap,
+} from "./write-third-party-notices";
 
 export { writeThirdPartyNotices } from "./write-third-party-notices";
 export function ThirdPartyNotices(
@@ -10,10 +13,16 @@ export function ThirdPartyNotices(
   return (
     _entryPoint: string,
     _preModules: ReadonlyArray<Module>,
-    _graph: Graph,
-    _options: SerializerOptions
+    graph: Graph,
+    serializerOptions: SerializerOptions
   ) => {
-    writeThirdPartyNotices(options);
+    if (!serializerOptions.dev) {
+      return;
+    }
+
+    const sources = Array.from(graph.dependencies.keys());
+    const moduleNameToPath = gatherModulesFromSources(sources, options);
+    writeThirdPartyNoticesFromMap(options, moduleNameToPath);
   };
 }
 

--- a/packages/third-party-notices/src/index.ts
+++ b/packages/third-party-notices/src/index.ts
@@ -21,13 +21,12 @@ export function ThirdPartyNotices(
       return;
     }
 
-    if (!options) {
-      options = {
-        rootPath: serializerOptions.projectRoot,
-        sourceMapFile: serializerOptions.sourceMapUrl || "",
-        json: false,
-      };
-    }
+    options = {
+      rootPath: serializerOptions.projectRoot,
+      sourceMapFile: serializerOptions.sourceMapUrl || "",
+      json: false,
+      ...(options as object),
+    };
 
     const sources = Array.from(graph.dependencies.keys());
     const moduleNameToPath = gatherModulesFromSources(sources, options);

--- a/packages/third-party-notices/src/index.ts
+++ b/packages/third-party-notices/src/index.ts
@@ -9,7 +9,7 @@ import {
 export { writeThirdPartyNotices } from "./write-third-party-notices";
 
 export function ThirdPartyNotices(
-  options: WriteThirdPartyNoticesOptions
+  inputOptions: Partial<WriteThirdPartyNoticesOptions>
 ): MetroPlugin {
   return (
     _entryPoint: string,
@@ -21,11 +21,11 @@ export function ThirdPartyNotices(
       return;
     }
 
-    options = {
+    const options = {
       rootPath: serializerOptions.projectRoot,
       sourceMapFile: serializerOptions.sourceMapUrl || "",
       json: false,
-      ...(options as object),
+      ...inputOptions,
     };
 
     const sources = Array.from(graph.dependencies.keys());

--- a/packages/third-party-notices/src/index.ts
+++ b/packages/third-party-notices/src/index.ts
@@ -1,5 +1,5 @@
-import { Graph, Module, SerializerOptions } from "metro";
-import { WriteThirdPartyNoticesOptions } from "./types";
+import type { Graph, Module, SerializerOptions } from "metro";
+import type { WriteThirdPartyNoticesOptions } from "./types";
 import type { MetroPlugin } from "@rnx-kit/metro-serializer";
 import {
   gatherModulesFromSources,

--- a/packages/third-party-notices/src/index.ts
+++ b/packages/third-party-notices/src/index.ts
@@ -1,5 +1,22 @@
-export type {
-  WriteThirdPartyNoticesOptions as IWriteThirdPartyNoticesOptions,
-  WriteThirdPartyNoticesOptions,
-} from "./types";
+import { Graph, Module, SerializerOptions } from "metro";
+import { WriteThirdPartyNoticesOptions } from "./types";
+import type { MetroPlugin } from "@rnx-kit/metro-serializer";
+import { writeThirdPartyNotices } from "./write-third-party-notices";
+
 export { writeThirdPartyNotices } from "./write-third-party-notices";
+export function ThirdPartyNotices(
+  options: WriteThirdPartyNoticesOptions
+): MetroPlugin {
+  return (
+    _entryPoint: string,
+    _preModules: ReadonlyArray<Module>,
+    _graph: Graph,
+    _options: SerializerOptions
+  ) => {
+    writeThirdPartyNotices(options);
+  };
+}
+
+ThirdPartyNotices.type = "serializer";
+
+export default ThirdPartyNotices;

--- a/packages/third-party-notices/src/index.ts
+++ b/packages/third-party-notices/src/index.ts
@@ -7,6 +7,7 @@ import {
 } from "./write-third-party-notices";
 
 export { writeThirdPartyNotices } from "./write-third-party-notices";
+
 export function ThirdPartyNotices(
   options: WriteThirdPartyNoticesOptions
 ): MetroPlugin {

--- a/packages/third-party-notices/src/index.ts
+++ b/packages/third-party-notices/src/index.ts
@@ -17,7 +17,7 @@ export function ThirdPartyNotices(
     graph: Graph,
     serializerOptions: SerializerOptions
   ) => {
-    if (!serializerOptions.dev) {
+    if (serializerOptions.dev) {
       return;
     }
 

--- a/packages/third-party-notices/src/write-third-party-notices.ts
+++ b/packages/third-party-notices/src/write-third-party-notices.ts
@@ -67,12 +67,12 @@ export async function writeThirdPartyNotices(
 
 export async function writeThirdPartyNoticesFromMap(
   options: WriteThirdPartyNoticesOptions,
-  moduleNameToPath: Map<string, string>
+  moduleNameToPathMap: Map<string, string>
 ): Promise<void> {
   const { additionalText, json, preambleText, sourceMapFile } = options;
   let { outputFile } = options;
 
-  const licenses = await extractLicenses(moduleNameToPath);
+  const licenses = await extractLicenses(moduleNameToPathMap);
   const outputText = json
     ? createLicenseJSON(licenses)
     : createLicenseFileContents(licenses, preambleText, additionalText);

--- a/packages/third-party-notices/src/write-third-party-notices.ts
+++ b/packages/third-party-notices/src/write-third-party-notices.ts
@@ -82,8 +82,7 @@ export async function writeThirdPartyNoticesFromMap(
     outputFile = prefix + ".LICENSE.txt";
   }
 
-  const writeFileAsync = promisify(fs.writeFile);
-  await writeFileAsync(outputFile, outputText, "utf8");
+  fs.writeFileSync(outputFile, outputText);
 }
 
 export async function getCurrentPackageId(

--- a/packages/third-party-notices/src/write-third-party-notices.ts
+++ b/packages/third-party-notices/src/write-third-party-notices.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import { findPackage, readPackage } from "@rnx-kit/tools-node/package";
 import { resolve } from "path";
 import { promisify } from "util";
+import type { BasicSourceMap } from "metro-source-map";
 import { createLicenseJSON } from "./output/json";
 import { createLicenseFileContents } from "./output/text";
 import type {
@@ -62,6 +63,27 @@ export async function writeThirdPartyNotices(
   } else {
     console.log(outputText);
   }
+}
+
+export async function writeThirdPartyNoticesFromMap(
+  options: WriteThirdPartyNoticesOptions,
+  moduleNameToPath: Map<string, string>
+): Promise<void> {
+  const { additionalText, json, preambleText, sourceMapFile } = options;
+  let { outputFile } = options;
+
+  const licenses = await extractLicenses(moduleNameToPath);
+  const outputText = json
+    ? createLicenseJSON(licenses)
+    : createLicenseFileContents(licenses, preambleText, additionalText);
+
+  if (!outputFile) {
+    const prefix = sourceMapFile?.replace(/\.map$/, "") ?? "main";
+    outputFile = prefix + ".LICENSE.txt";
+  }
+
+  const writeFileAsync = promisify(fs.writeFile);
+  await writeFileAsync(outputFile, outputText, "utf8");
 }
 
 export async function getCurrentPackageId(
@@ -222,4 +244,19 @@ export async function extractLicenses(
       lhs < rhs ? -1 : lhs > rhs ? 1 : 0
     )
   );
+}
+
+export function gatherModulesFromSources(
+  sources: BasicSourceMap["sources"],
+  options: WriteThirdPartyNoticesOptions
+): Map<string, string> {
+  const moduleNameToPath = new Map<string, string>();
+
+  sources.forEach((source) => {
+    if (source.includes("node_modules/")) {
+      parseModule(options, moduleNameToPath, source);
+    }
+  });
+
+  return moduleNameToPath;
 }


### PR DESCRIPTION
### Description

Adding metro plugin support for @rnx-kit/third-party-notices as it makes integration simpler and more streamlined.
### Test plan

Build and install pods:
```
cd packages/test-app
yarn build --dependencies
pod install --project-directory=ios
```

Ran `yarn bundle` with these changes:
```diff
diff --git a/packages/test-app/package.json b/packages/test-app/package.json
index c651e9ae..3c25f2df 100644
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -38,6 +38,7 @@
     "@rnx-kit/cli": "*",
     "@rnx-kit/metro-config": "*",
     "@rnx-kit/metro-plugin-cyclic-dependencies-detector": "*",
+    "@rnx-kit/third-party-notices": "*",
     "@rnx-kit/metro-plugin-duplicates-checker": "*",
     "@rnx-kit/metro-resolver-symlinks": "*",
     "@rnx-kit/metro-serializer": "*",
@@ -89,7 +90,14 @@
               ]
             }
           ],
-          "@rnx-kit/metro-plugin-typescript"
+          "@rnx-kit/metro-plugin-typescript",
+          [
+            "@rnx-kit/third-party-notices",
+            {
+              "rootPath": ".",
+              "sourceMapFile": "./dist/main.android.bundle.map"
+            }
+          ]
         ],
         "targets": [
           "android",
```

Example *.LICENSE.txt file generated:
[*.LICENSE.txt](https://github.com/microsoft/rnx-kit/files/10455109/main.android.bundle.LICENSE.txt)