### PR TITLE
chore(webapis): rollout to npm experimental webapis (battery-status and polyfills) packages

### DIFF
--- a/.changeset/stupid-buses-boil.md
+++ b/.changeset/stupid-buses-boil.md
@@ -1,0 +1,6 @@
+---
+"@react-native-webapis/battery-status": minor
+"@rnx-kit/polyfills": minor
+---
+
+bump to 0.1 so to publish

--- a/incubator/@react-native-webapis/battery-status/RNWBatteryStatus.podspec
+++ b/incubator/@react-native-webapis/battery-status/RNWBatteryStatus.podspec
@@ -5,7 +5,7 @@ version = package['version']
 repository = package['repository']
 
 Pod::Spec.new do |s|
-  s.name      = 'RNWBatteryStatus'
+  File.basename(__FILE__, '.podspec')
   s.version   = version
   s.author    = { package['author']['name'] => package['author']['email'] }
   s.license   = package['license']

--- a/incubator/@react-native-webapis/battery-status/android/build.gradle
+++ b/incubator/@react-native-webapis/battery-status/android/build.gradle
@@ -55,7 +55,7 @@ android {
     compileSdkVersion getExtProp("compileSdkVersion", 33)
     defaultConfig {
         minSdkVersion getExtProp("minSdkVersion", 23)
-        targetSdkVersion getExtProp("targetSdkVersion", 29)
+        targetSdkVersion getExtProp("targetSdkVersion", 33)
     }
     lintOptions {
         abortOnError false

--- a/incubator/@react-native-webapis/battery-status/package.json
+++ b/incubator/@react-native-webapis/battery-status/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "@react-native-webapis/battery-status",
   "version": "0.0.1",
   "description": "EXPERIMENTAL - USE WITH CAUTION - Battery Status API for React Native",

--- a/incubator/@react-native-webapis/battery-status/package.json
+++ b/incubator/@react-native-webapis/battery-status/package.json
@@ -38,6 +38,7 @@
     "lint:kt": "ktlint --relative 'android/src/**/*.kt'"
   },
   "peerDependencies": {
+    "react": ">=18.2.0",
     "react-native": ">=0.71.0-0"
   },
   "devDependencies": {

--- a/incubator/polyfills/package.json
+++ b/incubator/polyfills/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "@rnx-kit/polyfills",
   "version": "0.0.1",
   "description": "EXPERIMENTAL - USE WITH CAUTION - New package called polyfills",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3177,6 +3177,7 @@ __metadata:
     prettier: ^3.0.0
     typescript: ^5.0.0
   peerDependencies:
+    react: ">=18.2.0"
     react-native: ">=0.71.0-0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Description

A quick PR to get our CI infra to release the first 0.1.0 release of both the packages we have related to webapis so that they can be used in further "experiments" 🧪

On top of that, picking up a few changes for battery status from https://github.com/microsoft/rnx-kit/pull/2735/files

### Test plan

N/A
