### PR TITLE
fix(cli): add --id flag to rnx-start

### DIFF
--- a/.changeset/silly-penguins-applaud.md
+++ b/.changeset/silly-penguins-applaud.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Add `--id` flag to `rnx-start`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -180,6 +180,7 @@ from the bundle configuration (or its [defaults](#bundle-defaults)).
 | --cert [path]                       | Path to a custom SSL certificate file to use for secure (https) communication.                                                                                   |
 | --config [string]                   | Path to the Metro configuration file.                                                                                                                            |
 | --no-interactive                    | Disables interactive mode.                                                                                                                                       |
+| --id                                | Specify which bundle configuration to use.                                                                                                                       |
 
 ## Manage Dependencies
 

--- a/packages/cli/react-native.config.js
+++ b/packages/cli/react-native.config.js
@@ -98,6 +98,10 @@ module.exports = {
           name: "--no-interactive",
           description: "Disables interactive mode.",
         },
+        {
+          name: "--id [string]",
+          description: "Specify which bundle configuration to use.",
+        },
       ],
     },
     rnxCopyAssetsCommand,

--- a/packages/cli/src/serve/kit-config.ts
+++ b/packages/cli/src/serve/kit-config.ts
@@ -7,6 +7,7 @@ type ServerConfigOverrides = {
   projectRoot?: string;
   assetPlugins?: string[];
   sourceExts?: string[];
+  id?: string;
 };
 
 type CliServerConfig = ServerConfig & {
@@ -26,7 +27,7 @@ export function getKitServerConfig(
   const kitConfig = getKitConfig();
   let serverConfig = kitConfig?.server;
   if (!serverConfig && kitConfig) {
-    const maybeBundleConfig = getBundleConfig(kitConfig);
+    const maybeBundleConfig = getBundleConfig(kitConfig, overrides?.id);
     if (maybeBundleConfig) {
       serverConfig = pickValues(maybeBundleConfig, [
         "detectCyclicDependencies",

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -45,6 +45,7 @@ export type CLIStartOptions = {
   cert?: string;
   config?: string;
   interactive: boolean;
+  id?: string;
 };
 
 function friendlyRequire<T>(...modules: string[]): T {


### PR DESCRIPTION
### Description
The default bundle configuration (first configuration) is used by `rnx-start` when the server configuration is absent. 
Adding `--id` flag to `rnx-start` which enables specifying which bundle configuration to use. 


### Test plan
Remove the server configuration and modify `start.ts` to verify which configuration is loaded:

```diff
diff --git a/packages/cli/src/start.ts b/packages/cli/src/start.ts
index 61b73e29..4221bff3 100644
--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -74,6 +74,7 @@ export async function rnxStart(
   cliOptions: CLIStartOptions
 ): Promise<void> {
   const serverConfig = getKitServerConfig(cliOptions);
+  console.log(serverConfig);

   const { createDevServerMiddleware, indexPageMiddleware } = friendlyRequire<
     typeof CliServerApi
diff --git a/packages/test-app/package.json b/packages/test-app/package.json
index 196b9672..0b2ea748 100644
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -155,21 +155,6 @@
         }
       }
     ],
-    "server": {
-      "projectRoot": "src",
-      "plugins": [
-        "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
-        [
-          "@rnx-kit/metro-plugin-duplicates-checker",
-          {
-            "ignoredModules": [
-              "react-is"
-            ]
-          }
-        ],
-        "@rnx-kit/metro-plugin-typescript"
-      ]
-    },
     "alignDeps": {
       "presets": [
         "microsoft/react-native",
```

Build and run Metro server:

```
cd packages/test-app
yarn build --dependencies
yarn start --id esbuild
```
