### PR TITLE
docs(changeset): bump `@rnx-kit/cli` and `@rnx-kit/config`

### DIFF
--- a/.changeset/dirty-otters-flash.md
+++ b/.changeset/dirty-otters-flash.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/cli": patch
+"@rnx-kit/config": patch
+---
+
+Bump dependencies to handle `@react-native-community/cli-plugin-metro` -> `@react-native/community-cli-plugin`


### PR DESCRIPTION
### Description

Bump `@rnx-kit/cli` and `@rnx-kit/config` so they'll start requiring the packages with `@react-native-community/cli-plugin-metro` -> `@react-native/community-cli-plugin` fixes.

### Test plan

n/a