### PR TITLE
fix(metro-resolver-symlinks): correctly handle redirected modules

### DIFF
--- a/.changeset/red-balloons-arrive.md
+++ b/.changeset/red-balloons-arrive.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Correctly handle redirected modules

--- a/packages/metro-resolver-symlinks/src/symlinkResolver.ts
+++ b/packages/metro-resolver-symlinks/src/symlinkResolver.ts
@@ -16,13 +16,20 @@ import { remapImportPath } from "./utils/remapImportPath";
 
 function applyMetroResolver(
   resolve: CustomResolver,
-  context: ResolutionContext,
+  ctx: ResolutionContext,
   moduleName: string,
   platform: string
 ): Resolution {
-  const modifiedModuleName = resolveModulePath(context, moduleName, platform);
+  // Resolve redirects before we try to resolve the module:
+  // https://github.com/facebook/metro/blob/v0.76.7/docs/Resolution.md#redirectmodulepath-string--string--false
+  const realModuleName = ctx.redirectModulePath(moduleName);
+  if (realModuleName === false) {
+    return { type: "empty" };
+  }
+
+  const modifiedModuleName = resolveModulePath(ctx, realModuleName, platform);
   // @ts-expect-error We pass 4 arguments instead of 3 to be backwards compatible
-  return resolve(context, normalizePath(modifiedModuleName), platform, null);
+  return resolve(ctx, normalizePath(modifiedModuleName), platform, null);
 }
 
 export function makeResolver(options: Options = {}): MetroResolver {


### PR DESCRIPTION
### Description

Handle redirected modules as `metro-resolver` does: https://github.com/facebook/metro/blob/5feb0d75320bd2a7a964da38c315f8b3e37640b1/packages/metro-resolver/src/resolve.js#L52-L65

Resolves #2478.

### Test plan

1. Apply diff:
    ```diff
    diff --git a/packages/test-app/package.json b/packages/test-app/package.json
    index bf87fe69..b0ed7384 100644
    --- a/packages/test-app/package.json
    +++ b/packages/test-app/package.json
    @@ -25,6 +25,9 @@
         "start": "react-native rnx-start"
       },
       "dependencies": {
    +    "@aws-sdk/chunked-blob-reader-native": "3.310.0",
    +    "@aws-sdk/hash-blob-browser": "3.357.0",
    +    "getstream": "8.1.5",
         "react": "18.2.0",
         "react-native": "^0.71.0",
         "react-native-macos": "^0.71.0",
    diff --git a/packages/test-app/src/App.native.tsx b/packages/test-app/src/App.native.tsx
    index ad34b41d..8479e5bb 100644
    --- a/packages/test-app/src/App.native.tsx
    +++ b/packages/test-app/src/App.native.tsx
    @@ -1,4 +1,6 @@
     import { acquireTokenWithScopes } from "@rnx-kit/react-native-auth";
    +import { connect } from "getstream";
    +import { blobHasher } from "@aws-sdk/hash-blob-browser";
     import React, { useCallback, useMemo, useState } from "react";
     import type { LayoutChangeEvent } from "react-native";
     import {
    @@ -193,6 +195,12 @@ function App({ concurrentRoot }: { concurrentRoot?: boolean }) {
       const [isFabric, setFabric] = useState(false);
       const onLayout = useCallback(
         (ev: LayoutChangeEvent) => {
    +      const client = connect("apikey", "userToken", "appid");
    +      client.createUserToken("the-user-id");
    +      if (!blobHasher) {
    +        throw new Error();
    +      }
    +
           setFabric(
             Boolean(
               // @ts-expect-error Internal handle to determine whether Fabric is enabled
    ```
2. Build:
    ```
    yarn
    cd packages/test-app
    yarn build --dependencies
    yarn bundle --platform android --reset-cache
    ```