### PR TITLE
fix(eslint-plugin): ignore namespace exports

### DIFF
--- a/.changeset/bright-clocks-switch.md
+++ b/.changeset/bright-clocks-switch.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/eslint-plugin": patch
+---
+
+no-export-all: Don't flag or autofix namespace exports (`export * as ns`)

--- a/packages/eslint-plugin/src/rules/no-export-all.js
+++ b/packages/eslint-plugin/src/rules/no-export-all.js
@@ -4,6 +4,7 @@
 /**
  * @typedef {import("@typescript-eslint/types").TSESTree.Node} Node
  * @typedef {import("eslint").Rule.RuleContext} ESLintRuleContext
+ * @typedef {import("eslint").Rule.ReportFixer} ESLintReportFixer
  * @typedef {{ exports: string[], types: string[] }} NamedExports
  *
  * @typedef {{
@@ -375,11 +376,10 @@ module.exports = {
     return {
       ExportAllDeclaration: (node) => {
         const source = node.source.value;
-        if (
-          expand === "external-only" &&
-          source &&
-          source.toString().startsWith(".")
-        ) {
+        const isInternal = source && source.toString().startsWith(".");
+        // export * as foo from "foo";
+        const isExportNamespace = !!node.exported;
+        if ((expand === "external-only" && isInternal) || isExportNamespace) {
           return;
         }
 

--- a/packages/eslint-plugin/test/no-export-all.test.ts
+++ b/packages/eslint-plugin/test/no-export-all.test.ts
@@ -81,6 +81,7 @@ describe("disallows `export *`", () => {
       "export default 'Arnold';",
       "const name = 'Arnold'; export { name as default };",
       "export { escape } from 'chopper';",
+      "export * as chopper from 'chopper';",
       {
         code: "export * from './internal';",
         options: [{ expand: "external-only" }],


### PR DESCRIPTION
### Description

Currently the `no-export-all` fixer has incorrect expansion of namespace exports (`export * as foo from './foo'`): it will export all the individual identifiers instead of the namespace, which breaks consuming code. More details in #2373.

~~This PR adds a different fix specific to this case. New example code:~~
```ts
// import * as foo from './foo';
// export { foo };
```
After discussion with @tido64, we decided to update the rule to ignore namespace exports.

Fixes #2373

### Test plan

- Added a test
