### PR TITLE
fix(build): use `xcdevice` instead of `xtrace`

### DIFF
--- a/.changeset/beige-clocks-yawn.md
+++ b/.changeset/beige-clocks-yawn.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+Use `xcdevice` instead of `xtrace` to find devices


### PR DESCRIPTION
### Description

Use `xcdevice` instead of `xtrace` to find devices.

### Test plan

```
cd incubator/build
yarn build --dependencies
yarn rnx-build -p ios --deploy local-only ../../packages/test-app
```