### PR TITLE
fix(align-deps): print excluded packages

### DIFF
--- a/.changeset/thick-fans-cry.md
+++ b/.changeset/thick-fans-cry.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": patch
+---
+
+Print packages that have been excluded

--- a/packages/align-deps/src/cli.ts
+++ b/packages/align-deps/src/cli.ts
@@ -209,8 +209,8 @@ export async function cli({ packages, ...args }: Args): Promise<void> {
   const errors = manifests.reduce((errors, manifest) => {
     try {
       const result = command(manifest);
+      printError(manifest, result);
       if (result !== "success" && result !== "excluded") {
-        printError(manifest, result);
         return errors + 1;
       }
     } catch (e) {

--- a/packages/align-deps/src/errors.ts
+++ b/packages/align-deps/src/errors.ts
@@ -9,7 +9,10 @@ export function isError<T>(config: T | ErrorCode): config is ErrorCode {
 export function printError(manifestPath: string, code: ErrorCode): void {
   switch (code) {
     case "success":
+      break;
+
     case "excluded":
+      info(`${manifestPath} was ignored`);
       break;
 
     case "invalid-app-requirements":


### PR DESCRIPTION
### Description

Print excluded packages.

### Test plan

```
yarn rnx-align-deps
```

Example output:

```diff
+info incubator/build/package.json was ignored
 warn packages/test-app/package.json: Found dependencies that are currently missing from capabilities:
 	  - @types/react-native can be managed by '@types/react-native'
 	  - eslint can be managed by 'eslint'
 	  - jest-cli can be managed by 'jest-cli'
 	  - prettier can be managed by 'prettier'
 	  - react-test-renderer can be managed by 'react-test-renderer'
 	  - typescript can be managed by 'typescript'
 info Note: Capabilities will never be added automatically, even with '--write'.
```