### PR TITLE
fix(build): handle build jobs that are slow to start up

### DIFF
--- a/.changeset/afraid-experts-own.md
+++ b/.changeset/afraid-experts-own.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+GitHub: Fix job ending prematurely when it takes longer than usual to start up (proper)

--- a/incubator/build/src/filesystem.ts
+++ b/incubator/build/src/filesystem.ts
@@ -1,5 +1,5 @@
-import * as fs from "node:fs/promises";
+import * as fs from "node:fs";
 
-export function ensureDir(dir: string): Promise<string | undefined> {
-  return fs.mkdir(dir, { recursive: true, mode: 0o755 });
+export function ensureDir(dir: string): string | undefined {
+  return fs.mkdirSync(dir, { recursive: true, mode: 0o755 });
 }

--- a/incubator/build/src/platforms/android.ts
+++ b/incubator/build/src/platforms/android.ts
@@ -1,6 +1,5 @@
 import { spawn } from "node:child_process";
-import { existsSync as fileExists } from "node:fs";
-import * as fs from "node:fs/promises";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Ora } from "ora";
 import { idle, retry } from "../async";
@@ -41,13 +40,13 @@ const EMULATOR_PATH = path.join(ANDROID_HOME, "emulator", "emulator");
 
 const adb = makeCommand(ADB_PATH);
 
-async function getBuildToolsPath(): Promise<string | null> {
+function getBuildToolsPath(): string | null {
   const buildToolsInstallPath = path.join(ANDROID_HOME, "build-tools");
-  if (!fileExists(buildToolsInstallPath)) {
+  if (!fs.existsSync(buildToolsInstallPath)) {
     return null;
   }
 
-  const versions = await fs.readdir(buildToolsInstallPath);
+  const versions = fs.readdirSync(buildToolsInstallPath);
   return path.join(buildToolsInstallPath, latestVersion(versions));
 }
 
@@ -78,8 +77,8 @@ async function getEmulators(): Promise<string[]> {
     .filter(Boolean);
 }
 
-async function getPackageName(apk: string): Promise<PackageInfo | Error> {
-  const buildToolsPath = await getBuildToolsPath();
+function getPackageName(apk: string): PackageInfo | Error {
+  const buildToolsPath = getBuildToolsPath();
   if (!buildToolsPath) {
     return new Error("Could not find Android SDK Build-Tools");
   }
@@ -205,7 +204,7 @@ export async function deploy(
     return;
   }
 
-  const info = await getPackageName(apk);
+  const info = getPackageName(apk);
   if (info instanceof Error) {
     spinner.fail(info.message);
     return;

--- a/incubator/build/src/platforms/windows.ts
+++ b/incubator/build/src/platforms/windows.ts
@@ -1,5 +1,5 @@
 import { XMLParser } from "fast-xml-parser";
-import * as fs from "node:fs/promises";
+import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Ora } from "ora";
@@ -44,9 +44,9 @@ function makePowerShell(
   }
 }
 
-async function getPackageInfo(app: string): Promise<PackageInfo | null> {
+function getPackageInfo(app: string): PackageInfo | null {
   const filename = path.join(app, "AppxManifest.xml");
-  const content = await fs.readFile(filename, { encoding: "utf-8" });
+  const content = fs.readFileSync(filename, { encoding: "utf-8" });
 
   const xml = new XMLParser({ ignoreAttributes: false });
   const manifest = xml.parse(content);
@@ -87,7 +87,7 @@ async function install(
   app: string,
   tryUninstall = true
 ): Promise<string | Error> {
-  const packageInfo = await getPackageInfo(app);
+  const packageInfo = getPackageInfo(app);
   if (!packageInfo) {
     return new Error(
       "Failed to get package name and/or app id from build artifact"

--- a/incubator/build/src/remotes/github.ts
+++ b/incubator/build/src/remotes/github.ts
@@ -143,9 +143,8 @@ async function watchWorkflowRun(
     //   - https://docs.github.com/en/rest/overview/resources-in-the-rest-api#conditional-requests
     if (count++ % 5 === 0) {
       try {
-        const result = await octokit().rest.actions.listJobsForWorkflowRun(
-          params
-        );
+        const gh = octokit();
+        const result = await gh.rest.actions.listJobsForWorkflowRun(params);
         const activeJobs = result.data.jobs.filter(
           (job) => job && job.conclusion !== "skipped"
         );


### PR DESCRIPTION
### Description

Proper fix for job ending prematurely when it takes longer than usual to start up.

Also prefer using synchronous fs functions to avoid having to wait on the event loop to continue processing.

### Test plan

Build should succeed:
```
yarn rnx-build --platform ios --device-type simulator ../../packages/test-app
```