### PR TITLE
RuntimeScheduler is only used by TurboModule Manager in >RN0.72

### DIFF
--- a/.changeset/loud-walls-fail.md
+++ b/.changeset/loud-walls-fail.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+RuntimeScheduler is only used by TurboModule Manager in >RN0.72

--- a/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
+++ b/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
@@ -31,12 +31,7 @@
 #define USE_RUNTIME_SCHEDULER 0
 #endif  // __has_include(<React-RCTAppDelegate/RCTLegacyInteropComponents.h>)
 
-// RCTAppSetupDefaultJsExecutorFactory is in different locations for iOS (0.71)/macOS(0.71)
-#if !TARGET_OS_OSX
-#import <React/RCTAppSetupUtils.h>
-#else
-#import <React-RCTAppDelegate/RCTAppSetupUtils.h>
-#endif // TARGET_OS_OSX
+#endif  // __has_include(<React/RCTAppSetupUtils.h>)
 
 #endif  // USE_TURBOMODULE
 

--- a/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
+++ b/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
@@ -45,7 +45,7 @@
     _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
                                                                delegate:self
                                                               jsInvoker:callInvoker];
-    return RCTAppSetupDefaultJsExecutorFactory(bridge, _turboModuleManager, _runtimeScheduler);
+    return RCTAppSetupDefaultJsExecutorFactory(bridge, _turboModuleManager);
 #else
     _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
                                                                delegate:self

--- a/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
+++ b/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
@@ -16,10 +16,27 @@
 #else
 #import <React-RCTAppDelegate/RCTAppSetupUtils.h>
 #import <React/RCTSurfacePresenterBridgeAdapter.h>
+
+// We still get into this path because react-native-macos 0.71 picked up some
+// 0.72 bits. AFAICT, `RCTLegacyInteropComponents.h` is a new addition in 0.72
+// in both react-native and react-native-macos.
+#if __has_include(<React-RCTAppDelegate/RCTLegacyInteropComponents.h>)
 #import <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
+#if __has_include(<React/RCTRuntimeExecutorFromBridge.h>)
+#import <React/RCTRuntimeExecutorFromBridge.h>
+#endif  // __has_include(<React/RCTRuntimeExecutorFromBridge.h>)
 #define USE_RUNTIME_SCHEDULER 1
-#endif  // __has_include(<React/RCTAppSetupUtils.h>)
+#else
+#define USE_RUNTIME_SCHEDULER 0
+#endif  // __has_include(<React-RCTAppDelegate/RCTLegacyInteropComponents.h>)
+
+// RCTAppSetupDefaultJsExecutorFactory is in different locations for iOS (0.71)/macOS(0.71)
+#if !TARGET_OS_OSX
+#import <React/RCTAppSetupUtils.h>
+#else
+#import <React-RCTAppDelegate/RCTAppSetupUtils.h>
+#endif // TARGET_OS_OSX
 
 #endif  // USE_TURBOMODULE
 
@@ -45,7 +62,7 @@
     _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
                                                                delegate:self
                                                               jsInvoker:callInvoker];
-    return RCTAppSetupDefaultJsExecutorFactory(bridge, _turboModuleManager);
+    return RCTAppSetupDefaultJsExecutorFactory(bridge, _turboModuleManager, _runtimeScheduler);
 #else
     _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
                                                                delegate:self


### PR DESCRIPTION
### Description

- When I was testing loading AsyncStorage as a [TurboModule for macOS](https://github.com/j-piasecki/react-native-async-storage/commit/6d2faaaab9770ef54bb4d1175d24f30a21bc03d8), I ran into this build error:
`No matching function for call to 'RCTAppSetupDefaultJsExecutorFactory'`
![CleanShot 2023-06-14 at 09 33 44](https://github.com/microsoft/rnx-kit/assets/96719/bc357c18-fff2-4ec8-b828-4dbafe67e308)

- `RuntimeScheduler` was added as a param to `RCTAppSetupDefaultJsExecutorFactory` [in RN Core here](https://github.com/facebook/react-native/pull/36209)
https://github.com/facebook/react-native/pull/36209/files#diff-1e16648bc876095f7583276815d1964d165986e1f5174ff23123c8c027a2ef0bR44

- We could pick that change, or just remove the param till it's merged.

### Test plan

- Not sure how to test this inside RNXKit, however here is the AsyncStorage TM working on macOS with this fix:

https://github.com/microsoft/rnx-kit/assets/96719/2dfe7e90-2047-4a92-8a8c-a4feebb748bc



