### PR TITLE
fix(metro-config): fix `@react-native/metro-config` not being resolved

### DIFF
--- a/.changeset/nice-ears-notice.md
+++ b/.changeset/nice-ears-notice.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Fix `@react-native/metro-config` not being resolved correctly in a pnpm setup

--- a/packages/metro-config/src/defaultConfig.js
+++ b/packages/metro-config/src/defaultConfig.js
@@ -109,7 +109,11 @@ function getDefaultConfig(projectRoot) {
     const manifest = fs.readFileSync(pkgJson, { encoding: "utf-8" });
     if (manifest.includes("@react-native/metro-config")) {
       // @ts-ignore Cannot find module or its corresponding type declarations.
-      const { getDefaultConfig } = require("@react-native/metro-config");
+      const metroConfigPath = require.resolve(
+        "@react-native/metro-config",
+        { paths: [projectRoot] }
+      );
+      const { getDefaultConfig } = require(metroConfigPath);
       const { getAvailablePlatforms } = require("@rnx-kit/tools-react-native");
 
       const defaultConfig = getDefaultConfig(projectRoot);

--- a/packages/metro-config/src/defaultConfig.js
+++ b/packages/metro-config/src/defaultConfig.js
@@ -109,10 +109,9 @@ function getDefaultConfig(projectRoot) {
     const manifest = fs.readFileSync(pkgJson, { encoding: "utf-8" });
     if (manifest.includes("@react-native/metro-config")) {
       // @ts-ignore Cannot find module or its corresponding type declarations.
-      const metroConfigPath = require.resolve(
-        "@react-native/metro-config",
-        { paths: [projectRoot] }
-      );
+      const metroConfigPath = require.resolve("@react-native/metro-config", {
+        paths: [projectRoot],
+      });
       const { getDefaultConfig } = require(metroConfigPath);
       const { getAvailablePlatforms } = require("@rnx-kit/tools-react-native");
 


### PR DESCRIPTION
### Description

Fix `@react-native/metro-config` not being resolved correctly in a pnpm setup.

### Test plan

n/a