### PR TITLE
fix(metro-config): skip populating `watchFolders` if provided by user config

### DIFF
--- a/.changeset/metal-oranges-greet.md
+++ b/.changeset/metal-oranges-greet.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Skip populating `watchFolders` if provided by user config

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -229,7 +229,7 @@ module.exports = {
             },
           }),
         },
-        watchFolders: defaultWatchFolders(),
+        watchFolders: customConfig.watchFolders ?? defaultWatchFolders(),
       },
       {
         ...customConfig,


### PR DESCRIPTION
### Description

Skip populating `watchFolders` if provided by user config.

Resolves #2143.

### Test plan

Load the config and verify that `watchFolders` is populated:

```sh
node -e "console.log(require('./metro.config.js'))"
```

Set `watchFolders` to an empty array:

```diff
diff --git a/packages/test-app/metro.config.js b/packages/test-app/metro.config.js
index 0a8bd04a..247e9075 100644
--- a/packages/test-app/metro.config.js
+++ b/packages/test-app/metro.config.js
@@ -31,4 +31,5 @@ module.exports = makeMetroConfig({
     blacklistRE: blockList,
     blockList,
   },
+  watchFolders: [],
 });
```

Load the config and verify that `watchFolders` is empty:

```sh
node -e "console.log(require('./metro.config.js'))"
```