### PR TITLE
fix(align-deps): always run unconfigured check

### DIFF
--- a/.changeset/gorgeous-jokes-try.md
+++ b/.changeset/gorgeous-jokes-try.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": patch
+---
+
+Always run the unconfigured check following the configured one when in "vigilant" mode

--- a/packages/align-deps/src/commands/check.ts
+++ b/packages/align-deps/src/commands/check.ts
@@ -153,10 +153,9 @@ export function makeCheckCommand(options: Options): Command {
 
     // If the package is configured, run the normal check first.
     if (!isError(config)) {
-      const result = checkPackageManifest(manifest, options, config);
-      return result !== "success"
-        ? result
-        : checkPackageManifestUnconfigured(manifest, options, config);
+      const res1 = checkPackageManifest(manifest, options, config);
+      const res2 = checkPackageManifestUnconfigured(manifest, options, config);
+      return res1 !== "success" ? res1 : res2;
     }
 
     // Otherwise, run the unconfigured check only.


### PR DESCRIPTION
### Description

`align-deps` should report all errors when in vigilant mode.

Resolves #2170

### Test plan

Make the following changes:

```diff
diff --git a/packages/test-app/package.json b/packages/test-app/package.json
index 76c0b90f..f4ae8da0 100644
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -25,7 +25,7 @@
     "start": "react-native rnx-start"
   },
   "dependencies": {
-    "react": "17.0.2",
+    "react": "18.0.0",
     "react-native": "^0.68.0",
     "react-native-macos": "^0.68.0",
     "react-native-windows": "^0.68.0"
@@ -51,7 +51,7 @@
     "@types/react-native": "^0.68.0",
     "jest-cli": "^27.5.1",
     "metro-react-native-babel-preset": "^0.67.0",
-    "react-native-test-app": "^2.0.2",
+    "react-native-test-app": "^2.1.2",
     "react-test-renderer": "17.0.2",
     "typescript": "^4.0.0"
   },
@@ -182,8 +182,7 @@
         "core-macos",
         "core-windows",
         "babel-preset-react-native",
-        "react",
-        "test-app"
+        "react"
       ]
     }
   }
```

`yarn rnx-align-deps` should report the `react` version misalignment in a diff and the misalignment of `react-native-test-app` as a normal error message.