### PR TITLE
docs(metro-serializer-esbuild): add change file to bump deps

### DIFF
--- a/.changeset/slow-zoos-appear.md
+++ b/.changeset/slow-zoos-appear.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Resolve `metro` via `react-native` to ensure the correct instance is used


### PR DESCRIPTION
### Description

https://github.com/microsoft/rnx-kit/pull/2183 didn't bump `@rnx-kit/tools-react-native` in `metro-serializer-esbuild`.

### Test plan

n/a