### PR TITLE
Update new package creation command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ have introduced a small script to easily allow for new packages generation.
 Simply run
 
 ```sh
-yarn new-package --name TEST
+yarn new-package <package-name>
 ```
 
 To generate a sample project for you to use; this is based on


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

It is mentioned in the contribution guide that to create a new package we must run the command `yarn new-package --name <package_name>`. This does not seem to work. The command that works instead is `yarn new-package <package_name>`.

Updated the contribution guide


<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->

Since this is a documentation change, manual reviews should suffice
