### PR TITLE
Add Help and new lines to rnx-start

### DIFF
--- a/.changeset/new-buses-deliver.md
+++ b/.changeset/new-buses-deliver.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Add help support and enter for newlines to rnx-start

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -260,6 +260,10 @@ export async function rnxStart(
             terminal.log(chalk.green("Reloading app..."));
             messageSocketEndpoint.broadcast("reload", undefined);
             break;
+
+          case "return":
+            terminal.log("");
+            break;
         }
       }
     });

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -92,6 +92,20 @@ export async function rnxStart(
     cliOptions.customLogReporterPath
   );
 
+  const printHelp = () => {
+    const dim = chalk.dim;
+    const press = dim(" › Press ");
+    [
+      ["r", "reload the app"],
+      ["d", "open developer menu"],
+      ["a", "show bundler address QR code"],
+      ["h", "show this help message"],
+      ["ctrl-c", "quit"],
+    ].forEach(([key, description]) => {
+      terminal.log(press + key + dim(` to ${description}.`));
+    });
+  };
+
   // create a reporter function, to be bound to the Metro configuration.
   // which writes to the Metro terminal and
   // also notifies the `reportEvent` delegate.
@@ -103,16 +117,7 @@ export async function rnxStart(
         reportEventDelegate(event);
       }
       if (interactive && event.type === "dep_graph_loading") {
-        const dim = chalk.dim;
-        const press = dim(" › Press ");
-        [
-          ["r", "reload the app"],
-          ["d", "open developer menu"],
-          ["a", "show bundler address QR code"],
-          ["ctrl-c", "quit"],
-        ].forEach(([key, description]) => {
-          terminal.log(press + key + dim(` to ${description}.`));
-        });
+        printHelp();
       }
     },
   };
@@ -245,6 +250,10 @@ export async function rnxStart(
           case "d":
             terminal.log(chalk.green("Opening developer menu..."));
             messageSocketEndpoint.broadcast("devMenu", undefined);
+            break;
+
+          case "h":
+            printHelp();
             break;
 
           case "r":


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->
I like to be able to hit enter in rnx-start to clear space to more easily differentiate between previous and new log messages when debugging.

For good measure I also implemented a help function that reprints the initial help message.

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
* Run react-native rnx-start
* Press "h" and see help
* Hit enter a few times and see new lines
