### PR TITLE
fix(metro-service): warn if `projectRoot` may be misconfigured

### DIFF
--- a/.changeset/silent-foxes-grab.md
+++ b/.changeset/silent-foxes-grab.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/cli": patch
+"@rnx-kit/metro-service": patch
+---
+
+Warn if `projectRoot` may be misconfigured

--- a/packages/metro-service/package.json
+++ b/packages/metro-service/package.json
@@ -24,6 +24,7 @@
     "node": ">=12.13"
   },
   "dependencies": {
+    "@rnx-kit/console": "^1.0.0",
     "@rnx-kit/tools-language": "^2.0.0",
     "chalk": "^4.1.0"
   },

--- a/packages/metro-service/src/babel.ts
+++ b/packages/metro-service/src/babel.ts
@@ -1,0 +1,39 @@
+import { warn } from "@rnx-kit/console";
+import * as fs from "fs";
+import type { ConfigT } from "metro-config";
+import * as path from "path";
+
+export function ensureBabelConfig({ projectRoot }: ConfigT): void {
+  // Even though Babel supports more file extensions
+  // (https://babeljs.io/docs/config-files#supported-file-extensions),
+  // `@react-native/metro-babel-transformer` only supports the following. See
+  // https://github.com/facebook/react-native/blob/5eaf28b247fc66b46520a26271bdcded9d4d2338/packages/react-native-babel-transformer/src/index.js#L53.
+  const extensions = [".babelrc", ".babelrc.js", "babel.config.js"];
+
+  const projectBabelRC = extensions.some((rc) => {
+    return fs.existsSync(path.join(projectRoot, rc));
+  });
+
+  if (projectBabelRC) {
+    return;
+  }
+
+  const cwd = process.cwd();
+  for (const ext of extensions) {
+    const babelRC = path.join(cwd, ext);
+    if (fs.existsSync(babelRC)) {
+      const rel = path.relative(cwd, projectRoot);
+      warn(
+        [
+          `Could not find Babel config in '${rel}' but did find one in the`,
+          "current working directory. Metro will not be able to find this",
+          "file. If this is unexpected, please make sure you've configured",
+          "'projectRoot' correctly. If you set 'projectRoot' to fix how the",
+          "bundle is served, consider adding a root 'index.js' that imports",
+          `'${rel}/index' instead.`,
+        ].join(" ")
+      );
+      break;
+    }
+  }
+}

--- a/packages/metro-service/src/bundle.ts
+++ b/packages/metro-service/src/bundle.ts
@@ -7,6 +7,7 @@ import Server from "metro/src/Server";
 import Bundle from "metro/src/shared/output/bundle";
 import path from "path";
 import { saveAssets } from "./asset";
+import { ensureBabelConfig } from "./babel";
 
 export type BundleArgs = {
   assetsDest?: string;
@@ -47,6 +48,9 @@ export async function bundle(
   config: ConfigT,
   output = Bundle
 ): Promise<void> {
+  // ensure Metro can find Babel config
+  ensureBabelConfig(config);
+
   const buildBundleWithConfig = getBundlerFromCliPlugin();
   if (buildBundleWithConfig) {
     return buildBundleWithConfig(args, config, output);

--- a/packages/metro-service/src/index.ts
+++ b/packages/metro-service/src/index.ts
@@ -1,12 +1,8 @@
-export { runServer as startServer } from "metro";
-
 export { bundle } from "./bundle";
 export type { BundleArgs } from "./bundle";
-
 export { loadMetroConfig } from "./config";
 export type { MetroConfigOverrides } from "./config";
-
 export { ramBundle } from "./ramBundle";
-
+export { startServer } from "./server";
 export { createTerminal } from "./terminal";
 export type { MetroTerminal } from "./terminal";

--- a/packages/metro-service/src/server.ts
+++ b/packages/metro-service/src/server.ts
@@ -1,0 +1,7 @@
+import { runServer } from "metro";
+import { ensureBabelConfig } from "./babel";
+
+export const startServer: typeof runServer = (config, ...args) => {
+  ensureBabelConfig(config);
+  return runServer(config, ...args);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3804,6 +3804,7 @@ __metadata:
   resolution: "@rnx-kit/metro-service@workspace:packages/metro-service"
   dependencies:
     "@react-native-community/cli-types": ^10.0.0
+    "@rnx-kit/console": ^1.0.0
     "@rnx-kit/scripts": "*"
     "@rnx-kit/tools-language": ^2.0.0
     "@types/metro": ^0.76.0


### PR DESCRIPTION
### Description

Make sure that if `projectRoot` is set, that Metro can find `${projectRoot}/babel.config.js` (or equivalent). Otherwise, if a Babel config is found in the current working directory, warn that the user may have misconfigured `projectRoot`.

Resolves #706.

### Test plan

```
cd packages/test-app
yarn build --dependencies

# `bundle` is correctly configured and should not cause any warnings
yarn bundle:ios

# `start` is currently incorrectly configured and should cause a warning
yarn start

# If there is no Babel config, we should not warn
rm babel.config.js
yarn start
```