### PR TITLE
fix(metro-config): fix out-of-tree platforms not being included on react-native 0.72

### DIFF
--- a/.changeset/real-rules-speak.md
+++ b/.changeset/real-rules-speak.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/metro-config": patch
+"@rnx-kit/metro-service": patch
+---
+
+Fix out-of-tree platforms not being included on react-native 0.72

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -23,17 +23,22 @@
     "@rnx-kit/babel-preset-metro-react-native": "^1.1.4",
     "@rnx-kit/console": "^1.0.0",
     "@rnx-kit/tools-node": "^2.0.0",
+    "@rnx-kit/tools-react-native": "^1.3.1",
     "@rnx-kit/tools-workspaces": "^0.1.3"
   },
   "peerDependencies": {
     "@react-native/metro-config": "*",
     "metro-config": ">=0.58.0",
     "metro-react-native-babel-preset": "*",
+    "metro-resolver": ">=0.58.0",
     "react": "*",
     "react-native": "*"
   },
   "peerDependenciesMeta": {
     "@react-native/metro-config": {
+      "optional": true
+    },
+    "metro-resolver": {
       "optional": true
     }
   },

--- a/packages/metro-config/src/defaultConfig.js
+++ b/packages/metro-config/src/defaultConfig.js
@@ -12,6 +12,24 @@ const path = require("path");
  */
 
 /**
+ * @param {string} moduleName
+ * @param {string} implementation
+ */
+function redirectToPlatform(moduleName, implementation) {
+  if (implementation) {
+    if (moduleName === "react-native") {
+      return implementation;
+    }
+
+    const prefix = "react-native/";
+    if (moduleName.startsWith(prefix)) {
+      return `${implementation}/${moduleName.slice(prefix.length)}`;
+    }
+  }
+  return moduleName;
+}
+
+/**
  * @param {PlatformImplementations} implementations
  */
 function outOfTreePlatformResolver(implementations) {
@@ -30,17 +48,8 @@ function outOfTreePlatformResolver(implementations) {
     }
 
     try {
-      let modifiedModuleName = moduleName;
-      const reactNativePlatform = implementations[platform];
-      if (reactNativePlatform) {
-        if (moduleName === "react-native") {
-          modifiedModuleName = reactNativePlatform;
-        } else if (moduleName.startsWith("react-native/")) {
-          modifiedModuleName = `${reactNativePlatform}/${modifiedModuleName.slice(
-            "react-native/".length
-          )}`;
-        }
-      }
+      const impl = implementations[platform];
+      const modifiedModuleName = redirectToPlatform(moduleName, impl);
       // @ts-expect-error We pass 4 arguments instead of 3 to be backwards compatible
       return resolve(context, modifiedModuleName, platform, null);
     } finally {

--- a/packages/metro-config/src/defaultConfig.js
+++ b/packages/metro-config/src/defaultConfig.js
@@ -12,6 +12,25 @@ const path = require("path");
  */
 
 /**
+ * @param {PlatformImplementations} availablePlatforms
+ */
+function getPreludeModules(availablePlatforms) {
+  // Include all instances of `InitializeCore` here and let Metro exclude
+  // the unused ones.
+  const mainModules = new Set([
+    require.resolve("react-native/Libraries/Core/InitializeCore"),
+  ]);
+  for (const moduleName of Object.values(availablePlatforms)) {
+    if (moduleName) {
+      mainModules.add(
+        require.resolve(`${moduleName}/Libraries/Core/InitializeCore`)
+      );
+    }
+  }
+  return Array.from(mainModules);
+}
+
+/**
  * @param {string} moduleName
  * @param {string} implementation
  */
@@ -87,20 +106,9 @@ function getDefaultConfig(projectRoot) {
       defaultConfig.resolver.resolveRequest =
         outOfTreePlatformResolver(availablePlatforms);
 
-      // Include all instances of `InitializeCore` here and let Metro exclude
-      // the unused ones.
-      const mainModules = new Set([
-        require.resolve("react-native/Libraries/Core/InitializeCore"),
-      ]);
-      for (const moduleName of Object.values(availablePlatforms)) {
-        if (moduleName) {
-          mainModules.add(
-            require.resolve(`${moduleName}/Libraries/Core/InitializeCore`)
-          );
-        }
-      }
+      const preludeModules = getPreludeModules(availablePlatforms);
       defaultConfig.serializer.getModulesRunBeforeMainModule = () => {
-        return Array.from(mainModules);
+        return preludeModules;
       };
 
       return [defaultConfig];

--- a/packages/metro-config/src/defaultConfig.js
+++ b/packages/metro-config/src/defaultConfig.js
@@ -1,0 +1,105 @@
+// @ts-check
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * @typedef {import("metro-config").MetroConfig} MetroConfig;
+ * @typedef {import("metro-resolver").CustomResolver} CustomResolver;
+ * @typedef {import("metro-resolver").Resolution} Resolution;
+ * @typedef {import("metro-resolver").ResolutionContext} ResolutionContext;
+ *
+ * @typedef {ReturnType<typeof import("@rnx-kit/tools-react-native").getAvailablePlatforms>} PlatformImplementations;
+ */
+
+/**
+ * @param {PlatformImplementations} implementations
+ */
+function outOfTreePlatformResolver(implementations) {
+  /** @type {(context: ResolutionContext, moduleName: string, platform: string) => Resolution} */
+  const platformResolver = (context, moduleName, platform) => {
+    const { resolve: metroResolver } = require("metro-resolver");
+
+    /** @type {CustomResolver} */
+    let resolve = metroResolver;
+    const resolveRequest = context.resolveRequest;
+    if (platformResolver === resolveRequest) {
+      // @ts-expect-error We intentionally delete `resolveRequest` here and restore it later
+      delete context.resolveRequest;
+    } else if (resolveRequest) {
+      resolve = resolveRequest;
+    }
+
+    try {
+      let modifiedModuleName = moduleName;
+      const reactNativePlatform = implementations[platform];
+      if (reactNativePlatform) {
+        if (moduleName === "react-native") {
+          modifiedModuleName = reactNativePlatform;
+        } else if (moduleName.startsWith("react-native/")) {
+          modifiedModuleName = `${reactNativePlatform}/${modifiedModuleName.slice(
+            "react-native/".length
+          )}`;
+        }
+      }
+      // @ts-expect-error We pass 4 arguments instead of 3 to be backwards compatible
+      return resolve(context, modifiedModuleName, platform, null);
+    } finally {
+      if (!context.resolveRequest) {
+        // @ts-expect-error We intentionally deleted `resolveRequest` and restore it here
+        context.resolveRequest = resolveRequest;
+      }
+    }
+  };
+  return platformResolver;
+}
+
+/**
+ * Returns default Metro config.
+ *
+ * Starting with `react-native` 0.72, we need to build a complete Metro config
+ * as `@react-native-community/cli` will no longer provide defaults.
+ *
+ * @param {string} projectRoot
+ * @returns {MetroConfig[]}
+ */
+function getDefaultConfig(projectRoot) {
+  try {
+    const pkgJson = path.join(projectRoot, "package.json");
+    const manifest = fs.readFileSync(pkgJson, { encoding: "utf-8" });
+    if (manifest.includes("@react-native/metro-config")) {
+      // @ts-ignore Cannot find module or its corresponding type declarations.
+      const { getDefaultConfig } = require("@react-native/metro-config");
+      const { getAvailablePlatforms } = require("@rnx-kit/tools-react-native");
+
+      const defaultConfig = getDefaultConfig(projectRoot);
+
+      const availablePlatforms = getAvailablePlatforms(projectRoot);
+      defaultConfig.resolver.platforms = Object.keys(availablePlatforms);
+      defaultConfig.resolver.resolveRequest =
+        outOfTreePlatformResolver(availablePlatforms);
+
+      // Include all instances of `InitializeCore` here and let Metro exclude
+      // the unused ones.
+      const mainModules = new Set([
+        require.resolve("react-native/Libraries/Core/InitializeCore"),
+      ]);
+      for (const moduleName of Object.values(availablePlatforms)) {
+        if (moduleName) {
+          mainModules.add(
+            require.resolve(`${moduleName}/Libraries/Core/InitializeCore`)
+          );
+        }
+      }
+      defaultConfig.serializer.getModulesRunBeforeMainModule = () => {
+        return Array.from(mainModules);
+      };
+
+      return [defaultConfig];
+    }
+  } catch (_) {
+    // Ignore
+  }
+  return [];
+}
+
+exports.getDefaultConfig = getDefaultConfig;

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -58,30 +58,6 @@ function defaultWatchFolders() {
 }
 
 /**
- * Returns default Metro config.
- *
- * Starting with `react-native` 0.72, we need to build a complete Metro config
- * as `@react-native-community/cli` will no longer provide defaults.
- *
- * @param {string} projectRoot
- * @returns {MetroConfig[]}
- */
-function getDefaultConfig(projectRoot) {
-  try {
-    const pkgJson = path.join(projectRoot, "package.json");
-    const manifest = fs.readFileSync(pkgJson, { encoding: "utf-8" });
-    if (manifest.includes("@react-native/metro-config")) {
-      // @ts-ignore Cannot find module or its corresponding type declarations.
-      const { getDefaultConfig } = require("@react-native/metro-config");
-      return [getDefaultConfig(projectRoot)];
-    }
-  } catch (_) {
-    // Ignore
-  }
-  return [];
-}
-
-/**
  * Returns the path to specified module; `undefined` if not found.
  *
  * Note that this function resolves symlinks. This is necessary for setups that
@@ -226,6 +202,7 @@ module.exports = {
   makeMetroConfig: (customConfig = {}) => {
     const { mergeConfig } = require("metro-config");
     const { enhanceMiddleware } = require("./assetPluginForMonorepos");
+    const { getDefaultConfig } = require("./defaultConfig");
 
     const projectRoot = customConfig.projectRoot || process.cwd();
     const blockList = exclusionList([], projectRoot);

--- a/packages/metro-service/src/config.ts
+++ b/packages/metro-service/src/config.ts
@@ -160,10 +160,15 @@ function getDefaultConfigProvider(): typeof getDefaultConfigInternal {
     const {
       getDefaultConfig,
     } = require("@react-native-community/cli-plugin-metro");
-    return getDefaultConfig;
+
+    // Starting with `react-native` 0.72, we need to build a complete Metro
+    // config upfront and will no longer need to get a default config here.
+    return getDefaultConfig ? getDefaultConfig : () => ({});
   } catch (_) {
-    return getDefaultConfigInternal;
+    // Ignore
   }
+
+  return getDefaultConfigInternal;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3606,6 +3606,7 @@ __metadata:
     "@rnx-kit/console": ^1.0.0
     "@rnx-kit/scripts": "*"
     "@rnx-kit/tools-node": ^2.0.0
+    "@rnx-kit/tools-react-native": ^1.3.1
     "@rnx-kit/tools-workspaces": ^0.1.3
     "@types/babel__core": ^7.0.0
     "@types/jest": ^29.2.1
@@ -3623,10 +3624,13 @@ __metadata:
     "@react-native/metro-config": "*"
     metro-config: ">=0.58.0"
     metro-react-native-babel-preset: "*"
+    metro-resolver: ">=0.58.0"
     react: "*"
     react-native: "*"
   peerDependenciesMeta:
     "@react-native/metro-config":
+      optional: true
+    metro-resolver:
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Description

Fix compatibility with react-native 0.72

Resolves #2466.

### Test plan

n/a