### PR TITLE
fix(react-native-host): cxxreact is only needed when New Arch is enabled

### DIFF
--- a/.changeset/soft-parrots-lie.md
+++ b/.changeset/soft-parrots-lie.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+`React-cxxreact` is only needed when New Arch is enabled

--- a/packages/react-native-host/ReactNativeHost.podspec
+++ b/packages/react-native-host/ReactNativeHost.podspec
@@ -29,11 +29,11 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.15'
 
   s.dependency 'React-Core'
-  s.dependency 'React-cxxreact'
 
   if new_arch_enabled
-    s.dependency 'ReactCommon/turbomodule/core'
+    s.dependency 'React-cxxreact'
     s.dependency 'React-RCTFabric'
+    s.dependency 'ReactCommon/turbomodule/core'
   end
 
   s.pod_target_xcconfig = {

--- a/packages/test-app/ios/Podfile.lock
+++ b/packages/test-app/ios/Podfile.lock
@@ -286,9 +286,8 @@ PODS:
     - React-jsi (= 0.68.6)
     - React-logger (= 0.68.6)
     - React-perflogger (= 0.68.6)
-  - ReactNativeHost (0.1.0):
+  - ReactNativeHost (0.2.1):
     - React-Core
-    - React-cxxreact
   - ReactTestApp-DevSupport (2.3.12):
     - React-Core
     - React-jsi
@@ -453,7 +452,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: be5f18ffc644f96f904e0e673ab639ca5d673ee8
   React-runtimeexecutor: d5498cfb7059bf8397b6416db4777843f3f4c1e7
   ReactCommon: 1974dab5108c79b40199f12a4833d2499b9f6303
-  ReactNativeHost: 067d8112f0a1c29cb0f6ea15dac7100026d157b2
+  ReactNativeHost: e55dee661a0656f2616fedf66dc16e19cd010064
   ReactTestApp-DevSupport: a33bfbe09dd21ff4ea512b117831db06174955b7
   ReactTestApp-MSAL: ad448d0b95393b58d1ec11d10f8c0cab226399d2
   ReactTestApp-Resources: 74a1cf509f4e7962b16361ea4e73cba3648fff5d

--- a/packages/test-app/macos/Podfile.lock
+++ b/packages/test-app/macos/Podfile.lock
@@ -286,9 +286,8 @@ PODS:
     - React-jsi (= 0.68.66)
     - React-logger (= 0.68.66)
     - React-perflogger (= 0.68.66)
-  - ReactNativeHost (0.1.0):
+  - ReactNativeHost (0.2.1):
     - React-Core
-    - React-cxxreact
   - ReactTestApp-DevSupport (2.3.12):
     - React-Core
     - React-jsi
@@ -453,7 +452,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 5e01780eb45effeb1e538fc3c64ffa186423eb2a
   React-runtimeexecutor: 17ad66d482998fbe0a92253cced17a5cbc06a125
   ReactCommon: d4e6d01d12414c52ec5d0de14d9ad8cd5d09ad61
-  ReactNativeHost: 067d8112f0a1c29cb0f6ea15dac7100026d157b2
+  ReactNativeHost: e55dee661a0656f2616fedf66dc16e19cd010064
   ReactTestApp-DevSupport: a33bfbe09dd21ff4ea512b117831db06174955b7
   ReactTestApp-MSAL: ad448d0b95393b58d1ec11d10f8c0cab226399d2
   ReactTestApp-Resources: bb546b3a5dca4b7931bee423d4ef28cd94b346cf


### PR DESCRIPTION
### Description

`React-cxxreact` is only needed when New Arch is enabled.

### Test plan

CI should still pass. This just removes an unused dependency.