### PR TITLE
fix(metro-plugin-typescript): proper support for TypeScript 5.0

### DIFF
--- a/.changeset/serious-parents-beam.md
+++ b/.changeset/serious-parents-beam.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/metro-plugin-typescript": patch
+"@rnx-kit/typescript-service": patch
+---
+
+Implemented replacements for `resolveModuleNames` and `resolveTypeReferenceDirectives` deprecated in TypeScript 5.0 (https://github.com/microsoft/TypeScript/commit/9e845d224859950fb263dec43f8fa1f7334e52da)

--- a/packages/metro-plugin-typescript/src/host.ts
+++ b/packages/metro-plugin-typescript/src/host.ts
@@ -3,7 +3,12 @@ import type { AllPlatforms } from "@rnx-kit/tools-react-native/platform";
 import { platformExtensions } from "@rnx-kit/tools-react-native/platform";
 import semverSatisfies from "semver/functions/satisfies";
 import ts from "typescript";
-import { resolveModuleNames, resolveTypeReferenceDirectives } from "./resolver";
+import {
+  resolveModuleNames,
+  resolveModuleNameLiterals,
+  resolveTypeReferenceDirectives,
+  resolveTypeReferenceDirectiveReferences,
+} from "./resolver";
 import type { ResolverContext } from "./types";
 
 const DEFAULT_PACKAGE_NAME = "react-native";
@@ -88,10 +93,17 @@ export function createEnhanceLanguageServiceHost(
       ),
     };
 
-    host.resolveModuleNames = resolveModuleNames.bind(undefined, context);
-    host.resolveTypeReferenceDirectives = resolveTypeReferenceDirectives.bind(
-      undefined,
-      context
-    );
+    if (semverSatisfies(tsVersion, ">=5.0")) {
+      host.resolveModuleNameLiterals = (...args) =>
+        resolveModuleNameLiterals(context, ...args);
+      host.resolveTypeReferenceDirectiveReferences = (...args) =>
+        resolveTypeReferenceDirectiveReferences(context, ...args);
+    } else {
+      host.resolveModuleNames = resolveModuleNames.bind(undefined, context);
+      host.resolveTypeReferenceDirectives = resolveTypeReferenceDirectives.bind(
+        undefined,
+        context
+      );
+    }
   };
 }

--- a/packages/metro-plugin-typescript/src/resolver.ts
+++ b/packages/metro-plugin-typescript/src/resolver.ts
@@ -25,7 +25,7 @@ export function resolveModuleName(
   redirectedReference: ts.ResolvedProjectReference | undefined,
   options: ts.CompilerOptions,
   { resolveModuleName } = ts
-): ts.ResolvedModuleFull | undefined {
+): ts.ResolvedModuleWithFailedLookupLocations {
   // Ensure the compiler options has `moduleSuffixes` set correctly for this RN
   // project. If `moduleName` points to a package (no paths), don't add platform
   // suffixes as they are not used when looking at main fields.
@@ -57,7 +57,7 @@ export function resolveModuleName(
     | ts.ModuleKind.ESNext
     | undefined = undefined;
 
-  const module = resolveModuleName(
+  return resolveModuleName(
     moduleName,
     containingFile,
     optionsWithSuffixes,
@@ -66,32 +66,66 @@ export function resolveModuleName(
     redirectedReference,
     resolutionMode
   );
-  return module.resolvedModule;
 }
 
 /**
  * Resolve a set of modules for a TypeScript program, all referenced from a
- * single containing file. Prefer type (.d.ts) files and TypeScript source
- * (.ts[x]) files, as they usually carry more type information than JavaScript
- * source (.js[x]) files.
- * single containing file. When possible, delegate module resolution to TypeScript
- * itself, rather than using our custom resolver, as the TypeScript resolver
- * supports more scenarios than ours.
+ * single containing file. When possible, delegate module resolution to
+ * TypeScript itself, rather than using our custom resolver, as the TypeScript
+ * resolver supports more scenarios than ours.
  *
  * When doing the module resolution ourselves, we prefer type (.d.ts) files and
  * TypeScript source (.ts[x]) files, as they usually carry more type information
  * than JavaScript source (.js[x]) files.
  *
  * @param context Resolver context
- * @param moduleNames List of module names, as they appear in each require/import statement
+ * @param moduleLiterals List of module names, as they appear in each require/import statement
  * @param containingFile File from which the modules were all required/imported
- * @param _reusedNames
  * @param redirectedReference Head node in the program's graph of type references
  * @param options Compiler options to use when resolving this module
  * @param _containingSourceFile
+ * @param _reusedNames
  * @param typescript Used for _mocking_ only. This parameter must _always_ be last.
  * @returns Array of results. Each entry will have resolved module information, or will be `undefined` if resolution failed. The array will have one element for each entry in the module name list.
  */
+export function resolveModuleNameLiterals(
+  context: ResolverContext,
+  moduleLiterals: readonly ts.StringLiteralLike[],
+  containingFile: string,
+  redirectedReference: ts.ResolvedProjectReference | undefined,
+  options: ts.CompilerOptions,
+  _containingSourceFile: ts.SourceFile,
+  _reusedNames: readonly ts.StringLiteralLike[] | undefined,
+  typescript = ts
+): readonly ts.ResolvedModuleWithFailedLookupLocations[] {
+  const { host, replaceReactNativePackageName } = context;
+  const resolutions: ts.ResolvedModuleWithFailedLookupLocations[] = [];
+
+  const trace = options.traceResolution ? host.trace : undefined;
+
+  for (const moduleLiteral of moduleLiterals) {
+    const moduleName = moduleLiteral.text;
+    const finalModuleName = replaceReactNativePackageName(moduleName);
+    if (trace && finalModuleName !== moduleName) {
+      trace(`Substituting module '${moduleName}' with '${finalModuleName}'.`);
+    }
+
+    const resolvedModule = resolveModuleName(
+      context,
+      finalModuleName,
+      containingFile,
+      redirectedReference,
+      options,
+      typescript
+    );
+
+    resolutions.push(resolvedModule);
+  }
+
+  return resolutions;
+}
+
+// TODO: Remove when we drop support for TypeScript 4.
 export function resolveModuleNames(
   context: ResolverContext,
   moduleNames: string[],
@@ -113,7 +147,7 @@ export function resolveModuleNames(
       trace(`Substituting module '${moduleName}' with '${finalModuleName}'.`);
     }
 
-    const module = resolveModuleName(
+    const { resolvedModule } = resolveModuleName(
       context,
       finalModuleName,
       containingFile,
@@ -122,7 +156,7 @@ export function resolveModuleNames(
       typescript
     );
 
-    resolutions.push(module);
+    resolutions.push(resolvedModule);
   }
 
   return resolutions;
@@ -143,14 +177,69 @@ export function resolveModuleNames(
  *    `types: ["node", "jest"]`
  *
  * @param context Resolver context
- * @param typeDirectiveNames List of type names, as they appear in each type reference directive
+ * @param typeDirectiveReferences List of type names, as they appear in each type reference directive
  * @param containingFile File from which the type names were all referenced
  * @param redirectedReference Head node in the program's graph of type references
  * @param options Compiler options
- * @param containingFileMode Indicates whether the containing file is an ESNext module or a CommonJS module
+ * @param containingSourceFile The containing source file
+ * @param _reusedNames
  * @param ts Used for _mocking_ only. This parameter must _always_ be last.
  * @returns Array of results. Each entry will have resolved type information, or will be `undefined` if resolution failed. The array will have one element for each entry in the type name list.
  */
+export function resolveTypeReferenceDirectiveReferences<
+  T extends ts.FileReference | string,
+>(
+  { host, platformFileExtensions: moduleSuffixes }: ResolverContext,
+  typeDirectiveReferences: readonly T[],
+  containingFile: string,
+  redirectedReference: ts.ResolvedProjectReference | undefined,
+  options: ts.CompilerOptions,
+  containingSourceFile: ts.SourceFile | undefined,
+  _reusedNames: readonly T[] | undefined,
+  { resolveTypeReferenceDirective } = ts
+): readonly ts.ResolvedTypeReferenceDirectiveWithFailedLookupLocations[] {
+  const resolutions: ts.ResolvedTypeReferenceDirectiveWithFailedLookupLocations[] =
+    [];
+
+  for (const ref of typeDirectiveReferences) {
+    const name = typeof ref === "string" ? ref : ref.fileName.toLowerCase();
+
+    //  Ensure the compiler options has `moduleSuffixes` set correctly for this RN project.
+    const optionsWithSuffixes = { ...options, moduleSuffixes };
+
+    //
+    //  Invoke the built-in TypeScript type-reference resolver.
+    //
+    //  One of the params it takes is a resolution cache. We don't currently use this,
+    //  and TypeScript can operate without it, though it may be slower. We have not done
+    //  perf analysis to see how much of a benefit the cache provides.
+    //
+    //  If, down the road, we decide to add a cache, it should be created using:
+    //
+    //    `ts.createTypeReferenceDirectiveResolutionCache(currentDirectory, ...)`
+    //
+    //  And we should store each per-directory cache in a map, attached to `context`.
+    //
+    const cache: ts.TypeReferenceDirectiveResolutionCache | undefined =
+      undefined;
+
+    const directive = resolveTypeReferenceDirective(
+      name,
+      containingFile,
+      optionsWithSuffixes,
+      host,
+      redirectedReference,
+      cache,
+      containingSourceFile?.impliedNodeFormat
+    );
+
+    resolutions.push(directive);
+  }
+
+  return resolutions;
+}
+
+// TODO: Remove when we drop support for TypeScript 4.
 export function resolveTypeReferenceDirectives(
   context: ResolverContext,
   typeDirectiveNames: string[] | readonly ts.FileReference[],

--- a/packages/metro-plugin-typescript/test/host.test.ts
+++ b/packages/metro-plugin-typescript/test/host.test.ts
@@ -4,7 +4,9 @@ import type ts from "typescript";
 import { createEnhanceLanguageServiceHost } from "../src/host";
 import {
   resolveModuleNames,
+  resolveModuleNameLiterals,
   resolveTypeReferenceDirectives,
+  resolveTypeReferenceDirectiveReferences,
 } from "../src/resolver";
 
 //
@@ -15,8 +17,8 @@ import {
 //  testing we are doing here.
 //
 
-describe("Host (TS v4.6.0)", () => {
-  // Force TS version to 4.6, which pre-dates moduleSuffixes.
+describe("Host (TypeScript <4.7)", () => {
+  // Force TypeScript version to 4.6, which pre-dates `moduleSuffixes`.
   const tsMock = { version: "4.6.4" } as unknown as typeof ts;
 
   afterEach(() => {
@@ -31,14 +33,17 @@ describe("Host (TS v4.6.0)", () => {
   });
 });
 
-describe("Host (TS >= 4.7.0)", () => {
+describe("Host (TypeScript >=4.7 <5.0)", () => {
+  // Force TypeScript version to 4.7, which supports `moduleSuffixes`.
+  const tsMock = { version: "4.7.0" } as unknown as typeof ts;
+
   afterEach(() => {
     jest.resetAllMocks();
   });
 
   test("hooks are set to the TS-delegating resolver functions", () => {
     const host = { getCurrentDirectory: process.cwd } as ts.LanguageServiceHost;
-    createEnhanceLanguageServiceHost("ios")(host);
+    createEnhanceLanguageServiceHost("ios", tsMock)(host);
 
     host.resolveModuleNames?.(
       ["module"],
@@ -64,7 +69,7 @@ describe("Host (TS >= 4.7.0)", () => {
 
   test("empty extension is added to the end of the platform file extension list", () => {
     const host = { getCurrentDirectory: process.cwd } as ts.LanguageServiceHost;
-    createEnhanceLanguageServiceHost("ios")(host);
+    createEnhanceLanguageServiceHost("ios", tsMock)(host);
 
     host.resolveModuleNames?.(
       ["module"],
@@ -78,6 +83,66 @@ describe("Host (TS >= 4.7.0)", () => {
     expect(resolveModuleNames).toBeCalledTimes(1);
     // 1st argument: ResolverContext
     expect((resolveModuleNames as jest.Mock).mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        platformFileExtensions: [".ios", ".native", ""],
+      })
+    );
+  });
+});
+
+describe("Host (TypeScript >=5.0)", () => {
+  // Force TypeScript version to 5.0, which deprecates `resolveModuleNames` and
+  // `resolveTypeReferenceDirectives`.
+  const tsMock = { version: "5.0.0" } as unknown as typeof ts;
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("hooks are set to the TS-delegating resolver functions", () => {
+    const host = { getCurrentDirectory: process.cwd } as ts.LanguageServiceHost;
+    createEnhanceLanguageServiceHost("ios", tsMock)(host);
+
+    host.resolveModuleNameLiterals?.(
+      [{ text: "module" } as ts.StringLiteral],
+      "containing-file",
+      undefined,
+      {},
+      {} as ts.SourceFile,
+      undefined
+    );
+
+    expect(resolveModuleNameLiterals).toBeCalledTimes(1);
+
+    host.resolveTypeReferenceDirectiveReferences?.(
+      ["type-reference"],
+      "containing-file",
+      undefined,
+      {},
+      {} as ts.SourceFile,
+      undefined
+    );
+
+    expect(resolveTypeReferenceDirectiveReferences).toBeCalledTimes(1);
+  });
+
+  test("empty extension is added to the end of the platform file extension list", () => {
+    const host = { getCurrentDirectory: process.cwd } as ts.LanguageServiceHost;
+    createEnhanceLanguageServiceHost("ios", tsMock)(host);
+
+    host.resolveModuleNameLiterals?.(
+      [{ text: "module" } as ts.StringLiteral],
+      "containing-file",
+      undefined,
+      {},
+      {} as ts.SourceFile,
+      undefined
+    );
+
+    expect(resolveModuleNameLiterals).toBeCalledTimes(1);
+
+    // 1st argument: ResolverContext
+    expect((resolveModuleNameLiterals as jest.Mock).mock.calls[0][0]).toEqual(
       expect.objectContaining({
         platformFileExtensions: [".ios", ".native", ""],
       })

--- a/packages/typescript-service/src/cache.ts
+++ b/packages/typescript-service/src/cache.ts
@@ -16,11 +16,11 @@ export class ProjectFileCache {
 
   set(fileName: string, snapshot?: ts.IScriptSnapshot): void {
     const normalized = normalizePath(fileName);
-    if (!this.files.has(normalized)) {
+    const file = this.files.get(normalized);
+    if (!file) {
       this.files.set(normalized, new VersionedSnapshot(normalized, snapshot));
     } else {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Map has the element, and we only store non-null objects
-      this.files.get(normalized)!.update(snapshot);
+      file.update(snapshot);
     }
   }
 
@@ -61,7 +61,6 @@ export class ExternalFileCache {
       this.files.set(normalized, file);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Map has the element, and we only store non-null objects
-    return this.files.get(normalized)!.getSnapshot();
+    return file.getSnapshot();
   }
 }


### PR DESCRIPTION
### Description

Address the [deprecation of `resolveModuleNames` and `resolveTypeReferenceDirectives`](https://github.com/microsoft/TypeScript/commit/9e845d224859950fb263dec43f8fa1f7334e52da) in TypeScript 5.0.

Resolves #2211.

### Test plan

n/a