### PR TITLE
@rnx-kit/metro-plugin-typescript fails to typecheck on windows

### DIFF
--- a/.changeset/itchy-ghosts-collect.md
+++ b/.changeset/itchy-ghosts-collect.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-plugin-typescript": patch
+---
+
+Fix failure to typecheck when running on Windows

--- a/packages/metro-plugin-typescript/src/serializerHook.ts
+++ b/packages/metro-plugin-typescript/src/serializerHook.ts
@@ -3,6 +3,7 @@ import type { AllPlatforms } from "@rnx-kit/tools-react-native/platform";
 import type { Project } from "@rnx-kit/typescript-service";
 import { createProjectCache } from "./projectCache";
 import type { SerializerHook } from "./types";
+import { normalizePath } from "@rnx-kit/tools-node";
 
 /**
  * Create a hook function to be registered with Metro during serialization.
@@ -63,7 +64,7 @@ export function TypeScriptPlugin(
         if (projectInfo) {
           // This is a TypeScript project. Validate it.
           const { tsproject, tssourceFiles } = projectInfo;
-          if (tssourceFiles.has(sourceFile)) {
+          if (tssourceFiles.has(normalizePath(sourceFile))) {
             tsproject.setFile(sourceFile);
             tsprojectsToValidate.add(tsproject);
           }


### PR DESCRIPTION
There is a mismatch of path separators when running on windows that causes @rnx-kit/metro-plugin-typescript to not type check anything when running on windows machines.