### PR TITLE
docs(changeset): adjust `metro-resolver-symlinks` metro patch

### DIFF
--- a/.changeset/shaggy-trains-press.md
+++ b/.changeset/shaggy-trains-press.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+adjust `metro-resolver-symlinks` metro patch to use any available hasteFS alias

--- a/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
+++ b/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
@@ -92,8 +92,8 @@ export function patchMetro(options: Options): void {
   DependencyGraph.prototype.orig__createModuleResolver =
     DependencyGraph.prototype._createModuleResolver;
   DependencyGraph.prototype._createModuleResolver = function (): void {
+    const hasteFS = this._hasteFS || this._snapshotFS || this._fileSystem;
     this._doesFileExist = (filePath: string): boolean => {
-      const hasteFS = this._hasteFS || this._snapshotFS || this._fileSystem;
       return hasteFS.exists(filePath) || fileExists(filePath);
     };
 

--- a/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
+++ b/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
@@ -93,7 +93,8 @@ export function patchMetro(options: Options): void {
     DependencyGraph.prototype._createModuleResolver;
   DependencyGraph.prototype._createModuleResolver = function (): void {
     this._doesFileExist = (filePath: string): boolean => {
-      return this._hasteFS.exists(filePath) || fileExists(filePath);
+      const hasteFS = this._hasteFS || this._snapshotFS || this._fileSystem;
+      return hasteFS.exists(filePath) || fileExists(filePath);
     };
 
     this.orig__createModuleResolver();


### PR DESCRIPTION
adjust `metro-resolver-symlinks` metro patch to use any available hasteFS alias


### Description

There is an experimental functionality for a "metro-resolver-symlinks", that patches metro DependencyGraph to use `fs.existsSync` as fallback resolution method.

packages/metro-resolver-symlinks/src/utils/patchMetro.ts
```typescript
this._doesFileExist = (filePath: string): boolean => {
  return this._hasteFS.exists(filePath) || fileExists(filePath);
};
```

Right now it brakes latest version of Metro, because facebook team changed `_hasteFS` property name first to `_snapshotFS` and shortly after to `_fileSystem`.

One potential fix would be to just update the hasteFS property name to what it currently is.
```typescript
this._doesFileExist = (filePath: string): boolean => {
  return this._fileSystem.exists(filePath) || fileExists(filePath);
};
```

But it would break backward compatibility with all the previous metro-resolver versions, so a better approach would be to try all known hasteFS aliases.
```typescript
this._doesFileExist = (filePath: string): boolean => {
  const hasteFS = this._hasteFS || this._snapshotFS || this._fileSystem;
  return hasteFS.exists(filePath) || fileExists(filePath);
};
```

Resolves [#2191](https://github.com/microsoft/rnx-kit/issues/2191)

### Test plan

Issue can be reproduced by setting up hello world with latest react-native (that will include the latest metro version).
You then just apply the `metro-resolver-symlinks` as per README with `experimental_retryResolvingFromDisk: true` option.

```javascript
// metro.config.js
const MetroSymlinksResolver = require('@rnx-kit/metro-resolver-symlinks');

module.exports = {
  resolver: {
    resolveRequest: MetroSymlinksResolver({
      experimental_retryResolvingFromDisk: true,
    })
  }
};
```

The only possible edge-case or improvement i can think about is to either make hasteFS alias list configurable, so users can patch the problem themselves in the future. Because it looks like facebook team took a fancy to changing hasteFS property name.
