### PR TITLE
fix(metro-plugin-typescript): fix required TypeScript version

### DIFF
--- a/.changeset/proud-dingos-shave.md
+++ b/.changeset/proud-dingos-shave.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/typescript-service": patch
+---
+
+Declare support for TypeScript 5.0

--- a/.changeset/small-ears-try.md
+++ b/.changeset/small-ears-try.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-plugin-typescript": patch
+---
+
+Fix TypeScript version being set too high

--- a/packages/metro-plugin-typescript/package.json
+++ b/packages/metro-plugin-typescript/package.json
@@ -35,7 +35,7 @@
     "@rnx-kit/typescript-service": "^1.5.4",
     "lodash": "^4.17.21",
     "semver": "^7.0.0",
-    "typescript": "^5.0.0"
+    "typescript": ">=4.7.0"
   },
   "devDependencies": {
     "@rnx-kit/scripts": "*",

--- a/packages/typescript-service/package.json
+++ b/packages/typescript-service/package.json
@@ -26,7 +26,7 @@
     "chalk": "^4.1.0"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": ">=4.0"
   },
   "devDependencies": {
     "@rnx-kit/scripts": "*",

--- a/scripts/rnx-align-deps.mjs
+++ b/scripts/rnx-align-deps.mjs
@@ -13,5 +13,5 @@ cli({
   ],
   requirements: ["react-native@0.68"],
   write: process.argv.includes("--write"),
-  "exclude-packages": ["@rnx-kit/build"],
+  "exclude-packages": ["@rnx-kit/build", "@rnx-kit/metro-plugin-typescript"],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3834,7 +3834,7 @@ __metadata:
     temp-dir: ^2.0.0
     typescript: ^5.0.0
   peerDependencies:
-    typescript: ^5.0.0
+    typescript: ">=4.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3407,7 +3407,7 @@ __metadata:
     lodash: ^4.17.21
     prettier: ^2.8.0
     semver: ^7.0.0
-    typescript: ^5.0.0
+    typescript: ">=4.7.0"
   languageName: unknown
   linkType: soft
 
@@ -13608,7 +13608,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.0.0":
+"typescript@npm:>=4.7.0, typescript@npm:^5.0.0":
   version: 5.0.2
   resolution: "typescript@npm:5.0.2"
   bin:
@@ -13618,7 +13618,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.0.0#~builtin<compat/typescript>":
+"typescript@patch:typescript@>=4.7.0#~builtin<compat/typescript>, typescript@patch:typescript@^5.0.0#~builtin<compat/typescript>":
   version: 5.0.2
   resolution: "typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>::version=5.0.2&hash=1f5320"
   bin:


### PR DESCRIPTION
### Description

Fix TypeScript version being set too high.

### Test plan

n/a