### PR TITLE
fix(third-party-notices): normalize module path to resolve errors on Windows

### DIFF
--- a/.changeset/quick-readers-juggle.md
+++ b/.changeset/quick-readers-juggle.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/third-party-notices": patch
+---
+
+Normalize module path to resolve errors on Windows

--- a/packages/third-party-notices/src/write-third-party-notices.ts
+++ b/packages/third-party-notices/src/write-third-party-notices.ts
@@ -252,7 +252,8 @@ export function gatherModulesFromSources(
   const moduleNameToPath = new Map<string, string>();
 
   sources.forEach((source) => {
-    if (source.includes("node_modules/")) {
+    if (source.includes("node_modules")) {
+      source = normalizePath(source);
       parseModule(options, moduleNameToPath, source);
     }
   });


### PR DESCRIPTION
### Description
On Windows the license file generated by `third-party-notices` is empty because we only parse modules with a path that includes `node_modules/`, however Windows uses the backslash (\) for the file system delimiter. Additionally, the module path isn't normalized which causes an error when running `third-party-notices` as a Metro plugin.

Error message:

```
❯ yarn bundle
yarn run v1.22.19
$ react-native rnx-bundle
info Bundling android...
Welcome to Metro!
Fast - Scalable - Integrated

info Writing bundle output to:, dist/main.android.bundle
info Writing sourcemap output to:, dist/main.android.bundle.map
C:\Users\abdul\dev\rnx-kit\node_modules\metro-hermes-compiler\src\emhermesc.js:77
throw ex;
^

RuntimeError: abort(Error: ENOENT: no such file or directory, open 'C:\Users\abdul\dev\rnx-kit\node_modules\@babel\runtime\helpers\arrayLikeToArray.js\package.json'). Build with -s ASSERTIONS=1 for more info.
at process.abort (C:\Users\abdul\dev\rnx-kit\node_modules\metro-hermes-compiler\src\emhermesc.js:402:15)
at process.emit (node:events:525:35)
at process.emit (C:\Users\abdul\dev\rnx-kit\node_modules\source-map-support\source-map-support.js:516:21)
at emit (node:internal/process/promises:149:20)
at processPromiseRejections (node:internal/process/promises:283:27)
at processTicksAndRejections (node:internal/process/task_queues:96:32)
```


### Test plan

Executing `yarn bundle` in test-app with `third-party-notices` as a Metro plugin on Windows, and ensuring that the `*.LICENSE.txt` file is generated and the error doesn't occur anymore. 