### PR TITLE
fix(metro-service): fix reporter not being correctly overridden

### DIFF
--- a/.changeset/perfect-camels-sleep.md
+++ b/.changeset/perfect-camels-sleep.md
@@ -1,4 +1,5 @@
 ---
+"@rnx-kit/cli": patch
 "@rnx-kit/metro-service": patch
 ---
 

--- a/.changeset/perfect-camels-sleep.md
+++ b/.changeset/perfect-camels-sleep.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-service": patch
+---
+
+Fix reporter not being correctly overridden

--- a/packages/metro-service/src/config.ts
+++ b/packages/metro-service/src/config.ts
@@ -202,14 +202,21 @@ export function loadMetroConfig(
   const getDefaultConfig = getDefaultConfigProvider(cliConfig.root);
   const defaultConfig = getDefaultConfig(cliConfig);
 
-  //  apply overrides that loadConfig() doesn't do for us
-  if (overrides.reporter) {
-    defaultConfig.reporter = overrides.reporter;
-  }
   if (overrides.assetPlugins) {
     // @ts-expect-error We want to assign to read-only `assetPlugins`
     defaultConfig.transformer.assetPlugins = assetPlugins;
   }
 
-  return loadConfig({ cwd: cliConfig.root, ...overrides }, defaultConfig);
+  let config = loadConfig({ cwd: cliConfig.root, ...overrides }, defaultConfig);
+
+  // apply overrides that loadConfig() doesn't do for us
+  if (overrides.reporter) {
+    config = config.then((config) => {
+      // @ts-expect-error We want to override `reporter`
+      config.reporter = overrides.reporter;
+      return config;
+    });
+  }
+
+  return config;
 }


### PR DESCRIPTION
### Description

Fix `yarn start` not showing help on startup.

### Test plan

```
cd packages/test-app
yarn build --dependencies
yarn start
```

A help message should appear.