### PR TITLE
fix(metro-resolver-symlinks): disable exports map

### DIFF
--- a/.changeset/sweet-eggs-explode.md
+++ b/.changeset/sweet-eggs-explode.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+When `experimental_retryResolvingFromDisk` is enabled, don't parse exports maps as they currently take precedence over the `react-native` field.

--- a/packages/metro-resolver-symlinks/src/utils/enhancedResolve.ts
+++ b/packages/metro-resolver-symlinks/src/utils/enhancedResolve.ts
@@ -22,6 +22,9 @@ const getEnhancedResolver = (() => {
         // conditional. See
         // https://github.com/webpack/enhanced-resolve/issues/313
         conditionNames: ["require", "node"],
+        // Disable exports map as it currently takes precedence over the
+        // `react-native` field. Revisit when Metro gets support for the field.
+        exportsFields: [],
         extensions:
           platform === "common"
             ? extensions


### PR DESCRIPTION
### Description

When `experimental_retryResolvingFromDisk` is enabled, don't parse exports maps as they currently take precedence over the `react-native` field.

In the scenario I was investigating, it's increasing the bundle size because CJS was picked over ESM.

### Test plan

Tested internally.