### PR TITLE
fix(eslint-plugin): add support for TS "export import ="

### DIFF
--- a/.changeset/fifty-numbers-complain.md
+++ b/.changeset/fifty-numbers-complain.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/eslint-plugin": patch
+---
+
+no-export-all: add support in fixer for TS `export import =`

--- a/packages/eslint-plugin/src/rules/no-export-all.js
+++ b/packages/eslint-plugin/src/rules/no-export-all.js
@@ -330,6 +330,14 @@ function extractExports(context, moduleId, depth) {
             }
             break;
           }
+
+          case "TSImportEqualsDeclaration":
+            if (node.isExport) {
+              // export import foo = require('./foo');
+              // export import Bar = Foo.Bar;
+              exports.add(node.id.name);
+            }
+            break;
         }
       },
     });

--- a/packages/eslint-plugin/test/no-export-all.test.ts
+++ b/packages/eslint-plugin/test/no-export-all.test.ts
@@ -43,6 +43,19 @@ export interface IChopper {
 
 export declare function escape(): void;
 `,
+  "ts-import-equals": `
+import * as chopper from 'chopper';
+export import notChopper = chopper;
+export import IChopper = chopper.IChopper;
+export import name = chopper.name;
+export import chopper = require('chopper');
+
+namespace Foo {
+  export const foo = 'foo';
+}
+export import foo = Foo.foo;
+export const bar = 'bar';
+`,
   "@fluentui/font-icons-mdl2": `
 export const enum IconNames {
   PageLink = 'PageLink',
@@ -117,6 +130,12 @@ describe("disallows `export *`", () => {
           "export type { IChopper, Predator } from 'types';",
           "export { Helicopter, escape } from 'types';"
         ),
+      },
+      {
+        code: "export * from 'ts-import-equals';",
+        errors: 1,
+        output:
+          "export { IChopper, bar, chopper, foo, name, notChopper } from 'ts-import-equals';",
       },
       {
         code: lines("export * from './internal';", "export * from 'types';"),


### PR DESCRIPTION
### Description

In TypeScript, it's possible to declare exports with the syntax `export import Foo = /*name or require()*/`. The fixer for `no-export-all` currently misses these exports, causing erroneous code to be generated. See #2375 for more details.

This PR adds support for detecting these kinds of exports. Currently it assumes that these are always value exports, due to the additional complexity required to figure out the actual type.

Fixes #2375 

### Test plan

- Added a test
- Locally link the rule to a repo with this type of export and verify the correct fix is applied.