### PR TITLE
fix issue caused by Lerna 7+ `useWorkspaces` deprecation

### DIFF
--- a/.changeset/twelve-sheep-press.md
+++ b/.changeset/twelve-sheep-press.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-workspaces": patch
+---
+
+fix issue caused by Lerna 7+ `useWorkspaces` deprecation

--- a/packages/tools-workspaces/src/lerna.ts
+++ b/packages/tools-workspaces/src/lerna.ts
@@ -19,11 +19,13 @@ function filterSentinels(): string[] {
 export async function findWorkspacePackages(
   configFile: string
 ): Promise<string[]> {
-  const { packages, useWorkspaces } = await readJSON(configFile);
-  if (!useWorkspaces) {
+  const { packages } = await readJSON(configFile);
+  // respect the Lerna `packages` property
+  if (packages) {
     return await findPackages(packages, path.dirname(configFile));
   }
 
+  // fallback to alternative sentinels regardless of `useWorkspaces`
   const root = path.dirname(configFile);
   const sentinels = filterSentinels();
   for (const sentinel of sentinels) {
@@ -34,6 +36,7 @@ export async function findWorkspacePackages(
     }
   }
 
+  // return empty list if there's no alternative sentinel to fall back to
   return [];
 }
 

--- a/packages/tools-workspaces/src/lerna.ts
+++ b/packages/tools-workspaces/src/lerna.ts
@@ -19,13 +19,15 @@ function filterSentinels(): string[] {
 export async function findWorkspacePackages(
   configFile: string
 ): Promise<string[]> {
-  const { packages } = await readJSON(configFile);
-  // respect the Lerna `packages` property
-  if (packages) {
+  const { packages, useWorkspaces } = await readJSON(configFile);
+
+  // `useWorkspaces` was deprecated: https://github.com/lerna/lerna/releases/tag/7.0.0
+  // respect Lerna `packages` property
+  if (packages && useWorkspaces !== true) {
     return await findPackages(packages, path.dirname(configFile));
   }
 
-  // fallback to alternative sentinels regardless of `useWorkspaces`
+  // fall back to alternative sentinel regardless of `useWorkspaces`
   const root = path.dirname(configFile);
   const sentinels = filterSentinels();
   for (const sentinel of sentinels) {
@@ -36,7 +38,7 @@ export async function findWorkspacePackages(
     }
   }
 
-  // return empty list if there's no alternative sentinel to fall back to
+  // return empty list if there is no alternative to fall back to
   return [];
 }
 


### PR DESCRIPTION
### Description

Lerna 7.0.0 introduced a [breaking change](https://github.com/lerna/lerna/blob/main/CHANGELOG.md#700-2023-06-08) that deprecates useWorkspaces. Instead Lerna now relies on a npmClient property to detect workspaces, unless package list is overriden by a packages property.

This in turn breaks the @rnx-kit/metro-config, since it is no longer able to correctly populate watchFolders property for metro config.

Please refer to the [issue](#2555) for more details
Resolves #2555 

### Test plan

Minimal example: https://github.com/poniraq/lerna7-tools-workspaces-bug-example
Alternatively, any workspace with Lerna 7+ will reproduce the issue unless you manually populate `packages` for Lerna.

My only concern is that this change technically introduces an uncovered edge case:
1) Lerna pre-7
2) workspace setup via pnpm or yarn
3) `useWorkspaces` is deliberately set to `false` in `lerna.json`