### PR TITLE
chore: use npm 8.x (Node 16) to publish packages

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: The version of Node to use
     type: number
-    default: 18
+    default: 16  # `npm pack` is broken in npm 9.x: https://github.com/npm/npm-packlist/issues/152
     required: true
   jdk-version:
     description: The Java JDK version to use, if specified


### PR DESCRIPTION
### Description

Recently discovered that npm 9 completely broke their glob implementation. Downgrading to avoid issues.

### Test plan

n/a