### PR TITLE
fix(metro-resolver-symlinks): fix aliases when `experimental_retryResolvingFromDisk` is enabled

### DIFF
--- a/.changeset/breezy-teachers-end.md
+++ b/.changeset/breezy-teachers-end.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Fix `extraNodeModules` not resolving correctly when `experimental_retryResolvingFromDisk` is enabled

--- a/packages/test-app/metro.config.js
+++ b/packages/test-app/metro.config.js
@@ -16,7 +16,7 @@ const blockList = exclusionList([
 module.exports = makeMetroConfig({
   resolver: {
     extraNodeModules: {
-      "internal": path.resolve(__dirname, "src", "internal"),
+      internal: path.resolve(__dirname, "src", "internal"),
       ...(useAuthMock
         ? {
             "@rnx-kit/react-native-auth": require("path").join(

--- a/packages/test-app/metro.config.js
+++ b/packages/test-app/metro.config.js
@@ -1,5 +1,6 @@
 const { exclusionList, makeMetroConfig } = require("@rnx-kit/metro-config");
 const MetroSymlinksResolver = require("@rnx-kit/metro-resolver-symlinks");
+const path = require("node:path");
 
 // If USE_AUTH_MOCK=1, exclude the real module to enable the mock.
 const useAuthMock = process.env["USE_AUTH_MOCK"];
@@ -15,6 +16,7 @@ const blockList = exclusionList([
 module.exports = makeMetroConfig({
   resolver: {
     extraNodeModules: {
+      "internal": path.resolve(__dirname, "src", "internal"),
       ...(useAuthMock
         ? {
             "@rnx-kit/react-native-auth": require("path").join(

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -67,7 +67,10 @@
     "extends": "@rnx-kit/eslint-config"
   },
   "jest": {
-    "preset": "@rnx-kit/scripts"
+    "preset": "@rnx-kit/scripts",
+    "moduleNameMapper": {
+      "^internal(.*)$": "<rootDir>/src/internal$1"
+    }
   },
   "rnx-kit": {
     "kitType": "app",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -58,6 +58,11 @@
     "react-test-renderer": "18.2.0",
     "typescript": "^5.0.0"
   },
+  "depcheck": {
+    "ignoreMatches": [
+      "internal"
+    ]
+  },
   "eslintConfig": {
     "extends": "@rnx-kit/eslint-config"
   },

--- a/packages/test-app/src/App.native.tsx
+++ b/packages/test-app/src/App.native.tsx
@@ -1,4 +1,12 @@
 import { acquireTokenWithScopes } from "@rnx-kit/react-native-auth";
+// Both `internal` imports are used to verify that `metro-resolver-symlinks`
+// resolves them correctly when `experimental_retryResolvingFromDisk` is
+// enabled.
+import {
+  getReactNativeVersion,
+  getRemoteDebuggingAvailability,
+} from "internal";
+import { getHermesVersion } from "internal/hermes";
 import React, { useCallback, useMemo, useState } from "react";
 import type { LayoutChangeEvent } from "react-native";
 import {
@@ -13,8 +21,6 @@ import {
   View,
   useColorScheme,
 } from "react-native";
-// @ts-expect-error no types for "react-native/Libraries/Core/ReactNativeVersion"
-import { version as coreVersion } from "react-native/Libraries/Core/ReactNativeVersion";
 import { Colors, Header } from "react-native/Libraries/NewAppScreen";
 // @ts-expect-error no types for "react-native/Libraries/Utilities/DebugEnvironment"
 import { isAsyncDebugging } from "react-native/Libraries/Utilities/DebugEnvironment";
@@ -36,29 +42,6 @@ type FeatureProps =
       disabled?: boolean;
       onValueChange?: (value: boolean) => void;
     };
-
-function getHermesVersion() {
-  return (
-    // @ts-expect-error `HermesInternal` is set when on Hermes
-    global.HermesInternal?.getRuntimeProperties?.()["OSS Release Version"] ??
-    false
-  );
-}
-
-function getReactNativeVersion() {
-  const version = `${coreVersion.major}.${coreVersion.minor}.${coreVersion.patch}`;
-  return coreVersion.prerelease
-    ? version + `-${coreVersion.prerelease}`
-    : version;
-}
-
-function getRemoteDebuggingAvailability() {
-  return (
-    // @ts-expect-error `RN$Bridgeless` is a react-native specific property
-    global.RN$Bridgeless !== true &&
-    typeof NativeModules["DevSettings"]?.setIsDebuggingRemotely === "function"
-  );
-}
 
 function isOnOrOff(value: unknown): "Off" | "On" {
   return value ? "On" : "Off";

--- a/packages/test-app/src/internal/hermes.ts
+++ b/packages/test-app/src/internal/hermes.ts
@@ -1,0 +1,7 @@
+export function getHermesVersion() {
+  return (
+    // @ts-expect-error `HermesInternal` is set when on Hermes
+    global.HermesInternal?.getRuntimeProperties?.()["OSS Release Version"] ??
+    false
+  );
+}

--- a/packages/test-app/src/internal/index.ts
+++ b/packages/test-app/src/internal/index.ts
@@ -1,0 +1,18 @@
+import { NativeModules } from "react-native";
+// @ts-expect-error no types for "react-native/Libraries/Core/ReactNativeVersion"
+import { version as coreVersion } from "react-native/Libraries/Core/ReactNativeVersion";
+
+export function getReactNativeVersion() {
+  const version = `${coreVersion.major}.${coreVersion.minor}.${coreVersion.patch}`;
+  return coreVersion.prerelease
+    ? version + `-${coreVersion.prerelease}`
+    : version;
+}
+
+export function getRemoteDebuggingAvailability() {
+  return (
+    // @ts-expect-error `RN$Bridgeless` is a react-native internal property
+    global.RN$Bridgeless !== true &&
+    typeof NativeModules["DevSettings"]?.setIsDebuggingRemotely === "function"
+  );
+}

--- a/packages/test-app/tsconfig.json
+++ b/packages/test-app/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "compilerOptions": {
-    "checkJs": false
+    "checkJs": false,
+    "noEmit": true,
+    "paths": {
+      "internal": ["./src/internal"],
+      "internal/*": ["./src/internal/*"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
### Description

When `experimental_retryResolvingFromDisk` is enabled, aliases are not correctly resolved because `enhanced-resolve` is looking for real packages:

```
error Can't resolve 'internal' in '/~/packages/test-app/src/internal'.
```

### Test plan

Enable `experimental_retryResolvingFromDisk`:

```diff
diff --git a/packages/test-app/metro.config.js b/packages/test-app/metro.config.js
index 476802a1..83068b3d 100644
--- a/packages/test-app/metro.config.js
+++ b/packages/test-app/metro.config.js
@@ -29,7 +29,7 @@ module.exports = makeMetroConfig({
           }
         : {}),
     },
-    resolveRequest: MetroSymlinksResolver(),
+    resolveRequest: MetroSymlinksResolver({ experimental_retryResolvingFromDisk: true }),
     blacklistRE: blockList,
     blockList,
   },
```

Build and bundle:

```
cd packages/test-app
yarn build --dependencies
yarn bundle --platform ios --reset-cache
```