### PR TITLE
fix(metro-serializer-esbuild): warn when `export *` is used

### DIFF
--- a/.changeset/new-boats-itch.md
+++ b/.changeset/new-boats-itch.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Warn when `export *` is used on log level 'debug'


### PR DESCRIPTION
### Description

Warn when `export *` is used on log level 'debug'

### Test plan

```
cd packages/test-app
yarn build --dependencies
yarn bundle+esbuild --platform android --dev false
```

Output:

```
info Bundling android...
                Welcome to Metro v0.73.9
              Fast - Scalable - Integrated


warn Found uses of 'export *' in ../../node_modules/react-native/Libraries/ReactNative/RendererProxy.js

  main+esbuild.android.bundle      593.2kb
  main+esbuild.android.bundle.map    2.8mb

⚡ Done in 324ms
info esbuild bundle size: 607473
info Writing bundle output to:, dist/main+esbuild.android.bundle
info Writing sourcemap output to:, dist/main+esbuild.android.bundle.map
info Done writing bundle output
info Done writing sourcemap output
info Copying 1 asset files
info Done copying assets
```