### PR TITLE
fix(react-native-host): fix 0.72 + New Architecture

### DIFF
--- a/.changeset/silent-turtles-pull.md
+++ b/.changeset/silent-turtles-pull.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Fix 0.72 + New Architecture not being able to find `RCTAppSetupUtils.h`

--- a/packages/react-native-host/ReactNativeHost.podspec
+++ b/packages/react-native-host/ReactNativeHost.podspec
@@ -32,6 +32,7 @@ Pod::Spec.new do |s|
   s.dependency 'React-cxxreact'
 
   if new_arch_enabled
+    s.dependency 'React-RCTAppDelegate'
     s.dependency 'React-RCTFabric'
     s.dependency 'ReactCommon/turbomodule/core'
   end

--- a/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
+++ b/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
@@ -14,8 +14,7 @@
 #import <React/RCTAppSetupUtils.h>
 #define USE_RUNTIME_SCHEDULER 0
 #else
-#import <RCTAppSetupUtils.h>
-
+#import <React-RCTAppDelegate/RCTAppSetupUtils.h>
 #import <React/RCTSurfacePresenterBridgeAdapter.h>
 #import <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>


### PR DESCRIPTION
### Description

Fix 0.72 + New Architecture not being able to find `RCTAppSetupUtils.h`.

### Test plan

Check out this branch: https://github.com/microsoft/react-native-test-app/pull/1363

```
npm run set-react-version 0.72
yarn
cd example
RCT_NEW_ARCH_ENABLED=1 pod install --project-directory=ios
yarn ios
```