### PR TITLE
fix(react-native-host): fix empty package

### DIFF
--- a/.changeset/silent-buckets-laugh.md
+++ b/.changeset/silent-buckets-laugh.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Fixed empty package

--- a/packages/react-native-host/package.json
+++ b/packages/react-native-host/package.json
@@ -11,7 +11,7 @@
   "files": [
     "ReactNativeHost.podspec",
     "android/",
-    "mac/"
+    "cocoa/"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description

Fixed empty package.

### Test plan

Verify that `npm pack` includes all files under `cocoa/`:

```
cd packages/react-native-host
npm pack --dry-run
```