### PR TITLE
fix(build): use custom actions

### DIFF
--- a/.changeset/clever-vans-guess.md
+++ b/.changeset/clever-vans-guess.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+GitHub: Fix job ending prematurely when it takes longer than usual to start up

--- a/.changeset/unlucky-gifts-switch.md
+++ b/.changeset/unlucky-gifts-switch.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+Use `setup-toolchain` action from `react-native-test-app`

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -3,47 +3,43 @@ on:
   workflow_dispatch:
     inputs:
       architecture:
-        description: "Supported architectures are `arm64`, `x64`"
+        description: Supported architectures are `arm64`, `x64`
         required: true
-        default: "x64"
+        default: x64
       deviceType:
-        description: "Supported device types are `device`, `emulator`, `simulator`"
+        description: Supported device types are `device`, `emulator`, `simulator`
         required: true
-        default: "simulator"
+        default: simulator
       distribution:
-        description: "Distribution config string, e.g. `local` or `firebase:<appId>`"
+        description: Distribution config string, e.g. `local` or `firebase:<appId>`
         required: true
-        default: "local"
+        default: local
       packageManager:
-        description: "Binary name of the package manager used in the current repo"
+        description: Binary name of the package manager used in the current repo
         required: true
-        default: "yarn"
+        default: yarn
       platform:
-        description: "Supported platforms are `android`, `ios`, `macos`, `windows`"
+        description: Supported platforms are `android`, `ios`, `macos`, `windows`
         required: true
       projectRoot:
-        description: "Root of the project"
+        description: Root of the project
         required: true
       scheme:
-        description: "The workspace scheme to build (iOS and macOS only)"
-        default: "ReactTestApp"
+        description: The workspace scheme to build (iOS and macOS only)
+        default: ReactTestApp
 jobs:
   build-android:
-    name: "Build Android"
+    name: Build Android
     if: ${{ github.event.inputs.platform == 'android' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3.10.0
+      - name: Set up toolchain
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@8c264e9e8f0849ab996ef87bcf6317e905c55e2e
         with:
-          distribution: temurin
-          java-version: 11
-      - name: Set up Node 18
-        uses: actions/setup-node@v3.6.0
-        with:
-          node-version: 18
+          platform: android
+          cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Build Android app
@@ -60,7 +56,7 @@ jobs:
           if-no-files-found: error
           retention-days: 14
   build-ios:
-    name: "Build iOS"
+    name: Build iOS
     if: ${{ github.event.inputs.platform == 'ios' }}
     runs-on: macos-12
     env:
@@ -71,10 +67,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up Node 18
-        uses: actions/setup-node@v3.6.0
+      - name: Set up toolchain
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@8c264e9e8f0849ab996ef87bcf6317e905c55e2e
         with:
-          node-version: 18
+          platform: ios
+          project-root: ${{ github.event.inputs.projectRoot }}
+          cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Pods
@@ -117,16 +115,18 @@ jobs:
           if-no-files-found: error
           retention-days: 14
   build-macos:
-    name: "Build macOS"
+    name: Build macOS
     if: ${{ github.event.inputs.platform == 'macos' }}
     runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up Node 18
-        uses: actions/setup-node@v3.6.0
+      - name: Set up toolchain
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@8c264e9e8f0849ab996ef87bcf6317e905c55e2e
         with:
-          node-version: 18
+          platform: macos
+          project-root: ${{ github.event.inputs.projectRoot }}
+          cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Pods
@@ -149,18 +149,17 @@ jobs:
           if-no-files-found: error
           retention-days: 14
   build-windows:
-    name: "Build Windows"
+    name: Build Windows
     if: ${{ github.event.inputs.platform == 'windows' }}
     runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v1.3
-      - name: Set up Node 18
-        uses: actions/setup-node@v3.6.0
+      - name: Set up toolchain
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@8c264e9e8f0849ab996ef87bcf6317e905c55e2e
         with:
-          node-version: 18
+          platform: windows
+          cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Windows test app
@@ -192,9 +191,9 @@ jobs:
           if-no-files-found: error
           retention-days: 14
   distribute:
-    name: "Distribute build"
+    name: Distribute build
     needs: [build-android, build-ios]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: ${{ github.event.inputs.distribution != 'local' && !cancelled() && !failure() }} # `success()` excludes skipped jobs
     steps:
       - name: Download build artifact

--- a/incubator/build/README.md
+++ b/incubator/build/README.md
@@ -135,6 +135,24 @@ module.exports = (config: Partial<Config>): DistributionPlugin => {
 };
 ```
 
+## GitHub Actions
+
+Allow the following actions and reusable workflows:
+
+```
+actions/cache@*,
+actions/checkout@*,
+actions/download-artifact@*,
+actions/setup-java@*,
+actions/setup-node@*,
+actions/upload-artifact@*,
+darenm/Setup-VSTest@*,
+gradle/gradle-build-action@*,
+microsoft/react-native-test-app/.github/actions/*,
+microsoft/setup-msbuild@*,
+ruby/setup-ruby@*,
+```
+
 ## Assumptions
 
 ### Folder Structure

--- a/incubator/build/src/remotes/github.ts
+++ b/incubator/build/src/remotes/github.ts
@@ -9,7 +9,7 @@ import {
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as readline from "node:readline";
-import ora from "ora";
+import type ora from "ora";
 import { idle, once, withRetry } from "../async";
 import {
   BUILD_ID,

--- a/incubator/build/src/remotes/github.ts
+++ b/incubator/build/src/remotes/github.ts
@@ -150,6 +150,11 @@ async function watchWorkflowRun(
         const result = await octokit().rest.actions.listJobsForWorkflowRun(
           params
         );
+        if (result.data.jobs.length === 0) {
+          // Still starting up
+          continue;
+        }
+
         const activeJobs = result.data.jobs.filter(
           (job) => job && job.conclusion !== "skipped"
         );

--- a/incubator/build/workflows/github.yml
+++ b/incubator/build/workflows/github.yml
@@ -3,47 +3,43 @@ on:
   workflow_dispatch:
     inputs:
       architecture:
-        description: "Supported architectures are `arm64`, `x64`"
+        description: Supported architectures are `arm64`, `x64`
         required: true
-        default: "x64"
+        default: x64
       deviceType:
-        description: "Supported device types are `device`, `emulator`, `simulator`"
+        description: Supported device types are `device`, `emulator`, `simulator`
         required: true
-        default: "simulator"
+        default: simulator
       distribution:
-        description: "Distribution config string, e.g. `local` or `firebase:<appId>`"
+        description: Distribution config string, e.g. `local` or `firebase:<appId>`
         required: true
-        default: "local"
+        default: local
       packageManager:
-        description: "Binary name of the package manager used in the current repo"
+        description: Binary name of the package manager used in the current repo
         required: true
-        default: "yarn"
+        default: yarn
       platform:
-        description: "Supported platforms are `android`, `ios`, `macos`, `windows`"
+        description: Supported platforms are `android`, `ios`, `macos`, `windows`
         required: true
       projectRoot:
-        description: "Root of the project"
+        description: Root of the project
         required: true
       scheme:
-        description: "The workspace scheme to build (iOS and macOS only)"
-        default: "ReactTestApp"
+        description: The workspace scheme to build (iOS and macOS only)
+        default: ReactTestApp
 jobs:
   build-android:
-    name: "Build Android"
+    name: Build Android
     if: ${{ github.event.inputs.platform == 'android' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3.10.0
+      - name: Set up toolchain
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@8c264e9e8f0849ab996ef87bcf6317e905c55e2e
         with:
-          distribution: temurin
-          java-version: 11
-      - name: Set up Node 18
-        uses: actions/setup-node@v3.6.0
-        with:
-          node-version: 18
+          platform: android
+          cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Build Android app
@@ -60,7 +56,7 @@ jobs:
           if-no-files-found: error
           retention-days: 14
   build-ios:
-    name: "Build iOS"
+    name: Build iOS
     if: ${{ github.event.inputs.platform == 'ios' }}
     runs-on: macos-12
     env:
@@ -71,10 +67,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up Node 18
-        uses: actions/setup-node@v3.6.0
+      - name: Set up toolchain
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@8c264e9e8f0849ab996ef87bcf6317e905c55e2e
         with:
-          node-version: 18
+          platform: ios
+          project-root: ${{ github.event.inputs.projectRoot }}
+          cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Pods
@@ -117,16 +115,18 @@ jobs:
           if-no-files-found: error
           retention-days: 14
   build-macos:
-    name: "Build macOS"
+    name: Build macOS
     if: ${{ github.event.inputs.platform == 'macos' }}
     runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up Node 18
-        uses: actions/setup-node@v3.6.0
+      - name: Set up toolchain
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@8c264e9e8f0849ab996ef87bcf6317e905c55e2e
         with:
-          node-version: 18
+          platform: macos
+          project-root: ${{ github.event.inputs.projectRoot }}
+          cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Pods
@@ -149,18 +149,17 @@ jobs:
           if-no-files-found: error
           retention-days: 14
   build-windows:
-    name: "Build Windows"
+    name: Build Windows
     if: ${{ github.event.inputs.platform == 'windows' }}
     runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v1.3
-      - name: Set up Node 18
-        uses: actions/setup-node@v3.6.0
+      - name: Set up toolchain
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@8c264e9e8f0849ab996ef87bcf6317e905c55e2e
         with:
-          node-version: 18
+          platform: windows
+          cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Windows test app
@@ -192,9 +191,9 @@ jobs:
           if-no-files-found: error
           retention-days: 14
   distribute:
-    name: "Distribute build"
+    name: Distribute build
     needs: [build-android, build-ios]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: ${{ github.event.inputs.distribution != 'local' && !cancelled() && !failure() }} # `success()` excludes skipped jobs
     steps:
       - name: Download build artifact


### PR DESCRIPTION
### Description

- Use `setup-toolchain` action from `react-native-test-app`
- GitHub: Fix job ending prematurely when it takes longer than usual to start up

### Test plan

```
cd incubator/build
yarn build --dependencies
yarn rnx-build -p android --deploy local-only ../../packages/test-app
```