### PR TITLE
feat(react-native-lazy-index): Extend experiences section

### DIFF
--- a/.changeset/dirty-crabs-hang.md
+++ b/.changeset/dirty-crabs-hang.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-lazy-index": patch
+---
+
+Extend `parseExperiencesFromObject` to support enabling/disabling flighted experiences

--- a/.changeset/dirty-crabs-hang.md
+++ b/.changeset/dirty-crabs-hang.md
@@ -1,5 +1,5 @@
 ---
-"@rnx-kit/react-native-lazy-index": patch
+"@rnx-kit/react-native-lazy-index": minor
 ---
 
 Extend `parseExperiencesFromObject` to support enabling/disabling flighted experiences

--- a/packages/react-native-lazy-index/src/experiences.js
+++ b/packages/react-native-lazy-index/src/experiences.js
@@ -67,7 +67,24 @@ function parseExperiencesFromArray(experiences) {
  */
 function parseExperiencesFromObject(experiences) {
   return Object.keys(experiences).reduce((components, name) => {
-    const moduleId = experiences[name];
+    let moduleId = experiences[name];
+
+    if (
+      moduleId &&
+      typeof moduleId === "object" &&
+      "module" in moduleId &&
+      typeof moduleId.module === "string" &&
+      "flighted" in moduleId &&
+      typeof moduleId.flighted === "boolean"
+    ) {
+      const flightedModule = moduleId;
+      if (flightedModule.flighted) {
+        return components;
+      }
+
+      moduleId = flightedModule.module;
+    }
+
     if (typeof moduleId !== "string") {
       return components;
     }

--- a/packages/react-native-lazy-index/src/experiences.js
+++ b/packages/react-native-lazy-index/src/experiences.js
@@ -36,7 +36,7 @@ function parseIntDefault(s, defaultValue) {
  * @param {unknown} moduleId
  * @returns {{module: string, flights: string[]} | undefined}
  */
-function getFlight(moduleId) {
+function getFlightedModule(moduleId) {
   if (
     moduleId &&
     typeof moduleId === "object" &&
@@ -45,8 +45,10 @@ function getFlight(moduleId) {
     "flights" in moduleId &&
     Array.isArray(moduleId.flights)
   ) {
-    // @ts-ignore
-    return moduleId;
+    return {
+      module: moduleId.module,
+      flights: moduleId.flights,
+    };
   }
   return undefined;
 }
@@ -90,7 +92,7 @@ function parseExperiencesFromObject(experiences) {
 
   return Object.keys(experiences).reduce((components, name) => {
     let moduleId = experiences[name];
-    const flightedModule = getFlight(moduleId);
+    const flightedModule = getFlightedModule(moduleId);
 
     if (flightedModule) {
       const flighted = flights?.some((flight) => {
@@ -139,4 +141,4 @@ function parseExperiences(experiences) {
 }
 
 exports.parseExperiences = parseExperiences;
-exports.getFlight = getFlight;
+exports.getFlightedModule = getFlightedModule;

--- a/packages/react-native-lazy-index/test/experiences.test.ts
+++ b/packages/react-native-lazy-index/test/experiences.test.ts
@@ -1,12 +1,12 @@
 import { resolveModule } from "./../src/module";
-import { parseExperiences } from "./../src/experiences";
+import { parseExperiences, getFlight } from "./../src/experiences";
 import fs from "fs";
 
 describe("parseExperiences()", () => {
   test("missing experiences section", () => {
     const packageManifest = resolveModule("./package.json");
     const { experiences } = JSON.parse(
-      fs.readFileSync(packageManifest, "utf-8"),
+      fs.readFileSync(packageManifest, "utf-8")
     );
     const result = () => {
       parseExperiences(experiences);
@@ -57,11 +57,14 @@ describe("parseExperiences()", () => {
     });
   });
 
-  test("flighted experiences", () => {
+  test("single flighted experiences", () => {
     let experiences = {
       SomeFeature: "@awesome-app/some-feature",
       "callable:AnotherFeature": "@awesome-app/another-feature",
-      FinalFeature: { module: "@awesome-app/final-feature", flighted: true },
+      FinalFeature: {
+        module: "@awesome-app/final-feature",
+        flights: ["FinalFeature"],
+      },
     };
     let result = parseExperiences(experiences);
     expect(result).toEqual({
@@ -77,10 +80,14 @@ describe("parseExperiences()", () => {
       },
     });
 
+    process.env.RN_LAZY_INDEX_FLIGHTS = "FinalFeature";
     experiences = {
       SomeFeature: "@awesome-app/some-feature",
       "callable:AnotherFeature": "@awesome-app/another-feature",
-      FinalFeature: { module: "@awesome-app/final-feature", flighted: false },
+      FinalFeature: {
+        module: "@awesome-app/final-feature",
+        flights: ["FinalFeature"],
+      },
     };
     result = parseExperiences(experiences);
     expect(result).toEqual({
@@ -99,6 +106,107 @@ describe("parseExperiences()", () => {
         source: "package.json",
         type: "app",
       },
+    });
+  });
+
+  test("multiple flighted experiences", () => {
+    process.env.RN_LAZY_INDEX_FLIGHTS = "";
+    let experiences = {
+      SomeFeature: {
+        module: "@awesome-app/some-feature",
+        flights: ["SomeFeature"],
+      },
+      "callable:AnotherFeature": "@awesome-app/another-feature",
+      FinalFeature: {
+        module: "@awesome-app/final-feature",
+        flights: ["FinalFeature"],
+      },
+    };
+    let result = parseExperiences(experiences);
+    expect(result).toEqual({
+      AnotherFeature: {
+        moduleId: "@awesome-app/another-feature",
+        source: "package.json",
+        type: "callable",
+      },
+    });
+
+    process.env.RN_LAZY_INDEX_FLIGHTS = "SomeFeature,FinalFeature";
+    experiences = {
+      SomeFeature: {
+        module: "@awesome-app/some-feature",
+        flights: ["SomeFeature"],
+      },
+      "callable:AnotherFeature": "@awesome-app/another-feature",
+      FinalFeature: {
+        module: "@awesome-app/final-feature",
+        flights: ["FinalFeature"],
+      },
+    };
+    result = parseExperiences(experiences);
+    expect(result).toEqual({
+      AnotherFeature: {
+        moduleId: "@awesome-app/another-feature",
+        source: "package.json",
+        type: "callable",
+      },
+      SomeFeature: {
+        moduleId: "@awesome-app/some-feature",
+        source: "package.json",
+        type: "app",
+      },
+      FinalFeature: {
+        moduleId: "@awesome-app/final-feature",
+        source: "package.json",
+        type: "app",
+      },
+    });
+  });
+});
+
+describe("getFlight()", () => {
+  test("empty flight object", () => {
+    const emptyFlight = {};
+    const result = getFlight(emptyFlight);
+    expect(result).toBeUndefined();
+  });
+
+  test("missing fields", () => {
+    const noModule = { flights: ["SomeFeature"] };
+    expect(getFlight(noModule)).toBeUndefined();
+
+    const noFlight = { module: "@awesome-app/some-feature" };
+    expect(getFlight(noFlight)).toBeUndefined();
+  });
+
+  test("wrong field type", () => {
+    const flightsString = { flights: "SomeFeature" };
+    expect(getFlight(flightsString)).toBeUndefined();
+
+    const moduleArray = { module: ["@awesome-app/some-feature"] };
+    expect(getFlight(moduleArray)).toBeUndefined();
+
+    const flightsObject = { flights: { val: "SomeFeature" } };
+    expect(getFlight(flightsObject)).toBeUndefined();
+
+    const moduleObject = { module: { val: "@awesome-app/some-feature" } };
+    expect(getFlight(moduleObject)).toBeUndefined();
+
+    const flightsInt = { flights: 1 };
+    expect(getFlight(flightsInt)).toBeUndefined();
+
+    const moduleInt = { module: 1 };
+    expect(getFlight(moduleInt)).toBeUndefined();
+  });
+
+  test("valid flight object", () => {
+    const flight = {
+      module: "@awesome-app/some-feature",
+      flights: ["SomeFeature"],
+    };
+    expect(getFlight(flight)).toEqual({
+      module: "@awesome-app/some-feature",
+      flights: ["SomeFeature"],
     });
   });
 });

--- a/packages/react-native-lazy-index/test/experiences.test.ts
+++ b/packages/react-native-lazy-index/test/experiences.test.ts
@@ -1,0 +1,104 @@
+import { resolveModule } from "./../src/module";
+import { parseExperiences } from "./../src/experiences";
+import fs from "fs";
+
+describe("parseExperiences()", () => {
+  test("missing experiences section", () => {
+    const packageManifest = resolveModule("./package.json");
+    const { experiences } = JSON.parse(
+      fs.readFileSync(packageManifest, "utf-8"),
+    );
+    const result = () => {
+      parseExperiences(experiences);
+    };
+    expect(result).toThrow(Error);
+    expect(result).toThrow("Missing `experiences` section in `package.json`");
+  });
+
+  test("invalid experiences section", () => {
+    const experiences = "MyAwesomeApp";
+    const result = () => {
+      parseExperiences(experiences);
+    };
+    expect(result).toThrow(Error);
+    expect(result).toThrow("Invalid `experiences` section in `package.json`");
+  });
+
+  test("object experiences section", () => {
+    const experiences = {
+      SomeFeature: "@awesome-app/some-feature",
+      "callable:AnotherFeature": "@awesome-app/another-feature",
+      YetAnotherFeature: "@awesome-app/yet-another-feature",
+      FinalFeature: "@awesome-app/final-feature",
+      ExtraFeature: 5,
+    };
+    const result = parseExperiences(experiences);
+    expect(result).toEqual({
+      AnotherFeature: {
+        moduleId: "@awesome-app/another-feature",
+        source: "package.json",
+        type: "callable",
+      },
+      FinalFeature: {
+        moduleId: "@awesome-app/final-feature",
+        source: "package.json",
+        type: "app",
+      },
+      SomeFeature: {
+        moduleId: "@awesome-app/some-feature",
+        source: "package.json",
+        type: "app",
+      },
+      YetAnotherFeature: {
+        moduleId: "@awesome-app/yet-another-feature",
+        source: "package.json",
+        type: "app",
+      },
+    });
+  });
+
+  test("flighted experiences", () => {
+    let experiences = {
+      SomeFeature: "@awesome-app/some-feature",
+      "callable:AnotherFeature": "@awesome-app/another-feature",
+      FinalFeature: { module: "@awesome-app/final-feature", flighted: true },
+    };
+    let result = parseExperiences(experiences);
+    expect(result).toEqual({
+      AnotherFeature: {
+        moduleId: "@awesome-app/another-feature",
+        source: "package.json",
+        type: "callable",
+      },
+      SomeFeature: {
+        moduleId: "@awesome-app/some-feature",
+        source: "package.json",
+        type: "app",
+      },
+    });
+
+    experiences = {
+      SomeFeature: "@awesome-app/some-feature",
+      "callable:AnotherFeature": "@awesome-app/another-feature",
+      FinalFeature: { module: "@awesome-app/final-feature", flighted: false },
+    };
+    result = parseExperiences(experiences);
+    expect(result).toEqual({
+      AnotherFeature: {
+        moduleId: "@awesome-app/another-feature",
+        source: "package.json",
+        type: "callable",
+      },
+      SomeFeature: {
+        moduleId: "@awesome-app/some-feature",
+        source: "package.json",
+        type: "app",
+      },
+      FinalFeature: {
+        moduleId: "@awesome-app/final-feature",
+        source: "package.json",
+        type: "app",
+      },
+    });
+  });
+});

--- a/packages/react-native-lazy-index/test/index.test.ts
+++ b/packages/react-native-lazy-index/test/index.test.ts
@@ -2,24 +2,8 @@ import type { BabelFileResult } from "@babel/core";
 
 describe("react-native-lazy-index", () => {
   const babel = require("@babel/core");
-  const { spawnSync } = require("child_process");
   const path = require("path");
-
   const currentWorkingDir = process.cwd();
-
-  /**
-   * Generates a sequence from RegEx matches.
-   */
-  function* generateSequence(
-    str: string,
-    regex: RegExp
-  ): Generator<string, void> {
-    let m = regex.exec(str);
-    while (m) {
-      yield m[1];
-      m = regex.exec(str);
-    }
-  }
 
   /**
    * Tests the specified fixture.


### PR DESCRIPTION
### Description
Extending `parseExperiencesFromObject` to support new format to enable/disable flighted experiences. An experience won't be loaded when setting `flighted: false`. 
 
### Test plan
Added unit tests

