### PR TITLE
fix(deps): include peers for yarn

### DIFF
--- a/.changeset/nasty-fireants-heal.md
+++ b/.changeset/nasty-fireants-heal.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/babel-preset-metro-react-native": patch
+"@rnx-kit/metro-config": patch
+---
+
+fix(deps): include peer dependencies for yarn

--- a/.changeset/nasty-fireants-heal.md
+++ b/.changeset/nasty-fireants-heal.md
@@ -3,4 +3,4 @@
 "@rnx-kit/metro-config": patch
 ---
 
-fix(deps): include peer dependencies for yarn
+Include missing peer dependencies detected by Yarn 3.0.

--- a/packages/babel-preset-metro-react-native/package.json
+++ b/packages/babel-preset-metro-react-native/package.json
@@ -23,6 +23,7 @@
     "babel-plugin-const-enum": "^1.0.0"
   },
   "peerDependencies": {
+    "@babel/core": "^7.0.0",
     "@babel/plugin-transform-typescript": "^7.0.0",
     "metro-react-native-babel-preset": "*"
   },

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -27,6 +27,7 @@
   },
   "peerDependencies": {
     "metro-config": ">=0.58.0",
+    "metro-react-native-babel-preset": "*",
     "react": "*",
     "react-native": "*"
   },


### PR DESCRIPTION
This removes the peer warnings produced when installing with yarn.

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/85772/213726211-63d5414a-0e88-4a2d-ba43-93ba62d3213b.png">

```
➤ YN0002: │ @rnx-kit/babel-preset-metro-react-native@npm:1.1.3 [9cab9] doesn't provide @babel/core (p7af16), requested by babel-plugin-const-enum
➤ YN0002: │ @rnx-kit/metro-config@npm:1.3.3 [ee509] doesn't provide metro-react-native-babel-preset (pb0d92), requested by @rnx-kit/babel-preset-metro-react-native
```