### PR TITLE
fix(build): use version number instead of SHA

### DIFF
--- a/.changeset/friendly-worms-march.md
+++ b/.changeset/friendly-worms-march.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+Use version number instead of SHA now that a new RNTA release is out

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@8c264e9e8f0849ab996ef87bcf6317e905c55e2e
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.11
         with:
           platform: android
           cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@8c264e9e8f0849ab996ef87bcf6317e905c55e2e
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.11
         with:
           platform: ios
           project-root: ${{ github.event.inputs.projectRoot }}
@@ -122,7 +122,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@8c264e9e8f0849ab996ef87bcf6317e905c55e2e
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.11
         with:
           platform: macos
           project-root: ${{ github.event.inputs.projectRoot }}
@@ -156,7 +156,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@8c264e9e8f0849ab996ef87bcf6317e905c55e2e
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.11
         with:
           platform: windows
           cache-npm-dependencies: ${{ github.event.inputs.packageManager }}

--- a/incubator/build/workflows/github.yml
+++ b/incubator/build/workflows/github.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@8c264e9e8f0849ab996ef87bcf6317e905c55e2e
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.11
         with:
           platform: android
           cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@8c264e9e8f0849ab996ef87bcf6317e905c55e2e
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.11
         with:
           platform: ios
           project-root: ${{ github.event.inputs.projectRoot }}
@@ -122,7 +122,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@8c264e9e8f0849ab996ef87bcf6317e905c55e2e
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.11
         with:
           platform: macos
           project-root: ${{ github.event.inputs.projectRoot }}
@@ -156,7 +156,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@8c264e9e8f0849ab996ef87bcf6317e905c55e2e
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.11
         with:
           platform: windows
           cache-npm-dependencies: ${{ github.event.inputs.packageManager }}


### PR DESCRIPTION
### Description

Use version number instead of SHA now that a new RNTA release is out.

### Test plan

```
cd incubator/build
yarn build --dependencies
yarn rnx-build --platform ios --device-type simulator ../../packages/test-app
```