### PR TITLE
fix(test-app): fix 'duplicate `__self` prop found' error

### DIFF
--- a/packages/test-app/babel.config.js
+++ b/packages/test-app/babel.config.js
@@ -1,3 +1,19 @@
 module.exports = {
-  presets: ["@rnx-kit/babel-preset-metro-react-native"],
+  presets: [
+    [
+      "@rnx-kit/babel-preset-metro-react-native",
+      { useTransformReactJSXExperimental: true },
+    ],
+  ],
+  overrides: [
+    {
+      plugins: [
+        [
+          require("@babel/plugin-transform-react-jsx"),
+          { runtime: "automatic" },
+        ],
+        [require("@babel/plugin-transform-react-jsx-source")],
+      ],
+    },
+  ],
 };


### PR DESCRIPTION
### Description

```
error: App.native.tsx: /~/packages/test-app/App.native.tsx: Duplicate __self prop found. You are most likely using the deprecated transform-react-jsx-self Babel plugin. Both __source and __self are automatically set when using the automatic runtime. Please remove transform-react-jsx-source and transform-react-jsx-self from your Babel config.
  119 |       onPress={onPress}
  120 |     >
> 121 |       <Text style={styles.groupItemLabel}>{children}</Text>
      |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  122 |     </Pressable>
  123 |   );
  124 | }
```

### Test plan

```
cd packages/test-app
yarn build --dependencies
yarn android

# In a separate terminal, start the dev server
yarn start
```