### PR TITLE
fix(metro-service): `cli-plugin-metro` has been deprecated

### DIFF
--- a/.changeset/long-avocados-protect.md
+++ b/.changeset/long-avocados-protect.md
@@ -1,0 +1,12 @@
+---
+"@rnx-kit/metro-service": patch
+---
+
+`@react-native-community/cli-plugin-metro` has been deprecated. Sync to the
+latest changes and don't depend on it for bundling.
+
+`@react-native-community/cli-plugin-metro` is being moved into the
+`react-native` repository. In the process, it was renamed and its API surface
+has been reduced to the bare minimum. `buildBundleWithConfig`, which we need to
+pass our custom config to the bundler, has also been axed. For more details, see
+https://github.com/facebook/react-native/pull/38795.

--- a/packages/metro-service/src/asset/android.ts
+++ b/packages/metro-service/src/asset/android.ts
@@ -1,50 +1,25 @@
+// https://github.com/react-native-community/cli/blob/716555851b442a83a1bf5e0db27b6226318c9a69/packages/cli-plugin-metro/src/commands/bundle/getAssetDestPathAndroid.ts
+
 import * as path from "path";
+import { getResourceIdentifier } from "./assetPathUtils";
 import type { PackagerAsset } from "./types";
 
-/**
- * Decide if two numbers, integer or decimal, are "approximately" equal.
- * They're equal if they are close enough to be within the given tolerance.
- *
- * This is useful for comparing decimal values, as they aren't precise enough
- * to use equality.
- *
- * @param lhs First value to compare
- * @param rhs Second value to compare
- * @param tolerance Number indicating how far apart the first and second values can be before they are considered not equal.
- * @returns True if the difference between the first and second value is less than the tolerance
- */
-export function isApproximatelyEqual(
-  lhs: number,
-  rhs: number,
-  tolerance: number
-): boolean {
-  return Math.abs(lhs - rhs) < tolerance;
-}
-
-export function getAndroidAssetSuffix(
-  asset: PackagerAsset,
-  scale: number
-): string {
+export function getAndroidAssetSuffix(scale: number): string {
   const tolerance = 0.01;
-  if (isApproximatelyEqual(scale, 0.75, tolerance)) {
-    return "ldpi";
-  } else if (isApproximatelyEqual(scale, 1, tolerance)) {
-    return "mdpi";
-  } else if (isApproximatelyEqual(scale, 1.5, tolerance)) {
-    return "hdpi";
-  } else if (isApproximatelyEqual(scale, 2, tolerance)) {
-    return "xhdpi";
-  } else if (isApproximatelyEqual(scale, 3, tolerance)) {
-    return "xxhdpi";
-  } else if (isApproximatelyEqual(scale, 4, tolerance)) {
+  const scaleApprox = scale + tolerance;
+  if (scaleApprox >= 4) {
     return "xxxhdpi";
+  } else if (scaleApprox >= 3) {
+    return "xxhdpi";
+  } else if (scaleApprox >= 2) {
+    return "xhdpi";
+  } else if (scaleApprox >= 1.5) {
+    return "hdpi";
+  } else if (scaleApprox >= 1) {
+    return "mdpi";
+  } else {
+    return "ldpi";
   }
-
-  throw new Error(
-    `Don't know which android drawable suffix to use for asset: ${JSON.stringify(
-      asset
-    )}`
-  );
 }
 
 // See https://developer.android.com/guide/topics/resources/drawable-resource.html
@@ -64,24 +39,9 @@ function getAndroidResourceFolderName(
   if (!drawableFileTypes.has(asset.type)) {
     return "raw";
   }
-  return `drawable-${getAndroidAssetSuffix(asset, scale)}`;
-}
-
-function getBasePath(asset: PackagerAsset): string {
-  let basePath = asset.httpServerLocation;
-  if (basePath[0] === "/") {
-    basePath = basePath.substring(1);
-  }
-  return basePath;
-}
-
-function getAndroidResourceIdentifier(asset: PackagerAsset): string {
-  const folderPath = getBasePath(asset);
-  return `${folderPath}/${asset.name}`
-    .toLowerCase()
-    .replace(/\//g, "_") // Encode folder structure in file name
-    .replace(/([^a-z0-9_])/g, "") // Remove illegal chars
-    .replace(/^assets_/, ""); // Remove "assets_" prefix
+  const suffix = getAndroidAssetSuffix(scale);
+  const androidFolder = `drawable-${suffix}`;
+  return androidFolder;
 }
 
 export function getAssetDestPathAndroid(
@@ -89,6 +49,6 @@ export function getAssetDestPathAndroid(
   scale: number
 ): string {
   const androidFolder = getAndroidResourceFolderName(asset, scale);
-  const fileName = getAndroidResourceIdentifier(asset);
+  const fileName = getResourceIdentifier(asset);
   return path.join(androidFolder, `${fileName}.${asset.type}`);
 }

--- a/packages/metro-service/src/asset/assetPathUtils.ts
+++ b/packages/metro-service/src/asset/assetPathUtils.ts
@@ -1,0 +1,20 @@
+// https://github.com/react-native-community/cli/blob/716555851b442a83a1bf5e0db27b6226318c9a69/packages/cli-plugin-metro/src/commands/bundle/assetPathUtils.ts
+
+import type { PackagerAsset } from "./types";
+
+function getBasePath(asset: PackagerAsset): string {
+  let basePath = asset.httpServerLocation;
+  if (basePath[0] === "/") {
+    basePath = basePath.substring(1);
+  }
+  return basePath;
+}
+
+export function getResourceIdentifier(asset: PackagerAsset): string {
+  const folderPath = getBasePath(asset);
+  return `${folderPath}/${asset.name}`
+    .toLowerCase()
+    .replace(/\//g, "_") // Encode folder structure in file name
+    .replace(/([^a-z0-9_])/g, "") // Remove illegal chars
+    .replace(/^assets_/, ""); // Remove "assets_" prefix
+}

--- a/packages/metro-service/src/asset/filter.ts
+++ b/packages/metro-service/src/asset/filter.ts
@@ -1,3 +1,5 @@
+// https://github.com/react-native-community/cli/blob/716555851b442a83a1bf5e0db27b6226318c9a69/packages/cli-plugin-metro/src/commands/bundle/filterPlatformAssetScales.ts
+
 const ALLOWED_SCALES: { [key: string]: number[] } = {
   ios: [1, 2, 3],
 };

--- a/packages/metro-service/src/asset/ios.ts
+++ b/packages/metro-service/src/asset/ios.ts
@@ -1,5 +1,72 @@
+// https://github.com/react-native-community/cli/blob/716555851b442a83a1bf5e0db27b6226318c9a69/packages/cli-plugin-metro/src/commands/bundle/assetCatalogIOS.ts
+// https://github.com/react-native-community/cli/blob/716555851b442a83a1bf5e0db27b6226318c9a69/packages/cli-plugin-metro/src/commands/bundle/getAssetDestPathIOS.ts
+
+import fs from "fs";
+import type { AssetData } from "metro";
 import path from "path";
+import { getResourceIdentifier } from "./assetPathUtils";
 import type { PackagerAsset } from "./types";
+
+type ImageSet = {
+  basePath: string;
+  files: { name: string; src: string; scale: number }[];
+};
+
+export function cleanAssetCatalog(catalogDir: string): void {
+  const files = fs
+    .readdirSync(catalogDir)
+    .filter((file) => file.endsWith(".imageset"));
+  for (const file of files) {
+    fs.rmSync(path.join(catalogDir, file));
+  }
+}
+
+export function getImageSet(
+  catalogDir: string,
+  asset: AssetData,
+  scales: readonly number[]
+): ImageSet {
+  const fileName = getResourceIdentifier(asset);
+  return {
+    basePath: path.join(catalogDir, `${fileName}.imageset`),
+    files: scales.map((scale, idx) => {
+      const suffix = scale === 1 ? "" : `@${scale}x`;
+      return {
+        name: `${fileName + suffix}.${asset.type}`,
+        scale,
+        src: asset.files[idx],
+      };
+    }),
+  };
+}
+
+export function isCatalogAsset(asset: AssetData): boolean {
+  return asset.type === "png" || asset.type === "jpg" || asset.type === "jpeg";
+}
+
+export function writeImageSet(imageSet: ImageSet): void {
+  fs.mkdirSync(imageSet.basePath, { recursive: true });
+
+  for (const file of imageSet.files) {
+    const dest = path.join(imageSet.basePath, file.name);
+    fs.copyFileSync(file.src, dest);
+  }
+
+  fs.writeFileSync(
+    path.join(imageSet.basePath, "Contents.json"),
+    JSON.stringify({
+      images: imageSet.files.map((file) => ({
+        filename: file.name,
+        idiom: "universal",
+        scale: `${file.scale}x`,
+      })),
+      info: {
+        author: "xcode",
+        version: 1,
+      },
+    })
+  );
+}
 
 export function getAssetDestPathIOS(
   asset: PackagerAsset,
@@ -11,7 +78,7 @@ export function getAssetDestPathIOS(
     // Assets can have relative paths outside of the project root.
     // Replace `../` with `_` to make sure they don't end up outside of
     // the expected assets directory.
-    asset.httpServerLocation.substr(1).replace(/\.\.\//g, "_"),
+    asset.httpServerLocation.substring(1).replace(/\.\.\//g, "_"),
     fileName
   );
 }

--- a/packages/metro-service/src/asset/write.ts
+++ b/packages/metro-service/src/asset/write.ts
@@ -1,46 +1,84 @@
+// https://github.com/react-native-community/cli/blob/716555851b442a83a1bf5e0db27b6226318c9a69/packages/cli-plugin-metro/src/commands/bundle/saveAssets.ts
+
+import { error, info, warn } from "@rnx-kit/console";
 import * as fs from "fs";
 import type { AssetData } from "metro";
 import * as path from "path";
 import { getAssetDestPathAndroid } from "./android";
 import { filterPlatformAssetScales } from "./filter";
-import { getAssetDestPathIOS } from "./ios";
+import {
+  cleanAssetCatalog,
+  getAssetDestPathIOS,
+  getImageSet,
+  isCatalogAsset,
+  writeImageSet,
+} from "./ios";
 
-function copy(src: string, dest: string): void {
+function copy(
+  src: string,
+  dest: string,
+  callback: (error: NodeJS.ErrnoException) => void
+): void {
   const destDir = path.dirname(dest);
-  fs.mkdirSync(destDir, { recursive: true, mode: 0o755 });
-  fs.copyFileSync(src, dest);
+  fs.mkdir(destDir, { recursive: true }, (err?) => {
+    if (err) {
+      callback(err);
+      return;
+    }
+    fs.createReadStream(src)
+      .pipe(fs.createWriteStream(dest))
+      .on("finish", callback);
+  });
 }
 
-function copyAll(filesToCopy: Record<string, string>): void {
+function copyAll(filesToCopy: Record<string, string>) {
   const queue = Object.keys(filesToCopy);
   if (queue.length === 0) {
-    return;
-  }
-
-  console.info(`Copying ${queue.length} asset files`);
-  for (const src of queue) {
-    copy(src, filesToCopy[src]);
-  }
-}
-
-export async function saveAssets(
-  assets: readonly AssetData[],
-  platform: string,
-  assetsDest: string | undefined
-): Promise<void> {
-  if (!assetsDest) {
-    console.warn("Assets destination folder is not set, skipping...");
     return Promise.resolve();
   }
+
+  info(`Copying ${queue.length} asset files`);
+  return new Promise<void>((resolve, reject) => {
+    const copyNext = (error?: NodeJS.ErrnoException) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      if (queue.length === 0) {
+        info("Done copying assets");
+        resolve();
+      } else {
+        // queue.length === 0 is checked in previous branch, so this is string
+        const src = queue.shift() as string;
+        const dest = filesToCopy[src];
+        copy(src, dest, copyNext);
+      }
+    };
+    copyNext();
+  });
+}
+
+export function saveAssets(
+  assets: ReadonlyArray<AssetData>,
+  platform: string,
+  assetsDest: string | undefined,
+  assetCatalogDest: string | undefined
+): Promise<void> {
+  if (!assetsDest) {
+    warn("Assets destination folder is not set, skipping...");
+    return Promise.resolve();
+  }
+
+  const filesToCopy: Record<string, string> = Object.create(null); // Map src -> dest
 
   const getAssetDestPath =
     platform === "android" ? getAssetDestPathAndroid : getAssetDestPathIOS;
 
-  const filesToCopy: Record<string, string> = Object.create(null); // Map src -> dest
-  assets.forEach((asset) => {
+  const addAssetToCopy = (asset: AssetData) => {
     const validScales = new Set(
       filterPlatformAssetScales(platform, asset.scales)
     );
+
     asset.scales.forEach((scale, idx) => {
       if (!validScales.has(scale)) {
         return;
@@ -49,8 +87,37 @@ export async function saveAssets(
       const dest = path.join(assetsDest, getAssetDestPath(asset, scale));
       filesToCopy[src] = dest;
     });
-  });
+  };
 
-  copyAll(filesToCopy);
-  return Promise.resolve();
+  if (platform === "ios" && assetCatalogDest != null) {
+    // Use iOS Asset Catalog for images. This will allow Apple app thinning to
+    // remove unused scales from the optimized bundle.
+    const catalogDir = path.join(assetCatalogDest, "RNAssets.xcassets");
+    if (!fs.existsSync(catalogDir)) {
+      error(
+        `Could not find asset catalog 'RNAssets.xcassets' in ${assetCatalogDest}. Make sure to create it if it does not exist.`
+      );
+      return Promise.reject();
+    }
+
+    info("Adding images to asset catalog", catalogDir);
+    cleanAssetCatalog(catalogDir);
+    for (const asset of assets) {
+      if (isCatalogAsset(asset)) {
+        const imageSet = getImageSet(
+          catalogDir,
+          asset,
+          filterPlatformAssetScales(platform, asset.scales)
+        );
+        writeImageSet(imageSet);
+      } else {
+        addAssetToCopy(asset);
+      }
+    }
+    info("Done adding images to asset catalog");
+  } else {
+    assets.forEach(addAssetToCopy);
+  }
+
+  return copyAll(filesToCopy);
 }

--- a/packages/metro-service/test/asset/__snapshots__/android.test.ts.snap
+++ b/packages/metro-service/test/asset/__snapshots__/android.test.ts.snap
@@ -1,5 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`MetroService getAndroidAssetSuffix throw for invalid scale 0.70 1`] = `"Don't know which android drawable suffix to use for asset: {"httpServerLocation":"https://my-server.com/assets","name":"logo","type":"jpg"}"`;
-
-exports[`MetroService getAndroidAssetSuffix throw for invalid scale 1.23 1`] = `"Don't know which android drawable suffix to use for asset: {"httpServerLocation":"https://my-server.com/assets","name":"logo","type":"jpg"}"`;

--- a/packages/metro-service/test/asset/android.test.ts
+++ b/packages/metro-service/test/asset/android.test.ts
@@ -1,73 +1,117 @@
-import type { PackagerAsset } from "../../src/asset/types";
+import * as path from "path";
 import {
   getAndroidAssetSuffix,
-  isApproximatelyEqual,
+  getAssetDestPathAndroid,
 } from "../../src/asset/android";
 
-describe("MetroService", () => {
-  const asset: PackagerAsset = {
-    httpServerLocation: "https://my-server.com/assets",
-    name: "logo",
-    type: "jpg",
-  };
-
-  test("getAndroidAssetSuffix returns ldpi for scale 0.75", () => {
-    expect(getAndroidAssetSuffix(asset, 0.75)).toEqual("ldpi");
+describe("getAndroidAssetSuffix", () => {
+  test("returns 'ldpi' for scale 0.75", () => {
+    expect(getAndroidAssetSuffix(0.75)).toEqual("ldpi");
   });
 
-  test("getAndroidAssetSuffix returns mdpi for scale 1", () => {
-    expect(getAndroidAssetSuffix(asset, 1)).toEqual("mdpi");
+  test("returns 'mdpi' for scale 1", () => {
+    expect(getAndroidAssetSuffix(1)).toEqual("mdpi");
   });
 
-  test("getAndroidAssetSuffix returns hdpi for scale 1.5", () => {
-    expect(getAndroidAssetSuffix(asset, 1.5)).toEqual("hdpi");
+  test("returns 'hdpi' for scale 1.5", () => {
+    expect(getAndroidAssetSuffix(1.5)).toEqual("hdpi");
   });
 
-  test("getAndroidAssetSuffix returns xhdpi for scale 2", () => {
-    expect(getAndroidAssetSuffix(asset, 2)).toEqual("xhdpi");
+  test("returns 'xhdpi' for scale 2", () => {
+    expect(getAndroidAssetSuffix(2)).toEqual("xhdpi");
   });
 
-  test("getAndroidAssetSuffix returns xxhdpi for scale 3", () => {
-    expect(getAndroidAssetSuffix(asset, 3)).toEqual("xxhdpi");
+  test("returns 'xxhdpi' for scale 3", () => {
+    expect(getAndroidAssetSuffix(3)).toEqual("xxhdpi");
   });
 
-  test("getAndroidAssetSuffix returns xxxhdpi for scale 4", () => {
-    expect(getAndroidAssetSuffix(asset, 4)).toEqual("xxxhdpi");
+  test("returns 'xxxhdpi' for scale 4", () => {
+    expect(getAndroidAssetSuffix(4)).toEqual("xxxhdpi");
   });
 
-  test("getAndroidAssetSuffix returns ldpi for scale 0.741", () => {
-    expect(getAndroidAssetSuffix(asset, 0.741)).toEqual("ldpi");
+  test("returns 'ldpi' for scale 0.741", () => {
+    expect(getAndroidAssetSuffix(0.741)).toEqual("ldpi");
   });
 
-  test("getAndroidAssetSuffix returns ldpi for scale 0.759", () => {
-    expect(getAndroidAssetSuffix(asset, 0.759)).toEqual("ldpi");
+  test("returns 'ldpi' for scale 0.759", () => {
+    expect(getAndroidAssetSuffix(0.759)).toEqual("ldpi");
   });
 
-  test("getAndroidAssetSuffix throw for invalid scale 0.70", () => {
-    expect(() =>
-      getAndroidAssetSuffix(asset, 0.7)
-    ).toThrowErrorMatchingSnapshot();
+  test("returns 'ldpi' for scale 0.70", () => {
+    expect(getAndroidAssetSuffix(0.7)).toEqual("ldpi");
   });
 
-  test("getAndroidAssetSuffix throw for invalid scale 1.23", () => {
-    expect(() =>
-      getAndroidAssetSuffix(asset, 1.23)
-    ).toThrowErrorMatchingSnapshot();
+  test("returns 'mdpi' for scale 1.23", () => {
+    expect(getAndroidAssetSuffix(1.23)).toEqual("mdpi");
+  });
+});
+
+describe("getAssetDestPathAndroid", () => {
+  test("should use the right destination folder", () => {
+    const asset = {
+      name: "icon",
+      type: "png",
+      httpServerLocation: "/assets/test",
+    };
+
+    const expectDestPathForScaleToStartWith = (scale, location) => {
+      if (!getAssetDestPathAndroid(asset, scale).startsWith(location)) {
+        throw new Error(
+          `asset for scale ${scale} should start with path '${location}'`
+        );
+      }
+    };
+
+    expectDestPathForScaleToStartWith(1, "drawable-mdpi");
+    expectDestPathForScaleToStartWith(1.5, "drawable-hdpi");
+    expectDestPathForScaleToStartWith(2, "drawable-xhdpi");
+    expectDestPathForScaleToStartWith(3, "drawable-xxhdpi");
+    expectDestPathForScaleToStartWith(4, "drawable-xxxhdpi");
   });
 
-  test("isApproximatelyEqual(1.25, 1.2499, tolerance=0.001) returns true", () => {
-    expect(isApproximatelyEqual(1.25, 1.2499, 0.001)).toBe(true);
+  test("should lowercase path", () => {
+    const asset = {
+      name: "Icon",
+      type: "png",
+      httpServerLocation: "/assets/App/Test",
+    };
+
+    expect(getAssetDestPathAndroid(asset, 1)).toBe(
+      path.normalize("drawable-mdpi/app_test_icon.png")
+    );
   });
 
-  test("isApproximatelyEqual(1.25, 1.2499, tolerance=0.000001) returns false", () => {
-    expect(isApproximatelyEqual(1.25, 1.2499, 0.000001)).toBe(false);
+  test("should remove `assets/` prefix", () => {
+    const asset = {
+      name: "icon",
+      type: "png",
+      httpServerLocation: "/assets/RKJSModules/Apps/AndroidSample/Assets",
+    };
+
+    expect(getAssetDestPathAndroid(asset, 1).startsWith("assets_")).toBeFalsy();
   });
 
-  test("isApproximatelyEqual(10, 11, tolerance=2) returns true", () => {
-    expect(isApproximatelyEqual(10, 11, 2)).toBe(true);
+  test("should put non-drawable resources to `raw/`", () => {
+    const asset = {
+      name: "video",
+      type: "mp4",
+      httpServerLocation: "/assets/app/test",
+    };
+
+    expect(getAssetDestPathAndroid(asset, 1)).toBe(
+      path.normalize("raw/app_test_video.mp4")
+    );
   });
 
-  test("isApproximatelyEqual(10, 11, tolerance=0.5) returns false", () => {
-    expect(isApproximatelyEqual(10, 11, 0.5)).toBe(false);
+  test("should handle assets with a relative path outside of root", () => {
+    const asset = {
+      name: "icon",
+      type: "png",
+      httpServerLocation: "/assets/../../test",
+    };
+
+    expect(getAssetDestPathAndroid(asset, 1)).toBe(
+      path.normalize("drawable-mdpi/__test_icon.png")
+    );
   });
 });

--- a/packages/metro-service/test/asset/filter.test.ts
+++ b/packages/metro-service/test/asset/filter.test.ts
@@ -1,0 +1,23 @@
+import { filterPlatformAssetScales } from "../../src/asset/filter";
+
+describe("filterPlatformAssetScales", () => {
+  test("removes everything but 2x and 3x for iOS", () => {
+    expect(filterPlatformAssetScales("ios", [1, 1.5, 2, 3, 4])).toEqual([
+      1, 2, 3,
+    ]);
+    expect(filterPlatformAssetScales("ios", [3, 4])).toEqual([3]);
+  });
+
+  test("keeps closest largest one if nothing matches", () => {
+    expect(filterPlatformAssetScales("ios", [0.5, 4, 100])).toEqual([4]);
+    expect(filterPlatformAssetScales("ios", [0.5, 100])).toEqual([100]);
+    expect(filterPlatformAssetScales("ios", [0.5])).toEqual([0.5]);
+    expect(filterPlatformAssetScales("ios", [])).toEqual([]);
+  });
+
+  test("keeps all scales for unknown platform", () => {
+    expect(filterPlatformAssetScales("freebsd", [1, 1.5, 2, 3.7])).toEqual([
+      1, 1.5, 2, 3.7,
+    ]);
+  });
+});

--- a/packages/metro-service/test/asset/ios.test.ts
+++ b/packages/metro-service/test/asset/ios.test.ts
@@ -1,0 +1,43 @@
+import * as path from "path";
+import { getAssetDestPathIOS } from "../../src/asset/ios";
+
+describe("getAssetDestPathIOS", () => {
+  test("should build correct path", () => {
+    const asset = {
+      name: "icon",
+      type: "png",
+      httpServerLocation: "/assets/test",
+    };
+
+    expect(getAssetDestPathIOS(asset, 1)).toBe(
+      path.normalize("assets/test/icon.png")
+    );
+  });
+
+  test("should consider scale", () => {
+    const asset = {
+      name: "icon",
+      type: "png",
+      httpServerLocation: "/assets/test",
+    };
+
+    expect(getAssetDestPathIOS(asset, 2)).toBe(
+      path.normalize("assets/test/icon@2x.png")
+    );
+    expect(getAssetDestPathIOS(asset, 3)).toBe(
+      path.normalize("assets/test/icon@3x.png")
+    );
+  });
+
+  test("should handle assets with a relative path outside of root", () => {
+    const asset = {
+      name: "icon",
+      type: "png",
+      httpServerLocation: "/assets/../../test",
+    };
+
+    expect(getAssetDestPathIOS(asset, 1)).toBe(
+      path.normalize("assets/__test/icon.png")
+    );
+  });
+});

--- a/packages/test-app/app.json
+++ b/packages/test-app/app.json
@@ -30,7 +30,7 @@
     "userPrincipalName": "arnold@contoso.com"
   },
   "resources": {
-    "android": ["dist/res", "dist/main.android.jsbundle"],
+    "android": ["dist/res", "dist/main.android.bundle"],
     "ios": ["app.json", "dist/assets", "dist/main.ios.jsbundle"],
     "macos": ["app.json", "dist/assets", "dist/main.macos.jsbundle"],
     "windows": ["dist/assets", "dist/main.windows.bundle"]


### PR DESCRIPTION
### Description

Sync to the latest changes and don't depend on it for bundling.

`@react-native-community/cli-plugin-metro` is being moved into the `react-native` repository. In the process, it was renamed and its API surface has been reduced to the bare minimum. `buildBundleWithConfig`, which we need to pass our custom config to the bundler, has also been axed.

Resolves #328.

### Test plan

```
cd packages/test-app
yarn build --dependencies
yarn bundle:android
yarn android
```