### PR TITLE
fix(metro-config): forward `@babel/core` dependency

### DIFF
--- a/.changeset/grumpy-pears-dream.md
+++ b/.changeset/grumpy-pears-dream.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+`@rnx-kit/babel-preset-metro-react-native` has a peer dependency on `@babel/core` so we need to forward it

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -27,6 +27,7 @@
     "@rnx-kit/tools-workspaces": "^0.1.3"
   },
   "peerDependencies": {
+    "@babel/core": "^7.0.0",
     "@react-native/metro-config": "*",
     "react": "*",
     "react-native": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3718,6 +3718,7 @@ __metadata:
     type-fest: ^4.0.0
     typescript: ^5.0.0
   peerDependencies:
+    "@babel/core": ^7.0.0
     "@react-native/metro-config": "*"
     react: "*"
     react-native: "*"


### PR DESCRIPTION
### Description

`@rnx-kit/babel-preset-metro-react-native` has a peer dependency on `@babel/core` so we need to forward it.

```
➤ YN0002: │ @rnx-kit/metro-config@npm:1.3.9 [260cb] doesn't provide @babel/core (p3b087), requested by @rnx-kit/babel-preset-metro-react-native
```

### Test plan

n/a