### PR TITLE
fix(eslint-plugin/no-export-all): declared classes/functions are not types

### DIFF
--- a/.changeset/dirty-tools-return.md
+++ b/.changeset/dirty-tools-return.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/eslint-plugin": patch
+---
+
+Fixed `@rnx-kit/no-export-all` autofix treating `export declare` as types

--- a/packages/eslint-plugin/src/rules/no-export-all.js
+++ b/packages/eslint-plugin/src/rules/no-export-all.js
@@ -254,8 +254,7 @@ function extractExports(context, moduleId, depth) {
                 case "TSDeclareFunction": {
                   const name = declaration.id && declaration.id.name;
                   if (name) {
-                    const set = declaration.declare ? types : exports;
-                    set.add(name);
+                    exports.add(name);
                   }
                   break;
                 }
@@ -394,10 +393,6 @@ module.exports = {
             : (fixer) => {
                 /** @type {string[]} */
                 const lines = [];
-                if (result.exports.length > 0) {
-                  const names = result.exports.sort().join(", ");
-                  lines.push(`export { ${names} } from ${node.source.raw};`);
-                }
                 if (result.types.length > 0) {
                   const uniqueTypes = result.types.filter(
                     (type) => !result.exports.includes(type)
@@ -408,6 +403,10 @@ module.exports = {
                       `export type { ${types} } from ${node.source.raw};`
                     );
                   }
+                }
+                if (result.exports.length > 0) {
+                  const names = result.exports.sort().join(", ");
+                  lines.push(`export { ${names} } from ${node.source.raw};`);
                 }
                 return fixer.replaceText(node, lines.join("\n"));
               },

--- a/packages/eslint-plugin/test/no-export-all.test.ts
+++ b/packages/eslint-plugin/test/no-export-all.test.ts
@@ -24,8 +24,8 @@ export function escape() {
   console.log("Get to da choppah!");
 }
 
-export { escape as escapeRe, name as nameRe };
 export type { IChopper as IChopperRe, Predator as PredatorRe };
+export { escape as escapeRe, name as nameRe };
 `,
   conquerer: "export * from 'destroyer'",
   destroyer: "export * from 'barbarian'",
@@ -91,8 +91,8 @@ describe("disallows `export *`", () => {
         code: "export * from 'chopper';",
         errors: 1,
         output: lines(
-          "export { Chopper, Kind, escape, escapeRe, name, nameRe } from 'chopper';",
-          "export type { IChopper, IChopperRe, Predator, PredatorRe } from 'chopper';"
+          "export type { IChopper, IChopperRe, Predator, PredatorRe } from 'chopper';",
+          "export { Chopper, Kind, escape, escapeRe, name, nameRe } from 'chopper';"
         ),
       },
       {
@@ -113,15 +113,18 @@ describe("disallows `export *`", () => {
       {
         code: "export * from 'types';",
         errors: 1,
-        output:
-          "export type { Helicopter, IChopper, Predator, escape } from 'types';",
+        output: lines(
+          "export type { IChopper, Predator } from 'types';",
+          "export { Helicopter, escape } from 'types';"
+        ),
       },
       {
         code: lines("export * from './internal';", "export * from 'types';"),
         errors: 1,
         output: lines(
           "export * from './internal';",
-          "export type { Helicopter, IChopper, Predator, escape } from 'types';"
+          "export type { IChopper, Predator } from 'types';",
+          "export { Helicopter, escape } from 'types';"
         ),
         options: [{ expand: "external-only" }],
       },


### PR DESCRIPTION
### Description

Fixed `@rnx-kit/no-export-all` autofix treating `export declare` as types.

### Test plan

```
cd packages/tools-react-native
yarn build --dependencies
```

For the next steps, verification is easiest in VS Code:

1. Restart VS Code (this is to clear any lingering ESLint processes)
2. Open `packages/tools-react-native/platform.js`
3. You should see a red squiggly line under `export * from "./lib/platform";`
4. Hover the line and click on "Quick Fix…"
5. Select "Fix this @rnx-kit/no-export-all problem"
6. Verify that the export has been correctly expanded as below:
    ```ts
    export type { AllPlatforms } from "./lib/platform";
    export { expandPlatformExtensions, getAvailablePlatforms, getAvailablePlatformsUncached, parsePlatform, platformExtensions } from "./lib/platform";
    ```