### PR TITLE
fix(metro-config): help Metro resolve `@babel/runtime`

### DIFF
--- a/.changeset/selfish-days-begin.md
+++ b/.changeset/selfish-days-begin.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Help Metro resolve `@babel/runtime` in pnpm setups

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -132,7 +132,7 @@ function resolveUniqueModules(modules, projectRoot) {
 
   // Additional modules that often cause issues in pnpm setups
 
-  /** @type {(curr: string | undefined, next: string) => string | undefined} */
+  /** @type {(prev: string | undefined, curr: string) => string | undefined} */
   const chainedResolve = (prev, curr) =>
     prev ? resolveModule(curr, prev) : undefined;
 

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -115,6 +115,50 @@ function resolveUniqueModule(packageName, searchStartDir) {
 }
 
 /**
+ * Resolves modules that need to be unique.
+ * @param {string[]} modules
+ * @param {string} projectRoot
+ * @returns {Record<string, string>}
+ */
+function resolveUniqueModules(modules, projectRoot) {
+  /** @type Record<string, string> */
+  const extraModules = {};
+  for (const name of modules) {
+    const resolvedPath = resolveModule(name, projectRoot);
+    if (resolvedPath) {
+      extraModules[name] = resolvedPath;
+    }
+  }
+
+  // Additional modules that often cause issues in pnpm setups
+
+  /** @type {(curr: string | undefined, next: string) => string | undefined} */
+  const chainedResolve = (prev, curr) =>
+    prev ? resolveModule(curr, prev) : undefined;
+
+  const metroDir = findMetroPath(projectRoot) || require.resolve("metro");
+  const babelRuntime =
+    // Starting with `metro` 0.71.0, `@babel/runtime` can be found through
+    // `metro` -> `metro-runtime`
+    ["metro-runtime", "@babel/runtime"].reduce(chainedResolve, metroDir) ||
+    // Prior to `metro` 0.71.0, we can find `@babel/runtime` by going through
+    // `metro-react-native-babel-preset`
+    //     -> `@babel/plugin-transform-regenerator`
+    //     -> `regenerator-transform`
+    [
+      "metro-react-native-babel-preset",
+      "@babel/plugin-transform-regenerator",
+      "regenerator-transform",
+      "@babel/runtime",
+    ].reduce(chainedResolve, projectRoot);
+  if (babelRuntime) {
+    extraModules["@babel/runtime"] = babelRuntime;
+  }
+
+  return extraModules;
+}
+
+/**
  * Returns a regex to exclude extra copies of specified package.
  *
  * Note that when using this function to exclude packages, you should also add
@@ -189,8 +233,6 @@ function exclusionList(additionalExclusions = [], projectRoot = process.cwd()) {
 }
 
 module.exports = {
-  UNIQUE_PACKAGES,
-
   defaultWatchFolders,
   excludeExtraCopiesOf,
   exclusionList,
@@ -253,13 +295,7 @@ module.exports = {
              * duplicated.
              * @see exclusionList for further information.
              */
-            ...UNIQUE_PACKAGES.reduce((extraModules, name) => {
-              const resolvedPath = resolveModule(name, projectRoot);
-              if (resolvedPath) {
-                extraModules[name] = resolvedPath;
-              }
-              return extraModules;
-            }, /** @type Record<string, string> */ ({})),
+            ...resolveUniqueModules(UNIQUE_PACKAGES, projectRoot),
             ...(customConfig.resolver
               ? customConfig.resolver.extraNodeModules
               : {}),

--- a/packages/metro-config/test/index.test.ts
+++ b/packages/metro-config/test/index.test.ts
@@ -6,7 +6,6 @@ import {
   exclusionList,
   makeMetroConfig,
   resolveUniqueModule,
-  UNIQUE_PACKAGES,
 } from "../src/index";
 
 describe("@rnx-kit/metro-config", () => {
@@ -278,9 +277,11 @@ describe("makeMetroConfig", () => {
       fail("Expected `config.watchFolders` to be an array");
     }
 
-    expect(Object.keys(config.resolver.extraNodeModules)).toEqual(
-      UNIQUE_PACKAGES
-    );
+    expect(Object.keys(config.resolver.extraNodeModules)).toEqual([
+      "react",
+      "react-native",
+      "@babel/runtime",
+    ]);
 
     const blockList = exclusionList().source;
     expect(config.resolver.blacklistRE.source).toBe(blockList);
@@ -343,9 +344,11 @@ describe("makeMetroConfig", () => {
       fail("Expected `config.watchFolders` to be an array");
     }
 
-    expect(Object.keys(config.resolver.extraNodeModules)).toEqual(
-      UNIQUE_PACKAGES
-    );
+    expect(Object.keys(config.resolver.extraNodeModules)).toEqual([
+      "react",
+      "react-native",
+      "@babel/runtime",
+    ]);
 
     const blockList = exclusionList().source;
     expect(config.resolver.blacklistRE.source).toBe(blockList);
@@ -385,6 +388,7 @@ describe("makeMetroConfig", () => {
     }
 
     expect(Object.keys(extraNodeModules).sort()).toEqual([
+      "@babel/runtime",
       "my-awesome-package",
       "react",
       "react-native",


### PR DESCRIPTION
### Description

Help Metro resolve `@babel/runtime` in pnpm setups

### Test plan

n/a