### PR TITLE
fix(metro-service): clean up after `cli-plugin-metro` deprecation

### DIFF
--- a/.changeset/old-years-hug.md
+++ b/.changeset/old-years-hug.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-service": patch
+---
+
+Use `@react-native/metro-config` to determine whether we need `getDefaultConfig` to load Metro config

--- a/packages/metro-service/package.json
+++ b/packages/metro-service/package.json
@@ -29,7 +29,8 @@
     "chalk": "^4.1.0"
   },
   "peerDependencies": {
-    "@react-native-community/cli-plugin-metro": ">=6.1.0",
+    "@react-native-community/cli-plugin-metro": "*",
+    "@react-native/metro-config": "*",
     "metro": ">=0.66.1",
     "metro-config": ">=0.66.1",
     "metro-core": ">=0.66.1",
@@ -39,6 +40,9 @@
   },
   "peerDependenciesMeta": {
     "@react-native-community/cli-plugin-metro": {
+      "optional": true
+    },
+    "@react-native/metro-config": {
       "optional": true
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3833,7 +3833,8 @@ __metadata:
     prettier: ^3.0.0
     typescript: ^5.0.0
   peerDependencies:
-    "@react-native-community/cli-plugin-metro": ">=6.1.0"
+    "@react-native-community/cli-plugin-metro": "*"
+    "@react-native/metro-config": "*"
     metro: ">=0.66.1"
     metro-config: ">=0.66.1"
     metro-core: ">=0.66.1"
@@ -3842,6 +3843,8 @@ __metadata:
     metro-runtime: ">=0.66.1"
   peerDependenciesMeta:
     "@react-native-community/cli-plugin-metro":
+      optional: true
+    "@react-native/metro-config":
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Description

Use `@react-native/metro-config` to determine whether we need `getDefaultConfig` to load Metro config.

### Test plan

n/a