### PR TITLE
fix(metro-plugin-typescript): don't apply module suffixes to main fields

### DIFF
--- a/.changeset/loud-avocados-know.md
+++ b/.changeset/loud-avocados-know.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-plugin-typescript": patch
+---
+
+Don't apply module suffixes when resolving main fields

--- a/packages/test-app/src/App.native.tsx
+++ b/packages/test-app/src/App.native.tsx
@@ -1,8 +1,8 @@
 import { acquireTokenWithScopes } from "@rnx-kit/react-native-auth";
 import React, { useCallback, useMemo, useState } from "react";
 import {
-  Pressable,
   NativeModules,
+  Pressable,
   SafeAreaView,
   ScrollView,
   StatusBar,

--- a/packages/tools-node/src/module.ts
+++ b/packages/tools-node/src/module.ts
@@ -36,7 +36,7 @@ export function parseModuleRef(r: string): PackageModuleRef | FileModuleRef {
   const ref: PackageModuleRef = parsePackageRef(r);
 
   const indexPath = ref.name.indexOf("/");
-  if (indexPath > -1) {
+  if (indexPath >= 0) {
     const p = ref.name.substring(indexPath + 1);
     if (p) {
       ref.path = p;


### PR DESCRIPTION
### Description

Don't apply module suffixes when resolving main fields.

Resolves #2247.

### Test plan

1. Add `react-native-screens` to test app:
    ```diff
    diff --git a/packages/test-app/package.json b/packages/test-app/package.json
    index 95246bde..605eb00e 100644
    --- a/packages/test-app/package.json
    +++ b/packages/test-app/package.json
    @@ -28,6 +28,7 @@
         "react": "17.0.2",
         "react-native": "^0.68.0",
         "react-native-macos": "^0.68.0",
    +    "react-native-screens": "*",
         "react-native-windows": "^0.68.0"
       },
       "devDependencies": {
    diff --git a/packages/test-app/src/App.native.tsx b/packages/test-app/src/App.native.tsx
    index 1345c498..7e3ec0f7 100644
    --- a/packages/test-app/src/App.native.tsx
    +++ b/packages/test-app/src/App.native.tsx
    @@ -17,6 +17,7 @@ import { version as coreVersion } from "react-native/Libraries/Core/ReactNativeV
     import { Colors, Header } from "react-native/Libraries/NewAppScreen";
     // @ts-expect-error no types for "react-native/Libraries/Utilities/DebugEnvironment"
     import { isAsyncDebugging } from "react-native/Libraries/Utilities/DebugEnvironment";
    +import { enableScreens } from "react-native-screens";
     import manifest from "../app.json";
    
     type ButtonProps = {
    @@ -36,6 +37,8 @@ type FeatureProps =
           onValueChange?: (value: boolean) => void;
         };
    
    +enableScreens(false);
    +
     function getHermesVersion() {
       return (
         // @ts-expect-error `HermesInternal` is set when on Hermes
    ```
2. Install: `yarn`
3. Build `test-app`: `yarn build-scope test-app`
4. Bundle:
    ```
    cd packages/test-app
    yarn bundle:ios
    ```