### PR TITLE
fix(metro-serializer-esbuild): add support for `metafile`

### DIFF
--- a/.changeset/famous-numbers-share.md
+++ b/.changeset/famous-numbers-share.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Add support for `metafile` flag

--- a/packages/metro-serializer-esbuild/README.md
+++ b/packages/metro-serializer-esbuild/README.md
@@ -214,6 +214,15 @@ Values: `verbose` | `debug` | `info` | `warning` | `error` | `silent`
 
 Defaults to `warning`.
 
+### `metafile`
+
+The path to write metadata to, relative to the package root.
+
+Determines whether esbuild should produce some metadata about the build in JSON
+format.
+
+See the full documentation at https://esbuild.github.io/api/#metafile.
+
 ## Metro + ESM Support
 
 Metro currently does not support ESM. However, if you're looking to save even


### PR DESCRIPTION
### Description

Add support for the `metafile` flag.

### Test plan

Prepare:

```
cd packages/test-app
yarn build --dependencies
```

Then for each verification step, run `yarn bundle+esbuild --dev false --platform android`:

1. Make sure `package.json` is clean. Verify that no analysis/metafile is output.
2. Verify that only analysis is output:
    ```diff
    diff --git a/packages/test-app/package.json b/packages/test-app/package.json
    index bf87fe69..64b62c32 100644
    --- a/packages/test-app/package.json
    +++ b/packages/test-app/package.json
    @@ -118,7 +118,9 @@
             "id": "esbuild",
             "entryFile": "src/index.ts",
             "assetsDest": "dist",
    -        "treeShake": true,
    +        "treeShake": {
    +          "analyze": true
    +        },
             "plugins": [
               "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
               [
    ```
3. Verify that only a metafile is output:
    ```diff
    diff --git a/packages/test-app/package.json b/packages/test-app/package.json
    index bf87fe69..64b62c32 100644
    --- a/packages/test-app/package.json
    +++ b/packages/test-app/package.json
    @@ -118,7 +118,9 @@
             "id": "esbuild",
             "entryFile": "src/index.ts",
             "assetsDest": "dist",
    -        "treeShake": true,
    +        "treeShake": {
    +          "metafile": "meta.json"
    +        },
             "plugins": [
               "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
               [
    ```
4. Verify that both are output:
    ```diff
    diff --git a/packages/test-app/package.json b/packages/test-app/package.json
    index bf87fe69..64b62c32 100644
    --- a/packages/test-app/package.json
    +++ b/packages/test-app/package.json
    @@ -118,7 +118,9 @@
             "id": "esbuild",
             "entryFile": "src/index.ts",
             "assetsDest": "dist",
    -        "treeShake": true,
    +        "treeShake": {
    +          "analyze": true,
    +          "metafile": "meta.json"
    +        },
             "plugins": [
               "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
               [
    ```
5. Verify that the output `meta.json` is valid by importing it here: https://esbuild.github.io/analyze/