### PR TITLE
ci: drop Node 14, add 20

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,7 +45,7 @@ jobs:
     name: "Build"
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [16, 18, 20]
         os: [ubuntu-22.04, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:

--- a/nx.json
+++ b/nx.json
@@ -5,6 +5,7 @@
   "namedInputs": {
     "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "sharedGlobals": [
+      "{workspaceRoot}/.github/workflows/pr.yml",
       "{workspaceRoot}/nx.json",
       "{workspaceRoot}/packages/eslint-config/*",
       "{workspaceRoot}/packages/eslint-plugin/*",


### PR DESCRIPTION
### Description

Node >=16 is now required for a number of packages (such as [typescript-eslint](https://github.com/microsoft/rnx-kit/pull/2628)).

### Test plan

CI should pass.