### PR TITLE
fix(metro-config): apply `@react-native/metro-config` if available

### DIFF
--- a/.changeset/healthy-geese-sing.md
+++ b/.changeset/healthy-geese-sing.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Get default config from `@react-native/metro-config` if available

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -26,10 +26,16 @@
     "@rnx-kit/tools-workspaces": "^0.1.3"
   },
   "peerDependencies": {
+    "@react-native/metro-config": "*",
     "metro-config": ">=0.58.0",
     "metro-react-native-babel-preset": "*",
     "react": "*",
     "react-native": "*"
+  },
+  "peerDependenciesMeta": {
+    "@react-native/metro-config": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",
@@ -55,7 +61,10 @@
     ]
   },
   "eslintConfig": {
-    "extends": "@rnx-kit/eslint-config"
+    "extends": "@rnx-kit/eslint-config",
+    "rules": {
+      "@typescript-eslint/ban-ts-comment": "off"
+    }
   },
   "jest": {
     "preset": "@rnx-kit/scripts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3469,10 +3469,14 @@ __metadata:
     type-fest: ^3.0.0
     typescript: ^5.0.0
   peerDependencies:
+    "@react-native/metro-config": "*"
     metro-config: ">=0.58.0"
     metro-react-native-babel-preset: "*"
     react: "*"
     react-native: "*"
+  peerDependenciesMeta:
+    "@react-native/metro-config":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

Get default config from `@react-native/metro-config` if available.

This will be required react-native-test-app to support 0.72: https://github.com/microsoft/react-native-test-app/issues/1359

### Test plan

Make sure configs are correctly merged:

```
cd packages/test-app
yarn build --dependencies
node -e "console.log(require('./metro.config.js'))"
```