### PR TITLE
fix(align-deps): fix write inconsistency

### DIFF
--- a/.changeset/wicked-pears-guess.md
+++ b/.changeset/wicked-pears-guess.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": patch
+---
+
+Fix `--write` not writing all reported misalignments when in "vigilant" mode

--- a/packages/align-deps/src/commands/check.ts
+++ b/packages/align-deps/src/commands/check.ts
@@ -41,6 +41,8 @@ function stringify(manifest: PackageManifest): string {
  *   requirements may only resolve to a single profile. If multiple profiles
  *   satisfy the requirements, the command will fail.
  *
+ * Note that this function mutates the manifest when `write` is `true`.
+ *
  * @see {@link updatePackageManifest}
  *
  * @param manifestPath Path to the package manifest to check

--- a/packages/align-deps/src/commands/check.ts
+++ b/packages/align-deps/src/commands/check.ts
@@ -101,6 +101,9 @@ export function checkPackageManifest(
 
   if (updatedManifestJson !== normalizedManifestJson) {
     if (options.write) {
+      // The config object may be passed to other commands, so we need to
+      // update it in-place to ensure consistency.
+      inputConfig.manifest = updatedManifest;
       modifyManifest(manifestPath, updatedManifest);
     } else {
       const diff = diffLinesUnified(

--- a/packages/align-deps/src/commands/vigilant.ts
+++ b/packages/align-deps/src/commands/vigilant.ts
@@ -172,6 +172,9 @@ const buildManifestProfileCached = ((): typeof buildManifestProfile => {
 /**
  * Compares the package manifest with the desired profile and returns all
  * dependencies that are misaligned.
+ *
+ * Note that this function mutates the manifest when `write` is `true`.
+ *
  * @param manifest The package manifest
  * @param profile The desired profile to compare against
  * @param write Whether misaligned dependencies should be updated


### PR DESCRIPTION
### Description

In vigilant mode + `--write`, align-deps only writes the changes reported by the unconfigured check.

### Test plan

Make the following changes:

```diff
diff --git a/packages/test-app/package.json b/packages/test-app/package.json
index 76c0b90f..f4ae8da0 100644
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -25,7 +25,7 @@
     "start": "react-native rnx-start"
   },
   "dependencies": {
-    "react": "17.0.2",
+    "react": "18.0.0",
     "react-native": "^0.68.0",
     "react-native-macos": "^0.68.0",
     "react-native-windows": "^0.68.0"
@@ -51,7 +51,7 @@
     "@types/react-native": "^0.68.0",
     "jest-cli": "^27.5.1",
     "metro-react-native-babel-preset": "^0.67.0",
-    "react-native-test-app": "^2.0.2",
+    "react-native-test-app": "^2.1.2",
     "react-test-renderer": "17.0.2",
     "typescript": "^4.0.0"
   },
@@ -182,8 +182,7 @@
         "core-macos",
         "core-windows",
         "babel-preset-react-native",
-        "react",
-        "test-app"
+        "react"
       ]
     }
   }
```

`yarn rnx-align-deps --write` should correct both `react` and `react-native-test-app`.