### PR TITLE
fix(metro-plugin-typescript): respect root `moduleSuffixes`

### DIFF
--- a/.changeset/lucky-mirrors-provide.md
+++ b/.changeset/lucky-mirrors-provide.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-plugin-typescript": patch
+---
+
+Respect `moduleSuffixes` set at the root level

--- a/packages/metro-plugin-typescript/test/resolver.test.ts
+++ b/packages/metro-plugin-typescript/test/resolver.test.ts
@@ -1,6 +1,5 @@
 import type ts from "typescript";
 import {
-  getCompilerOptionsWithReactNativeModuleSuffixes,
   resolveModuleNames,
   resolveTypeReferenceDirectives,
 } from "../src/resolver";
@@ -65,77 +64,6 @@ describe("Resolver", () => {
 
     expect(Array.isArray(modules)).toBe(true);
     expect(modules).toEqual(resolvedModules);
-  });
-
-  test("adds moduleSuffixes when it is not present", () => {
-    // platform is ios, and is set by context.platform. moduleSuffixes must be set
-    // to the list of ios-related extensions.
-    const inputOptions = {};
-    const outputOptions = getCompilerOptionsWithReactNativeModuleSuffixes(
-      context,
-      "module",
-      "containing-file",
-      inputOptions
-    );
-    expect(outputOptions).toEqual({
-      moduleSuffixes: [".ios", ".native", ""],
-    });
-  });
-
-  test("verifies that moduleSuffixes is valid when it is already present", () => {
-    // platform is ios, and is set by context.platform. moduleSuffixes must have
-    // all of the ios-related extensions, in order, but can have others mixed in.
-    const inputOptions = {
-      moduleSuffixes: [
-        ".goobers",
-        ".ios",
-        ".milk-duds",
-        ".lemonheads",
-        ".native",
-        "",
-        ".snickers",
-      ],
-    };
-    const outputOptions = getCompilerOptionsWithReactNativeModuleSuffixes(
-      context,
-      "module",
-      "containing-file",
-      inputOptions
-    );
-    expect(outputOptions).toEqual({
-      moduleSuffixes: inputOptions.moduleSuffixes, // output must match input
-    });
-  });
-
-  test("verifies that moduleSuffixes is valid when it is already present without a platform name", () => {
-    // platform is ios, and is set by context.platform. moduleSuffixes must have
-    // all of the ios-related extensions, in order, but can have others mixed in.
-    const inputOptions = {
-      moduleSuffixes: [".lemonheads", ".native", "", ".snickers"],
-    };
-    const outputOptions = getCompilerOptionsWithReactNativeModuleSuffixes(
-      context,
-      "module",
-      "containing-file",
-      inputOptions
-    );
-    expect(outputOptions).toEqual({
-      moduleSuffixes: inputOptions.moduleSuffixes, // output must match input
-    });
-  });
-
-  test("fails when moduleSuffixes is set, but is invalid for the target platform", () => {
-    const inputOptions = {
-      moduleSuffixes: ["this isn't going to work"],
-    };
-    expect(() =>
-      getCompilerOptionsWithReactNativeModuleSuffixes(
-        context,
-        "module",
-        "containing-file",
-        inputOptions
-      )
-    ).toThrowError();
   });
 
   test("resolves type reference directives", () => {


### PR DESCRIPTION
### Description

We should only set `moduleSuffixes` once at the project root.

See also discussions https://github.com/evanw/esbuild/issues/2395 and https://github.com/evanw/esbuild/issues/3019.

### Test plan

Existing tests should pass.

To verify that file extensions change with the target platform, apply the following patch:

```
diff --git a/packages/metro-plugin-typescript/src/resolver.ts b/packages/metro-plugin-typescript/src/resolver.ts
index 9b150754..e173049e 100644
--- a/packages/metro-plugin-typescript/src/resolver.ts
+++ b/packages/metro-plugin-typescript/src/resolver.ts
@@ -160,6 +160,8 @@ export function resolveTypeReferenceDirectives(
   containingFileMode: ts.SourceFile["impliedNodeFormat"] | undefined,
   { resolveTypeReferenceDirective } = ts
 ): (ts.ResolvedTypeReferenceDirective | undefined)[] {
+  console.log(context.platform, context.platformFileExtensions);
+
   const { host } = context;

   const resolutions: (ts.ResolvedTypeReferenceDirective | undefined)[] = [];
```

Rebuild, then start the dev server. Example output:

```
% yarn start

                        ▒▒▓▓▓▓▒▒
                     ▒▓▓▓▒▒░░▒▒▓▓▓▒
                  ▒▓▓▓▓░░░▒▒▒▒░░░▓▓▓▓▒
                 ▓▓▒▒▒▓▓▓▓▓▓▓▓▓▓▓▓▒▒▒▓▓
                 ▓▓░░░░░▒▓▓▓▓▓▓▒░░░░░▓▓
                 ▓▓░░▓▓▒░░░▒▒░░░▒▓▒░░▓▓
                 ▓▓░░▓▓▓▓▓▒▒▒▒▓▓▓▓▒░░▓▓
                 ▓▓░░▓▓▓▓▓▓▓▓▓▓▓▓▓▒░░▓▓
                 ▓▓▒░░▒▒▓▓▓▓▓▓▓▓▒░░░▒▓▓
                  ▒▓▓▓▒░░░▒▓▓▒░░░▒▓▓▓▒
                     ▒▓▓▓▒░░░░▒▓▓▓▒
                        ▒▒▓▓▓▓▒▒


                Welcome to Metro v0.73.10
              Fast - Scalable - Integrated


 › Press r to reload the app.
 › Press d to open developer menu.
 › Press a to show bundler address QR code.
 › Press h to show this help message.
 › Press ctrl-c to quit.

 BUNDLE  src/index.ts ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░ 96.2% (507/518)ios [ '.ios', '.native', '' ]
ios [ '.ios', '.native', '' ]
ios [ '.ios', '.native', '' ]
ios [ '.ios', '.native', '' ]
ios [ '.ios', '.native', '' ]
ios [ '.ios', '.native', '' ]
ios [ '.ios', '.native', '' ]
ios [ '.ios', '.native', '' ]
ios [ '.ios', '.native', '' ]
ios [ '.ios', '.native', '' ]
 BUNDLE  src/index.ts

 BUNDLE  src/index.ts ▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░ 93.1% (497/516)android [ '.android', '.native', '' ]
android [ '.android', '.native', '' ]
android [ '.android', '.native', '' ]
android [ '.android', '.native', '' ]
android [ '.android', '.native', '' ]
android [ '.android', '.native', '' ]
android [ '.android', '.native', '' ]
android [ '.android', '.native', '' ]
android [ '.android', '.native', '' ]
android [ '.android', '.native', '' ]
 BUNDLE  src/index.ts

 BUNDLE  src/index.ts ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░ 96.2% (512/523)windows [ '.windows', '.win', '.native', '' ]
windows [ '.windows', '.win', '.native', '' ]
windows [ '.windows', '.win', '.native', '' ]
windows [ '.windows', '.win', '.native', '' ]
windows [ '.windows', '.win', '.native', '' ]
windows [ '.windows', '.win', '.native', '' ]
windows [ '.windows', '.win', '.native', '' ]
windows [ '.windows', '.win', '.native', '' ]
windows [ '.windows', '.win', '.native', '' ]
windows [ '.windows', '.win', '.native', '' ]
 BUNDLE  src/index.ts
```