### PR TITLE
fix(metro-service): avoid spinning up the file watcher

### DIFF
--- a/.changeset/polite-needles-tell.md
+++ b/.changeset/polite-needles-tell.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/metro-service": patch
+"@rnx-kit/cli": patch
+---
+
+Avoid spinning up the file watcher when bundling

--- a/packages/metro-service/src/bundle.ts
+++ b/packages/metro-service/src/bundle.ts
@@ -87,7 +87,7 @@ export async function bundle(
     platform: args.platform,
     unstable_transformProfile: args.unstableTransformProfile,
   };
-  const server = new Server(config);
+  const server = new Server(config, { watch: false });
 
   try {
     const bundle = await output.build(server, requestOpts);


### PR DESCRIPTION
### Description

Avoid spinning up the file watcher when bundling.

Resolves #2332.

### Test plan

n/a