### PR TITLE
fix(metro-resolver-symlinks): support `unstable_enablePackageExports`

### DIFF
--- a/.changeset/cold-birds-pay.md
+++ b/.changeset/cold-birds-pay.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Add support for the experimental `unstable_enablePackageExports` flag in 0.75.1

--- a/packages/metro-resolver-symlinks/src/helper.ts
+++ b/packages/metro-resolver-symlinks/src/helper.ts
@@ -1,4 +1,7 @@
-import { findPackageDependencyDir, readPackage } from "@rnx-kit/tools-node";
+import {
+  findPackageDependencyDir,
+  readPackage,
+} from "@rnx-kit/tools-node/package";
 
 export function resolveFrom(
   moduleName: string,

--- a/packages/metro-resolver-symlinks/src/resolver.ts
+++ b/packages/metro-resolver-symlinks/src/resolver.ts
@@ -1,5 +1,5 @@
-import { isFileModuleRef, parseModuleRef } from "@rnx-kit/tools-node";
-import { getAvailablePlatforms } from "@rnx-kit/tools-react-native";
+import { isFileModuleRef, parseModuleRef } from "@rnx-kit/tools-node/module";
+import { getAvailablePlatforms } from "@rnx-kit/tools-react-native/platform";
 import * as path from "path";
 import { resolveFrom } from "./helper";
 import type { ModuleResolver } from "./types";

--- a/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
+++ b/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
@@ -33,15 +33,16 @@ function supportsRetryResolvingFromDisk(): boolean {
   const { version } = importMetroModule("/package.json");
   const [major, minor] = version.split(".");
   const v = major * 1000 + minor;
-  return v >= 64 && v <= 73;
+  return v >= 64 && v <= 75;
 }
 
 export function shouldEnableRetryResolvingFromDisk({
   experimental_retryResolvingFromDisk,
 }: Options): boolean {
   if (
-    !supportsRetryResolvingFromDisk() &&
-    experimental_retryResolvingFromDisk !== "force"
+    experimental_retryResolvingFromDisk &&
+    experimental_retryResolvingFromDisk !== "force" &&
+    !supportsRetryResolvingFromDisk()
   ) {
     console.warn(
       "The version of Metro you're using has not been tested with " +

--- a/packages/metro-resolver-symlinks/src/utils/remapImportPath.ts
+++ b/packages/metro-resolver-symlinks/src/utils/remapImportPath.ts
@@ -1,10 +1,10 @@
-import type { PackageModuleRef } from "@rnx-kit/tools-node";
 import {
   isFileModuleRef,
   parseModuleRef,
   readPackage,
 } from "@rnx-kit/tools-node";
-import { expandPlatformExtensions } from "@rnx-kit/tools-react-native";
+import type { PackageModuleRef } from "@rnx-kit/tools-node/module";
+import { expandPlatformExtensions } from "@rnx-kit/tools-react-native/platform";
 import * as path from "path";
 import type { ModuleResolver, ResolutionContext } from "../types";
 


### PR DESCRIPTION
### Description

Add support for the experimental `unstable_enablePackageExports` flag in 0.75.1

Resolves #2255.

### Test plan

1. Add resolutions to install latest Metro:
    ```diff
    diff --git a/package.json b/package.json
    index 8a6c3d02..73400c2a 100644
    --- a/package.json
    +++ b/package.json
    @@ -61,6 +61,14 @@
       "resolutions": {
         "@vue/compiler-sfc": "link:./incubator/ignore",
         "eslint-plugin-react": "^7.26.0",
    +    "metro": "^0.75.0",
    +    "metro-config": "^0.75.0",
    +    "metro-core": "^0.75.0",
    +    "metro-react-native-babel-preset": "^0.75.0",
    +    "metro-react-native-babel-transformer": "^0.75.0",
    +    "metro-resolver": "^0.75.0",
    +    "metro-runtime": "^0.75.0",
    +    "metro-transform-worker": "^0.75.0",
         "micromatch": "^4.0.0",
         "nx/chalk": "^4.1.0",
         "nx/fast-glob": "^3.2.7",
    ```
2. Enable `unstable_enablePackageExports` in `metro.config.js`:
    ```diff
    diff --git a/packages/test-app/metro.config.js b/packages/test-app/metro.config.js
    index 0a8bd04a..023286a6 100644
    --- a/packages/test-app/metro.config.js
    +++ b/packages/test-app/metro.config.js
    @@ -27,8 +27,11 @@ module.exports = makeMetroConfig({
               }
             : {}),
         },
    -    resolveRequest: MetroSymlinksResolver(),
    +    resolveRequest: MetroSymlinksResolver({
    +      experimental_retryResolvingFromDisk: "force",
    +    }),
         blacklistRE: blockList,
         blockList,
    +    unstable_enablePackageExports: true,
       },
     });
    ```
3. Bundle:
    ```
    cd packages/test-app
    yarn build --dependencies
    yarn bundle:ios
    ```