### PR TITLE
fix(third-party-notices): fix `splitSourcePath` potentially getting wrong module name

### DIFF
--- a/.changeset/tough-dancers-perform.md
+++ b/.changeset/tough-dancers-perform.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/third-party-notices": patch
+---
+
+Fix `splitSourcePath` potentially getting wrong module name

--- a/packages/third-party-notices/src/write-third-party-notices.ts
+++ b/packages/third-party-notices/src/write-third-party-notices.ts
@@ -13,7 +13,7 @@ import type {
   WriteThirdPartyNoticesOptions,
 } from "./types";
 
-const modulesRoot = "node_modules/";
+const modulesRoot = "node_modules";
 
 /**
  * Function to write third party notices based on the specified source map.
@@ -134,7 +134,9 @@ export function splitSourcePath(rootPath: string, p: string): string[] {
     throw new Error(`Unexpected module: ${p}`);
   }
 
-  const ref = parseModuleRef(absolutePath.substring(idx + modulesRoot.length));
+  const ref = parseModuleRef(
+    absolutePath.substring(idx + modulesRoot.length + 1)
+  );
   if (!isPackageModuleRef(ref)) {
     throw new Error(`Could not parse module: ${p}`);
   }

--- a/packages/third-party-notices/src/write-third-party-notices.ts
+++ b/packages/third-party-notices/src/write-third-party-notices.ts
@@ -13,7 +13,7 @@ import type {
   WriteThirdPartyNoticesOptions,
 } from "./types";
 
-const modulesRoot = "node_modules";
+const modulesRoot = "node_modules/";
 
 /**
  * Function to write third party notices based on the specified source map.
@@ -128,15 +128,13 @@ export function splitSourcePath(rootPath: string, p: string): string[] {
     p = p.substring(DELEGATED_PREFIX.length);
   }
 
-  const absolutePath = path.resolve(rootPath, p);
+  const absolutePath = path.resolve(rootPath, p).replace(/[\\]+/g, "/");
   const idx = absolutePath.lastIndexOf(modulesRoot);
   if (idx == null || idx < 0) {
     throw new Error(`Unexpected module: ${p}`);
   }
 
-  const ref = parseModuleRef(
-    absolutePath.substring(idx + modulesRoot.length + 1)
-  );
+  const ref = parseModuleRef(absolutePath.substring(idx + modulesRoot.length));
   if (!isPackageModuleRef(ref)) {
     throw new Error(`Could not parse module: ${p}`);
   }

--- a/packages/third-party-notices/test/__mocks__/fs.js
+++ b/packages/third-party-notices/test/__mocks__/fs.js
@@ -1,0 +1,5 @@
+const fs = jest.createMockFromModule("node:fs");
+
+fs.existsSync = (p) => !p.includes("missing");
+
+module.exports = fs;

--- a/packages/third-party-notices/test/parseModule.test.ts
+++ b/packages/third-party-notices/test/parseModule.test.ts
@@ -4,10 +4,6 @@ import { absolutePathRoot, osSpecificPath } from "./pathHelper";
 
 jest.mock("fs");
 
-require("fs").existsSync = jest.fn().mockImplementation((path) => {
-  return path.indexOf("missing") == -1;
-});
-
 const options: WriteThirdPartyNoticesOptions = {
   rootPath: `${absolutePathRoot}src`,
   json: false,
@@ -27,7 +23,7 @@ describe("parseModule", () => {
 
     expect(map.size).toBe(1);
     expect(map.get("myPackage")).toBe(
-      osSpecificPath(`${absolutePathRoot}src\\node_modules\\myPackage`)
+      osSpecificPath(`${absolutePathRoot}src/node_modules/myPackage`)
     );
   });
 
@@ -37,9 +33,7 @@ describe("parseModule", () => {
 
     expect(map.size).toBe(1);
     expect(map.get("@myScope/myPackage")).toBe(
-      osSpecificPath(
-        `${absolutePathRoot}src\\node_modules\\@myScope\\myPackage`
-      )
+      osSpecificPath(`${absolutePathRoot}src/node_modules/@myScope/myPackage`)
     );
   });
 
@@ -67,9 +61,7 @@ describe("parseModule", () => {
 
     expect(map.size).toBe(1);
     expect(map.get("@scope/ignoredModule")).toBe(
-      osSpecificPath(
-        `${absolutePathRoot}src\\node_modules\\@scope\\ignoredModule`
-      )
+      osSpecificPath(`${absolutePathRoot}src/node_modules/@scope/ignoredModule`)
     );
   });
 
@@ -95,7 +87,7 @@ describe("parseModule", () => {
     expect(map.size).toBe(1);
     expect(map.get("@ignoredScopeYetNot/myPackage")).toBe(
       osSpecificPath(
-        `${absolutePathRoot}src\\node_modules\\@ignoredScopeYetNot\\myPackage`
+        `${absolutePathRoot}src/node_modules/@ignoredScopeYetNot/myPackage`
       )
     );
   });

--- a/packages/third-party-notices/test/parseModule.test.ts
+++ b/packages/third-party-notices/test/parseModule.test.ts
@@ -1,6 +1,6 @@
 import type { WriteThirdPartyNoticesOptions } from "../src/types";
 import { parseModule } from "../src/write-third-party-notices";
-import { absolutePathRoot, osSpecificPath } from "./pathHelper";
+import { absolutePathRoot } from "./pathHelper";
 
 jest.mock("fs");
 
@@ -23,7 +23,7 @@ describe("parseModule", () => {
 
     expect(map.size).toBe(1);
     expect(map.get("myPackage")).toBe(
-      osSpecificPath(`${absolutePathRoot}src/node_modules/myPackage`)
+      `${absolutePathRoot}src/node_modules/myPackage`
     );
   });
 
@@ -33,7 +33,7 @@ describe("parseModule", () => {
 
     expect(map.size).toBe(1);
     expect(map.get("@myScope/myPackage")).toBe(
-      osSpecificPath(`${absolutePathRoot}src/node_modules/@myScope/myPackage`)
+      `${absolutePathRoot}src/node_modules/@myScope/myPackage`
     );
   });
 
@@ -61,7 +61,7 @@ describe("parseModule", () => {
 
     expect(map.size).toBe(1);
     expect(map.get("@scope/ignoredModule")).toBe(
-      osSpecificPath(`${absolutePathRoot}src/node_modules/@scope/ignoredModule`)
+      `${absolutePathRoot}src/node_modules/@scope/ignoredModule`
     );
   });
 
@@ -86,9 +86,7 @@ describe("parseModule", () => {
 
     expect(map.size).toBe(1);
     expect(map.get("@ignoredScopeYetNot/myPackage")).toBe(
-      osSpecificPath(
-        `${absolutePathRoot}src/node_modules/@ignoredScopeYetNot/myPackage`
-      )
+      `${absolutePathRoot}src/node_modules/@ignoredScopeYetNot/myPackage`
     );
   });
 });

--- a/packages/third-party-notices/test/pathHelper.ts
+++ b/packages/third-party-notices/test/pathHelper.ts
@@ -1,7 +1,3 @@
 import os from "node:os";
 
-export const absolutePathRoot = os.platform() === "win32" ? "o:\\" : "/";
-
-export function osSpecificPath(p: string): string {
-  return os.platform() === "win32" ? p.replace(/[/]+/g, "\\") : p;
-}
+export const absolutePathRoot = os.platform() === "win32" ? "o:/" : "/";

--- a/packages/third-party-notices/test/pathHelper.ts
+++ b/packages/third-party-notices/test/pathHelper.ts
@@ -1,7 +1,7 @@
-import os from "os";
+import os from "node:os";
 
 export const absolutePathRoot = os.platform() === "win32" ? "o:\\" : "/";
 
 export function osSpecificPath(p: string): string {
-  return os.platform() === "win32" ? p : p.replace(/[\\]+/g, "/");
+  return os.platform() === "win32" ? p.replace(/[/]+/g, "\\") : p;
 }

--- a/packages/third-party-notices/test/sourceMap.test.ts
+++ b/packages/third-party-notices/test/sourceMap.test.ts
@@ -3,7 +3,7 @@ import {
   extractModuleNameToPathMap,
   parseSourceMap,
 } from "../src/write-third-party-notices";
-import { absolutePathRoot, osSpecificPath } from "./pathHelper";
+import { absolutePathRoot } from "./pathHelper";
 
 jest.mock("fs");
 
@@ -26,12 +26,10 @@ describe("parseModule", () => {
 
     expect(map.size).toBe(2);
     expect(map.get("myPackage")).toBe(
-      osSpecificPath(`${absolutePathRoot}src/node_modules/myPackage`)
+      `${absolutePathRoot}src/node_modules/myPackage`
     );
     expect(map.get("@scope/myOtherPackage")).toBe(
-      osSpecificPath(
-        `${absolutePathRoot}src/node_modules/@scope/myOtherPackage`
-      )
+      `${absolutePathRoot}src/node_modules/@scope/myOtherPackage`
     );
   });
 
@@ -64,20 +62,16 @@ describe("parseModule", () => {
 
     expect(map.size).toBe(4);
     expect(map.get("myPackage")).toBe(
-      osSpecificPath(`${absolutePathRoot}src/node_modules/myPackage`)
+      `${absolutePathRoot}src/node_modules/myPackage`
     );
     expect(map.get("myPackage2")).toBe(
-      osSpecificPath(`${absolutePathRoot}src/node_modules/myPackage2`)
+      `${absolutePathRoot}src/node_modules/myPackage2`
     );
     expect(map.get("@scope/myOtherPackage")).toBe(
-      osSpecificPath(
-        `${absolutePathRoot}src/node_modules/@scope/myOtherPackage`
-      )
+      `${absolutePathRoot}src/node_modules/@scope/myOtherPackage`
     );
     expect(map.get("@scope2/myOtherPackage")).toBe(
-      osSpecificPath(
-        `${absolutePathRoot}src/node_modules/@scope2/myOtherPackage`
-      )
+      `${absolutePathRoot}src/node_modules/@scope2/myOtherPackage`
     );
   });
 });

--- a/packages/third-party-notices/test/sourceMap.test.ts
+++ b/packages/third-party-notices/test/sourceMap.test.ts
@@ -7,10 +7,6 @@ import { absolutePathRoot, osSpecificPath } from "./pathHelper";
 
 jest.mock("fs");
 
-require("fs").existsSync = jest.fn().mockImplementation((path) => {
-  return path.indexOf("missing") == -1;
-});
-
 const options: WriteThirdPartyNoticesOptions = {
   rootPath: `${absolutePathRoot}src`,
   json: false,
@@ -30,11 +26,11 @@ describe("parseModule", () => {
 
     expect(map.size).toBe(2);
     expect(map.get("myPackage")).toBe(
-      osSpecificPath(`${absolutePathRoot}src\\node_modules\\myPackage`)
+      osSpecificPath(`${absolutePathRoot}src/node_modules/myPackage`)
     );
     expect(map.get("@scope/myOtherPackage")).toBe(
       osSpecificPath(
-        `${absolutePathRoot}src\\node_modules\\@scope\\myOtherPackage`
+        `${absolutePathRoot}src/node_modules/@scope/myOtherPackage`
       )
     );
   });
@@ -68,19 +64,19 @@ describe("parseModule", () => {
 
     expect(map.size).toBe(4);
     expect(map.get("myPackage")).toBe(
-      osSpecificPath(`${absolutePathRoot}src\\node_modules\\myPackage`)
+      osSpecificPath(`${absolutePathRoot}src/node_modules/myPackage`)
     );
     expect(map.get("myPackage2")).toBe(
-      osSpecificPath(`${absolutePathRoot}src\\node_modules\\myPackage2`)
+      osSpecificPath(`${absolutePathRoot}src/node_modules/myPackage2`)
     );
     expect(map.get("@scope/myOtherPackage")).toBe(
       osSpecificPath(
-        `${absolutePathRoot}src\\node_modules\\@scope\\myOtherPackage`
+        `${absolutePathRoot}src/node_modules/@scope/myOtherPackage`
       )
     );
     expect(map.get("@scope2/myOtherPackage")).toBe(
       osSpecificPath(
-        `${absolutePathRoot}src\\node_modules\\@scope2\\myOtherPackage`
+        `${absolutePathRoot}src/node_modules/@scope2/myOtherPackage`
       )
     );
   });

--- a/packages/third-party-notices/test/splitSourcePath.test.ts
+++ b/packages/third-party-notices/test/splitSourcePath.test.ts
@@ -1,5 +1,5 @@
 import { splitSourcePath } from "../src/write-third-party-notices";
-import { absolutePathRoot, osSpecificPath } from "./pathHelper";
+import { absolutePathRoot } from "./pathHelper";
 
 describe("splitSourcePath", () => {
   test("absolutePath", () => {
@@ -8,8 +8,8 @@ describe("splitSourcePath", () => {
       `${absolutePathRoot}src/root/node_modules/myPackage/myFile.js`
     );
     expect(moduleName).toBe("myPackage");
-    expect(osSpecificPath(modulePath)).toBe(
-      osSpecificPath(`${absolutePathRoot}src/root/node_modules/myPackage`)
+    expect(modulePath).toBe(
+      `${absolutePathRoot}src/root/node_modules/myPackage`
     );
   });
 
@@ -19,8 +19,8 @@ describe("splitSourcePath", () => {
       `${absolutePathRoot}src/root/node_modules/myPackage/myFile.js`
     );
     expect(moduleName).toBe("myPackage");
-    expect(osSpecificPath(modulePath)).toBe(
-      osSpecificPath(`${absolutePathRoot}src/root/node_modules/myPackage`)
+    expect(modulePath).toBe(
+      `${absolutePathRoot}src/root/node_modules/myPackage`
     );
   });
 
@@ -30,8 +30,8 @@ describe("splitSourcePath", () => {
       `${absolutePathRoot}src/root/node_modules/myPackage`
     );
     expect(moduleName).toBe("myPackage");
-    expect(osSpecificPath(modulePath)).toBe(
-      osSpecificPath(`${absolutePathRoot}src/root/node_modules/myPackage`)
+    expect(modulePath).toBe(
+      `${absolutePathRoot}src/root/node_modules/myPackage`
     );
   });
 
@@ -41,10 +41,8 @@ describe("splitSourcePath", () => {
       `${absolutePathRoot}src/root/node_modules/myPackage/node_modules/nestedPackage/nestedFile.js`
     );
     expect(moduleName).toBe("nestedPackage");
-    expect(osSpecificPath(modulePath)).toBe(
-      osSpecificPath(
-        `${absolutePathRoot}src/root/node_modules/myPackage/node_modules/nestedPackage`
-      )
+    expect(modulePath).toBe(
+      `${absolutePathRoot}src/root/node_modules/myPackage/node_modules/nestedPackage`
     );
   });
 
@@ -54,10 +52,8 @@ describe("splitSourcePath", () => {
       `${absolutePathRoot}src/root/node_modules/@myframework/driver-utils/node_modules/@myframework/telemetry-utils/lib/config.js`
     );
     expect(moduleName).toBe("@myframework/telemetry-utils");
-    expect(osSpecificPath(modulePath)).toBe(
-      osSpecificPath(
-        `${absolutePathRoot}src/root/node_modules/@myframework/driver-utils/node_modules/@myframework/telemetry-utils`
-      )
+    expect(modulePath).toBe(
+      `${absolutePathRoot}src/root/node_modules/@myframework/driver-utils/node_modules/@myframework/telemetry-utils`
     );
   });
 
@@ -67,10 +63,8 @@ describe("splitSourcePath", () => {
       `${absolutePathRoot}src/root/otherSrcFolder/node_modules/myPackage/myFile.js`
     );
     expect(moduleName).toBe("myPackage");
-    expect(osSpecificPath(modulePath)).toBe(
-      osSpecificPath(
-        `${absolutePathRoot}src/root/otherSrcFolder/node_modules/myPackage`
-      )
+    expect(modulePath).toBe(
+      `${absolutePathRoot}src/root/otherSrcFolder/node_modules/myPackage`
     );
   });
 
@@ -80,10 +74,8 @@ describe("splitSourcePath", () => {
       `${absolutePathRoot}src/root/node_modules/@scope/myPackage/myFile.js`
     );
     expect(moduleName).toBe("@scope/myPackage");
-    expect(osSpecificPath(modulePath)).toBe(
-      osSpecificPath(
-        `${absolutePathRoot}src/root/node_modules/@scope/myPackage`
-      )
+    expect(modulePath).toBe(
+      `${absolutePathRoot}src/root/node_modules/@scope/myPackage`
     );
   });
 
@@ -93,8 +85,8 @@ describe("splitSourcePath", () => {
       "node_modules/myPackage/myFile.js"
     );
     expect(moduleName).toBe("myPackage");
-    expect(osSpecificPath(modulePath)).toBe(
-      osSpecificPath(`${absolutePathRoot}src/root/node_modules/myPackage`)
+    expect(modulePath).toBe(
+      `${absolutePathRoot}src/root/node_modules/myPackage`
     );
   });
 
@@ -104,9 +96,7 @@ describe("splitSourcePath", () => {
       `../node_modules/myPackage/myFile.js`
     );
     expect(moduleName).toBe("myPackage");
-    expect(osSpecificPath(modulePath)).toBe(
-      osSpecificPath(`${absolutePathRoot}src/node_modules/myPackage`)
-    );
+    expect(modulePath).toBe(`${absolutePathRoot}src/node_modules/myPackage`);
   });
 
   test("relativePathsWithDotDotColldingOnNames", () => {
@@ -116,7 +106,7 @@ describe("splitSourcePath", () => {
     );
     expect(moduleName).toBe("myPackage");
     expect(modulePath).toBe(
-      osSpecificPath(`${absolutePathRoot}src/other/node_modules/myPackage`)
+      `${absolutePathRoot}src/other/node_modules/myPackage`
     );
   });
 });

--- a/packages/third-party-notices/test/splitSourcePath.test.ts
+++ b/packages/third-party-notices/test/splitSourcePath.test.ts
@@ -4,97 +4,97 @@ import { absolutePathRoot, osSpecificPath } from "./pathHelper";
 describe("splitSourcePath", () => {
   test("absolutePath", () => {
     const [moduleName, modulePath] = splitSourcePath(
-      `${absolutePathRoot}src\\root`,
+      `${absolutePathRoot}src/root`,
       `${absolutePathRoot}src/root/node_modules/myPackage/myFile.js`
     );
     expect(moduleName).toBe("myPackage");
     expect(osSpecificPath(modulePath)).toBe(
-      osSpecificPath(`${absolutePathRoot}src\\root\\node_modules\\myPackage`)
+      osSpecificPath(`${absolutePathRoot}src/root/node_modules/myPackage`)
     );
   });
 
   test("nonRootAbsolutePath", () => {
     const [moduleName, modulePath] = splitSourcePath(
-      `${absolutePathRoot}src\\otherRoot`,
+      `${absolutePathRoot}src/otherRoot`,
       `${absolutePathRoot}src/root/node_modules/myPackage/myFile.js`
     );
     expect(moduleName).toBe("myPackage");
     expect(osSpecificPath(modulePath)).toBe(
-      osSpecificPath(`${absolutePathRoot}src\\root\\node_modules\\myPackage`)
+      osSpecificPath(`${absolutePathRoot}src/root/node_modules/myPackage`)
     );
   });
 
   test("packageFolderWithoutFile", () => {
     const [moduleName, modulePath] = splitSourcePath(
-      `${absolutePathRoot}src\\root`,
+      `${absolutePathRoot}src/root`,
       `${absolutePathRoot}src/root/node_modules/myPackage`
     );
     expect(moduleName).toBe("myPackage");
     expect(osSpecificPath(modulePath)).toBe(
-      osSpecificPath(`${absolutePathRoot}src\\root\\node_modules\\myPackage`)
+      osSpecificPath(`${absolutePathRoot}src/root/node_modules/myPackage`)
     );
   });
 
   test("packageFolderWithNestedNodeModulesFiles", () => {
     const [moduleName, modulePath] = splitSourcePath(
-      `${absolutePathRoot}src\\root`,
+      `${absolutePathRoot}src/root`,
       `${absolutePathRoot}src/root/node_modules/myPackage/node_modules/nestedPackage/nestedFile.js`
     );
     expect(moduleName).toBe("nestedPackage");
     expect(osSpecificPath(modulePath)).toBe(
       osSpecificPath(
-        `${absolutePathRoot}src\\root\\node_modules\\myPackage\\node_modules\\nestedPackage`
+        `${absolutePathRoot}src/root/node_modules/myPackage/node_modules/nestedPackage`
       )
     );
   });
 
   test("packageFolderWithNestedNodeModulesFilesAndNamespaces", () => {
     const [moduleName, modulePath] = splitSourcePath(
-      `${absolutePathRoot}src\\root`,
+      `${absolutePathRoot}src/root`,
       `${absolutePathRoot}src/root/node_modules/@myframework/driver-utils/node_modules/@myframework/telemetry-utils/lib/config.js`
     );
     expect(moduleName).toBe("@myframework/telemetry-utils");
     expect(osSpecificPath(modulePath)).toBe(
       osSpecificPath(
-        `${absolutePathRoot}src\\root\\node_modules\\@myframework\\driver-utils\\node_modules\\@myframework\\telemetry-utils`
+        `${absolutePathRoot}src/root/node_modules/@myframework/driver-utils/node_modules/@myframework/telemetry-utils`
       )
     );
   });
 
   test("intermediateFolders", () => {
     const [moduleName, modulePath] = splitSourcePath(
-      `${absolutePathRoot}src\\root`,
+      `${absolutePathRoot}src/root`,
       `${absolutePathRoot}src/root/otherSrcFolder/node_modules/myPackage/myFile.js`
     );
     expect(moduleName).toBe("myPackage");
     expect(osSpecificPath(modulePath)).toBe(
       osSpecificPath(
-        `${absolutePathRoot}src\\root\\otherSrcFolder\\node_modules\\myPackage`
+        `${absolutePathRoot}src/root/otherSrcFolder/node_modules/myPackage`
       )
     );
   });
 
   test("scopedPackage", () => {
     const [moduleName, modulePath] = splitSourcePath(
-      `${absolutePathRoot}src\\root`,
+      `${absolutePathRoot}src/root`,
       `${absolutePathRoot}src/root/node_modules/@scope/myPackage/myFile.js`
     );
     expect(moduleName).toBe("@scope/myPackage");
     expect(osSpecificPath(modulePath)).toBe(
       osSpecificPath(
-        `${absolutePathRoot}src\\root\\node_modules\\@scope\\myPackage`
+        `${absolutePathRoot}src/root/node_modules/@scope/myPackage`
       )
     );
   });
 
   test("relativePaths", () => {
     const [moduleName, modulePath] = splitSourcePath(
-      `${absolutePathRoot}src\\root`,
+      `${absolutePathRoot}src/root`,
       "node_modules/myPackage/myFile.js"
     );
     expect(moduleName).toBe("myPackage");
     expect(osSpecificPath(modulePath)).toBe(
-      osSpecificPath(`${absolutePathRoot}src\\root\\node_modules\\myPackage`)
+      osSpecificPath(`${absolutePathRoot}src/root/node_modules/myPackage`)
     );
   });
 
@@ -105,14 +105,18 @@ describe("splitSourcePath", () => {
     );
     expect(moduleName).toBe("myPackage");
     expect(osSpecificPath(modulePath)).toBe(
-      osSpecificPath(`${absolutePathRoot}src\\node_modules\\myPackage`)
+      osSpecificPath(`${absolutePathRoot}src/node_modules/myPackage`)
     );
   });
 
-  // BUG #188: Code should normalize path before extracting package names
-  // test("relativePathsWithDotDotColldingOnNames", () => {
-  //   const [moduleName, modulePath] = splitSourcePath(`${absolutePathRoot}src\\root", "../node_modules/../other/node_modules/wrongPackage/../myPackage/myFile.js");
-  //   expect(moduleName).toBe("myPackage");
-  //   expect(modulePath).toBe(`${absolutePathRoot}src\\other\\node_modules\\myPackage");
-  // });
+  test("relativePathsWithDotDotColldingOnNames", () => {
+    const [moduleName, modulePath] = splitSourcePath(
+      `${absolutePathRoot}src/root`,
+      "../node_modules/../other/node_modules/wrongPackage/../myPackage/myFile.js"
+    );
+    expect(moduleName).toBe("myPackage");
+    expect(modulePath).toBe(
+      osSpecificPath(`${absolutePathRoot}src/other/node_modules/myPackage`)
+    );
+  });
 });


### PR DESCRIPTION
### Description

Fix `splitSourcePath` potentially getting wrong module name.

Resolves #188.

### Test plan

Test was enabled.