### PR TITLE
fix(babel-preset-metro-react-native): help Babel resolve `@babel/plugin-transform-classes`

### DIFF
--- a/.changeset/two-months-look.md
+++ b/.changeset/two-months-look.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/babel-preset-metro-react-native": patch
+---
+
+Help Babel find `@babel/plugin-transform-classes` in pnpm setups

--- a/packages/babel-preset-metro-react-native/package.json
+++ b/packages/babel-preset-metro-react-native/package.json
@@ -50,11 +50,13 @@
     "@types/node": "^18.0.0",
     "eslint": "^8.0.0",
     "jest": "^29.2.1",
+    "metro-react-native-babel-preset": "^0.76.5",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"
   },
   "depcheck": {
     "ignoreMatches": [
+      "@babel/plugin-transform-classes",
       "@rnx-kit/babel-plugin-import-path-remapper"
     ]
   },

--- a/packages/babel-preset-metro-react-native/test/index.test.js
+++ b/packages/babel-preset-metro-react-native/test/index.test.js
@@ -7,7 +7,7 @@ describe("@rnx-kit/babel-preset-metro-react-native", () => {
   const prettier = require("prettier");
   const preset = require("../src/index");
 
-  const thisBabelPreset = path.resolve(__dirname, "..");
+  const thisBabelPreset = path.dirname(__dirname);
 
   const optionsWithAdditionalPlugins = {
     additionalPlugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3418,6 +3418,7 @@ __metadata:
     babel-plugin-const-enum: ^1.0.0
     eslint: ^8.0.0
     jest: ^29.2.1
+    metro-react-native-babel-preset: ^0.76.5
     prettier: ^3.0.0
     typescript: ^5.0.0
   peerDependencies:


### PR DESCRIPTION
### Description

Help Babel find `@babel/plugin-transform-classes` in pnpm setups

### Test plan

Enable pnpm mode:

```diff
diff --git a/.yarnrc.yml b/.yarnrc.yml
index f59a253e..b2cfdf1f 100644
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,7 +7,7 @@ logFilters:
     level: discard
   - code: YN0013 # X can't be found in the cache and will be fetched from the remote registry
     level: discard
-nodeLinker: node-modules
+nodeLinker: pnpm
 npmRegistryServer: "https://registry.npmjs.org"
 packageExtensions:
   "@fluentui/utilities@*":
```

Run:

```
yarn
cd packages/babel-preset-metro-react-native
yarn test
```