### PR TITLE
fix(metro-plugin-typescript): lower Node version requirement

### DIFF
--- a/.changeset/sixty-pandas-bathe.md
+++ b/.changeset/sixty-pandas-bathe.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-plugin-typescript": patch
+---
+
+Lower Node version requirement to support any 14 LTS

--- a/packages/metro-plugin-typescript/package.json
+++ b/packages/metro-plugin-typescript/package.json
@@ -19,7 +19,7 @@
     "directory": "packages/metro-plugin-typescript"
   },
   "engines": {
-    "node": ">=14.18"
+    "node": ">=14.15"
   },
   "scripts": {
     "build": "rnx-kit-scripts build",


### PR DESCRIPTION
### Description

There's no reason why we need to be on 14.18+. The first 14 LTS should also work.

### Test plan

n/a