### PR TITLE
fix(cli): forward build options to `metro-serializer-esbuild`

### DIFF
--- a/.changeset/great-fans-drum.md
+++ b/.changeset/great-fans-drum.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Forward build options to `metro-serializer-esbuild`

--- a/packages/cli/src/metro-config.ts
+++ b/packages/cli/src/metro-config.ts
@@ -158,8 +158,12 @@ export function customizeMetroConfig(
   }
 
   if (extraParams.treeShake) {
-    metroConfig.serializer.customSerializer =
-      MetroSerializerEsbuild(metroPlugins);
+    metroConfig.serializer.customSerializer = MetroSerializerEsbuild(
+      metroPlugins,
+      typeof extraParams.treeShake === "object"
+        ? extraParams.treeShake
+        : undefined
+    );
     Object.assign(metroConfig.transformer, esbuildTransformerConfig);
   } else if (metroPlugins.length > 0) {
     // MetroSerializer acts as a CustomSerializer, and it works with both

--- a/packages/cli/src/metro-config.ts
+++ b/packages/cli/src/metro-config.ts
@@ -158,6 +158,11 @@ export function customizeMetroConfig(
   }
 
   if (extraParams.treeShake) {
+    if (metroConfig.serializer.customSerializer) {
+      warn(
+        "`serializer.customSerializer` in `metro.config.js` will be overwritten to enable tree shaking"
+      );
+    }
     metroConfig.serializer.customSerializer = MetroSerializerEsbuild(
       metroPlugins,
       typeof extraParams.treeShake === "object"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@rnx-kit/metro-plugin-cyclic-dependencies-detector": "*",
     "@rnx-kit/metro-plugin-duplicates-checker": "*",
+    "@rnx-kit/metro-serializer-esbuild": "*",
     "@rnx-kit/scripts": "*",
     "@rnx-kit/tools-react-native": "*",
     "@types/lodash": "^4.14.172",

--- a/packages/config/src/bundleConfig.ts
+++ b/packages/config/src/bundleConfig.ts
@@ -1,6 +1,7 @@
-import type { AllPlatforms } from "@rnx-kit/tools-react-native/platform";
 import type { PluginOptions as CyclicDetectorOptions } from "@rnx-kit/metro-plugin-cyclic-dependencies-detector";
 import type { Options as DuplicateDetectorOptions } from "@rnx-kit/metro-plugin-duplicates-checker";
+import type { Options as EsbuildOptions } from "@rnx-kit/metro-serializer-esbuild";
+import type { AllPlatforms } from "@rnx-kit/tools-react-native/platform";
 import type { OutputOptions } from "metro";
 
 export type TypeScriptValidationOptions = {
@@ -102,7 +103,7 @@ export type BundleParameters = BundlerPlugins & {
    *
    * Only applies to `rnx-bundle` command.
    */
-  treeShake?: boolean;
+  treeShake?: boolean | EsbuildOptions;
 
   /**
    * List of plugins to add to the bundling process.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3137,6 +3137,7 @@ __metadata:
     "@rnx-kit/console": ^1.0.11
     "@rnx-kit/metro-plugin-cyclic-dependencies-detector": "*"
     "@rnx-kit/metro-plugin-duplicates-checker": "*"
+    "@rnx-kit/metro-serializer-esbuild": "*"
     "@rnx-kit/scripts": "*"
     "@rnx-kit/tools-node": ^1.2.7
     "@rnx-kit/tools-react-native": "*"


### PR DESCRIPTION
### Description

Forward build options to `metro-serializer-esbuild`. This allows users to configure what standard to target.

### Test plan

n/a