### PR TITLE
fix(react-native-host): make TM headers available to config plugins

### DIFF
--- a/.changeset/large-cobras-relate.md
+++ b/.changeset/large-cobras-relate.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Make headers from `ReactCommon/turbomodule/core` available to config plugins

--- a/packages/react-native-host/ReactNativeHost.podspec
+++ b/packages/react-native-host/ReactNativeHost.podspec
@@ -31,10 +31,13 @@ Pod::Spec.new do |s|
   s.dependency 'React-Core'
   s.dependency 'React-cxxreact'
 
+  # Normally, we wouldn't need this unless New Arch was enabled. However,
+  # Reanimated requires a header from here.
+  s.dependency 'ReactCommon/turbomodule/core'
+
   if new_arch_enabled
     s.dependency 'React-RCTAppDelegate'
     s.dependency 'React-RCTFabric'
-    s.dependency 'ReactCommon/turbomodule/core'
   end
 
   s.pod_target_xcconfig = {


### PR DESCRIPTION
### Description

Make headers from `ReactCommon/turbomodule/core` available to config plugins.

### Test plan

See https://github.com/microsoft/react-native-test-app/issues/1428.