### PR TITLE
Resolve npmPackageName from project root not local paths

### DIFF
--- a/.changeset/bright-otters-type.md
+++ b/.changeset/bright-otters-type.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/metro-service": patch
+"@rnx-kit/metro-config": patch
+---
+
+Resolve npmPackageName from project root not local paths

--- a/packages/metro-config/src/defaultConfig.js
+++ b/packages/metro-config/src/defaultConfig.js
@@ -13,17 +13,25 @@ const path = require("path");
 
 /**
  * @param {PlatformImplementations} availablePlatforms
+ * @param {string} projectRoot
  */
-function getPreludeModules(availablePlatforms) {
+function getPreludeModules(availablePlatforms, projectRoot) {
   // Include all instances of `InitializeCore` here and let Metro exclude
   // the unused ones.
+  const requireOptions = { paths: [projectRoot] };
   const mainModules = new Set([
-    require.resolve("react-native/Libraries/Core/InitializeCore"),
+    require.resolve(
+      "react-native/Libraries/Core/InitializeCore",
+      requireOptions
+    ),
   ]);
   for (const moduleName of Object.values(availablePlatforms)) {
     if (moduleName) {
       mainModules.add(
-        require.resolve(`${moduleName}/Libraries/Core/InitializeCore`)
+        require.resolve(
+          `${moduleName}/Libraries/Core/InitializeCore`,
+          requireOptions
+        )
       );
     }
   }
@@ -106,7 +114,7 @@ function getDefaultConfig(projectRoot) {
       defaultConfig.resolver.resolveRequest =
         outOfTreePlatformResolver(availablePlatforms);
 
-      const preludeModules = getPreludeModules(availablePlatforms);
+      const preludeModules = getPreludeModules(availablePlatforms, projectRoot);
       defaultConfig.serializer.getModulesRunBeforeMainModule = () => {
         return preludeModules;
       };

--- a/packages/metro-service/src/config.ts
+++ b/packages/metro-service/src/config.ts
@@ -124,7 +124,8 @@ function getDefaultConfigInternal(cliConfig: CLIConfig): InputConfigT {
           require.resolve(
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             `${cliConfig.platforms[platform]
-              .npmPackageName!}/Libraries/Core/InitializeCore`
+              .npmPackageName!}/Libraries/Core/InitializeCore`,
+            { paths: [cliConfig.root] }
           )
         ),
       ],


### PR DESCRIPTION
### Description
Part of this was submitted to rn cli here: https://github.com/react-native-community/cli/pull/1996

This change helps ensure that we resolve the same version of these packages as the app intended to resolve.