### PR TITLE
fix(cli): resolve `cli-server-api` starting from `react-native`

### DIFF
--- a/.changeset/eight-poets-eat.md
+++ b/.changeset/eight-poets-eat.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Resolve `@react-native-community/cli-server-api` starting from `react-native` to avoid relying hoisting

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,14 +40,22 @@
     "readline": "^1.3.0"
   },
   "peerDependencies": {
+    "@react-native-community/cli": ">=5.0.1",
     "@react-native-community/cli-server-api": ">=5.0.1",
-    "jest-cli": "^26.0 || ^27.0"
+    "jest-cli": "^26.0 || ^27.0",
+    "react-native": ">=0.64"
   },
   "peerDependenciesMeta": {
+    "@react-native-community/cli": {
+      "optional": true
+    },
     "@react-native-community/cli-server-api": {
       "optional": true
     },
     "jest-cli": {
+      "optional": true
+    },
+    "react-native": {
       "optional": true
     }
   },

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -47,10 +47,14 @@ export type CLIStartOptions = {
   interactive: boolean;
 };
 
-function friendlyRequire<T>(module: string): T {
+function friendlyRequire<T>(...modules: string[]): T {
   try {
-    return require(module) as T;
+    const modulePath = modules.reduce((startDir, module) => {
+      return require.resolve(module, { paths: [startDir] });
+    }, process.cwd());
+    return require(modulePath) as T;
   } catch (_) {
+    const module = modules[modules.length - 1];
     throw new Error(
       `Cannot find module '${module}'. This probably means that '@rnx-kit/cli' is not compatible with the version of '@react-native-community/cli' that you are currently using. Please update to the latest version and try again. If the issue still persists after the update, please file a bug at https://github.com/microsoft/rnx-kit/issues.`
     );
@@ -72,7 +76,11 @@ export async function rnxStart(
 
   const { createDevServerMiddleware, indexPageMiddleware } = friendlyRequire<
     typeof CliServerApi
-  >("@react-native-community/cli-server-api");
+  >(
+    "react-native",
+    "@react-native-community/cli",
+    "@react-native-community/cli-server-api"
+  );
 
   // interactive mode requires raw access to stdin
   let interactive = cliOptions.interactive;


### PR DESCRIPTION
### Description

Resolve `@react-native-community/cli-server-api` starting from `react-native` to avoid relying hoisting.

### Test plan

Tested internally.