### PR TITLE
fix(eslint-plugin): cache access to `NODE_ENV`

### DIFF
--- a/.changeset/tasty-stingrays-add.md
+++ b/.changeset/tasty-stingrays-add.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/eslint-plugin": patch
+---
+
+Cache access to `NODE_ENV`

--- a/packages/eslint-plugin/src/rules/no-export-all.js
+++ b/packages/eslint-plugin/src/rules/no-export-all.js
@@ -41,6 +41,8 @@ const DEFAULT_CONFIG = {
   eslintScopeManager: true,
 };
 
+const NODE_ENV = process.env.NODE_ENV;
+
 /**
  * Returns whether there are any named exports.
  * @param {NamedExports?} namedExports
@@ -93,7 +95,7 @@ const resolveFrom =
   /** @type {() => (fromDir: string, moduleId: string) => string} */
   (
     () => {
-      if (process.env.NODE_ENV === "test") {
+      if (NODE_ENV === "test") {
         return (_, moduleId) => moduleId;
       }
 


### PR DESCRIPTION
### Description

Cache access to `NODE_ENV`. `process.env` is apparently a special object and is slow to access. We don't expect `NODE_ENV` to change here, so we should cache it.

### Test plan

n/a