### PR TITLE
fix(metro-resolver-symlinks): print Metro path

### DIFF
--- a/.changeset/breezy-dolphins-greet.md
+++ b/.changeset/breezy-dolphins-greet.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Print the path to the Metro instance that will be monkey patched if `experimental_retryResolvingFromDisk` is enabled

--- a/packages/metro-resolver-symlinks/package.json
+++ b/packages/metro-resolver-symlinks/package.json
@@ -22,6 +22,7 @@
     "test": "rnx-kit-scripts test"
   },
   "dependencies": {
+    "@rnx-kit/console": "^1.0.0",
     "@rnx-kit/tools-node": "^2.0.0",
     "@rnx-kit/tools-react-native": "^1.3.2",
     "enhanced-resolve": "^5.8.3"

--- a/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
+++ b/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
@@ -1,3 +1,4 @@
+import { info, warn } from "@rnx-kit/console";
 import { findMetroPath } from "@rnx-kit/tools-react-native/metro";
 import * as fs from "fs";
 import * as path from "path";
@@ -40,7 +41,7 @@ export function shouldEnableRetryResolvingFromDisk({
     experimental_retryResolvingFromDisk !== "force" &&
     !supportsRetryResolvingFromDisk()
   ) {
-    console.warn(
+    warn(
       "The version of Metro you're using has not been tested with " +
         "`experimental_retryResolvingFromDisk`. If you still want to enable " +
         "it, please set it to 'force'."
@@ -82,6 +83,8 @@ export function patchMetro(options: Options): void {
   if (!shouldEnableRetryResolvingFromDisk(options)) {
     return;
   }
+
+  info(`experimental_retryResolvingFromDisk: Patching '${findMetroPath()}'`);
 
   const DependencyGraph = importMetroModule("/src/node-haste/DependencyGraph");
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3787,6 +3787,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rnx-kit/metro-resolver-symlinks@workspace:packages/metro-resolver-symlinks"
   dependencies:
+    "@rnx-kit/console": ^1.0.0
     "@rnx-kit/eslint-config": "*"
     "@rnx-kit/scripts": "*"
     "@rnx-kit/tools-node": ^2.0.0


### PR DESCRIPTION
### Description

Print the path to the Metro instance that will be monkey patched if `experimental_retryResolvingFromDisk` is enabled. This helps with debugging when there are multiple Metro instances.

### Test plan

n/a