### PR TITLE
Fix metro 0.72 sourcemap options

### DIFF
--- a/.changeset/ten-keys-hope.md
+++ b/.changeset/ten-keys-hope.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Add `shouldAddToIgnoreList` to `sourceMappingOptions`, this became mandatory in Metro 0.76.3

--- a/packages/metro-serializer-esbuild/src/sourceMap.ts
+++ b/packages/metro-serializer-esbuild/src/sourceMap.ts
@@ -6,6 +6,7 @@ import * as path from "path";
 const sourceMappingOptions = {
   processModuleFilter: () => true,
   excludeSource: false,
+  shouldAddToIgnoreList: () => false,
 };
 
 export function absolutizeSourceMap(outputPath: string, text: string): string {


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

When using the esbuild serializer with RN 0.72 (Metro 0.76.5), the build crashes with this error:
```
✘ [ERROR] options.shouldAddToIgnoreList is not a function [plugin @rnx-kit/metro-serializer-esbuild]

    ../../node_modules/metro/src/DeltaBundler/Serializers/helpers/getSourceMapInfo.js:18:23:
      18 │     isIgnored: options.shouldAddToIgnoreList(module),
```

`shouldAddToIgnoreList` has been added in https://github.com/facebook/metro/commit/82bd64a9720174a9e2a02fb73bbef292153e20f1#diff-6a12274bc59498289ea08e6f204df8fe5e262338a7c77344463497df264440c1R175 but does not have a default or a fallback, so Metro crashes as we dont provide it.

### Test plan

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->

I tested that it fixes the production build on my app after upgrading to RN 0.72