### PR TITLE
feat(react-native-test-app-msal): add flag to support optional auth module registration

### DIFF
--- a/.changeset/short-fishes-speak.md
+++ b/.changeset/short-fishes-speak.md
@@ -1,5 +1,5 @@
 ---
-"@rnx-kit/react-native-test-app-msal": patch
+"@rnx-kit/react-native-test-app-msal": minor
 ---
 
 add flag to support optional auth module registration

--- a/.changeset/short-fishes-speak.md
+++ b/.changeset/short-fishes-speak.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-test-app-msal": patch
+---
+
+add flag to support optional auth module registration

--- a/packages/react-native-test-app-msal/android/build.gradle
+++ b/packages/react-native-test-app-msal/android/build.gradle
@@ -73,12 +73,12 @@ repositories {
     }
 }
 
-def rnxDisableAuthProperty = "com.microsoft.reacttestapp.msal.disableRnxAuthModule"
 def rnxAuth = findNodeModulesPath("@rnx-kit/react-native-auth")
+def rnxDisableAuthProperty = "com.microsoft.reacttestapp.msal.disableRnxAuthModule"
 def skipAuthModuleRegistration =
     rnxAuth != null &&
-        rootProject.hasProperty(rnxDisableAuthProperty) &&
-        rootProject.property(rnxDisableAuthProperty).toString().equalsIgnoreCase("true")
+    rootProject.hasProperty(rnxDisableAuthProperty) &&
+    rootProject.property(rnxDisableAuthProperty).toString().equalsIgnoreCase("true")
 
 android {
     def manifest = new JsonSlurper().parseText(findFile("app.json").text)
@@ -153,7 +153,7 @@ android {
 
         main.res.srcDirs += generatedResDir
 
-        if (skipAuthModuleRegistration || rnxAuth == null) {
+        if (skipAuthModuleRegistration) {
             main.java.srcDirs += "src/nornx/java"
         } else {
             main.java.srcDirs += "src/rnx/java"

--- a/packages/react-native-test-app-msal/android/build.gradle
+++ b/packages/react-native-test-app-msal/android/build.gradle
@@ -73,12 +73,11 @@ repositories {
     }
 }
 
-def rnxAuth = findNodeModulesPath("@rnx-kit/react-native-auth")
+def rnxAuthPackage = findNodeModulesPath("@rnx-kit/react-native-auth")
 def rnxDisableAuthProperty = "com.microsoft.reacttestapp.msal.disableRnxAuthModule"
-def skipAuthModuleRegistration =
-    rnxAuth != null &&
-    rootProject.hasProperty(rnxDisableAuthProperty) &&
-    rootProject.property(rnxDisableAuthProperty).toString().equalsIgnoreCase("true")
+def rnxAuthSkipModuleRegistration =
+    rnxAuthPackage == null ||
+    (rootProject.hasProperty(rnxDisableAuthProperty) && rootProject.property(rnxDisableAuthProperty).toString().equalsIgnoreCase("true"))
 
 android {
     def manifest = new JsonSlurper().parseText(findFile("app.json").text)
@@ -153,7 +152,7 @@ android {
 
         main.res.srcDirs += generatedResDir
 
-        if (skipAuthModuleRegistration) {
+        if (rnxAuthSkipModuleRegistration) {
             main.java.srcDirs += "src/nornx/java"
         } else {
             main.java.srcDirs += "src/rnx/java"
@@ -173,7 +172,7 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"
 
-    if (rnxAuth != null) {
+    if (rnxAuthPackage != null) {
         implementation project(path: ":rnx-kit_react-native-auth")
     }
 }

--- a/packages/react-native-test-app-msal/android/build.gradle
+++ b/packages/react-native-test-app-msal/android/build.gradle
@@ -76,8 +76,9 @@ repositories {
 def rnxDisableAuthProperty = "com.microsoft.reacttestapp.msal.disableRnxAuthModule"
 def rnxAuth = findNodeModulesPath("@rnx-kit/react-native-auth")
 def skipAuthModuleRegistration =
-    rootProject.hasProperty(rnxDisableAuthProperty) &&
-    rootProject.property(rnxDisableAuthProperty)
+    rnxAuth != null &&
+        rootProject.hasProperty(rnxDisableAuthProperty) &&
+        rootProject.property(rnxDisableAuthProperty).toString().equalsIgnoreCase("true")
 
 android {
     def manifest = new JsonSlurper().parseText(findFile("app.json").text)

--- a/packages/react-native-test-app-msal/android/build.gradle
+++ b/packages/react-native-test-app-msal/android/build.gradle
@@ -73,7 +73,11 @@ repositories {
     }
 }
 
+def rnxDisableAuthProperty = "com.microsoft.reacttestapp.msal.disableRnxAuthModule"
 def rnxAuth = findNodeModulesPath("@rnx-kit/react-native-auth")
+def skipAuthModuleRegistration =
+    rootProject.hasProperty(rnxDisableAuthProperty) &&
+    rootProject.property(rnxDisableAuthProperty)
 
 android {
     def manifest = new JsonSlurper().parseText(findFile("app.json").text)
@@ -148,7 +152,7 @@ android {
 
         main.res.srcDirs += generatedResDir
 
-        if (rnxAuth == null) {
+        if (skipAuthModuleRegistration || rnxAuth == null) {
             main.java.srcDirs += "src/nornx/java"
         } else {
             main.java.srcDirs += "src/rnx/java"


### PR DESCRIPTION
### Description

The issue I am trying to resolve here is concerning situations where the hostapp is providing its own auth module with its own registration. 

I am addressing the issue of 'multiple module with the same name' by preventing the sources for the MSAL provided auth module in this package to load if a special flag has been set.

The name of this flag is `com.microsoft.reacttestapp.msal.disableRnxAuthModule`which is a boolean.

This is a sample setting for disabling the auto-linking module registration if the customer wants to provide a custom auth module in their host-app themselves:

```gradle.properties
...
...
com.microsoft.reacttestapp.msal.disableRnxAuthModule=true
```

Please note that the modified build.gradle file here still must include the dependency to the `rnx-kit_react-native-auth` unconditionally. This is due to the fact that the host-provided auth module would be using the class definitions for the auth module it provides.

### Test plan

Two scenarios in mind when testing, with and without the hostapp providing its own auth module.
