### PR TITLE
fix(react-native-host): fix building with react-native 0.64

### DIFF
--- a/.changeset/curvy-lobsters-type.md
+++ b/.changeset/curvy-lobsters-type.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Fixed Xcode not being able to find a number of headers when targeting react-native 0.64

--- a/packages/react-native-host/ReactNativeHost.podspec
+++ b/packages/react-native-host/ReactNativeHost.podspec
@@ -41,11 +41,11 @@ Pod::Spec.new do |s|
     'DEFINES_MODULE' => 'YES',
     'GCC_PREPROCESSOR_DEFINITIONS' => preprocessor_definitions,
     'HEADER_SEARCH_PATHS' => [
-      '$(PODS_ROOT)/Headers/Private/React-Core',
       '$(PODS_ROOT)/boost',
       '$(PODS_ROOT)/boost-for-react-native',
       '$(PODS_ROOT)/RCT-Folly',
       '$(PODS_ROOT)/DoubleConversion',
+      '$(PODS_ROOT)/Headers/Private/React-Core',
     ],
   }
 

--- a/packages/react-native-host/ReactNativeHost.podspec
+++ b/packages/react-native-host/ReactNativeHost.podspec
@@ -9,7 +9,7 @@ repository = package['repository']
 repo_dir = repository['directory']
 
 new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
-preprocessor_definitions = ['FOLLY_NO_CONFIG=1']
+preprocessor_definitions = ['FOLLY_NO_CONFIG=1', 'FOLLY_MOBILE=1', 'FOLLY_USE_LIBCPP=1']
 if new_arch_enabled
   preprocessor_definitions << 'RCT_NEW_ARCH_ENABLED=1'
   preprocessor_definitions << 'USE_FABRIC=1'
@@ -29,9 +29,9 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.15'
 
   s.dependency 'React-Core'
+  s.dependency 'React-cxxreact'
 
   if new_arch_enabled
-    s.dependency 'React-cxxreact'
     s.dependency 'React-RCTFabric'
     s.dependency 'ReactCommon/turbomodule/core'
   end
@@ -43,6 +43,9 @@ Pod::Spec.new do |s|
     'HEADER_SEARCH_PATHS' => [
       '$(PODS_ROOT)/Headers/Private/React-Core',
       '$(PODS_ROOT)/boost',
+      '$(PODS_ROOT)/boost-for-react-native',
+      '$(PODS_ROOT)/RCT-Folly',
+      '$(PODS_ROOT)/DoubleConversion',
     ],
   }
 


### PR DESCRIPTION
### Description

Fixed Xcode not being able to find a number of headers when targeting react-native 0.64

### Test plan

Tested internally.