### PR TITLE
ci: use fine-grained access token for publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,7 @@ jobs:
   build_and_publish:
     name: "Build and publish"
     permissions:
-      contents: write # create releases (changesets/action), deploy to GitHub Pages (peaceiris/actions-gh-pages)
-      pull-requests: write # create publish PRs (changesets/action)
+      contents: write # deploy to GitHub Pages (peaceiris/actions-gh-pages)
     if: ${{ github.repository == 'microsoft/rnx-kit' }}
     runs-on: ubuntu-22.04
     steps:
@@ -40,7 +39,7 @@ jobs:
           publish: yarn publish:changesets
           version: yarn version:changesets
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Deploy website
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
### Description

Use fine-grained access token for publishing.

### Test plan

No way to test this. We need to at least set this up to use a different secret so I can test with a token from a system account.