### PR TITLE
fix(babel-preset-metro-react-native): use `@react-native/babel-preset` with 0.73

### DIFF
--- a/.changeset/twelve-actors-repeat.md
+++ b/.changeset/twelve-actors-repeat.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/babel-preset-metro-react-native": patch
+---
+
+Use `@react-native/babel-preset` when it's specified in `package.json`

--- a/packages/babel-preset-metro-react-native/package.json
+++ b/packages/babel-preset-metro-react-native/package.json
@@ -25,10 +25,17 @@
   "peerDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/plugin-transform-typescript": "^7.0.0",
+    "@react-native/babel-preset": "*",
     "metro-react-native-babel-preset": "*"
   },
   "peerDependenciesMeta": {
     "@babel/plugin-transform-typescript": {
+      "optional": true
+    },
+    "@react-native/babel-preset": {
+      "optional": true
+    },
+    "metro-react-native-babel-preset": {
       "optional": true
     }
   },

--- a/packages/babel-preset-metro-react-native/src/index.js
+++ b/packages/babel-preset-metro-react-native/src/index.js
@@ -49,7 +49,10 @@ function constEnumPlugin() {
 
 function loadPreset(projectRoot = process.cwd()) {
   const fs = require("fs");
-  const manifest = fs.readFileSync("package.json", { encoding: "utf-8" });
+  const path = require("path");
+
+  const manifestPath = path.join(projectRoot, "package.json");
+  const manifest = fs.readFileSync(manifestPath, { encoding: "utf-8" });
   const isTesting = manifest.includes(
     '"name": "@rnx-kit/babel-preset-metro-react-native"'
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3408,9 +3408,14 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
     "@babel/plugin-transform-typescript": ^7.0.0
+    "@react-native/babel-preset": "*"
     metro-react-native-babel-preset: "*"
   peerDependenciesMeta:
     "@babel/plugin-transform-typescript":
+      optional: true
+    "@react-native/babel-preset":
+      optional: true
+    metro-react-native-babel-preset:
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Description

`metro-react-native-babel-preset` was renamed to `@react-native/babel-preset` in 0.73. We need to start picking it up if it's present.

### Test plan

n/a