### PR TITLE
Refactor saveAssets code to allow out of tree overrides

### DIFF
--- a/.changeset/metal-ladybugs-wave.md
+++ b/.changeset/metal-ladybugs-wave.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-service": minor
+---
+
+Refactor saveAssets code to allow out of tree overrides

--- a/packages/metro-service/package.json
+++ b/packages/metro-service/package.json
@@ -64,6 +64,7 @@
   },
   "depcheck": {
     "ignoreMatches": [
+      "@office-iss/react-native-win32",
       "metro-babel-transformer"
     ]
   },

--- a/packages/metro-service/src/asset/android.ts
+++ b/packages/metro-service/src/asset/android.ts
@@ -3,6 +3,7 @@
 import * as path from "path";
 import { getResourceIdentifier } from "./assetPathUtils";
 import type { PackagerAsset } from "./types";
+import type {AssetData} from 'metro';
 
 export function getAndroidAssetSuffix(scale: number): string {
   const tolerance = 0.01;
@@ -51,4 +52,20 @@ export function getAssetDestPathAndroid(
   const androidFolder = getAndroidResourceFolderName(asset, scale);
   const fileName = getResourceIdentifier(asset);
   return path.join(androidFolder, `${fileName}.${asset.type}`);
+}
+
+export function saveAssetsAndroid(
+  assets: ReadonlyArray<AssetData>,
+  _platform: string,
+  _assetsDest: string | undefined,
+  _assetCatalogDest: string | undefined,
+  addAssetToCopy: (
+    asset: AssetData,
+    allowedScales: number[] | undefined,
+    getAssetDestPath: (asset: AssetData, scale: number) => string,
+  ) => void,
+) {
+  assets.forEach((asset) =>
+    addAssetToCopy(asset, undefined, getAssetDestPathAndroid),
+  );
 }

--- a/packages/metro-service/src/asset/default.ts
+++ b/packages/metro-service/src/asset/default.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import path from "path";
+import type {AssetData} from 'metro';
+import type { PackagerAsset } from "./types";
+
+export function getAssetDestPath(
+  asset: PackagerAsset,
+  scale: number
+): string {
+  const suffix = scale === 1 ? "" : `@${scale}x`;
+  const fileName = `${asset.name + suffix}.${asset.type}`;
+  return path.join(
+    // Assets can have relative paths outside of the project root.
+    // Replace `../` with `_` to make sure they don't end up outside of
+    // the expected assets directory.
+    asset.httpServerLocation.substr(1).replace(/\.\.\//g, "_"),
+    fileName
+  );
+}
+
+export function saveAssetsDefault(
+  assets: ReadonlyArray<AssetData>,
+  _platform: string,
+  _assetsDest: string | undefined,
+  _assetCatalogDest: string | undefined,
+  addAssetToCopy: (
+    asset: AssetData,
+    allowedScales: number[] | undefined,
+    getAssetDestPath: (asset: AssetData, scale: number) => string,
+  ) => void,
+) {
+  assets.forEach((asset) => addAssetToCopy(asset, undefined, getAssetDestPath));
+}
+

--- a/packages/metro-service/src/asset/filter.ts
+++ b/packages/metro-service/src/asset/filter.ts
@@ -1,14 +1,9 @@
 // https://github.com/react-native-community/cli/blob/716555851b442a83a1bf5e0db27b6226318c9a69/packages/cli-plugin-metro/src/commands/bundle/filterPlatformAssetScales.ts
 
-const ALLOWED_SCALES: { [key: string]: number[] } = {
-  ios: [1, 2, 3],
-};
-
 export function filterPlatformAssetScales(
-  platform: string,
+  allowlist: ReadonlyArray<number> | undefined,
   scales: readonly number[]
 ): readonly number[] {
-  const allowlist: number[] = ALLOWED_SCALES[platform];
   if (!allowlist) {
     return scales;
   }

--- a/packages/metro-service/src/asset/ios.ts
+++ b/packages/metro-service/src/asset/ios.ts
@@ -3,9 +3,11 @@
 
 import fs from "fs";
 import type { AssetData } from "metro";
+import { error, info } from "@rnx-kit/console";
 import path from "path";
 import { getResourceIdentifier } from "./assetPathUtils";
-import type { PackagerAsset } from "./types";
+import { filterPlatformAssetScales } from './filter';
+import { getAssetDestPath } from './default';
 
 type ImageSet = {
   basePath: string;
@@ -68,17 +70,48 @@ export function writeImageSet(imageSet: ImageSet): void {
   );
 }
 
-export function getAssetDestPathIOS(
-  asset: PackagerAsset,
-  scale: number
-): string {
-  const suffix = scale === 1 ? "" : `@${scale}x`;
-  const fileName = `${asset.name + suffix}.${asset.type}`;
-  return path.join(
-    // Assets can have relative paths outside of the project root.
-    // Replace `../` with `_` to make sure they don't end up outside of
-    // the expected assets directory.
-    asset.httpServerLocation.substring(1).replace(/\.\.\//g, "_"),
-    fileName
-  );
+const ALLOWED_SCALES = [1, 2, 3];
+
+export function saveAssetsIOS(
+  assets: ReadonlyArray<AssetData>,
+  _platform: string,
+  _assetsDest: string | undefined,
+  assetCatalogDest: string | undefined,
+  addAssetToCopy: (
+    asset: AssetData,
+    allowedScales: number[] | undefined,
+    getAssetDestPath: (asset: AssetData, scale: number) => string,
+  ) => void,
+) {
+  if (assetCatalogDest != null) {
+    // Use iOS Asset Catalog for images. This will allow Apple app thinning to
+    // remove unused scales from the optimized bundle.
+    const catalogDir = path.join(assetCatalogDest, 'RNAssets.xcassets');
+    if (!fs.existsSync(catalogDir)) {
+      error(
+        `Could not find asset catalog 'RNAssets.xcassets' in ${assetCatalogDest}. Make sure to create it if it does not exist.`,
+      );
+      return;
+    }
+
+    info('Adding images to asset catalog', catalogDir);
+    cleanAssetCatalog(catalogDir);
+    for (const asset of assets) {
+      if (isCatalogAsset(asset)) {
+        const imageSet = getImageSet(
+          catalogDir,
+          asset,
+          filterPlatformAssetScales(ALLOWED_SCALES, asset.scales),
+        );
+        writeImageSet(imageSet);
+      } else {
+        addAssetToCopy(asset, ALLOWED_SCALES, getAssetDestPath);
+      }
+    }
+    info('Done adding images to asset catalog');
+  } else {
+    assets.forEach((asset) =>
+      addAssetToCopy(asset, ALLOWED_SCALES, getAssetDestPath),
+    );
+  }
 }


### PR DESCRIPTION
### Description
This change brings in most of https://github.com/react-native-community/cli/pull/2002 into rnx-kit.  Minus the config loading part, since that schema is controlled by the RN cli.

Currently the CLI provides logic to saveAssets for iOS/Android. -- with some combination of the two implementations working for the basic cases for other platforms. But as other platforms mature, they want to be able to provide more platform specific optimizations similar to how iOS provides logic to generate asset catalogs.

https://github.com/microsoft/react-native-windows/pull/11839 adds support for the new saveAssetsPlugin to successfully relocate assets - and this PR will automatically pick up the new plugin in @office-iss/react-native-win32, without going through rn-config.  Once it is added to the config we will be able to remove this special case logic.