### PR TITLE
fix(metro-serializer-esbuild): don't add namespace to all source files

### DIFF
--- a/.changeset/fresh-pillows-matter.md
+++ b/.changeset/fresh-pillows-matter.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Don't add namespace to all source files. esbuild currently adds it to all file paths in the source map (see https://github.com/evanw/esbuild/issues/2283). This prevents tools from resolving files correctly.

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /incubator/*/bin/
 /incubator/*/dist/
 /incubator/*/lib/
+/packages/*/*.LICENSE.txt
 /packages/*/*/rnx-build/
 /packages/*/bin/
 /packages/*/dist/

--- a/packages/metro-serializer-esbuild/src/sourceMap.ts
+++ b/packages/metro-serializer-esbuild/src/sourceMap.ts
@@ -18,7 +18,7 @@ export function absolutizeSourceMap(outputPath: string, text: string): string {
   const sourceRoot = path.dirname(outputPath);
   const sourcemap = JSON.parse(text);
   const sources = sourcemap.sources.map((file: string) =>
-    path.resolve(sourceRoot, file)
+    file.startsWith("virtual:") ? file : path.resolve(sourceRoot, file)
   );
 
   return JSON.stringify({ ...sourcemap, sources });

--- a/packages/metro-serializer-esbuild/test/index.test.ts
+++ b/packages/metro-serializer-esbuild/test/index.test.ts
@@ -41,20 +41,7 @@ describe("metro-serializer-esbuild", () => {
       {
         ...require("metro/src/shared/output/bundle"),
         save: ({ code }) => {
-          result = code
-            .split("\n")
-            .map((line: string) => {
-              if (line.includes("virtual:metro:")) {
-                return line
-                  .replace(
-                    /virtual:metro:.*?[/\\](metro-serializer-esbuild|node_modules)[/\\]/g,
-                    "virtual:metro:/~/$1/"
-                  )
-                  .replace(/\\/g, "/");
-              }
-              return line;
-            })
-            .join("\n");
+          result = code;
         },
       }
     );
@@ -77,12 +64,12 @@ describe("metro-serializer-esbuild", () => {
         // virtual:metro:__rnx_prelude__
         var global = new Function(\\"return this;\\")();
 
-        // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts
+        // test/__fixtures__/base.ts
         function app() {
           \\"this should _not_ be removed\\";
         }
 
-        // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/direct.ts
+        // test/__fixtures__/direct.ts
         app();
       })();
       "
@@ -97,12 +84,12 @@ describe("metro-serializer-esbuild", () => {
         // virtual:metro:__rnx_prelude__
         var global = new Function(\\"return this;\\")();
 
-        // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts
+        // test/__fixtures__/base.ts
         function app() {
           \\"this should _not_ be removed\\";
         }
 
-        // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/exportAll.ts
+        // test/__fixtures__/exportAll.ts
         app();
       })();
       "
@@ -117,12 +104,12 @@ describe("metro-serializer-esbuild", () => {
         // virtual:metro:__rnx_prelude__
         var global = new Function(\\"return this;\\")();
 
-        // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts
+        // test/__fixtures__/base.ts
         function app() {
           \\"this should _not_ be removed\\";
         }
 
-        // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/nestedExportAll.ts
+        // test/__fixtures__/nestedExportAll.ts
         app();
       })();
       "
@@ -137,12 +124,12 @@ describe("metro-serializer-esbuild", () => {
         // virtual:metro:__rnx_prelude__
         var global = new Function(\\"return this;\\")();
 
-        // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts
+        // test/__fixtures__/base.ts
         function app() {
           \\"this should _not_ be removed\\";
         }
 
-        // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/importAll.ts
+        // test/__fixtures__/importAll.ts
         app();
       })();
       "
@@ -157,12 +144,12 @@ describe("metro-serializer-esbuild", () => {
         // virtual:metro:__rnx_prelude__
         var global = new Function(\\"return this;\\")();
 
-        // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts
+        // test/__fixtures__/base.ts
         function app() {
           \\"this should _not_ be removed\\";
         }
 
-        // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/importExportAll.ts
+        // test/__fixtures__/importExportAll.ts
         app();
       })();
       "
@@ -177,13 +164,13 @@ describe("metro-serializer-esbuild", () => {
         // virtual:metro:__rnx_prelude__
         var global = new Function(\\"return this;\\")();
 
-        // virtual:metro:/~/node_modules/lodash-es/head.js
+        // ../../node_modules/lodash-es/head.js
         function head(array) {
           return array && array.length ? array[0] : void 0;
         }
         var head_default = head;
 
-        // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/lodash-es.ts
+        // test/__fixtures__/lodash-es.ts
         console.log(head_default([]));
       })();
       "
@@ -208,16 +195,16 @@ describe("metro-serializer-esbuild", () => {
           }
         });
 
-        // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/sideEffectsArray.ts
+        // test/__fixtures__/sideEffectsArray.ts
         init_rnx_prelude();
 
-        // virtual:metro:/~/node_modules/@fluentui/utilities/lib/index.js
+        // ../../node_modules/@fluentui/utilities/lib/index.js
         init_rnx_prelude();
 
-        // virtual:metro:/~/node_modules/@fluentui/set-version/lib/index.js
+        // ../../node_modules/@fluentui/set-version/lib/index.js
         init_rnx_prelude();
 
-        // virtual:metro:/~/node_modules/@fluentui/set-version/lib/setVersion.js
+        // ../../node_modules/@fluentui/set-version/lib/setVersion.js
         init_rnx_prelude();
         var packagesCache = {};
         var _win = void 0;
@@ -236,10 +223,10 @@ describe("metro-serializer-esbuild", () => {
           }
         }
 
-        // virtual:metro:/~/node_modules/@fluentui/set-version/lib/index.js
+        // ../../node_modules/@fluentui/set-version/lib/index.js
         setVersion(\\"@fluentui/set-version\\", \\"6.0.0\\");
 
-        // virtual:metro:/~/node_modules/@fluentui/utilities/lib/warn/warn.js
+        // ../../node_modules/@fluentui/utilities/lib/warn/warn.js
         init_rnx_prelude();
         var _warningCallback = void 0;
         function warn(message) {
@@ -250,14 +237,14 @@ describe("metro-serializer-esbuild", () => {
           }
         }
 
-        // virtual:metro:/~/node_modules/@fluentui/utilities/lib/warn.js
+        // ../../node_modules/@fluentui/utilities/lib/warn.js
         init_rnx_prelude();
 
-        // virtual:metro:/~/node_modules/@fluentui/utilities/lib/version.js
+        // ../../node_modules/@fluentui/utilities/lib/version.js
         init_rnx_prelude();
         setVersion(\\"@fluentui/utilities\\", \\"8.12.0\\");
 
-        // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/sideEffectsArray.ts
+        // test/__fixtures__/sideEffectsArray.ts
         warn(\\"this should _not_ be removed\\");
       })();
       "
@@ -276,12 +263,12 @@ describe("metro-serializer-esbuild", () => {
         // virtual:metro:__rnx_prelude__
         var global = new Function(\\"return this;\\")();
 
-        // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/base.ts
+        // test/__fixtures__/base.ts
         function app() {
           \\"this should _not_ be removed\\";
         }
 
-        // virtual:metro:/~/metro-serializer-esbuild/test/__fixtures__/direct.ts
+        // test/__fixtures__/direct.ts
         app();
       })();
       //# sourceMappingURL=.test-output.jsbundle.map

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -46,6 +46,7 @@
     "@rnx-kit/react-native-auth": "*",
     "@rnx-kit/react-native-test-app-msal": "*",
     "@rnx-kit/scripts": "*",
+    "@rnx-kit/third-party-notices": "*",
     "@types/react": "^17.0.2",
     "@types/react-native": "^0.68.0",
     "jest-cli": "^27.5.1",
@@ -127,7 +128,8 @@
               ]
             }
           ],
-          "@rnx-kit/metro-plugin-typescript"
+          "@rnx-kit/metro-plugin-typescript",
+          "@rnx-kit/third-party-notices"
         ],
         "targets": [
           "android",


### PR DESCRIPTION
### Description

Don't add namespace to all source files. esbuild currently adds it to all file paths in the source map. This prevents tools from resolving files correctly.

### Test plan

```
cd packages/test-app
yarn build --dependencies
yarn bundle+esbuild --platform ios --dev false
node ../third-party-notices/lib/cli.js --rootPath . --sourceMapFile dist/main+esbuild.ios.jsbundle.map --outputFile LICENSE.txt
```

Verify that:
- `LICENSE.txt` is non-empty
- `dist/main+esbuild.ios.jsbundle.map` only contains a single instance of `virtual:metro`