### PR TITLE
Provide author name if no login

### DIFF
--- a/.changeset/smart-ghosts-protect.md
+++ b/.changeset/smart-ghosts-protect.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/rn-changelog-generator": patch
+---
+
+Address case where there is no author login property

--- a/incubator/rn-changelog-generator/src/utils/commits.ts
+++ b/incubator/rn-changelog-generator/src/utils/commits.ts
@@ -4,7 +4,12 @@ import { IncomingHttpHeaders } from "http";
 
 export interface Commit {
   sha: string;
-  commit: { message: string };
+  commit: {
+    message: string;
+    author?: {
+      name: string;
+    };
+  };
   author?: { login: string };
 }
 

--- a/incubator/rn-changelog-generator/src/utils/getChangeMessage.ts
+++ b/incubator/rn-changelog-generator/src/utils/getChangeMessage.ts
@@ -1,6 +1,15 @@
 import { Commit } from "./commits";
 import formatCommitLink from "./formatCommitLink";
 
+function getAuthorFormatting(item: Commit) {
+  if (item.author?.login != null) {
+    return `[@${item.author.login}](https://github.com/${item.author.login})`;
+  } else if (item.commit.author?.name != null) {
+    return item.commit.author.name;
+  }
+  return null;
+}
+
 export default function getChangeMessage(item: Commit, onlyMessage = false) {
   const commitMessage = item.commit.message.split("\n");
   let entry =
@@ -20,16 +29,9 @@ export default function getChangeMessage(item: Commit, onlyMessage = false) {
     return entry;
   }
 
+  const author = getAuthorFormatting(item);
   const authorSection = `([${item.sha.slice(0, 10)}](${formatCommitLink(
     item.sha
-  )})${
-    item.author
-      ? " by [@" +
-        item.author.login +
-        "](https://github.com/" +
-        item.author.login +
-        ")"
-      : ""
-  })`;
+  )})${author ? " by " + author : ""})`;
   return `- ${entry} ${authorSection}`;
 }

--- a/incubator/rn-changelog-generator/src/utils/getChangeMessage.ts
+++ b/incubator/rn-changelog-generator/src/utils/getChangeMessage.ts
@@ -2,9 +2,9 @@ import { Commit } from "./commits";
 import formatCommitLink from "./formatCommitLink";
 
 function getAuthorFormatting(item: Commit) {
-  if (item.author?.login != null) {
+  if (item.author?.login) {
     return `[@${item.author.login}](https://github.com/${item.author.login})`;
-  } else if (item.commit.author?.name != null) {
+  } else if (item.commit.author?.name) {
     return item.commit.author.name;
   }
   return null;

--- a/incubator/rn-changelog-generator/test/utils/getChangeMessage.test.ts
+++ b/incubator/rn-changelog-generator/test/utils/getChangeMessage.test.ts
@@ -18,4 +18,35 @@ describe(getChangeMessage, () => {
       "- Some great fixes! ([abcde12345](https://github.com/facebook/react-native/commit/abcde123456789) by [@alloy](https://github.com/alloy))"
     );
   });
+  it("formats a changelog entry with author name", () => {
+    expect(
+      getChangeMessage({
+        sha: "abcde123456789",
+        commit: {
+          author: {
+            name: "First Last",
+          },
+          message:
+            "Some ignored commit message\n\n[iOS] [Fixed] - Some great fixes! (#42)",
+        },
+        author: undefined,
+      })
+    ).toEqual(
+      "- Some great fixes! ([abcde12345](https://github.com/facebook/react-native/commit/abcde123456789) by First Last)"
+    );
+  });
+  it("formats a changelog entry without author", () => {
+    expect(
+      getChangeMessage({
+        sha: "abcde123456789",
+        commit: {
+          message:
+            "Some ignored commit message\n\n[iOS] [Fixed] - Some great fixes! (#42)",
+        },
+        author: undefined,
+      })
+    ).toEqual(
+      "- Some great fixes! ([abcde12345](https://github.com/facebook/react-native/commit/abcde123456789))"
+    );
+  });
 });


### PR DESCRIPTION
### Description

In some Github commit API responses, we don't get an author field. This results in changelogs that are missing identifiable authors. I'm not entirely sure why this is the case but this [comment](https://github.com/octokit/octokit.net/issues/1433#issuecomment-235617703) on a related issue is probably the reason -- where an email address isn't listed under the Github account.

From the commit json response, we can identify an author's first and last name. This PR adds that information when we don't have the Github username. 

#### Comparing the JSON responses 

What we expect (https://github.com/facebook/react-native/commit/63a4539e4d36ac90137eea6cdde0154ca06878c0)
```
{
  sha: '63a4539e4d',
  commit: {
    author: { 
      name: 'Oleksandr Melnykov',
      email: 'omelnykov@meta.com',
      date: '2022-11-10T23:17:24Z'
    },
    message: ..., 
    ...
  },
  author: {
    login: 'makovkastar',
    ...
  },
  ...
}
```
What we sometimes get  (note how the top-level `author` field is `null`) https://github.com/facebook/react-native/commit/db3ac93001f65bad84b748ec257fe79b79432976
```
{
  sha: 'db3ac93001f65bad84b748ec257fe79b79432976',
  commit: {
    author: {
      name: 'Lorenzo Blasa',
      email: 'lblasa@meta.com',
      date: '2022-11-24T15:46:00Z'
    },
    message: ..., 
    ...
  }
  author: null,
  ...
}
```


### Test plan

Added a test case