### PR TITLE
fix(metro-resolver-symlinks): fix asset loading

### DIFF
--- a/.changeset/blue-apes-attack.md
+++ b/.changeset/blue-apes-attack.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Fix handling of asset files when `experimental_retryResolvingFromDisk` is enabled

--- a/packages/metro-resolver-symlinks/src/types.ts
+++ b/packages/metro-resolver-symlinks/src/types.ts
@@ -1,4 +1,4 @@
-import type { ResolutionContext as MetroResolutionContext } from "metro-resolver";
+import type { ResolutionContext } from "metro-resolver";
 
 type ExperimentalOptions = {
   experimental_retryResolvingFromDisk?: boolean | "force";
@@ -6,13 +6,22 @@ type ExperimentalOptions = {
 
 export type MetroResolver = typeof import("metro-resolver").resolve;
 
-export type ResolutionContext = Pick<
-  MetroResolutionContext,
-  "extraNodeModules" | "originModulePath"
->;
+export type ResolutionContextCompat = ResolutionContext & {
+  /**
+   * Introduced in 0.76
+   * @see {@link https://github.com/facebook/metro/commit/c6548f7ccc5b8ad59ea98f4bd7f1f5822deec0cd}
+   */
+  assetExts?: Set<string>;
+
+  /**
+   * Removed in 0.76
+   * @see {@link https://github.com/facebook/metro/commit/c6548f7ccc5b8ad59ea98f4bd7f1f5822deec0cd}
+   */
+  isAssetFile?: (file: string) => boolean;
+};
 
 export type ModuleResolver = (
-  context: ResolutionContext,
+  context: ResolutionContextCompat,
   moduleName: string,
   platform: string
 ) => string;

--- a/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
+++ b/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
@@ -29,7 +29,7 @@ function supportsRetryResolvingFromDisk(): boolean {
   const { version } = importMetroModule("/package.json");
   const [major, minor] = version.split(".");
   const v = major * 1000 + minor;
-  return v >= 64 && v <= 75;
+  return v >= 64 && v <= 78;
 }
 
 export function shouldEnableRetryResolvingFromDisk({

--- a/packages/metro-resolver-symlinks/src/utils/remapImportPath.ts
+++ b/packages/metro-resolver-symlinks/src/utils/remapImportPath.ts
@@ -6,7 +6,7 @@ import {
 import type { PackageModuleRef } from "@rnx-kit/tools-node/module";
 import { expandPlatformExtensions } from "@rnx-kit/tools-react-native/platform";
 import * as path from "path";
-import type { ModuleResolver, ResolutionContext } from "../types";
+import type { ModuleResolver, ResolutionContextCompat } from "../types";
 
 type Resolver = (fromDir: string, moduleId: string) => string;
 
@@ -25,7 +25,7 @@ const DEFAULT_OPTIONS = {
 };
 
 export function remapLibToSrc(
-  { originModulePath }: ResolutionContext,
+  { originModulePath }: ResolutionContextCompat,
   ref: PackageModuleRef,
   resolver: Resolver
 ): string | undefined {
@@ -66,7 +66,7 @@ export function resolveModule(
 }
 
 export function resolveModulePath(
-  { originModulePath }: ResolutionContext,
+  { originModulePath }: ResolutionContextCompat,
   ref: PackageModuleRef,
   resolver: Resolver,
   options: ResolverOptions

--- a/packages/metro-resolver-symlinks/test/__mocks__/find-up.js
+++ b/packages/metro-resolver-symlinks/test/__mocks__/find-up.js
@@ -1,6 +1,6 @@
 const actualFindUp = jest.requireActual("find-up");
-const fs = jest.requireActual("fs");
-const path = jest.requireActual("path");
+const fs = jest.requireActual("node:fs");
+const path = jest.requireActual("node:path");
 
 const findUp = jest.createMockFromModule("find-up");
 

--- a/packages/metro-resolver-symlinks/test/fixtures.ts
+++ b/packages/metro-resolver-symlinks/test/fixtures.ts
@@ -1,5 +1,5 @@
 // istanbul ignore file
-import * as path from "path";
+import * as path from "node:path";
 
 export function useFixture(name: string): string {
   return path.join(__dirname, "__fixtures__", name);

--- a/packages/metro-resolver-symlinks/test/remapImportPath.test.ts
+++ b/packages/metro-resolver-symlinks/test/remapImportPath.test.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as path from "node:path";
 import { remapImportPath } from "../src/utils/remapImportPath";
 
 describe("remap-import-path", () => {

--- a/packages/metro-resolver-symlinks/test/utils/enhancedResolve.test.ts
+++ b/packages/metro-resolver-symlinks/test/utils/enhancedResolve.test.ts
@@ -1,0 +1,27 @@
+import type { ResolutionContextCompat } from "../../src/types";
+import { isAssetFile } from "../../src/utils/enhancedResolve";
+
+describe("isAssetFile", () => {
+  test("uses `isAssetFile` if it exists", () => {
+    const context = {
+      isAssetFile: () => true,
+    } as unknown as ResolutionContextCompat;
+    expect(isAssetFile(context, "test.png")).toBe(true);
+  });
+
+  test("uses `assetExts` if it exists", () => {
+    const context = {
+      assetExts: new Set(["png"]),
+      isAssetFile: () => false,
+    } as unknown as ResolutionContextCompat;
+    expect(isAssetFile(context, "test.png")).toBe(true);
+  });
+
+  test("resolves multipart extensions", () => {
+    const context = {
+      assetExts: new Set(["android.png"]),
+    } as unknown as ResolutionContextCompat;
+    expect(isAssetFile(context, "android.png")).toBe(false);
+    expect(isAssetFile(context, "test.android.png")).toBe(true);
+  });
+});


### PR DESCRIPTION
### Description

Fix handling of asset files when `experimental_retryResolvingFromDisk` is enabled

### Test plan

1. Enable `experimental_retryResolvingFromDisk`
    ```diff
    diff --git a/packages/test-app/metro.config.js b/packages/test-app/metro.config.js
    index 7c0dcfc2..094f8f78 100644
    --- a/packages/test-app/metro.config.js
    +++ b/packages/test-app/metro.config.js
    @@ -29,8 +29,11 @@ module.exports = makeMetroConfig({
               }
             : {}),
         },
    -    resolveRequest: MetroSymlinksResolver(),
    +    resolveRequest: MetroSymlinksResolver({
    +      experimental_retryResolvingFromDisk: true,
    +    }),
         blacklistRE: blockList,
         blockList,
       },
    +  watchFolders: [],
     });
    ```
2. Build and start the dev server:
    ```sh
    cd packages/test-app
    yarn build --dependencies
    yarn start
    ```
3. In a separate terminal, build and run the app:
    ```sh
    yarn ios
    ```
