### PR TITLE
fix(metro-plugin-typescript): disable if unsupported Metro version

### DIFF
--- a/.changeset/flat-pants-peel.md
+++ b/.changeset/flat-pants-peel.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-plugin-typescript": patch
+---
+
+Disable the plugin if the current Metro version is unsupported

--- a/.changeset/quick-taxis-yell.md
+++ b/.changeset/quick-taxis-yell.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-react-native": minor
+---
+
+Added functions for finding the installation path of Metro, and for retrieving its version

--- a/packages/metro-plugin-typescript/package.json
+++ b/packages/metro-plugin-typescript/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@rnx-kit/config": "^0.6.1",
+    "@rnx-kit/console": "^1.0.0",
     "@rnx-kit/tools-node": "^1.3.1",
     "@rnx-kit/tools-react-native": "^1.2.3",
     "@rnx-kit/typescript-react-native-resolver": "^0.3.1",

--- a/packages/metro-plugin-typescript/src/serializerHook.ts
+++ b/packages/metro-plugin-typescript/src/serializerHook.ts
@@ -40,7 +40,10 @@ export function TypeScriptPlugin(
     return () => void 0;
   }
 
-  const unsupportedMetroVersion = checkMetroVersion(">=0.66.0");
+  // TypeScript plugin requires the `transformOptions` property that was added
+  // in 0.66.1. If the version is older, disable the plugin. See
+  // https://github.com/facebook/metro/commit/57106d273690bbcad0a795b337e43252edbc1091
+  const unsupportedMetroVersion = checkMetroVersion(">=0.66.1");
   if (unsupportedMetroVersion) {
     warn(`TypeScriptPlugin disabled: ${unsupportedMetroVersion}`);
     return () => void 0;

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@rnx-kit/console": "^1.0.11",
     "@rnx-kit/tools-node": "^1.3.0",
+    "@rnx-kit/tools-react-native": "^1.2.3",
     "esbuild": "^0.17.0",
     "esbuild-plugin-lodash": "^1.2.0",
     "fast-glob": "^3.2.7",

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -1,6 +1,7 @@
 import { info, warn } from "@rnx-kit/console";
 import type { MetroPlugin } from "@rnx-kit/metro-serializer";
-import { findPackage, readPackage } from "@rnx-kit/tools-node";
+import { findPackage, readPackage } from "@rnx-kit/tools-node/package";
+import { getMetroVersion } from "@rnx-kit/tools-react-native/metro";
 import type { BuildOptions, BuildResult, Plugin } from "esbuild";
 import * as esbuild from "esbuild";
 import * as fs from "fs";
@@ -20,7 +21,11 @@ export type Options = Pick<BuildOptions, "logLevel" | "minify" | "target"> & {
 };
 
 function assertVersion(requiredVersion: string): void {
-  const { version } = require("metro/package.json");
+  const version = getMetroVersion();
+  if (!version) {
+    throw new Error(`Metro version ${requiredVersion} is required`);
+  }
+
   if (!semver.satisfies(version, requiredVersion)) {
     throw new Error(
       `Metro version ${requiredVersion} is required; got ${version}`

--- a/packages/tools-react-native/README.md
+++ b/packages/tools-react-native/README.md
@@ -28,6 +28,8 @@ import * from "@rnx-kit/tools-react-native/platform";
 
 | Category | Function                                               | Description                                                                                     |
 | -------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| metro    | `findMetroPath(projectRoot)`                           | Finds the installation path of Metro.                                                           |
+| metro    | `getMetroVersion(projectRoot)`                         | Returns Metro version number.                                                                   |
 | platform | `expandPlatformExtensions(platform, extensions)`       | Returns a list of extensions that should be tried for the target platform in prioritized order. |
 | platform | `getAvailablePlatforms(startDir)`                      | Returns a map of available React Native platforms. The result is cached.                        |
 | platform | `getAvailablePlatformsUncached(startDir, platformMap)` | Returns a map of available React Native platforms. The result is NOT cached.                    |

--- a/packages/tools-react-native/metro.d.ts
+++ b/packages/tools-react-native/metro.d.ts
@@ -1,0 +1,1 @@
+export { findMetroPath, getMetroVersion } from "./lib/metro";

--- a/packages/tools-react-native/metro.js
+++ b/packages/tools-react-native/metro.js
@@ -1,0 +1,1 @@
+module.exports = require("./lib/metro.js");

--- a/packages/tools-react-native/package.json
+++ b/packages/tools-react-native/package.json
@@ -6,8 +6,10 @@
   "license": "MIT",
   "files": [
     "lib/*",
-    "platform.js",
-    "platform.d.ts"
+    "metro.d.ts",
+    "metro.js",
+    "platform.d.ts",
+    "platform.js"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/tools-react-native/platform.d.ts
+++ b/packages/tools-react-native/platform.d.ts
@@ -1,1 +1,8 @@
-export * from "./lib/platform";
+export type { AllPlatforms } from "./lib/platform";
+export {
+  expandPlatformExtensions,
+  getAvailablePlatforms,
+  getAvailablePlatformsUncached,
+  parsePlatform,
+  platformExtensions,
+} from "./lib/platform";

--- a/packages/tools-react-native/src/index.ts
+++ b/packages/tools-react-native/src/index.ts
@@ -1,3 +1,4 @@
+export { findMetroPath, getMetroVersion } from "./metro";
 export {
   expandPlatformExtensions,
   getAvailablePlatforms,

--- a/packages/tools-react-native/src/metro.ts
+++ b/packages/tools-react-native/src/metro.ts
@@ -1,0 +1,51 @@
+import {
+  findPackageDependencyDir,
+  readPackage,
+} from "@rnx-kit/tools-node/package";
+
+function resolveDependency(name: string, startDir: string): string | undefined {
+  return findPackageDependencyDir(name, {
+    startDir,
+    resolveSymlinks: true,
+  });
+}
+
+/**
+ * Finds the installation path of Metro.
+ * @param projectRoot The root of the project; defaults to the current working directory
+ * @returns The path to the Metro installation; `undefined` if Metro could not be found
+ */
+export function findMetroPath(projectRoot = process.cwd()): string | undefined {
+  const rnPath = resolveDependency("react-native", projectRoot);
+  if (!rnPath) {
+    return undefined;
+  }
+
+  const cliPath = resolveDependency("@react-native-community/cli", rnPath);
+  if (!cliPath) {
+    return undefined;
+  }
+
+  const cliMetroPath = resolveDependency(
+    "@react-native-community/cli-plugin-metro",
+    cliPath
+  );
+  return resolveDependency("metro", cliMetroPath || cliPath);
+}
+
+/**
+ * Returns Metro version number.
+ * @param projectRoot The root of the project; defaults to the current working directory
+ * @returns Metro version number; `undefined` if Metro could not be found
+ */
+export function getMetroVersion(
+  projectRoot = process.cwd()
+): string | undefined {
+  const metroPath = findMetroPath(projectRoot);
+  if (!metroPath) {
+    return undefined;
+  }
+
+  const { version } = readPackage(metroPath);
+  return version;
+}


### PR DESCRIPTION
### Description

`@rnx-kit/metro-plugin-typescript` should be disabled if on Metro <0.66.

Resolves #1703.

### Test plan

```
cd packages/test-app
yarn build --dependencies
yarn bundle:ios
```