### PR TITLE
fix(react-native-host): check if `RCTAppDelegate` specification exists

### DIFF
--- a/.changeset/mighty-snails-travel.md
+++ b/.changeset/mighty-snails-travel.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Prevent adding `RCTAppDelegate` as dependency if it does not exist

--- a/packages/react-native-host/ReactNativeHost.podspec
+++ b/packages/react-native-host/ReactNativeHost.podspec
@@ -1,4 +1,5 @@
 require 'json'
+require 'rubygems'
 
 source_files = 'cocoa/*.{h,m,mm}'
 public_header_files = 'cocoa/{ReactNativeHost,RNXHostConfig}.h'
@@ -36,7 +37,12 @@ Pod::Spec.new do |s|
   s.dependency 'ReactCommon/turbomodule/core'
 
   if new_arch_enabled
-    s.dependency 'React-RCTAppDelegate'
+    # RCTAppDelegate was first introduced in RN 0.71,
+    # so it should be skipped if its spec does not exist.
+    if Gem::Specification.find_all_by_name('React-RCTAppDelegate').any?
+      s.dependency 'React-RCTAppDelegate'
+    end
+
     s.dependency 'React-RCTFabric'
   end
 


### PR DESCRIPTION
### Description
`RCTAppDelegate` was first introduced in React Native version 0.71. When running `RCT_NEW_ARCH_ENABLED=1 pod install` for RN < 0.71, it ends up with an error:

```
[!] Unable to find a specification for `React-RCTAppDelegate` depended upon by `ReactNativeHost`

You have either:
 * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.
```

This fix skips adding `RCTAppDelegate` as a dependency of `ReactNativeHost` if its spec doesn't exist.

### Test plan
With RN >= 0.71:
1. Run `RCT_NEW_ARCH_ENABLED=1 pod install`
2. Verify the process completed and `React-RCTAppDelegate` was installed

With RN < 0.71:
1. Run `RCT_NEW_ARCH_ENABLED=1 pod install`
2. Verify the process completed and `React-RCTAppDelegate` was not installed
