### PR TITLE
fix(build): explicitly disable sanitizers

### DIFF
--- a/.changeset/serious-candles-cheer.md
+++ b/.changeset/serious-candles-cheer.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+iOS/macOS: Explicitly disable sanitizers since they might be enabled by inherited flags

--- a/incubator/build/scripts/build-apple.sh
+++ b/incubator/build/scripts/build-apple.sh
@@ -56,8 +56,8 @@ case ${1-} in
                ${code_signing} \
                CLANG_ADDRESS_SANITIZER=NO \
                CLANG_UNDEFINED_BEHAVIOR_SANITIZER=NO \
-               OTHER_CFLAGS='$(inherited) -fstack-protector-strong' \
-               OTHER_LDFLAGS='$(inherited) -fstack-protector-strong' \
+               OTHER_CFLAGS='$(inherited) -fno-sanitize=undefined -fno-sanitize=bounds -fstack-protector-strong' \
+               OTHER_LDFLAGS='$(inherited) -fno-sanitize=undefined -fno-sanitize=bounds -fstack-protector-strong' \
                COMPILER_INDEX_STORE_ENABLE=NO \
                archive
     ;;
@@ -86,8 +86,8 @@ case ${1-} in
                CODE_SIGNING_ALLOWED=NO \
                CLANG_ADDRESS_SANITIZER=NO \
                CLANG_UNDEFINED_BEHAVIOR_SANITIZER=NO \
-               OTHER_CFLAGS='$(inherited) -fstack-protector-strong' \
-               OTHER_LDFLAGS='$(inherited) -fstack-protector-strong' \
+               OTHER_CFLAGS='$(inherited) -fno-sanitize=undefined -fno-sanitize=bounds -fstack-protector-strong' \
+               OTHER_LDFLAGS='$(inherited) -fno-sanitize=undefined -fno-sanitize=bounds -fstack-protector-strong' \
                COMPILER_INDEX_STORE_ENABLE=NO \
                build
     ;;


### PR DESCRIPTION
### Description

It looks like build flags are now inherited from [build schemes](https://github.com/microsoft/react-native-test-app/blob/2.3.11/ios/ReactTestApp/ReactTestApp.debug.xcconfig) as well. This means that we now have to explicitly disable sanitizers.

Resolves #2237.

### Test plan

This command should now successfully build and launch the sample app in the simulator:

```
yarn rnx-build --platform ios --device-type simulator ../../packages/test-app
```