### PR TITLE
fix(align-deps): validate input package paths

### DIFF
--- a/.changeset/nine-moose-admire.md
+++ b/.changeset/nine-moose-admire.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": patch
+---
+
+Validate input package paths


### PR DESCRIPTION
### Description

`align-deps` should validate paths input by users.

### Test plan

```
cd packages/align-deps
yarn build --dependencies
node lib/cli.js .                           # Should succeed
node lib/cli.js ./package.json              # Should succeed
node lib/cli.js ./src                       # Should succeed
node lib/cli.js ./this/path/does/not/exist  # Should fail
```