### PR TITLE
fix: use `node-fetch` only as fallback

### DIFF
--- a/.changeset/sweet-dingos-boil.md
+++ b/.changeset/sweet-dingos-boil.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/metro-service": patch
+"@rnx-kit/cli": patch
+---
+
+Use `node-fetch` only as fallback when current Node version doesn't implement Fetch API

--- a/packages/cli/src/serve/keyboard.ts
+++ b/packages/cli/src/serve/keyboard.ts
@@ -1,6 +1,6 @@
 import { info } from "@rnx-kit/console";
 import type { MetroTerminal } from "@rnx-kit/metro-service";
-import fetch from "node-fetch";
+import nodeFetch from "node-fetch";
 import qrcode from "qrcode";
 import readline from "readline";
 import type { DevServerMiddleware } from "./types";
@@ -43,7 +43,10 @@ export function attachKeyHandlers({
           break;
 
         case "j": {
-          fetch(devServerUrl + "/open-debugger", { method: "POST" });
+          info("Opening debugger...");
+          // TODO: Remove `node-fetch` when we drop support for Node 16
+          const ftch = "fetch" in globalThis ? fetch : nodeFetch;
+          ftch(devServerUrl + "/open-debugger", { method: "POST" });
           break;
         }
 

--- a/packages/metro-service/src/server.ts
+++ b/packages/metro-service/src/server.ts
@@ -1,6 +1,6 @@
 import { runServer } from "metro";
 import net from "net";
-import fetch from "node-fetch";
+import nodeFetch from "node-fetch";
 import { ensureBabelConfig } from "./babel";
 
 type ServerStatus = "not_running" | "already_running" | "in_use" | "unknown";
@@ -48,8 +48,10 @@ export async function isDevServerRunning(
       return "not_running";
     }
 
+    // TODO: Remove `node-fetch` when we drop support for Node 16
+    const ftch = "fetch" in globalThis ? fetch : nodeFetch;
     const statusUrl = `${scheme}://${host || "localhost"}:${port}/status`;
-    const statusResponse = await fetch(statusUrl);
+    const statusResponse = await ftch(statusUrl);
     const body = await statusResponse.text();
 
     return body === "packager-status:running" &&


### PR DESCRIPTION
### Description

Use `node-fetch` only as fallback when current Node version doesn't implement Fetch API

### Test plan

Repeat the following steps in both Node 16 and Node 18:

```
cd packages/test-app
yarn build --dependencies
yarn start
```

Once the dev server is running, press `j`. A message should indicate that we're trying to open the debugger, but nothing will show up. Just verify that it doesn't crash.

In a separate terminal, try to start another dev server:

```
% yarn start
error Another process is using port 8081. Please terminate this process and try again, or try another port with `--port`.
```

This one should fail with the error message above.

On Node 16, this is an error message we're trying to avoid:

```
node:internal/readline/emitKeypressEvents:71
            throw err;
            ^

ReferenceError: fetch is not defined
    at ReadStream.<anonymous> (/Users/tido/Source/rnx-kit/packages/cli/lib/serve/keyboard.js:36:21)
    at ReadStream.emit (node:events:513:28)
    at emitKeys (node:internal/readline/utils:357:14)
    at emitKeys.next (<anonymous>)
    at ReadStream.onData (node:internal/readline/emitKeypressEvents:61:36)
    at ReadStream.emit (node:events:513:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at ReadStream.Readable.push (node:internal/streams/readable:228:10)
    at TTY.onStreamRead (node:internal/stream_base_commons:190:23)
```