### PR TITLE
docs(changeset): `@rnx-kit/config` does not need to be bumped

### DIFF
--- a/.changeset/dirty-otters-flash.md
+++ b/.changeset/dirty-otters-flash.md
@@ -1,6 +1,5 @@
 ---
 "@rnx-kit/cli": patch
-"@rnx-kit/config": patch
 ---
 
 Bump dependencies to handle `@react-native-community/cli-plugin-metro` -> `@react-native/community-cli-plugin`


### PR DESCRIPTION
### Description

`@rnx-kit/config` does not need to be bumped

### Test plan

n/a