### PR TITLE
Fix: RNXAccountType was wrong on iOS

### DIFF
--- a/.changeset/tender-feet-knock.md
+++ b/.changeset/tender-feet-knock.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-auth": patch
+---
+
+fix: use correct ios account type string

--- a/.changeset/tender-feet-knock.md
+++ b/.changeset/tender-feet-knock.md
@@ -2,4 +2,4 @@
 "@rnx-kit/react-native-auth": patch
 ---
 
-fix: use correct ios account type string
+Use correct iOS account type string

--- a/packages/react-native-auth/ios/RNXAccountType.m
+++ b/packages/react-native-auth/ios/RNXAccountType.m
@@ -2,7 +2,7 @@
 
 RNXAccountType RNXAccountTypeFromString(NSString *type)
 {
-    if ([type isEqualToString:@"Microsoft"]) {
+    if ([type isEqualToString:@"MicrosoftAccount"]) {
         return RNXAccountTypeMicrosoftAccount;
     }
     if ([type isEqualToString:@"Organizational"]) {


### PR DESCRIPTION
Proper RNX account type for iOS

### Description

The problem that I am trying to solve here is a crash with MSA accounts on iOS.

In this screenshot, we can perhaps see this little bug show itself with the Typescript string "MicrosoftAccount" does not entirely match up with the iOS string compare on the native side coming in as "MicrosoftAccount" but we only accept the string "Microsoft" (without the suffix Account).

### Test plan

Running locally with an MSA account on iOS.

This does not seem to be an issue on Android.
