### PR TITLE
Add bundle size log even when metafile is set

### DIFF
--- a/.changeset/good-swans-act.md
+++ b/.changeset/good-swans-act.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Add bundle size log even when metafile option is set

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -427,6 +427,7 @@ export function MetroSerializer(
               path.join(path.dirname(sourcemapfile), buildOptions.metafile),
               typeof metafile === "string" ? metafile : JSON.stringify(metafile)
             );
+            info("esbuild bundle size:", result.code.length);
           }
         } else {
           info("esbuild bundle size:", result.code.length);


### PR DESCRIPTION
### Description
Log esbuild bundle size even when the esbuild metafile option is set.

### Test plan
Prepare:
```
cd packages/test-app
yarn build --dependencies
```
Bundle size should be logged:
````diff
diff --git a/packages/test-app/package.json b/packages/test-app/package.json
index bf87fe69..64b62c32 100644
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -118,7 +118,9 @@
         "id": "esbuild",
         "entryFile": "src/index.ts",
         "assetsDest": "dist",
-        "treeShake": true,
+        "treeShake": {
+          "metafile": "meta.json"
+        },
         "plugins": [
           "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
           [
````
