### PR TITLE
chore: allow `rnx-align-deps.mjs` to skip the build step

### DIFF
--- a/.changeset/proud-bulldogs-hide.md
+++ b/.changeset/proud-bulldogs-hide.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/babel-plugin-import-path-remapper": patch
+---
+
+Skip packages that declare entry points

--- a/.changeset/red-crabs-invent.md
+++ b/.changeset/red-crabs-invent.md
@@ -1,0 +1,10 @@
+---
+"@rnx-kit/tools-workspaces": patch
+"@rnx-kit/tools-language": patch
+"@rnx-kit/tools-node": patch
+"@rnx-kit/tools-react-native": patch
+"@rnx-kit/console": patch
+"@rnx-kit/config": patch
+---
+
+Allow bundling directly from TypeScript source

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint": "nx run-many --target lint --all",
     "new-package": "node scripts/new-package.mjs",
     "publish:changesets": "changeset publish",
-    "rnx-align-deps": "cd packages/align-deps && yarn bundle && cd ../.. && scripts/rnx-align-deps.mjs",
+    "rnx-align-deps": "yarn workspace @rnx-kit/align-deps bundle && scripts/rnx-align-deps.mjs",
     "show-affected": "nx show projects --affected",
     "test": "nx run-many --target test --output-style stream --all",
     "update-readme": "nx run-many --target update-readme --all",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint": "nx run-many --target lint --all",
     "new-package": "node scripts/new-package.mjs",
     "publish:changesets": "changeset publish",
-    "rnx-align-deps": "yarn build-scope @rnx-kit/align-deps && scripts/rnx-align-deps.mjs",
+    "rnx-align-deps": "cd packages/align-deps && yarn bundle && cd ../.. && scripts/rnx-align-deps.mjs",
     "show-affected": "nx show projects --affected",
     "test": "nx run-many --target test --output-style stream --all",
     "update-readme": "nx run-many --target update-readme --all",

--- a/packages/align-deps/tsconfig.json
+++ b/packages/align-deps/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "compilerOptions": {
-    "alwaysStrict": false
+    "alwaysStrict": false,
+    "emitDeclarationOnly": true
   },
   "include": ["src"]
 }

--- a/packages/align-deps/tsconfig.json
+++ b/packages/align-deps/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "@rnx-kit/scripts/tsconfig-shared.json",
   "compilerOptions": {
-    "alwaysStrict": false,
-    "emitDeclarationOnly": true
+    "alwaysStrict": false
   },
   "include": ["src"]
 }

--- a/packages/babel-plugin-import-path-remapper/src/index.js
+++ b/packages/babel-plugin-import-path-remapper/src/index.js
@@ -45,7 +45,12 @@ function findMainSourceFile(sourcePath, requester, customRemap) {
     resolveOptions
   );
 
-  const { main } = readPackage(manifestPath);
+  const { main, exports } = readPackage(manifestPath);
+  if (exports) {
+    // Skip packages that declare entry points
+    return;
+  }
+
   if (customRemap) {
     return customRemap(
       sourcePath,

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -4,8 +4,17 @@
   "description": "Define and query information about a kit package",
   "homepage": "https://github.com/microsoft/rnx-kit/tree/main/packages/config#readme",
   "license": "MIT",
+  "files": [
+    "lib/*",
+    "src/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "typescript": "./src/index.ts",
+    "default": "./lib/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -11,9 +11,12 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "exports": {
-    "types": "./lib/index.d.ts",
-    "typescript": "./src/index.ts",
-    "default": "./lib/index.js"
+    ".": {
+      "types": "./lib/index.d.ts",
+      "typescript": "./src/index.ts",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "repository": {
     "type": "git",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -11,9 +11,12 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "exports": {
-    "types": "./lib/index.d.ts",
-    "typescript": "./src/index.ts",
-    "default": "./lib/index.js"
+    ".": {
+      "types": "./lib/index.d.ts",
+      "typescript": "./src/index.ts",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "repository": {
     "type": "git",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -5,10 +5,16 @@
   "homepage": "https://github.com/microsoft/rnx-kit/tree/main/packages/console#readme",
   "license": "MIT",
   "files": [
-    "lib/*"
+    "lib/*",
+    "src/*"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "typescript": "./src/index.ts",
+    "default": "./lib/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/tools-language/package.json
+++ b/packages/tools-language/package.json
@@ -18,6 +18,7 @@
       "typescript": "./src/index.ts",
       "default": "./lib/index.js"
     },
+    "./package.json": "./package.json",
     "./properties": {
       "types": "./lib/properties.d.ts",
       "typescript": "./src/properties.ts",

--- a/packages/tools-language/package.json
+++ b/packages/tools-language/package.json
@@ -7,10 +7,23 @@
   "files": [
     "lib/*",
     "properties.d.ts",
-    "properties.js"
+    "properties.js",
+    "src/*"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "typescript": "./src/index.ts",
+      "default": "./lib/index.js"
+    },
+    "./properties": {
+      "types": "./lib/properties.d.ts",
+      "typescript": "./src/properties.ts",
+      "default": "./lib/properties.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/tools-node/package.json
+++ b/packages/tools-node/package.json
@@ -32,6 +32,7 @@
       "typescript": "./src/package.ts",
       "default": "./lib/package.js"
     },
+    "./package.json": "./package.json",
     "./path": {
       "types": "./lib/path.d.ts",
       "typescript": "./src/path.ts",

--- a/packages/tools-node/package.json
+++ b/packages/tools-node/package.json
@@ -11,10 +11,33 @@
     "package.d.ts",
     "package.js",
     "path.d.ts",
-    "path.js"
+    "path.js",
+    "src/*"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "typescript": "./src/index.ts",
+      "default": "./lib/index.js"
+    },
+    "./module": {
+      "types": "./lib/module.d.ts",
+      "typescript": "./src/module.ts",
+      "default": "./lib/module.js"
+    },
+    "./package": {
+      "types": "./lib/package.d.ts",
+      "typescript": "./src/package.ts",
+      "default": "./lib/package.js"
+    },
+    "./path": {
+      "types": "./lib/path.d.ts",
+      "typescript": "./src/path.ts",
+      "default": "./lib/path.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/tools-react-native/package.json
+++ b/packages/tools-react-native/package.json
@@ -9,10 +9,28 @@
     "metro.d.ts",
     "metro.js",
     "platform.d.ts",
-    "platform.js"
+    "platform.js",
+    "src/*"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "typescript": "./src/index.ts",
+      "default": "./lib/index.js"
+    },
+    "./metro": {
+      "types": "./lib/metro.d.ts",
+      "typescript": "./src/metro.ts",
+      "default": "./lib/metro.js"
+    },
+    "./platform": {
+      "types": "./lib/platform.d.ts",
+      "typescript": "./src/platform.ts",
+      "default": "./lib/platform.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/tools-react-native/package.json
+++ b/packages/tools-react-native/package.json
@@ -25,6 +25,7 @@
       "typescript": "./src/metro.ts",
       "default": "./lib/metro.js"
     },
+    "./package.json": "./package.json",
     "./platform": {
       "types": "./lib/platform.d.ts",
       "typescript": "./src/platform.ts",

--- a/packages/tools-workspaces/package.json
+++ b/packages/tools-workspaces/package.json
@@ -15,9 +15,12 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "exports": {
-    "types": "./lib/index.d.ts",
-    "typescript": "./src/index.ts",
-    "default": "./lib/index.js"
+    ".": {
+      "types": "./lib/index.d.ts",
+      "typescript": "./src/index.ts",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "repository": {
     "type": "git",

--- a/packages/tools-workspaces/package.json
+++ b/packages/tools-workspaces/package.json
@@ -9,10 +9,16 @@
     "email": "microsoftopensource@users.noreply.github.com"
   },
   "files": [
-    "lib/*"
+    "lib/*",
+    "src/*"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "typescript": "./src/index.ts",
+    "default": "./lib/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/scripts/src/commands/bundle.mjs
+++ b/scripts/src/commands/bundle.mjs
@@ -36,6 +36,7 @@ export default async function bundle(options) {
   const esbuild = await import("esbuild");
   await esbuild.build({
     bundle: true,
+    conditions: ["typescript"],
     entryPoints: ["src/index.ts"],
     external: [
       ...(dependencies ? Object.keys(dependencies) : []),


### PR DESCRIPTION
### Description

- Added [exports map](https://nodejs.org/api/packages.html#package-entry-points) to packages depended on by align-deps
- Reconfigured align-deps' `tsconfig.json` to emit declarations only
- Reconfigured `rnx-align-deps` to skip build

### Test plan

```
yarn clean
yarn
yarn rnx-align-deps
```

`yarn rnx-align-deps` should be fairly instant since it no longer builds all dependencies.

#### Before:

![image](https://github.com/microsoft/rnx-kit/assets/4123478/d367736f-b4a3-4090-b9f0-d3dfa02b906f)

#### After:

![image](https://github.com/microsoft/rnx-kit/assets/4123478/9cf6d025-3335-4979-91f2-2dad6ff9de0f)