### PR TITLE
fix(bundle-diff): ignore inlined source map

### DIFF
--- a/.changeset/heavy-owls-sin.md
+++ b/.changeset/heavy-owls-sin.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/bundle-diff": patch
+---
+
+Ignore inlined source map

--- a/packages/bundle-diff/src/diff.ts
+++ b/packages/bundle-diff/src/diff.ts
@@ -13,7 +13,12 @@ export function makeMap({
 }: BasicSourceMap): Record<string, number> {
   return sources.reduce<Record<string, number>>((map, file, index) => {
     const content = sourcesContent[index];
-    map[file] = content?.length ?? NaN;
+    if (content) {
+      const actualLength = content.lastIndexOf("//# sourceMappingURL=");
+      map[file] = actualLength > 0 ? actualLength : content.length;
+    } else {
+      map[file] = NaN;
+    }
     return map;
   }, {});
 }


### PR DESCRIPTION
### Description

Inlined source map is bloating the file size.

### Test plan

Tested internally.