### PR TITLE
Create fork of chromium-edge-launcher with fix for windows

### DIFF
--- a/.changeset/green-bats-smile.md
+++ b/.changeset/green-bats-smile.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/chromium-edge-launcher": major
+---
+
+Fork of chromium-edge-launcher with fix for finding Edge on windows

--- a/incubator/chromium-edge-launcher/.npmignore
+++ b/incubator/chromium-edge-launcher/.npmignore
@@ -1,0 +1,15 @@
+# folders
+.vscode/
+test/
+
+# dev files
+.editorconfig
+.eslintignore
+.eslintrc.js
+gulpfile.js
+
+# ignore TypeScript source files
+src/
+
+# allow JS & TypeScript declaration files
+!dist/

--- a/incubator/chromium-edge-launcher/LICENSE
+++ b/incubator/chromium-edge-launcher/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2014 Google Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/incubator/chromium-edge-launcher/README.md
+++ b/incubator/chromium-edge-launcher/README.md
@@ -1,0 +1,206 @@
+# Edge Launcher
+
+<img src="https://user-images.githubusercontent.com/4672033/107800563-adb9ce00-6d3d-11eb-8425-2256d0278894.png" align=right height=200>
+
+Launch Microsoft Edge with ease from node.
+
+- [Disables many Edge services](https://github.com/microsoft/rnx-kit/incubator/chromium-edge-launcher/blob/main/src/flags.ts)
+  that add noise to automated scenarios
+- Opens up the browser's `remote-debugging-port` on an available port
+- Automagically locates a Edge binary to launch
+- Uses a fresh Edge profile for each launch, and cleans itself up on `kill()`
+- Binds `Ctrl-C` (by default) to terminate the Edge process
+- Exposes a small set of [options](#api) for configurability over these details
+
+> \_This project started as a fork of
+> [Chrome Launcher](https://github.com/GoogleChrome/chrome-launcher) and
+> inherits, whereas possible, all its features.
+
+### Installing
+
+```sh
+yarn add @rnx-kit/chromium-edge-launcher
+
+# or with npm:
+npm install @rnx-kit/chromium-edge-launcher
+```
+
+## API
+
+### `.launch([opts])`
+
+#### Launch options
+
+```js
+{
+  // (optional) remote debugging port number to use. If provided port is already busy, launch() will reject
+  // Default: an available port is autoselected
+  port: number;
+
+  // (optional) Additional flags to pass to Edge, for example: ['--headless', '--disable-gpu']
+  // See: https://github.com/microsoft/rnx-kit/incubator/chromium-edge-launcher/blob/main/docs/edge-flags-for-tools.md
+  // Do note, many flags are set by default: https://github.com/microsoft/rnx-kit/incubator/chromium-edge-launcher/blob/main/src/flags.ts
+  edgeFlags: Array<string>;
+
+  // (optional) Close the Edge process on `Ctrl-C`
+  // Default: true
+  handleSIGINT: boolean;
+
+  // (optional) Explicit path of intended Edge binary
+  // * If this `edgePath` option is defined, it will be used.
+  // * Otherwise, the `EDGE_PATH` env variable will be used if set. (`LIGHTHOUSE_CHROMIUM_PATH` is deprecated)
+  // * Otherwise, a detected Edge Canary will be used if found
+  // * Otherwise, a detected Edge (stable) will be used
+  edgePath: string;
+
+  // (optional) Edge profile path to use, if set to `false` then the default profile will be used.
+  // By default, a fresh Edge profile will be created
+  userDataDir: string | boolean;
+
+  // (optional) Starting URL to open the browser with
+  // Default: `about:blank`
+  startingUrl: string;
+
+  // (optional) Logging level
+  // Default: 'silent'
+  logLevel: 'verbose'|'info'|'error'|'silent';
+
+  // (optional) Flags specific in [flags.ts](src/flags.ts) will not be included.
+  // Typically used with the defaultFlags() method and edgeFlags option.
+  // Default: false
+  ignoreDefaultFlags: boolean;
+
+  // (optional) Interval in ms, which defines how often launcher checks browser port to be ready.
+  // Default: 500
+  connectionPollInterval: number;
+
+  // (optional) A number of retries, before browser launch considered unsuccessful.
+  // Default: 50
+  maxConnectionRetries: number;
+
+  // (optional) A dict of environmental key value pairs to pass to the spawned edge process.
+  envVars: {[key: string]: string};
+};
+```
+
+#### Launched edge interface
+
+#### `.launch().then(edge => ...`
+
+```js
+// The remote debugging port exposed by the launched edge
+edge.port: number;
+
+// Method to kill Edge (and cleanup the profile folder)
+edge.kill: () => Promise<void>;
+
+// The process id
+edge.pid: number;
+
+// The childProcess object for the launched Edge
+edge.process: childProcess
+```
+
+### `EdgeLauncher.Launcher.defaultFlags()`
+
+Returns an `Array<string>` of the default [flags](docs/edge-flags-for-tools.md)
+Edge is launched with. Typically used along with the `ignoreDefaultFlags` and
+`edgeFlags` options.
+
+Note: This array will exclude the following flags: `--remote-debugging-port`
+`--disable-setuid-sandbox` `--user-data-dir`.
+
+### `EdgeLauncher.Launcher.getInstallations()`
+
+Returns an `Array<string>` of paths to available Edge installations. When
+`edgePath` is not provided to `.launch()`, the first installation returned from
+this method is used instead.
+
+Note: This method performs synchronous I/O operations.
+
+### `.killAll()`
+
+Attempts to kill all Edge instances created with
+[`.launch([opts])`](#launchopts). Returns a Promise that resolves to an array of
+errors that occurred while killing instances. If all instances were killed
+successfully, the array will be empty.
+
+```js
+const EdgeLauncher = require("@rnx-kit/chromium-edge-launcher");
+
+async function cleanup() {
+  await EdgeLauncher.killAll();
+}
+```
+
+## Examples
+
+#### Launching edge:
+
+```js
+const EdgeLauncher = require("@rnx-kit/chromium-edge-launcher");
+
+EdgeLauncher.launch({
+  startingUrl: "https://google.com",
+}).then((edge) => {
+  console.log(`Edge debugging port running on ${edge.port}`);
+});
+```
+
+#### Launching headless edge:
+
+```js
+const EdgeLauncher = require("@rnx-kit/chromium-edge-launcher");
+
+EdgeLauncher.launch({
+  startingUrl: "https://google.com",
+  edgeFlags: ["--headless", "--disable-gpu"],
+}).then((edge) => {
+  console.log(`Edge debugging port running on ${edge.port}`);
+});
+```
+
+#### Launching with support for extensions and audio:
+
+```js
+const EdgeLauncher = require('@rnx-kit/chromium-edge-launcher');
+
+const newFlags = EdgeLauncher.Launcher.defaultFlags().filter(flag => flag !== '--disable-extensions' && flag !== '--mute-audio');
+
+EdgeLauncher.launch({
+  ignoreDefaultFlags: true,
+  edgeFlags: newFlags,
+}).then(edge => { ... });
+```
+
+### Continuous Integration
+
+In a CI environment like Travis, Edge may not be installed. If you want to use
+`@rnx-kit/chromium-edge-launcher`, Travis can
+[install Edge at run time with an addon](https://docs.travis-ci.com/user/edge).
+Alternatively, you can also install Edge using the
+[`download-edge.sh`](https://raw.githubusercontent.com/cezaraugusto/chromium-edge-launcher/v0.8.0/scripts/download-edge.sh)
+script.
+
+Then in `.travis.yml`, use it like so:
+
+```yaml
+language: node_js
+install:
+  - yarn install
+before_script:
+  - export DISPLAY=:99.0
+  - export CHROME_PATH="$(pwd)/edge-linux/edge"
+  - sh -e /etc/init.d/xvfb start
+  - sleep 3 # wait for xvfb to boot
+
+addons:
+  edge: stable
+```
+
+### Acknowledgements
+
+This project is a fork of https://github.com/cezaraugusto/chromium-edge-launcher
+which started as a fork of, and is inspired by
+https://github.com/cezaraugusto/chromium-edge-launcher which is released under
+the Apache-2.0 License, and is copyright of Google Inc.

--- a/incubator/chromium-edge-launcher/changelog.md
+++ b/incubator/chromium-edge-launcher/changelog.md
@@ -1,0 +1,148 @@
+
+## v0.13.4 (Tue, Jul 7 2020)
+* `08406b28` fix: preserve existing getInstallations output
+* `f3669f45` perf: check default paths first when running on Mac (#209)
+* `aef94948` docs: update defaultFlags() example for new API (#205)
+
+## v0.13.3 (Thu, Jun 4 2020)
+* `6a5d0c72` flags: disable background tracing (#203)
+* `d9154291` chore(deps): update typescript and types (#202)
+* `88e49686` test: use strict version of assert functions (#201)
+
+## v0.13.2 (Thu, May 7 2020)
+* `7c1ea547` deps: bump to is-wsl@2.2.0 (#187)
+* `2ae5591d` fix: sanitize environment variables used in RegExp (#197)
+
+## v0.13.1 (Wed, Apr 1 2020)
+* `bf2957ac` deps: update various dependencies (#192)
+
+## v0.13.0 (Thu, Feb 27 2020)
+* `83da1e41` feat: add killAll function (#186)
+* `b8c89f84` flags: disable the default browser check (#181) (#182)
+* `6112555c` fix: log taskkill error based on logging opts (#178) (#179)
+* `7c935efa` docs: add missing quote in README.md example  (#180)
+* `2e829c7d` Skip --disable-setuid-sandbox flag when ignoreDefaultFlags = true (#171)
+
+## v0.12.0 (Wed, Oct 30 2019)
+* `66a5e226` flags: add new --disable flags to reduce noise and disable backgrounding (#170)
+  - --disable-component-extensions-with-background-pages
+  - --disable-backgrounding-occluded-windows
+  - --disable-renderer-backgrounding
+  - --disable-background-timer-throttling
+* `c4890ee3` feat: expose public interface for locating Chrome installations (#177)
+  - `Launcher.getInstallations()` returns an array of paths to available Chrome binaries
+* `a5ccaa4e` deps: update assorted dependencies (#175)
+* `e67a10df` --disable-translation is now --disable-features=TranslateUI (#167)
+
+## v0.11.2 (Mon, Jul 29 2019)
+* `1928187` fix: prevent mutation of default flags (#162)
+* `02a23c2` docs: fix launcher example in README (#160)
+* `90dc0e4` update manual-chrome-launcher with fixes from LH
+
+## v0.11.1 (Tue, Jul 09 2019)
+* `ec80f0ca` tests: drop support for node 9. continue supporting node 8 LTS (#159)
+* `4865f3af` deps(security): bump mocha to latest (#158)
+* `e0d2b09b` deps(security): bump handlebars from 4.0.11 to 4.1.2 (#157)
+* `982be53f` update changelog for v0.10.7 and v0.11.0
+
+## v0.11.0 (Tue, Jul 09 2019)
+* `a860504f` [Breaking change] remove enableExtensions. add ignoreDefaultFlags & defaultFlags() (#124)
+* `448a1d48` chrome-finder: Add support for MacOS Catalina (#149)
+* `55b891bb` deps(is-wsl): add support for WSL 2; drop Node 6 (#152)
+* `57e18181` deps: upgrade typescript and ts-node (#155)
+* `a8848116` deps(security): bump lodash from 4.17.4 to 4.17.11 (#147)
+* `0a775dab` Document that --enable-automation disables automatic page reloads (#140)
+* `c9f653e2` Removing dead --safebrowsing-disable-auto-update flag. (#139)
+* `be12d564` yarn.lock add integrity
+* `e361aa43` Update changelog.md (#137)
+
+## v0.10.7 (Wed, May 01 2019)
+* `55397e0c` deps: update yarn.lock from #142
+* `179a3f33` silence grep (#138)
+* `d2f6037a` fix: move unneeded ts types to devDeps (#142)
+* `984d61ce` docs(flags): remove a few flags that are gone.
+* `6316362c` docs: fix link to chrome-launcher's flags (#128)
+* `f1f6d162` Update chrome-flags-for-tools.md
+
+## v0.10.5 (Tue, Sep 25 2018)
+* `1328319b` fix: set the `which` command's stdio to pipe (#125)
+
+## v0.10.4 (Mon, Sep 17 2018)
+* `35842ba4` fix: ignore stdio on `which` call (#121)
+* `f126c3a0` fix: reject promise on failed kill() (#112)
+* `5ee0fde2` Set custom error codes for all errors.
+* `841bdf3f` Fix picking CHROME_PATH priority over other matches.
+* `6b10d748` Fix Travis CI build: GCE for chrome bug (#87)
+* `d4aa8295` Fix readme's default logLevel (#85)
+* `5be71243` Type improvements (#102)
+* `dd5fdd49` Stricter typing for logLevel (#105)
+* `c9394cf7` Fix README typo: booelan ==> boolean (#104)
+* Update chrome-flags-for-tools.md
+
+## v0.10.3 (Mon, Sep 17 2018)
+Bad release. Had a breaking change (#70). Unpublished.
+
+## v0.10.2 (Mon, Jan 8 2018)
+* `ef91605f` Fix TS typing (#82)
+* `baf2205f` tests(travis): test on Node 9, drop testing on Node 7 (#80)
+
+## v0.10.1 (Fri, Jan 5 2018)
+* `a5bc8180` Fix getLocalAppDataPath for wsl (#75)
+* `70a91885` readme: recommend use of cri with chrome-launcher (#78)
+* `d3ee63bd` folder refactor: ts in /src, js in /dist (#69)
+
+## 0.10.0 (Fri, Dec 8 2017)
+* `449c5238` Expose launched chrome child process object. (#67)
+* `0978891c` Enable users to pass env vars into spawned chrome. (#66)
+* `0261f43b` Add document covering the various chrome flags
+* `5617473c` Make launcher the default export. (#63)
+* `483acff5` fix: support alpine linux by retrying grep with -r  (#61)
+* `eaa0bb87` docs: update maxConnectionRetries default to 50 (#58)
+
+## 0.9.0 (Mon, 27 Nov 2017)
+* `4cc9c075` New: Add `userDataDir` flag to use default user profile instead (#48)
+* `94137051` Avoid selecting google-emacs (#35)
+
+## 0.8.0 (Wed, 20 Sept 2017)
+* `256399c` Add support for Windows Subsystem for Linux / BashOnWindows (#27)
+
+## 0.7.0 (Thu, 14 Sept 2017)
+* Project moved to its own repo: https://github.com/GoogleChrome/chrome-launcher
+* `8d0766eb` Retry connection for longer (#21)
+* `52cb50af` only include PROGRAMFILES(X86) if present (#20)
+* `530822b9` log pid to kill (#22)
+* `1d617ab3` add support for `connectionPollInterval ` and `maxConnectionRetries` (#19)
+* `7474971f` Fix errors inside spawnPromise being ignored (https://github.com/GoogleChrome/lighthouse/pull/2939)
+
+## 0.6.0 (Thu, 17 Aug 2017)
+* `43baee69` mute any audio (#3028)
+* `ae6e9551` Better SIGINT handling (#2959)
+* `3ab3a117` docs: add changelog to launcher (#2987)
+
+## 0.5.0 (Mon, 14 Aug 2017)
+* `494f9911` clarify priority of chromePath options
+* `1c11021a` add support for finding Chromium on Linux (#2950)
+* `391e2043` Publish type definitions instead of source TypeScript files (#2898)
+* `de408ad3` readme: update example using deprecated `LIGHTHOUSE_CHROMIUM_PATH` (#2929)
+* `8bc6d18e` add license file to launcher package. (#2849)
+
+## 0.4.0 (Tue, 1 Aug 2017)
+* `37fd38ce` pass --enable-extensions on from manual-chrome-launcher (#2735)
+* `c942d17e` support enabling extension loading (#2650)
+
+## 0.3.2 (Wed, 19 Jul 2017)
+* `112c2c7f` Fix chrome finder on linux/osx when process.env isn't populated (#2687)
+* `5728695f` Added CHROME_PATH to readme (#2694)
+* `fedc76a3` test: fix clang-format error (#2691)
+* `a6bbcaba` nuke 'as string'
+* `41df647f` cli: remove --select-chrome,--skip-autolaunch. Support CHROME_PATH env  (#2659)
+* `8c9724e2` fix launcher w/ arbitrary flags (#2670)
+* `9c0c0788` Expose LHR to modules consuming cli/run.ts (#2654)
+* `6df6b0e2` support custom port via chrome-debug binary (#2644)
+* `3f143b19` log the specific chrome spawn command.
+
+## 0.3.1 (Wed, 5 Jul 2017)
+* `ef081063` upgrade rimraf to latest (#2641)
+
+## 0.3.0 (Fri, 30 Jun 2017)
+* `edbb40d9` fix(driver): move performance observer registration to setupDriver (#2611)

--- a/incubator/chromium-edge-launcher/changelog.md
+++ b/incubator/chromium-edge-launcher/changelog.md
@@ -1,148 +1,186 @@
-
 ## v0.13.4 (Tue, Jul 7 2020)
-* `08406b28` fix: preserve existing getInstallations output
-* `f3669f45` perf: check default paths first when running on Mac (#209)
-* `aef94948` docs: update defaultFlags() example for new API (#205)
+
+- `08406b28` fix: preserve existing getInstallations output
+- `f3669f45` perf: check default paths first when running on Mac (#209)
+- `aef94948` docs: update defaultFlags() example for new API (#205)
 
 ## v0.13.3 (Thu, Jun 4 2020)
-* `6a5d0c72` flags: disable background tracing (#203)
-* `d9154291` chore(deps): update typescript and types (#202)
-* `88e49686` test: use strict version of assert functions (#201)
+
+- `6a5d0c72` flags: disable background tracing (#203)
+- `d9154291` chore(deps): update typescript and types (#202)
+- `88e49686` test: use strict version of assert functions (#201)
 
 ## v0.13.2 (Thu, May 7 2020)
-* `7c1ea547` deps: bump to is-wsl@2.2.0 (#187)
-* `2ae5591d` fix: sanitize environment variables used in RegExp (#197)
+
+- `7c1ea547` deps: bump to is-wsl@2.2.0 (#187)
+- `2ae5591d` fix: sanitize environment variables used in RegExp (#197)
 
 ## v0.13.1 (Wed, Apr 1 2020)
-* `bf2957ac` deps: update various dependencies (#192)
+
+- `bf2957ac` deps: update various dependencies (#192)
 
 ## v0.13.0 (Thu, Feb 27 2020)
-* `83da1e41` feat: add killAll function (#186)
-* `b8c89f84` flags: disable the default browser check (#181) (#182)
-* `6112555c` fix: log taskkill error based on logging opts (#178) (#179)
-* `7c935efa` docs: add missing quote in README.md example  (#180)
-* `2e829c7d` Skip --disable-setuid-sandbox flag when ignoreDefaultFlags = true (#171)
+
+- `83da1e41` feat: add killAll function (#186)
+- `b8c89f84` flags: disable the default browser check (#181) (#182)
+- `6112555c` fix: log taskkill error based on logging opts (#178) (#179)
+- `7c935efa` docs: add missing quote in README.md example (#180)
+- `2e829c7d` Skip --disable-setuid-sandbox flag when ignoreDefaultFlags = true
+  (#171)
 
 ## v0.12.0 (Wed, Oct 30 2019)
-* `66a5e226` flags: add new --disable flags to reduce noise and disable backgrounding (#170)
+
+- `66a5e226` flags: add new --disable flags to reduce noise and disable
+  backgrounding (#170)
   - --disable-component-extensions-with-background-pages
   - --disable-backgrounding-occluded-windows
   - --disable-renderer-backgrounding
   - --disable-background-timer-throttling
-* `c4890ee3` feat: expose public interface for locating Chrome installations (#177)
-  - `Launcher.getInstallations()` returns an array of paths to available Chrome binaries
-* `a5ccaa4e` deps: update assorted dependencies (#175)
-* `e67a10df` --disable-translation is now --disable-features=TranslateUI (#167)
+- `c4890ee3` feat: expose public interface for locating Chrome installations
+  (#177)
+  - `Launcher.getInstallations()` returns an array of paths to available Chrome
+    binaries
+- `a5ccaa4e` deps: update assorted dependencies (#175)
+- `e67a10df` --disable-translation is now --disable-features=TranslateUI (#167)
 
 ## v0.11.2 (Mon, Jul 29 2019)
-* `1928187` fix: prevent mutation of default flags (#162)
-* `02a23c2` docs: fix launcher example in README (#160)
-* `90dc0e4` update manual-chrome-launcher with fixes from LH
+
+- `1928187` fix: prevent mutation of default flags (#162)
+- `02a23c2` docs: fix launcher example in README (#160)
+- `90dc0e4` update manual-chrome-launcher with fixes from LH
 
 ## v0.11.1 (Tue, Jul 09 2019)
-* `ec80f0ca` tests: drop support for node 9. continue supporting node 8 LTS (#159)
-* `4865f3af` deps(security): bump mocha to latest (#158)
-* `e0d2b09b` deps(security): bump handlebars from 4.0.11 to 4.1.2 (#157)
-* `982be53f` update changelog for v0.10.7 and v0.11.0
+
+- `ec80f0ca` tests: drop support for node 9. continue supporting node 8 LTS
+  (#159)
+- `4865f3af` deps(security): bump mocha to latest (#158)
+- `e0d2b09b` deps(security): bump handlebars from 4.0.11 to 4.1.2 (#157)
+- `982be53f` update changelog for v0.10.7 and v0.11.0
 
 ## v0.11.0 (Tue, Jul 09 2019)
-* `a860504f` [Breaking change] remove enableExtensions. add ignoreDefaultFlags & defaultFlags() (#124)
-* `448a1d48` chrome-finder: Add support for MacOS Catalina (#149)
-* `55b891bb` deps(is-wsl): add support for WSL 2; drop Node 6 (#152)
-* `57e18181` deps: upgrade typescript and ts-node (#155)
-* `a8848116` deps(security): bump lodash from 4.17.4 to 4.17.11 (#147)
-* `0a775dab` Document that --enable-automation disables automatic page reloads (#140)
-* `c9f653e2` Removing dead --safebrowsing-disable-auto-update flag. (#139)
-* `be12d564` yarn.lock add integrity
-* `e361aa43` Update changelog.md (#137)
+
+- `a860504f` [Breaking change] remove enableExtensions. add ignoreDefaultFlags &
+  defaultFlags() (#124)
+- `448a1d48` chrome-finder: Add support for MacOS Catalina (#149)
+- `55b891bb` deps(is-wsl): add support for WSL 2; drop Node 6 (#152)
+- `57e18181` deps: upgrade typescript and ts-node (#155)
+- `a8848116` deps(security): bump lodash from 4.17.4 to 4.17.11 (#147)
+- `0a775dab` Document that --enable-automation disables automatic page reloads
+  (#140)
+- `c9f653e2` Removing dead --safebrowsing-disable-auto-update flag. (#139)
+- `be12d564` yarn.lock add integrity
+- `e361aa43` Update changelog.md (#137)
 
 ## v0.10.7 (Wed, May 01 2019)
-* `55397e0c` deps: update yarn.lock from #142
-* `179a3f33` silence grep (#138)
-* `d2f6037a` fix: move unneeded ts types to devDeps (#142)
-* `984d61ce` docs(flags): remove a few flags that are gone.
-* `6316362c` docs: fix link to chrome-launcher's flags (#128)
-* `f1f6d162` Update chrome-flags-for-tools.md
+
+- `55397e0c` deps: update yarn.lock from #142
+- `179a3f33` silence grep (#138)
+- `d2f6037a` fix: move unneeded ts types to devDeps (#142)
+- `984d61ce` docs(flags): remove a few flags that are gone.
+- `6316362c` docs: fix link to chrome-launcher's flags (#128)
+- `f1f6d162` Update chrome-flags-for-tools.md
 
 ## v0.10.5 (Tue, Sep 25 2018)
-* `1328319b` fix: set the `which` command's stdio to pipe (#125)
+
+- `1328319b` fix: set the `which` command's stdio to pipe (#125)
 
 ## v0.10.4 (Mon, Sep 17 2018)
-* `35842ba4` fix: ignore stdio on `which` call (#121)
-* `f126c3a0` fix: reject promise on failed kill() (#112)
-* `5ee0fde2` Set custom error codes for all errors.
-* `841bdf3f` Fix picking CHROME_PATH priority over other matches.
-* `6b10d748` Fix Travis CI build: GCE for chrome bug (#87)
-* `d4aa8295` Fix readme's default logLevel (#85)
-* `5be71243` Type improvements (#102)
-* `dd5fdd49` Stricter typing for logLevel (#105)
-* `c9394cf7` Fix README typo: booelan ==> boolean (#104)
-* Update chrome-flags-for-tools.md
+
+- `35842ba4` fix: ignore stdio on `which` call (#121)
+- `f126c3a0` fix: reject promise on failed kill() (#112)
+- `5ee0fde2` Set custom error codes for all errors.
+- `841bdf3f` Fix picking CHROME_PATH priority over other matches.
+- `6b10d748` Fix Travis CI build: GCE for chrome bug (#87)
+- `d4aa8295` Fix readme's default logLevel (#85)
+- `5be71243` Type improvements (#102)
+- `dd5fdd49` Stricter typing for logLevel (#105)
+- `c9394cf7` Fix README typo: booelan ==> boolean (#104)
+- Update chrome-flags-for-tools.md
 
 ## v0.10.3 (Mon, Sep 17 2018)
+
 Bad release. Had a breaking change (#70). Unpublished.
 
 ## v0.10.2 (Mon, Jan 8 2018)
-* `ef91605f` Fix TS typing (#82)
-* `baf2205f` tests(travis): test on Node 9, drop testing on Node 7 (#80)
+
+- `ef91605f` Fix TS typing (#82)
+- `baf2205f` tests(travis): test on Node 9, drop testing on Node 7 (#80)
 
 ## v0.10.1 (Fri, Jan 5 2018)
-* `a5bc8180` Fix getLocalAppDataPath for wsl (#75)
-* `70a91885` readme: recommend use of cri with chrome-launcher (#78)
-* `d3ee63bd` folder refactor: ts in /src, js in /dist (#69)
+
+- `a5bc8180` Fix getLocalAppDataPath for wsl (#75)
+- `70a91885` readme: recommend use of cri with chrome-launcher (#78)
+- `d3ee63bd` folder refactor: ts in /src, js in /dist (#69)
 
 ## 0.10.0 (Fri, Dec 8 2017)
-* `449c5238` Expose launched chrome child process object. (#67)
-* `0978891c` Enable users to pass env vars into spawned chrome. (#66)
-* `0261f43b` Add document covering the various chrome flags
-* `5617473c` Make launcher the default export. (#63)
-* `483acff5` fix: support alpine linux by retrying grep with -r  (#61)
-* `eaa0bb87` docs: update maxConnectionRetries default to 50 (#58)
+
+- `449c5238` Expose launched chrome child process object. (#67)
+- `0978891c` Enable users to pass env vars into spawned chrome. (#66)
+- `0261f43b` Add document covering the various chrome flags
+- `5617473c` Make launcher the default export. (#63)
+- `483acff5` fix: support alpine linux by retrying grep with -r (#61)
+- `eaa0bb87` docs: update maxConnectionRetries default to 50 (#58)
 
 ## 0.9.0 (Mon, 27 Nov 2017)
-* `4cc9c075` New: Add `userDataDir` flag to use default user profile instead (#48)
-* `94137051` Avoid selecting google-emacs (#35)
+
+- `4cc9c075` New: Add `userDataDir` flag to use default user profile instead
+  (#48)
+- `94137051` Avoid selecting google-emacs (#35)
 
 ## 0.8.0 (Wed, 20 Sept 2017)
-* `256399c` Add support for Windows Subsystem for Linux / BashOnWindows (#27)
+
+- `256399c` Add support for Windows Subsystem for Linux / BashOnWindows (#27)
 
 ## 0.7.0 (Thu, 14 Sept 2017)
-* Project moved to its own repo: https://github.com/GoogleChrome/chrome-launcher
-* `8d0766eb` Retry connection for longer (#21)
-* `52cb50af` only include PROGRAMFILES(X86) if present (#20)
-* `530822b9` log pid to kill (#22)
-* `1d617ab3` add support for `connectionPollInterval ` and `maxConnectionRetries` (#19)
-* `7474971f` Fix errors inside spawnPromise being ignored (https://github.com/GoogleChrome/lighthouse/pull/2939)
+
+- Project moved to its own repo: https://github.com/GoogleChrome/chrome-launcher
+- `8d0766eb` Retry connection for longer (#21)
+- `52cb50af` only include PROGRAMFILES(X86) if present (#20)
+- `530822b9` log pid to kill (#22)
+- `1d617ab3` add support for `connectionPollInterval ` and
+  `maxConnectionRetries` (#19)
+- `7474971f` Fix errors inside spawnPromise being ignored
+  (https://github.com/GoogleChrome/lighthouse/pull/2939)
 
 ## 0.6.0 (Thu, 17 Aug 2017)
-* `43baee69` mute any audio (#3028)
-* `ae6e9551` Better SIGINT handling (#2959)
-* `3ab3a117` docs: add changelog to launcher (#2987)
+
+- `43baee69` mute any audio (#3028)
+- `ae6e9551` Better SIGINT handling (#2959)
+- `3ab3a117` docs: add changelog to launcher (#2987)
 
 ## 0.5.0 (Mon, 14 Aug 2017)
-* `494f9911` clarify priority of chromePath options
-* `1c11021a` add support for finding Chromium on Linux (#2950)
-* `391e2043` Publish type definitions instead of source TypeScript files (#2898)
-* `de408ad3` readme: update example using deprecated `LIGHTHOUSE_CHROMIUM_PATH` (#2929)
-* `8bc6d18e` add license file to launcher package. (#2849)
+
+- `494f9911` clarify priority of chromePath options
+- `1c11021a` add support for finding Chromium on Linux (#2950)
+- `391e2043` Publish type definitions instead of source TypeScript files (#2898)
+- `de408ad3` readme: update example using deprecated `LIGHTHOUSE_CHROMIUM_PATH`
+  (#2929)
+- `8bc6d18e` add license file to launcher package. (#2849)
 
 ## 0.4.0 (Tue, 1 Aug 2017)
-* `37fd38ce` pass --enable-extensions on from manual-chrome-launcher (#2735)
-* `c942d17e` support enabling extension loading (#2650)
+
+- `37fd38ce` pass --enable-extensions on from manual-chrome-launcher (#2735)
+- `c942d17e` support enabling extension loading (#2650)
 
 ## 0.3.2 (Wed, 19 Jul 2017)
-* `112c2c7f` Fix chrome finder on linux/osx when process.env isn't populated (#2687)
-* `5728695f` Added CHROME_PATH to readme (#2694)
-* `fedc76a3` test: fix clang-format error (#2691)
-* `a6bbcaba` nuke 'as string'
-* `41df647f` cli: remove --select-chrome,--skip-autolaunch. Support CHROME_PATH env  (#2659)
-* `8c9724e2` fix launcher w/ arbitrary flags (#2670)
-* `9c0c0788` Expose LHR to modules consuming cli/run.ts (#2654)
-* `6df6b0e2` support custom port via chrome-debug binary (#2644)
-* `3f143b19` log the specific chrome spawn command.
+
+- `112c2c7f` Fix chrome finder on linux/osx when process.env isn't populated
+  (#2687)
+- `5728695f` Added CHROME_PATH to readme (#2694)
+- `fedc76a3` test: fix clang-format error (#2691)
+- `a6bbcaba` nuke 'as string'
+- `41df647f` cli: remove --select-chrome,--skip-autolaunch. Support CHROME_PATH
+  env (#2659)
+- `8c9724e2` fix launcher w/ arbitrary flags (#2670)
+- `9c0c0788` Expose LHR to modules consuming cli/run.ts (#2654)
+- `6df6b0e2` support custom port via chrome-debug binary (#2644)
+- `3f143b19` log the specific chrome spawn command.
 
 ## 0.3.1 (Wed, 5 Jul 2017)
-* `ef081063` upgrade rimraf to latest (#2641)
+
+- `ef081063` upgrade rimraf to latest (#2641)
 
 ## 0.3.0 (Fri, 30 Jun 2017)
-* `edbb40d9` fix(driver): move performance observer registration to setupDriver (#2611)
+
+- `edbb40d9` fix(driver): move performance observer registration to setupDriver
+  (#2611)

--- a/incubator/chromium-edge-launcher/chromium-edge-launcher/index.js
+++ b/incubator/chromium-edge-launcher/chromium-edge-launcher/index.js
@@ -1,0 +1,4 @@
+// This provides legacy support for a previously documented require pattern
+//    const edgeLauncher = require('chromium-edge-launcher/chromium-edge-launcher');
+
+module.exports = require("../");

--- a/incubator/chromium-edge-launcher/compiled-check.js
+++ b/incubator/chromium-edge-launcher/compiled-check.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const fs = require('fs');
+const path = require('path');
+
+module.exports = function(filename) {
+  if (!fs.existsSync(path.join(__dirname, filename))) {
+    console.log(
+        'Oops! Looks like the chromium-edge-launcher files needs to be compiled. Please run:');
+    console.log('   yarn; yarn build;');
+    process.exit(1);
+  }
+}

--- a/incubator/chromium-edge-launcher/compiled-check.js
+++ b/incubator/chromium-edge-launcher/compiled-check.js
@@ -1,13 +1,14 @@
-'use strict'
+"use strict";
 
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-module.exports = function(filename) {
+module.exports = function (filename) {
   if (!fs.existsSync(path.join(__dirname, filename))) {
     console.log(
-        'Oops! Looks like the chromium-edge-launcher files needs to be compiled. Please run:');
-    console.log('   yarn; yarn build;');
+      "Oops! Looks like the chromium-edge-launcher files needs to be compiled. Please run:"
+    );
+    console.log("   yarn; yarn build;");
     process.exit(1);
   }
-}
+};

--- a/incubator/chromium-edge-launcher/docs/edge-flags-for-tools.md
+++ b/incubator/chromium-edge-launcher/docs/edge-flags-for-tools.md
@@ -1,0 +1,139 @@
+# Edge Flags for Tooling
+
+Many tools maintain a list of runtime flags for Edge to configure the environment. This file
+is an attempt to document all edge flags that are relevant to tools, automation, benchmarking, etc.
+
+All use cases are different, so you'll have to choose which flags are most appropriate.
+
+## Commonly unwanted browser features
+
+* `--disable-client-side-phishing-detection`: Disables client-side phishing detection
+* `--disable-component-extensions-with-background-pages`: Disable some built-in extensions that aren't affected by `--disable-extensions`
+* `--disable-default-apps`: Disable installation of default apps
+* `--disable-extensions`: Disable all edge extensions
+* `--mute-audio`: Mute any audio
+* `--no-default-browser-check`: Disable the default browser check, do not prompt to set it as such
+* `--no-first-run`: Skip first run wizards
+* `--use-fake-device-for-media-stream`: Use fake device for Media Stream to replace camera and microphone
+* `--use-file-for-fake-video-capture=<path-to-file>`: Use file for fake video capture (.y4m or .mjpeg) Needs `--use-fake-device-for-media-stream`
+
+## Performance & web platform behavior
+
+* `--allow-running-insecure-content`
+* `--autoplay-policy=user-gesture-required`: Don't render video
+* `--disable-background-timer-throttling`: Disable timers being throttled in background pages/tabs
+* `--disable-backgrounding-occluded-windows`
+* `--disable-features=ScriptStreaming`: V8 script streaming
+* `--disable-hang-monitor`
+* `--disable-ipc-flooding-protection`: Some javascript functions can be used to flood the browser process with IPC. By default, protection is on to limit the number of IPC sent to 10 per second per frame. This flag disables it. https://crrev.com/604305
+* `--disable-notifications`: Disables the Web Notification and the Push APIs.
+* `--disable-popup-blocking`: Disable popup blocking.  `--block-new-web-contents` is the strict version of this.
+* `--disable-prompt-on-repost`: Reloading a page that came from a POST normally prompts the user.
+* `--disable-renderer-backgrounding`: This disables non-foreground tabs from getting a lower process priority This doesn't (on its own) affect timers or painting behavior. [karma-chromium-edge-launcher#123](https://github.com/karma-runner/karma-chromium-edge-launcher/issues/123)
+* `--js-flags=--random-seed=1157259157`: Initialize V8's RNG with a fixed seed.
+
+## Test & debugging flags
+
+* `--disable-device-discovery-notifications`: Avoid messages like "New printer on your network"
+* `--enable-automation`: Disable a few things considered not appropriate for automation. ([Original design doc](https://docs.google.com/a/google.com/document/d/1JYj9K61UyxIYavR8_HATYIglR9T_rDwAtLLsD3fbDQg/preview), though renamed [here](https://codereview.chromium.org/2564973002#msg24)) [codesearch](https://cs.chromium.org/search/?q=kEnableAutomation&type=cs). Note that some projects have chosen to **avoid** using this flag: [web-platform-tests/wpt/#6348](https://github.com/web-platform-tests/wpt/pull/6348)
+  - disables bubble notification about running development/unpacked extensions
+  - disables the password saving UI (which [covers](https://source.chromium.org/chromium/chromium/src/+/master:chrome/browser/password_manager/chrome_password_manager_client.cc;l=295-298;drc=00053fb4d880a925c890193b74a8ff35e1cef2a0) the usecase of the [removed](https://bugs.chromium.org/p/chromedriver/issues/detail?id=1015) `--disable-save-password-bubble` flag)
+  - disables infobar animations
+  - disables auto-reloading on network errors ([source](https://cs.chromium.org/chromium/src/chrome/renderer/net/net_error_helper_core.cc?l=917&rcl=6eaf0af71262eb876764c6237ee2fe021a3e7a18))
+  - means the default browser check prompt isn't shown
+  - avoids showing these 3 infobars: ShowBadFlagsPrompt, GoogleApiKeysInfoBarDelegate, ObsoleteSystemInfoBarDelegate
+  - adds this infobar: ![image](https://user-images.githubusercontent.com/39191/30349667-92a7a086-97c8-11e7-86b2-1365e3d407e3.png)
+* `--enable-logging=stderr`: Logging behavior slightly more appropriate for a server-type process.
+* `--log-level=0`: 0 means INFO and higher.
+* `--password-store=basic`: Avoid potential instability of using Gnome Keyring or KDE wallet. [chromium/linux/password_storage.md](https://chromium.googlesource.com/chromium/src/+/master/docs/linux/password_storage.md) https://crbug.com/571003
+* `--remote-debugging-pipe`: more secure than using protocol over a websocket
+* `--silent-debugger-extension-api`: Does not show an infobar when a Edge extension attaches to a page using `edge.debugger` page. Required to attach to extension background pages.
+* `--test-type`: Basically the 2014 version of `--enable-automation`. [codesearch](https://cs.chromium.org/search/?q=kTestType%5Cb&type=cs)
+  - It avoids creating application stubs in ~/Applications on mac.
+  - It makes exit codes slightly more correct
+  - windows navigation jumplists arent updated https://crbug.com/389375
+  - doesn't start some edge StartPageService
+  - disables initializing chromecast service
+  - "Component extensions with background pages are not enabled during tests because they generate a lot of background behavior that can interfere."
+  - when quitting the browser, it disables additional checks that may stop that quitting process. (like unsaved form modifications or unhandled profile notifications..)
+* `--use-mock-keychain`: Use mock keychain on Mac to prevent blocking permissions dialogs. https://crbug.com/865247
+
+## Background updates, networking, reporting
+
+* `--disable-background-networking`: Disable various background network services, including extension updating,safe browsing service, upgrade detector, translate, UMA
+* `--disable-breakpad`: Disable crashdump collection (reporting is already disabled in Chromium)
+* `--disable-component-update`: Don't update the browser 'components' listed at edge://components/
+* `--disable-domain-reliability`: Disables Domain Reliability Monitoring, which tracks whether the browser has difficulty contacting Google-owned sites and uploads reports to Google.
+* `--disable-sync`: Disable syncing to a Google account
+* `--enable-crash-reporter-for-testing`: Used for turning on Breakpad crash reporting in a debug environment where crash reporting is typically compiled but disabled.
+* `--metrics-recording-only`: Disable reporting to UMA, but allows for collection
+
+## Rendering & GPU
+
+* `--deterministic-mode`: An experimental meta flag. This sets the below indented flags which put the browser into a mode where rendering (border radius, etc) is deterministic and begin frames should be issued over DevTools Protocol. [codesearch](https://source.chromium.org/chromium/chromium/src/+/master:headless/app/headless_shell.cc;drc=df45d1abbc20abc7670643adda6d9625eea55b4d)
+  - `--run-all-compositor-stages-before-draw`
+  - `--disable-new-content-rendering-timeout`
+  - `--enable-begin-frame-control`
+  - `--disable-threaded-animation`
+  - `--disable-threaded-scrolling`
+  - `--disable-checker-imaging`
+  - `--disable-image-animation-resync`
+* `--disable-features=PaintHolding`: Don't defer paint commits (normally used to avoid flash of unstyled content)
+* `--disable-partial-raster`: https://crbug.com/919955
+* `--disable-skia-runtime-opts`: Do not use runtime-detected high-end CPU optimizations in Skia.
+* `--in-process-gpu`: Saves some memory by moving GPU process into a browser process thread
+* `--use-gl="swiftshader"`: Select which implementation of GL the GPU process should use. Options are: `desktop`: whatever desktop OpenGL the user has installed (Linux and Mac default). `egl`: whatever EGL / GLES2 the user has installed (Windows default - actually ANGLE). `swiftshader`: The SwiftShader software renderer.
+
+## Window & screen management
+
+* `--block-new-web-contents`: All pop-ups and calls to window.open will fail.
+* `--force-color-profile=srgb`: Force all monitors to be treated as though they have the specified color profile.
+* `--force-device-scale-factor=1`
+* `--new-window`: Launches URL in new browser window.
+* `--window-position=0,0`
+* `--window-size=1600,1024`
+
+## Process management
+
+* `--disable-features=site-per-process`: Disables OOPIF. https://www.chromium.org/Home/chromium-security/site-isolation
+* `--process-per-tab`: [Doesn't do anything](https://source.chromium.org/chromium/chromium/src/+/master:content/public/common/content_switches.cc;l=602-605;drc=2149a93144ce2030ab20863c2983b6c9d7bfd177). Use --single-process instead.
+* `--single-process`: Runs the renderer and plugins in the same process as the browser.
+
+## Headless
+
+* `--disable-dev-shm-usage`: Often used in Lambda, Cloud Functions scenarios. ([pptr issue](https://github.com/GoogleChrome/puppeteer/issues/1834), [crbug](https://bugs.chromium.org/p/chromium/issues/detail?id=736452))
+* `--no-sandbox`: [Sometimes used](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox) with headless, though not recommended.
+* `--disable-gpu`: Sometimes [used](https://bugs.chromium.org/p/chromium/issues/detail?id=737678) with headless.
+
+# ~Removed~ flags
+
+* `--disable-add-to-shelf`: [Removed June 2017](https://codereview.chromium.org/2944283002)
+* `--disable-background-downloads`: [Removed Oct 2014](https://codereview.chromium.org/607843002).
+* `--disable-browser-side-navigation` Disabled PlzNavigate.
+* `--disable-datasaver-prompt`
+* `--disable-desktop-notifications`
+* `--disable-features=TranslateUI`: renamed `TranslateUI` to `Translate` in [Sept 2020](https://chromium-review.googlesource.com/c/chromium/src/+/2404484).
+* `--disable-infobars`: [Removed April 2014](https://codereview.chromium.org/240193003)
+* `--disable-save-password-bubble`: [Removed May 2016](https://codereview.chromium.org/1978563002)
+* `--disable-translate`: [Removed April 2017](https://codereview.chromium.org/2819813002/) Used to disable built-in Google Translate service.
+* `--ignore-autoplay-restrictions`: [Removed December 2017](https://chromium-review.googlesource.com/#/c/816855/) Can use `--autoplay-policy=no-user-gesture-required` instead.
+* `--safebrowsing-disable-auto-update`: [Removed Nov 2017](https://bugs.chromium.org/p/chromium/issues/detail?id=74848#c26)
+
+# Sources
+
+* [chromium-edge-launcher's flags](https://github.com/cezaraugusto/chromium-edge-launcher/blob/master/src/flags.ts)
+* [Chromedriver's flags](https://cs.chromium.org/chromium/src/chrome/test/chromedriver/chrome_launcher.cc?type=cs&q=f:chrome_launcher++kDesktopSwitches&sq=package:chromium)
+* [Puppeteer's flags](https://github.com/puppeteer/puppeteer/blob/main/src/node/Launcher.ts)
+* [WebpageTest's flags](https://github.com/WPO-Foundation/wptagent/blob/master/internal/chrome_desktop.py)
+* [Catapult's flags](https://source.chromium.org/search?q=f:catapult%20f:desktop%20symbol:GetBrowserStartupArgs&ss=chromium%2Fchromium%2Fsrc)
+* [Karma's flags](https://github.com/karma-runner/karma-chromium-edge-launcher/blob/master/index.js)
+
+# All Edge flags
+
+* [The canonical list of Chrome command-line switches on peter.sh](http://peter.sh/experiments/chromium-command-line-switches/) (maintained by the Chromium team)
+
+FYI: (Probably) all flags are defined in files matching the pattern of [`*_switches.cc`](f:_switches\.cc).
+## Feature Flags FYI
+
+Chromium and Blink use feature flags to disable/enable many features at runtime. Chromium has [~400 features](https://source.chromium.org/search?q=%22const%20base::Feature%22%20f:%5C.cc&sq=&ss=chromium%2Fchromium%2Fsrc) that can be toggled with `--enable-features` / `--disable-features`. Indepdently, Blink has [many features](https://source.chromium.org/chromium/chromium/src/+/master:out/Debug/gen/third_party/blink/renderer/platform/runtime_enabled_features.cc;l=1559;drc=170473ad887b7990079f1f996b126548569c5902) that can be toggled [with commandline switches](https://chromium.googlesource.com/chromium/src/+/master/third_party/blink/renderer/platform/RuntimeEnabledFeatures.md#command_line-switches): `--enable-blink-features` / `--disable-blink-features`.
+

--- a/incubator/chromium-edge-launcher/docs/edge-flags-for-tools.md
+++ b/incubator/chromium-edge-launcher/docs/edge-flags-for-tools.md
@@ -1,76 +1,130 @@
 # Edge Flags for Tooling
 
-Many tools maintain a list of runtime flags for Edge to configure the environment. This file
-is an attempt to document all edge flags that are relevant to tools, automation, benchmarking, etc.
+Many tools maintain a list of runtime flags for Edge to configure the
+environment. This file is an attempt to document all edge flags that are
+relevant to tools, automation, benchmarking, etc.
 
-All use cases are different, so you'll have to choose which flags are most appropriate.
+All use cases are different, so you'll have to choose which flags are most
+appropriate.
 
 ## Commonly unwanted browser features
 
-* `--disable-client-side-phishing-detection`: Disables client-side phishing detection
-* `--disable-component-extensions-with-background-pages`: Disable some built-in extensions that aren't affected by `--disable-extensions`
-* `--disable-default-apps`: Disable installation of default apps
-* `--disable-extensions`: Disable all edge extensions
-* `--mute-audio`: Mute any audio
-* `--no-default-browser-check`: Disable the default browser check, do not prompt to set it as such
-* `--no-first-run`: Skip first run wizards
-* `--use-fake-device-for-media-stream`: Use fake device for Media Stream to replace camera and microphone
-* `--use-file-for-fake-video-capture=<path-to-file>`: Use file for fake video capture (.y4m or .mjpeg) Needs `--use-fake-device-for-media-stream`
+- `--disable-client-side-phishing-detection`: Disables client-side phishing
+  detection
+- `--disable-component-extensions-with-background-pages`: Disable some built-in
+  extensions that aren't affected by `--disable-extensions`
+- `--disable-default-apps`: Disable installation of default apps
+- `--disable-extensions`: Disable all edge extensions
+- `--mute-audio`: Mute any audio
+- `--no-default-browser-check`: Disable the default browser check, do not prompt
+  to set it as such
+- `--no-first-run`: Skip first run wizards
+- `--use-fake-device-for-media-stream`: Use fake device for Media Stream to
+  replace camera and microphone
+- `--use-file-for-fake-video-capture=<path-to-file>`: Use file for fake video
+  capture (.y4m or .mjpeg) Needs `--use-fake-device-for-media-stream`
 
 ## Performance & web platform behavior
 
-* `--allow-running-insecure-content`
-* `--autoplay-policy=user-gesture-required`: Don't render video
-* `--disable-background-timer-throttling`: Disable timers being throttled in background pages/tabs
-* `--disable-backgrounding-occluded-windows`
-* `--disable-features=ScriptStreaming`: V8 script streaming
-* `--disable-hang-monitor`
-* `--disable-ipc-flooding-protection`: Some javascript functions can be used to flood the browser process with IPC. By default, protection is on to limit the number of IPC sent to 10 per second per frame. This flag disables it. https://crrev.com/604305
-* `--disable-notifications`: Disables the Web Notification and the Push APIs.
-* `--disable-popup-blocking`: Disable popup blocking.  `--block-new-web-contents` is the strict version of this.
-* `--disable-prompt-on-repost`: Reloading a page that came from a POST normally prompts the user.
-* `--disable-renderer-backgrounding`: This disables non-foreground tabs from getting a lower process priority This doesn't (on its own) affect timers or painting behavior. [karma-chromium-edge-launcher#123](https://github.com/karma-runner/karma-chromium-edge-launcher/issues/123)
-* `--js-flags=--random-seed=1157259157`: Initialize V8's RNG with a fixed seed.
+- `--allow-running-insecure-content`
+- `--autoplay-policy=user-gesture-required`: Don't render video
+- `--disable-background-timer-throttling`: Disable timers being throttled in
+  background pages/tabs
+- `--disable-backgrounding-occluded-windows`
+- `--disable-features=ScriptStreaming`: V8 script streaming
+- `--disable-hang-monitor`
+- `--disable-ipc-flooding-protection`: Some javascript functions can be used to
+  flood the browser process with IPC. By default, protection is on to limit the
+  number of IPC sent to 10 per second per frame. This flag disables it.
+  https://crrev.com/604305
+- `--disable-notifications`: Disables the Web Notification and the Push APIs.
+- `--disable-popup-blocking`: Disable popup blocking. `--block-new-web-contents`
+  is the strict version of this.
+- `--disable-prompt-on-repost`: Reloading a page that came from a POST normally
+  prompts the user.
+- `--disable-renderer-backgrounding`: This disables non-foreground tabs from
+  getting a lower process priority This doesn't (on its own) affect timers or
+  painting behavior.
+  [karma-chromium-edge-launcher#123](https://github.com/karma-runner/karma-chromium-edge-launcher/issues/123)
+- `--js-flags=--random-seed=1157259157`: Initialize V8's RNG with a fixed seed.
 
 ## Test & debugging flags
 
-* `--disable-device-discovery-notifications`: Avoid messages like "New printer on your network"
-* `--enable-automation`: Disable a few things considered not appropriate for automation. ([Original design doc](https://docs.google.com/a/google.com/document/d/1JYj9K61UyxIYavR8_HATYIglR9T_rDwAtLLsD3fbDQg/preview), though renamed [here](https://codereview.chromium.org/2564973002#msg24)) [codesearch](https://cs.chromium.org/search/?q=kEnableAutomation&type=cs). Note that some projects have chosen to **avoid** using this flag: [web-platform-tests/wpt/#6348](https://github.com/web-platform-tests/wpt/pull/6348)
+- `--disable-device-discovery-notifications`: Avoid messages like "New printer
+  on your network"
+- `--enable-automation`: Disable a few things considered not appropriate for
+  automation.
+  ([Original design doc](https://docs.google.com/a/google.com/document/d/1JYj9K61UyxIYavR8_HATYIglR9T_rDwAtLLsD3fbDQg/preview),
+  though renamed [here](https://codereview.chromium.org/2564973002#msg24))
+  [codesearch](https://cs.chromium.org/search/?q=kEnableAutomation&type=cs).
+  Note that some projects have chosen to **avoid** using this flag:
+  [web-platform-tests/wpt/#6348](https://github.com/web-platform-tests/wpt/pull/6348)
   - disables bubble notification about running development/unpacked extensions
-  - disables the password saving UI (which [covers](https://source.chromium.org/chromium/chromium/src/+/master:chrome/browser/password_manager/chrome_password_manager_client.cc;l=295-298;drc=00053fb4d880a925c890193b74a8ff35e1cef2a0) the usecase of the [removed](https://bugs.chromium.org/p/chromedriver/issues/detail?id=1015) `--disable-save-password-bubble` flag)
+  - disables the password saving UI (which
+    [covers](https://source.chromium.org/chromium/chromium/src/+/master:chrome/browser/password_manager/chrome_password_manager_client.cc;l=295-298;drc=00053fb4d880a925c890193b74a8ff35e1cef2a0)
+    the usecase of the
+    [removed](https://bugs.chromium.org/p/chromedriver/issues/detail?id=1015)
+    `--disable-save-password-bubble` flag)
   - disables infobar animations
-  - disables auto-reloading on network errors ([source](https://cs.chromium.org/chromium/src/chrome/renderer/net/net_error_helper_core.cc?l=917&rcl=6eaf0af71262eb876764c6237ee2fe021a3e7a18))
+  - disables auto-reloading on network errors
+    ([source](https://cs.chromium.org/chromium/src/chrome/renderer/net/net_error_helper_core.cc?l=917&rcl=6eaf0af71262eb876764c6237ee2fe021a3e7a18))
   - means the default browser check prompt isn't shown
-  - avoids showing these 3 infobars: ShowBadFlagsPrompt, GoogleApiKeysInfoBarDelegate, ObsoleteSystemInfoBarDelegate
-  - adds this infobar: ![image](https://user-images.githubusercontent.com/39191/30349667-92a7a086-97c8-11e7-86b2-1365e3d407e3.png)
-* `--enable-logging=stderr`: Logging behavior slightly more appropriate for a server-type process.
-* `--log-level=0`: 0 means INFO and higher.
-* `--password-store=basic`: Avoid potential instability of using Gnome Keyring or KDE wallet. [chromium/linux/password_storage.md](https://chromium.googlesource.com/chromium/src/+/master/docs/linux/password_storage.md) https://crbug.com/571003
-* `--remote-debugging-pipe`: more secure than using protocol over a websocket
-* `--silent-debugger-extension-api`: Does not show an infobar when a Edge extension attaches to a page using `edge.debugger` page. Required to attach to extension background pages.
-* `--test-type`: Basically the 2014 version of `--enable-automation`. [codesearch](https://cs.chromium.org/search/?q=kTestType%5Cb&type=cs)
+  - avoids showing these 3 infobars: ShowBadFlagsPrompt,
+    GoogleApiKeysInfoBarDelegate, ObsoleteSystemInfoBarDelegate
+  - adds this infobar:
+    ![image](https://user-images.githubusercontent.com/39191/30349667-92a7a086-97c8-11e7-86b2-1365e3d407e3.png)
+- `--enable-logging=stderr`: Logging behavior slightly more appropriate for a
+  server-type process.
+- `--log-level=0`: 0 means INFO and higher.
+- `--password-store=basic`: Avoid potential instability of using Gnome Keyring
+  or KDE wallet.
+  [chromium/linux/password_storage.md](https://chromium.googlesource.com/chromium/src/+/master/docs/linux/password_storage.md)
+  https://crbug.com/571003
+- `--remote-debugging-pipe`: more secure than using protocol over a websocket
+- `--silent-debugger-extension-api`: Does not show an infobar when a Edge
+  extension attaches to a page using `edge.debugger` page. Required to attach to
+  extension background pages.
+- `--test-type`: Basically the 2014 version of `--enable-automation`.
+  [codesearch](https://cs.chromium.org/search/?q=kTestType%5Cb&type=cs)
   - It avoids creating application stubs in ~/Applications on mac.
   - It makes exit codes slightly more correct
   - windows navigation jumplists arent updated https://crbug.com/389375
   - doesn't start some edge StartPageService
   - disables initializing chromecast service
-  - "Component extensions with background pages are not enabled during tests because they generate a lot of background behavior that can interfere."
-  - when quitting the browser, it disables additional checks that may stop that quitting process. (like unsaved form modifications or unhandled profile notifications..)
-* `--use-mock-keychain`: Use mock keychain on Mac to prevent blocking permissions dialogs. https://crbug.com/865247
+  - "Component extensions with background pages are not enabled during tests
+    because they generate a lot of background behavior that can interfere."
+  - when quitting the browser, it disables additional checks that may stop that
+    quitting process. (like unsaved form modifications or unhandled profile
+    notifications..)
+- `--use-mock-keychain`: Use mock keychain on Mac to prevent blocking
+  permissions dialogs. https://crbug.com/865247
 
 ## Background updates, networking, reporting
 
-* `--disable-background-networking`: Disable various background network services, including extension updating,safe browsing service, upgrade detector, translate, UMA
-* `--disable-breakpad`: Disable crashdump collection (reporting is already disabled in Chromium)
-* `--disable-component-update`: Don't update the browser 'components' listed at edge://components/
-* `--disable-domain-reliability`: Disables Domain Reliability Monitoring, which tracks whether the browser has difficulty contacting Google-owned sites and uploads reports to Google.
-* `--disable-sync`: Disable syncing to a Google account
-* `--enable-crash-reporter-for-testing`: Used for turning on Breakpad crash reporting in a debug environment where crash reporting is typically compiled but disabled.
-* `--metrics-recording-only`: Disable reporting to UMA, but allows for collection
+- `--disable-background-networking`: Disable various background network
+  services, including extension updating,safe browsing service, upgrade
+  detector, translate, UMA
+- `--disable-breakpad`: Disable crashdump collection (reporting is already
+  disabled in Chromium)
+- `--disable-component-update`: Don't update the browser 'components' listed at
+  edge://components/
+- `--disable-domain-reliability`: Disables Domain Reliability Monitoring, which
+  tracks whether the browser has difficulty contacting Google-owned sites and
+  uploads reports to Google.
+- `--disable-sync`: Disable syncing to a Google account
+- `--enable-crash-reporter-for-testing`: Used for turning on Breakpad crash
+  reporting in a debug environment where crash reporting is typically compiled
+  but disabled.
+- `--metrics-recording-only`: Disable reporting to UMA, but allows for
+  collection
 
 ## Rendering & GPU
 
-* `--deterministic-mode`: An experimental meta flag. This sets the below indented flags which put the browser into a mode where rendering (border radius, etc) is deterministic and begin frames should be issued over DevTools Protocol. [codesearch](https://source.chromium.org/chromium/chromium/src/+/master:headless/app/headless_shell.cc;drc=df45d1abbc20abc7670643adda6d9625eea55b4d)
+- `--deterministic-mode`: An experimental meta flag. This sets the below
+  indented flags which put the browser into a mode where rendering (border
+  radius, etc) is deterministic and begin frames should be issued over DevTools
+  Protocol.
+  [codesearch](https://source.chromium.org/chromium/chromium/src/+/master:headless/app/headless_shell.cc;drc=df45d1abbc20abc7670643adda6d9625eea55b4d)
   - `--run-all-compositor-stages-before-draw`
   - `--disable-new-content-rendering-timeout`
   - `--enable-begin-frame-control`
@@ -78,62 +132,100 @@ All use cases are different, so you'll have to choose which flags are most appro
   - `--disable-threaded-scrolling`
   - `--disable-checker-imaging`
   - `--disable-image-animation-resync`
-* `--disable-features=PaintHolding`: Don't defer paint commits (normally used to avoid flash of unstyled content)
-* `--disable-partial-raster`: https://crbug.com/919955
-* `--disable-skia-runtime-opts`: Do not use runtime-detected high-end CPU optimizations in Skia.
-* `--in-process-gpu`: Saves some memory by moving GPU process into a browser process thread
-* `--use-gl="swiftshader"`: Select which implementation of GL the GPU process should use. Options are: `desktop`: whatever desktop OpenGL the user has installed (Linux and Mac default). `egl`: whatever EGL / GLES2 the user has installed (Windows default - actually ANGLE). `swiftshader`: The SwiftShader software renderer.
+- `--disable-features=PaintHolding`: Don't defer paint commits (normally used to
+  avoid flash of unstyled content)
+- `--disable-partial-raster`: https://crbug.com/919955
+- `--disable-skia-runtime-opts`: Do not use runtime-detected high-end CPU
+  optimizations in Skia.
+- `--in-process-gpu`: Saves some memory by moving GPU process into a browser
+  process thread
+- `--use-gl="swiftshader"`: Select which implementation of GL the GPU process
+  should use. Options are: `desktop`: whatever desktop OpenGL the user has
+  installed (Linux and Mac default). `egl`: whatever EGL / GLES2 the user has
+  installed (Windows default - actually ANGLE). `swiftshader`: The SwiftShader
+  software renderer.
 
 ## Window & screen management
 
-* `--block-new-web-contents`: All pop-ups and calls to window.open will fail.
-* `--force-color-profile=srgb`: Force all monitors to be treated as though they have the specified color profile.
-* `--force-device-scale-factor=1`
-* `--new-window`: Launches URL in new browser window.
-* `--window-position=0,0`
-* `--window-size=1600,1024`
+- `--block-new-web-contents`: All pop-ups and calls to window.open will fail.
+- `--force-color-profile=srgb`: Force all monitors to be treated as though they
+  have the specified color profile.
+- `--force-device-scale-factor=1`
+- `--new-window`: Launches URL in new browser window.
+- `--window-position=0,0`
+- `--window-size=1600,1024`
 
 ## Process management
 
-* `--disable-features=site-per-process`: Disables OOPIF. https://www.chromium.org/Home/chromium-security/site-isolation
-* `--process-per-tab`: [Doesn't do anything](https://source.chromium.org/chromium/chromium/src/+/master:content/public/common/content_switches.cc;l=602-605;drc=2149a93144ce2030ab20863c2983b6c9d7bfd177). Use --single-process instead.
-* `--single-process`: Runs the renderer and plugins in the same process as the browser.
+- `--disable-features=site-per-process`: Disables OOPIF.
+  https://www.chromium.org/Home/chromium-security/site-isolation
+- `--process-per-tab`:
+  [Doesn't do anything](https://source.chromium.org/chromium/chromium/src/+/master:content/public/common/content_switches.cc;l=602-605;drc=2149a93144ce2030ab20863c2983b6c9d7bfd177).
+  Use --single-process instead.
+- `--single-process`: Runs the renderer and plugins in the same process as the
+  browser.
 
 ## Headless
 
-* `--disable-dev-shm-usage`: Often used in Lambda, Cloud Functions scenarios. ([pptr issue](https://github.com/GoogleChrome/puppeteer/issues/1834), [crbug](https://bugs.chromium.org/p/chromium/issues/detail?id=736452))
-* `--no-sandbox`: [Sometimes used](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox) with headless, though not recommended.
-* `--disable-gpu`: Sometimes [used](https://bugs.chromium.org/p/chromium/issues/detail?id=737678) with headless.
+- `--disable-dev-shm-usage`: Often used in Lambda, Cloud Functions scenarios.
+  ([pptr issue](https://github.com/GoogleChrome/puppeteer/issues/1834),
+  [crbug](https://bugs.chromium.org/p/chromium/issues/detail?id=736452))
+- `--no-sandbox`:
+  [Sometimes used](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox)
+  with headless, though not recommended.
+- `--disable-gpu`: Sometimes
+  [used](https://bugs.chromium.org/p/chromium/issues/detail?id=737678) with
+  headless.
 
 # ~Removed~ flags
 
-* `--disable-add-to-shelf`: [Removed June 2017](https://codereview.chromium.org/2944283002)
-* `--disable-background-downloads`: [Removed Oct 2014](https://codereview.chromium.org/607843002).
-* `--disable-browser-side-navigation` Disabled PlzNavigate.
-* `--disable-datasaver-prompt`
-* `--disable-desktop-notifications`
-* `--disable-features=TranslateUI`: renamed `TranslateUI` to `Translate` in [Sept 2020](https://chromium-review.googlesource.com/c/chromium/src/+/2404484).
-* `--disable-infobars`: [Removed April 2014](https://codereview.chromium.org/240193003)
-* `--disable-save-password-bubble`: [Removed May 2016](https://codereview.chromium.org/1978563002)
-* `--disable-translate`: [Removed April 2017](https://codereview.chromium.org/2819813002/) Used to disable built-in Google Translate service.
-* `--ignore-autoplay-restrictions`: [Removed December 2017](https://chromium-review.googlesource.com/#/c/816855/) Can use `--autoplay-policy=no-user-gesture-required` instead.
-* `--safebrowsing-disable-auto-update`: [Removed Nov 2017](https://bugs.chromium.org/p/chromium/issues/detail?id=74848#c26)
+- `--disable-add-to-shelf`:
+  [Removed June 2017](https://codereview.chromium.org/2944283002)
+- `--disable-background-downloads`:
+  [Removed Oct 2014](https://codereview.chromium.org/607843002).
+- `--disable-browser-side-navigation` Disabled PlzNavigate.
+- `--disable-datasaver-prompt`
+- `--disable-desktop-notifications`
+- `--disable-features=TranslateUI`: renamed `TranslateUI` to `Translate` in
+  [Sept 2020](https://chromium-review.googlesource.com/c/chromium/src/+/2404484).
+- `--disable-infobars`:
+  [Removed April 2014](https://codereview.chromium.org/240193003)
+- `--disable-save-password-bubble`:
+  [Removed May 2016](https://codereview.chromium.org/1978563002)
+- `--disable-translate`:
+  [Removed April 2017](https://codereview.chromium.org/2819813002/) Used to
+  disable built-in Google Translate service.
+- `--ignore-autoplay-restrictions`:
+  [Removed December 2017](https://chromium-review.googlesource.com/#/c/816855/)
+  Can use `--autoplay-policy=no-user-gesture-required` instead.
+- `--safebrowsing-disable-auto-update`:
+  [Removed Nov 2017](https://bugs.chromium.org/p/chromium/issues/detail?id=74848#c26)
 
 # Sources
 
-* [chromium-edge-launcher's flags](https://github.com/cezaraugusto/chromium-edge-launcher/blob/master/src/flags.ts)
-* [Chromedriver's flags](https://cs.chromium.org/chromium/src/chrome/test/chromedriver/chrome_launcher.cc?type=cs&q=f:chrome_launcher++kDesktopSwitches&sq=package:chromium)
-* [Puppeteer's flags](https://github.com/puppeteer/puppeteer/blob/main/src/node/Launcher.ts)
-* [WebpageTest's flags](https://github.com/WPO-Foundation/wptagent/blob/master/internal/chrome_desktop.py)
-* [Catapult's flags](https://source.chromium.org/search?q=f:catapult%20f:desktop%20symbol:GetBrowserStartupArgs&ss=chromium%2Fchromium%2Fsrc)
-* [Karma's flags](https://github.com/karma-runner/karma-chromium-edge-launcher/blob/master/index.js)
+- [chromium-edge-launcher's flags](https://github.com/cezaraugusto/chromium-edge-launcher/blob/master/src/flags.ts)
+- [Chromedriver's flags](https://cs.chromium.org/chromium/src/chrome/test/chromedriver/chrome_launcher.cc?type=cs&q=f:chrome_launcher++kDesktopSwitches&sq=package:chromium)
+- [Puppeteer's flags](https://github.com/puppeteer/puppeteer/blob/main/src/node/Launcher.ts)
+- [WebpageTest's flags](https://github.com/WPO-Foundation/wptagent/blob/master/internal/chrome_desktop.py)
+- [Catapult's flags](https://source.chromium.org/search?q=f:catapult%20f:desktop%20symbol:GetBrowserStartupArgs&ss=chromium%2Fchromium%2Fsrc)
+- [Karma's flags](https://github.com/karma-runner/karma-chromium-edge-launcher/blob/master/index.js)
 
 # All Edge flags
 
-* [The canonical list of Chrome command-line switches on peter.sh](http://peter.sh/experiments/chromium-command-line-switches/) (maintained by the Chromium team)
+- [The canonical list of Chrome command-line switches on peter.sh](http://peter.sh/experiments/chromium-command-line-switches/)
+  (maintained by the Chromium team)
 
-FYI: (Probably) all flags are defined in files matching the pattern of [`*_switches.cc`](f:_switches\.cc).
+FYI: (Probably) all flags are defined in files matching the pattern of
+[`*_switches.cc`](f:_switches.cc).
+
 ## Feature Flags FYI
 
-Chromium and Blink use feature flags to disable/enable many features at runtime. Chromium has [~400 features](https://source.chromium.org/search?q=%22const%20base::Feature%22%20f:%5C.cc&sq=&ss=chromium%2Fchromium%2Fsrc) that can be toggled with `--enable-features` / `--disable-features`. Indepdently, Blink has [many features](https://source.chromium.org/chromium/chromium/src/+/master:out/Debug/gen/third_party/blink/renderer/platform/runtime_enabled_features.cc;l=1559;drc=170473ad887b7990079f1f996b126548569c5902) that can be toggled [with commandline switches](https://chromium.googlesource.com/chromium/src/+/master/third_party/blink/renderer/platform/RuntimeEnabledFeatures.md#command_line-switches): `--enable-blink-features` / `--disable-blink-features`.
-
+Chromium and Blink use feature flags to disable/enable many features at runtime.
+Chromium has
+[~400 features](https://source.chromium.org/search?q=%22const%20base::Feature%22%20f:%5C.cc&sq=&ss=chromium%2Fchromium%2Fsrc)
+that can be toggled with `--enable-features` / `--disable-features`.
+Indepdently, Blink has
+[many features](https://source.chromium.org/chromium/chromium/src/+/master:out/Debug/gen/third_party/blink/renderer/platform/runtime_enabled_features.cc;l=1559;drc=170473ad887b7990079f1f996b126548569c5902)
+that can be toggled
+[with commandline switches](https://chromium.googlesource.com/chromium/src/+/master/third_party/blink/renderer/platform/RuntimeEnabledFeatures.md#command_line-switches):
+`--enable-blink-features` / `--disable-blink-features`.

--- a/incubator/chromium-edge-launcher/eslint.config.js
+++ b/incubator/chromium-edge-launcher/eslint.config.js
@@ -1,0 +1,1 @@
+module.exports = require("@rnx-kit/eslint-config");

--- a/incubator/chromium-edge-launcher/manual-edge-launcher.js
+++ b/incubator/chromium-edge-launcher/manual-edge-launcher.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+'use strict';
+// Keep this file in sync with lighthouse
+// TODO: have LH depend on this one.
+
+/**
+ * @fileoverview Script to launch a clean Edge instance on-demand.
+ *
+ * Assuming Lighthouse is installed globally or `npm link`ed, use via:
+ *     edge-debug
+ * Optionally enable extensions or pass a port, additional edge flags, and/or a URL
+ *     edge-debug --port=9222
+ *     edge-debug http://goat.com
+ *     edge-debug --show-paint-rects
+ *     edge-debug --enable-extensions
+ */
+
+require('./compiled-check.js')('./dist/chromium-edge-launcher.js');
+const {Launcher, launch} = require('./dist/chromium-edge-launcher');
+
+const args = process.argv.slice(2);
+const edgeFlags = [];
+let startingUrl;
+let port;
+let ignoreDefaultFlags;
+
+if (args.length) {
+  const providedFlags = args.filter(flag => flag.startsWith('--'));
+
+  const portFlag = providedFlags.find(flag => flag.startsWith('--port='));
+  if (portFlag) port = parseInt(portFlag.replace('--port=', ''), 10);
+
+  const enableExtensions = !!providedFlags.find(flag => flag === '--enable-extensions');
+  // The basic pattern for enabling Edge extensions
+  if (enableExtensions) {
+    ignoreDefaultFlags = true;
+    edgeFlags.push(...Launcher.defaultFlags().filter(flag => flag !== '--disable-extensions'));
+  }
+
+  edgeFlags.push(...providedFlags);
+  startingUrl = args.find(flag => !flag.startsWith('--'));
+}
+
+launch({
+  startingUrl,
+  port,
+  ignoreDefaultFlags,
+  edgeFlags,
+})
+// eslint-disable-next-line no-console
+.then(v => console.log(`✨  Edge debugging port: ${v.port}`));

--- a/incubator/chromium-edge-launcher/manual-edge-launcher.js
+++ b/incubator/chromium-edge-launcher/manual-edge-launcher.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-'use strict';
+"use strict";
 // Keep this file in sync with lighthouse
 // TODO: have LH depend on this one.
 
@@ -16,8 +16,8 @@
  *     edge-debug --enable-extensions
  */
 
-require('./compiled-check.js')('./dist/chromium-edge-launcher.js');
-const {Launcher, launch} = require('./dist/chromium-edge-launcher');
+require("./compiled-check.js")("./dist/chromium-edge-launcher.js");
+const { Launcher, launch } = require("./dist/chromium-edge-launcher");
 
 const args = process.argv.slice(2);
 const edgeFlags = [];
@@ -26,20 +26,26 @@ let port;
 let ignoreDefaultFlags;
 
 if (args.length) {
-  const providedFlags = args.filter(flag => flag.startsWith('--'));
+  const providedFlags = args.filter((flag) => flag.startsWith("--"));
 
-  const portFlag = providedFlags.find(flag => flag.startsWith('--port='));
-  if (portFlag) port = parseInt(portFlag.replace('--port=', ''), 10);
+  const portFlag = providedFlags.find((flag) => flag.startsWith("--port="));
+  if (portFlag) port = parseInt(portFlag.replace("--port=", ""), 10);
 
-  const enableExtensions = !!providedFlags.find(flag => flag === '--enable-extensions');
+  const enableExtensions = !!providedFlags.find(
+    (flag) => flag === "--enable-extensions"
+  );
   // The basic pattern for enabling Edge extensions
   if (enableExtensions) {
     ignoreDefaultFlags = true;
-    edgeFlags.push(...Launcher.defaultFlags().filter(flag => flag !== '--disable-extensions'));
+    edgeFlags.push(
+      ...Launcher.defaultFlags().filter(
+        (flag) => flag !== "--disable-extensions"
+      )
+    );
   }
 
   edgeFlags.push(...providedFlags);
-  startingUrl = args.find(flag => !flag.startsWith('--'));
+  startingUrl = args.find((flag) => !flag.startsWith("--"));
 }
 
 launch({
@@ -48,5 +54,5 @@ launch({
   ignoreDefaultFlags,
   edgeFlags,
 })
-// eslint-disable-next-line no-console
-.then(v => console.log(`✨  Edge debugging port: ${v.port}`));
+  // eslint-disable-next-line no-console
+  .then((v) => console.log(`✨  Edge debugging port: ${v.port}`));

--- a/incubator/chromium-edge-launcher/package.json
+++ b/incubator/chromium-edge-launcher/package.json
@@ -1,0 +1,56 @@
+{
+  "private": true,
+  "name": "@rnx-kit/chromium-edge-launcher",
+  "version": "0.0.1",
+  "description": "EXPERIMENTAL - USE WITH CAUTION - Launch latest Edge with the Devtools Protocol port open",
+  "homepage": "https://github.com/microsoft/rnx-kit/tree/main/incubator/chromium-edge-launcher#readme",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "Microsoft Open Source",
+    "email": "microsoftopensource@users.noreply.github.com"
+  },
+  "files": [
+    "lib/*"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/rnx-kit",
+    "directory": "incubator/chromium-edge-launcher"
+  },
+  "engines": {
+    "node": ">=14.15"
+  },
+  "scripts": {
+    "build": "rnx-kit-scripts build",
+    "format": "rnx-kit-scripts format",
+    "lint": "rnx-kit-scripts lint",
+    "test": "rnx-kit-scripts test"
+  },
+  "dependencies": {
+    "@types/node": "*",
+    "escape-string-regexp": "^4.0.0",
+    "is-wsl": "^2.2.0",
+    "lighthouse-logger": "^1.0.0",
+    "mkdirp": "^1.0.4",
+    "rimraf": "^3.0.2"
+  },
+  "devDependencies": {
+    "@rnx-kit/eslint-config": "*",
+    "@rnx-kit/jest-preset": "*",
+    "@rnx-kit/scripts": "*",
+    "@types/mkdirp": "^1.0.1",
+    "@types/rimraf": "^3.0.0",
+    "@types/sinon": "^9.0.1",
+    "eslint": "^8.0.0",
+    "jest": "^29.2.1",
+    "prettier": "^3.0.0",
+    "sinon": "^9.0.1",
+    "typescript": "^5.0.0"
+  },
+  "jest": {
+    "preset": "@rnx-kit/jest-preset/private"
+  },
+  "experimental": true
+}

--- a/incubator/chromium-edge-launcher/package.json
+++ b/incubator/chromium-edge-launcher/package.json
@@ -29,7 +29,7 @@
     "test": "rnx-kit-scripts test"
   },
   "dependencies": {
-    "@types/node": "*",
+    "@types/node": "^18.0.0",
     "escape-string-regexp": "^4.0.0",
     "is-wsl": "^2.2.0",
     "lighthouse-logger": "^1.0.0",

--- a/incubator/chromium-edge-launcher/package.json
+++ b/incubator/chromium-edge-launcher/package.json
@@ -1,5 +1,5 @@
 {
-  "private": true,
+  "private": false,
   "name": "@rnx-kit/chromium-edge-launcher",
   "version": "0.0.1",
   "description": "EXPERIMENTAL - USE WITH CAUTION - Launch latest Edge with the Devtools Protocol port open",

--- a/incubator/chromium-edge-launcher/package.json
+++ b/incubator/chromium-edge-launcher/package.json
@@ -1,5 +1,4 @@
 {
-  "private": false,
   "name": "@rnx-kit/chromium-edge-launcher",
   "version": "0.0.1",
   "description": "EXPERIMENTAL - USE WITH CAUTION - Launch latest Edge with the Devtools Protocol port open",

--- a/incubator/chromium-edge-launcher/src/edge-finder.ts
+++ b/incubator/chromium-edge-launcher/src/edge-finder.ts
@@ -1,0 +1,299 @@
+/**
+ * @license Copyright 2016 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+"use strict";
+
+import fs = require("fs");
+import path = require("path");
+import { execFileSync, execSync } from "child_process";
+import { homedir } from "os";
+import escapeRegExp = require("escape-string-regexp");
+const log = require("lighthouse-logger");
+
+import { EdgePathNotSetError, getLocalAppDataPath } from "./utils";
+
+const newLineRegex = /\r?\n/;
+
+type Priorities = { regex: RegExp; weight: number }[];
+
+/**
+ * check for MacOS default app paths first to avoid waiting for the slow lsregister command
+ */
+export function darwinFast(): string | undefined {
+  const priorityOptions: (string | undefined)[] = [
+    process.env.EDGE_PATH,
+    process.env.LIGHTHOUSE_CHROMIUM_PATH,
+    "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+  ];
+
+  for (const edgePath of priorityOptions) {
+    if (edgePath && canAccess(edgePath)) return edgePath;
+  }
+
+  return darwin()[0];
+}
+
+export function darwin() {
+  const suffixes = ["/Contents/MacOS/Google Edge"];
+
+  const LSREGISTER =
+    "/System/Library/Frameworks/CoreServices.framework" +
+    "/Versions/A/Frameworks/LaunchServices.framework" +
+    "/Versions/A/Support/lsregister";
+
+  const installations: string[] = [];
+
+  const customEdgePath = resolveEdgePath();
+  if (customEdgePath) {
+    installations.push(customEdgePath);
+  }
+
+  execSync(
+    `${LSREGISTER} -dump` +
+      " | grep -i 'microsoft edge\\?\\.app'" +
+      " | awk '{$1=\"\"; print $0}'"
+  )
+    .toString()
+    .split(newLineRegex)
+    .forEach((inst: string) => {
+      suffixes.forEach((suffix) => {
+        const execPath = path.join(
+          inst.substring(0, inst.indexOf(".app") + 4).trim(),
+          suffix
+        );
+        if (canAccess(execPath) && installations.indexOf(execPath) === -1) {
+          installations.push(execPath);
+        }
+      });
+    });
+
+  // Retains one per line to maintain readability.
+  // clang-format off
+  const home = escapeRegExp(process.env.HOME || homedir());
+  const priorities: Priorities = [
+    { regex: new RegExp(`^${home}/Applications/.*Edge\\.app`), weight: 50 },
+    { regex: /^\/Applications\/.*Edge.app/, weight: 100 },
+    { regex: /^\/Volumes\/.*Edge.app/, weight: -2 },
+  ];
+
+  if (process.env.LIGHTHOUSE_CHROMIUM_PATH) {
+    priorities.unshift({
+      regex: new RegExp(escapeRegExp(process.env.LIGHTHOUSE_CHROMIUM_PATH)),
+      weight: 150,
+    });
+  }
+
+  if (process.env.EDGE_PATH) {
+    priorities.unshift({
+      regex: new RegExp(escapeRegExp(process.env.EDGE_PATH)),
+      weight: 151,
+    });
+  }
+
+  // clang-format on
+  return sort(installations, priorities);
+}
+
+function resolveEdgePath() {
+  if (canAccess(process.env.EDGE_PATH)) {
+    return process.env.EDGE_PATH;
+  }
+
+  if (canAccess(process.env.LIGHTHOUSE_CHROMIUM_PATH)) {
+    log.warn(
+      "EdgeLauncher",
+      "LIGHTHOUSE_CHROMIUM_PATH is deprecated, use EDGE_PATH env variable instead."
+    );
+    return process.env.LIGHTHOUSE_CHROMIUM_PATH;
+  }
+
+  return undefined;
+}
+
+/**
+ * Look for linux executables in 3 ways
+ * 1. Look into EDGE_PATH env variable
+ * 2. Look into the directories where .desktop are saved on gnome based distro's
+ * 3. Look for microsoft-edge-stable & microsoft-edge executables by using the which command
+ */
+export function linux() {
+  let installations: string[] = [];
+
+  // 1. Look into EDGE_PATH env variable
+  const customEdgePath = resolveEdgePath();
+  if (customEdgePath) {
+    installations.push(customEdgePath);
+  }
+
+  // 2. Look into the directories where .desktop are saved on gnome based distro's
+  const desktopInstallationFolders = [
+    path.join(homedir(), ".local/share/applications/"),
+    "/usr/share/applications/",
+  ];
+  desktopInstallationFolders.forEach((folder) => {
+    installations = installations.concat(findEdgeExecutables(folder));
+  });
+
+  // Look for microsoft-edge(-stable) & chromium(-browser) executables by using the which command
+  const executables = [
+    "microsoft-edge-stable",
+    "microsoft-edge",
+    "chromium-browser",
+    "chromium",
+  ];
+  executables.forEach((executable: string) => {
+    try {
+      const edgePath = execFileSync("which", [executable], { stdio: "pipe" })
+        .toString()
+        .split(newLineRegex)[0];
+
+      if (canAccess(edgePath)) {
+        installations.push(edgePath);
+      }
+    } catch (e) {
+      // Not installed.
+    }
+  });
+
+  if (!installations.length) {
+    throw new EdgePathNotSetError();
+  }
+
+  const priorities: Priorities = [
+    { regex: /edge-wrapper$/, weight: 51 },
+    { regex: /microsoft-edge-stable$/, weight: 50 },
+    { regex: /microsoft-edge$/, weight: 49 },
+    { regex: /edge-browser$/, weight: 48 },
+    { regex: /edge$/, weight: 47 },
+  ];
+
+  if (process.env.LIGHTHOUSE_CHROMIUM_PATH) {
+    priorities.unshift({
+      regex: new RegExp(escapeRegExp(process.env.LIGHTHOUSE_CHROMIUM_PATH)),
+      weight: 100,
+    });
+  }
+
+  if (process.env.EDGE_PATH) {
+    priorities.unshift({
+      regex: new RegExp(escapeRegExp(process.env.EDGE_PATH)),
+      weight: 101,
+    });
+  }
+
+  return sort(uniq(installations.filter(Boolean)), priorities);
+}
+
+export function wsl() {
+  // Manually populate the environment variables assuming it's the default config
+  process.env.LOCALAPPDATA = getLocalAppDataPath(`${process.env.PATH}`);
+  process.env.PROGRAMFILES = "/mnt/c/Program Files";
+  process.env["PROGRAMFILES(X86)"] = "/mnt/c/Program Files (x86)";
+
+  return win32();
+}
+
+export function win32() {
+  const installations: string[] = [];
+  const suffixes = [
+    `${path.sep}Microsoft${path.sep}Edge SxS${path.sep}Application${path.sep}msedge.exe`,
+    `${path.sep}Microsoft${path.sep}Edge${path.sep}Application${path.sep}msedge.exe`,
+  ];
+  const prefixes = [
+    process.env.LOCALAPPDATA,
+    process.env.PROGRAMFILES,
+    process.env["PROGRAMFILES(X86)"],
+  ].filter(Boolean) as string[];
+
+  const customEdgePath = resolveEdgePath();
+  if (customEdgePath) {
+    installations.push(customEdgePath);
+  }
+
+  prefixes.forEach((prefix) =>
+    suffixes.forEach((suffix) => {
+      const edgePath = path.join(prefix, suffix);
+      if (canAccess(edgePath)) {
+        installations.push(edgePath);
+      }
+    })
+  );
+  return installations;
+}
+
+function sort(installations: string[], priorities: Priorities) {
+  const defaultPriority = 10;
+  return (
+    installations
+      // assign priorities
+      .map((inst: string) => {
+        for (const pair of priorities) {
+          if (pair.regex.test(inst)) {
+            return { path: inst, weight: pair.weight };
+          }
+        }
+        return { path: inst, weight: defaultPriority };
+      })
+      // sort based on priorities
+      .sort((a, b) => b.weight - a.weight)
+      // remove priority flag
+      .map((pair) => pair.path)
+  );
+}
+
+function canAccess(file: string | undefined): boolean {
+  if (!file) {
+    return false;
+  }
+
+  try {
+    fs.accessSync(file);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function uniq<T>(arr: T[]) {
+  return Array.from(new Set(arr));
+}
+
+function findEdgeExecutables(folder: string): string[] {
+  const argumentsRegex = /(^[^ ]+).*/; // Take everything up to the first space
+  const edgeExecRegex = "^Exec=/.*/(microsoft-edge|edge)-.*";
+
+  const installations: string[] = [];
+  if (canAccess(folder)) {
+    // Output of the grep & print looks like:
+    //    /opt/google/edge/microsoft-edge --profile-directory
+    //    /home/user/Downloads/edge-linux/edge-wrapper %U
+    let execPaths;
+
+    // Some systems do not support grep -R so fallback to -r.
+    // See https://github.com/GoogleChrome/chrome-launcher/issues/46 for more context.
+    try {
+      execPaths = execSync(
+        `grep -ER "${edgeExecRegex}" ${folder} | awk -F '=' '{print $2}'`,
+        { stdio: "pipe" }
+      );
+    } catch (e) {
+      execPaths = execSync(
+        `grep -Er "${edgeExecRegex}" ${folder} | awk -F '=' '{print $2}'`,
+        { stdio: "pipe" }
+      );
+    }
+
+    execPaths = execPaths
+      .toString()
+      .split(newLineRegex)
+      .map((execPath: string) => execPath.replace(argumentsRegex, "$1"));
+
+    execPaths.forEach(
+      (execPath: string) => canAccess(execPath) && installations.push(execPath)
+    );
+  }
+
+  return installations;
+}

--- a/incubator/chromium-edge-launcher/src/edge-launcher.ts
+++ b/incubator/chromium-edge-launcher/src/edge-launcher.ts
@@ -1,0 +1,441 @@
+/**
+ * @license Copyright 2016 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+"use strict";
+
+import type { ChildProcess } from "child_process";
+import * as childProcess from "child_process";
+import * as fs from "fs";
+import * as net from "net";
+import * as rimraf from "rimraf";
+import * as edgeFinder from "./edge-finder";
+import { DEFAULT_FLAGS } from "./flags";
+import { getRandomPort } from "./random-port";
+import {
+  EdgeNotInstalledError,
+  InvalidUserDataDirectoryError,
+  UnsupportedPlatformError,
+  defaults,
+  delay,
+  getPlatform,
+  makeTmpDir,
+  toWinDirFormat,
+} from "./utils";
+const log = require("lighthouse-logger");
+const spawn = childProcess.spawn;
+const execSync = childProcess.execSync;
+const isWsl = getPlatform() === "wsl";
+const isWindows = getPlatform() === "win32";
+const _SIGINT = "SIGINT";
+const _SIGINT_EXIT_CODE = 130;
+const _SUPPORTED_PLATFORMS = new Set(["darwin", "linux", "win32", "wsl"]);
+
+type SupportedPlatforms = "darwin" | "linux" | "win32" | "wsl";
+
+const instances = new Set<Launcher>();
+
+export type RimrafModule = (
+  path: string,
+  callback: (error: Error | null | undefined) => void
+) => void;
+
+export type Options = {
+  startingUrl?: string;
+  edgeFlags?: string[];
+  port?: number;
+  handleSIGINT?: boolean;
+  edgePath?: string;
+  userDataDir?: string | boolean;
+  logLevel?: "verbose" | "info" | "error" | "silent";
+  ignoreDefaultFlags?: boolean;
+  connectionPollInterval?: number;
+  maxConnectionRetries?: number;
+  envVars?: Record<string, string | undefined>;
+};
+
+export type LaunchedEdge = {
+  pid: number;
+  port: number;
+  process: ChildProcess;
+  kill: () => Promise<void>;
+};
+
+export type ModuleOverrides = {
+  fs?: typeof fs;
+  rimraf?: RimrafModule;
+  spawn?: typeof childProcess.spawn;
+};
+
+const sigintListener = async () => {
+  await killAll();
+  process.exit(_SIGINT_EXIT_CODE);
+};
+
+async function launch(opts: Options = {}): Promise<LaunchedEdge> {
+  opts.handleSIGINT = defaults(opts.handleSIGINT, true);
+
+  const instance = new Launcher(opts);
+
+  // Kill spawned Edge process in case of ctrl-C.
+  if (opts.handleSIGINT && instances.size === 0) {
+    process.on(_SIGINT, sigintListener);
+  }
+  instances.add(instance);
+
+  await instance.launch();
+
+  const kill = async () => {
+    instances.delete(instance);
+    if (instances.size === 0) {
+      process.removeListener(_SIGINT, sigintListener);
+    }
+    return instance.kill();
+  };
+
+  return {
+    pid: instance.pid!,
+    port: instance.port!,
+    kill,
+    process: instance.edge!,
+  };
+}
+
+async function killAll(): Promise<Error[]> {
+  const errors: Error[] = [];
+  for (const instance of instances) {
+    try {
+      await instance.kill();
+      // only delete if kill did not error
+      // this means erroring instances remain in the Set
+      instances.delete(instance);
+    } catch (err) {
+      errors.push(err as Error);
+    }
+  }
+  return errors;
+}
+
+class Launcher {
+  private tmpDirandPidFileReady = false;
+  private pidFile?: string;
+  private startingUrl: string;
+  private outFile?: number;
+  private errFile?: number;
+  private edgePath?: string;
+  private ignoreDefaultFlags?: boolean;
+  private edgeFlags: string[];
+  private requestedPort?: number;
+  private connectionPollInterval: number;
+  private maxConnectionRetries: number;
+  private fs: typeof fs;
+  private rimraf: RimrafModule;
+  private spawn: typeof childProcess.spawn;
+  private useDefaultProfile: boolean;
+  private envVars: Record<string, string | undefined>;
+
+  edge?: childProcess.ChildProcess;
+  userDataDir?: string;
+  port?: number;
+  pid?: number;
+
+  constructor(
+    private opts: Options = {},
+    moduleOverrides: ModuleOverrides = {}
+  ) {
+    this.fs = moduleOverrides.fs || fs;
+    this.rimraf = moduleOverrides.rimraf || rimraf.default;
+    this.spawn = moduleOverrides.spawn || spawn;
+
+    log.setLevel(defaults(this.opts.logLevel, "silent"));
+
+    // choose the first one (default)
+    this.startingUrl = defaults(this.opts.startingUrl, "about:blank");
+    this.edgeFlags = defaults(this.opts.edgeFlags, []);
+    this.requestedPort = defaults(this.opts.port, 0);
+    this.edgePath = this.opts.edgePath;
+    this.ignoreDefaultFlags = defaults(this.opts.ignoreDefaultFlags, false);
+    this.connectionPollInterval = defaults(
+      this.opts.connectionPollInterval,
+      500
+    );
+    this.maxConnectionRetries = defaults(this.opts.maxConnectionRetries, 50);
+    this.envVars = defaults(opts.envVars, Object.assign({}, process.env));
+
+    if (typeof this.opts.userDataDir === "boolean") {
+      if (!this.opts.userDataDir) {
+        this.useDefaultProfile = true;
+        this.userDataDir = undefined;
+      } else {
+        throw new InvalidUserDataDirectoryError();
+      }
+    } else {
+      this.useDefaultProfile = false;
+      this.userDataDir = this.opts.userDataDir;
+    }
+  }
+
+  private get flags() {
+    const flags = this.ignoreDefaultFlags ? [] : DEFAULT_FLAGS.slice();
+    flags.push(`--remote-debugging-port=${this.port}`);
+
+    if (!this.ignoreDefaultFlags && getPlatform() === "linux") {
+      flags.push("--disable-setuid-sandbox");
+    }
+
+    if (!this.useDefaultProfile) {
+      // Place Edge profile in a custom location we'll rm -rf later
+      // If in WSL, we need to use the Windows format
+      flags.push(
+        `--user-data-dir=${
+          isWsl ? toWinDirFormat(this.userDataDir) : this.userDataDir
+        }`
+      );
+    }
+
+    flags.push(...this.edgeFlags);
+    flags.push(this.startingUrl);
+
+    return flags;
+  }
+
+  static defaultFlags() {
+    return DEFAULT_FLAGS.slice();
+  }
+
+  /** Returns the highest priority edge installation. */
+  static getFirstInstallation() {
+    if (getPlatform() === "darwin") return edgeFinder.darwinFast();
+    return edgeFinder[getPlatform() as SupportedPlatforms]()[0];
+  }
+
+  // Wrapper function to enable easy testing.
+  makeTmpDir() {
+    return makeTmpDir();
+  }
+
+  prepare() {
+    const platform = getPlatform() as SupportedPlatforms;
+    if (!_SUPPORTED_PLATFORMS.has(platform)) {
+      throw new UnsupportedPlatformError();
+    }
+
+    this.userDataDir = this.userDataDir || this.makeTmpDir();
+    this.outFile = this.fs.openSync(`${this.userDataDir}/edge-out.log`, "a");
+    this.errFile = this.fs.openSync(`${this.userDataDir}/edge-err.log`, "a");
+
+    // fix for Node4
+    // you can't pass a fd to fs.writeFileSync
+    this.pidFile = `${this.userDataDir}/edge.pid`;
+
+    log.verbose("EdgeLauncher", `created ${this.userDataDir}`);
+
+    this.tmpDirandPidFileReady = true;
+  }
+
+  async launch() {
+    if (this.requestedPort !== 0) {
+      this.port = this.requestedPort;
+
+      // If an explict port is passed first look for an open connection...
+      try {
+        return await this.isDebuggerReady();
+      } catch (err) {
+        log.log(
+          "EdgeLauncher",
+          `No debugging port found on port ${this.port}, launching a new Edge.`
+        );
+      }
+    }
+    if (this.edgePath === undefined) {
+      const installation = Launcher.getFirstInstallation();
+      if (!installation) {
+        throw new EdgeNotInstalledError();
+      }
+
+      this.edgePath = installation;
+    }
+
+    if (!this.tmpDirandPidFileReady) {
+      this.prepare();
+    }
+
+    this.pid = await this.spawnProcess(this.edgePath);
+    return Promise.resolve();
+  }
+
+  private async spawnProcess(execPath: string) {
+    const spawnPromise = (async () => {
+      if (this.edge) {
+        log.log(
+          "EdgeLauncher",
+          `Edge already running with pid ${this.edge.pid}.`
+        );
+        return this.edge.pid;
+      }
+
+      // If a zero value port is set, it means the launcher
+      // is responsible for generating the port number.
+      // We do this here so that we can know the port before
+      // we pass it into edge.
+      if (this.requestedPort === 0) {
+        this.port = await getRandomPort();
+      }
+
+      log.verbose(
+        "EdgeLauncher",
+        `Launching with command:\n"${execPath}" ${this.flags.join(" ")}`
+      );
+      console.trace(
+        "EdgeLauncher",
+        `Launching with command:\n"${execPath}" ${this.flags.join(" ")}`
+      );
+      const edge = this.spawn(execPath, this.flags, {
+        detached: true,
+        stdio: ["ignore", this.outFile, this.errFile],
+        env: this.envVars,
+      });
+      this.edge = edge;
+
+      this.fs.writeFileSync(this.pidFile!, edge.pid!.toString());
+
+      log.verbose(
+        "EdgeLauncher",
+        `Edge running with pid ${edge.pid} on port ${this.port}.`
+      );
+      return edge.pid;
+    })();
+
+    const pid = await spawnPromise;
+    await this.waitUntilReady();
+    return pid;
+  }
+
+  private cleanup(client?: net.Socket) {
+    if (client) {
+      client.removeAllListeners();
+      client.end();
+      client.destroy();
+      client.unref();
+    }
+  }
+
+  // resolves if ready, rejects otherwise
+  private isDebuggerReady(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const client = net.createConnection(this.port!);
+      client.once("error", (err) => {
+        this.cleanup(client);
+        reject(err);
+      });
+      client.once("connect", () => {
+        this.cleanup(client);
+        resolve();
+      });
+    });
+  }
+
+  // resolves when debugger is ready, rejects after 10 polls
+  waitUntilReady() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const launcher = this;
+
+    return new Promise<void>((resolve, reject) => {
+      let retries = 0;
+      let waitStatus = "Waiting for browser.";
+
+      const poll = () => {
+        if (retries === 0) {
+          log.log("EdgeLauncher", waitStatus);
+        }
+        retries++;
+        waitStatus += "..";
+        log.log("EdgeLauncher", waitStatus);
+
+        launcher
+          .isDebuggerReady()
+          .then(() => {
+            log.log("EdgeLauncher", waitStatus + `${log.greenify(log.tick)}`);
+            resolve();
+          })
+          .catch((err) => {
+            if (retries > launcher.maxConnectionRetries) {
+              log.error("EdgeLauncher", err.message);
+              const stderr = this.fs.readFileSync(
+                `${this.userDataDir}/edge-err.log`,
+                { encoding: "utf-8" }
+              );
+              log.error(
+                "EdgeLauncher",
+                `Logging contents of ${this.userDataDir}/edge-err.log`
+              );
+              log.error("EdgeLauncher", stderr);
+              return reject(err);
+            }
+            delay(launcher.connectionPollInterval).then(poll);
+          });
+      };
+      poll();
+    });
+  }
+
+  kill() {
+    return new Promise<void>((resolve, reject) => {
+      if (this.edge) {
+        this.edge.on("close", () => {
+          delete this.edge;
+          this.destroyTmp().then(resolve);
+        });
+
+        log.log("EdgeLauncher", `Killing Edge instance ${this.edge.pid}`);
+        try {
+          if (isWindows) {
+            // While pipe is the default, stderr also gets printed to process.stderr
+            // if you don't explicitly set `stdio`
+            execSync(`taskkill /pid ${this.edge.pid} /T /F`, { stdio: "pipe" });
+          } else {
+            process.kill(-this.edge.pid!);
+          }
+        } catch (err) {
+          const message = `Edge could not be killed ${
+            err ?? (err as unknown as { message: string }).message
+          }`;
+          log.warn("EdgeLauncher", message);
+          reject(new Error(message));
+        }
+      } else {
+        // fail silently as we did not start edge
+        resolve();
+      }
+    });
+  }
+
+  destroyTmp() {
+    return new Promise<void>((resolve) => {
+      // Only clean up the tmp dir if we created it.
+      if (
+        this.userDataDir === undefined ||
+        this.opts.userDataDir !== undefined
+      ) {
+        return resolve();
+      }
+
+      if (this.outFile) {
+        this.fs.closeSync(this.outFile);
+        delete this.outFile;
+      }
+
+      if (this.errFile) {
+        this.fs.closeSync(this.errFile);
+        delete this.errFile;
+      }
+
+      this.rimraf(this.userDataDir, () => resolve());
+    });
+  }
+}
+
+// eslint-disable-next-line no-restricted-exports
+export default Launcher;
+export { Launcher, killAll, launch };

--- a/incubator/chromium-edge-launcher/src/flags.ts
+++ b/incubator/chromium-edge-launcher/src/flags.ts
@@ -1,0 +1,50 @@
+/**
+ * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+// https://github.com/cezaraugusto/chromium-edge-launcher/blob/master/docs/edge-flags-for-tools.md
+
+export const DEFAULT_FLAGS: readonly string[] = [
+  // Disable built-in Google Translate service
+  '--disable-features=Translate',
+  // Disable all edge extensions
+  '--disable-extensions',
+  // Disable some extensions that aren't affected by --disable-extensions
+  '--disable-component-extensions-with-background-pages',
+  // Disable various background network services, including extension updating,
+  //   safe browsing service, upgrade detector, translate, UMA
+  '--disable-background-networking',
+  // Don't update the browser 'components' listed at edge://components/
+  '--disable-component-update',
+  // Disables client-side phishing detection.
+  '--disable-client-side-phishing-detection',
+  // Disable syncing to a Google account
+  '--disable-sync',
+  // Disable reporting to UMA, but allows for collection
+  '--metrics-recording-only',
+  // Disable installation of default apps on first run
+  '--disable-default-apps',
+  // Mute any audio
+  '--mute-audio',
+  // Disable the default browser check, do not prompt to set it as such
+  '--no-default-browser-check',
+  // Skip first run wizards
+  '--no-first-run',
+  // Disable backgrounding renders for occluded windows
+  '--disable-backgrounding-occluded-windows',
+  // Disable renderer process backgrounding
+  '--disable-renderer-backgrounding',
+  // Disable task throttling of timer tasks from background pages.
+  '--disable-background-timer-throttling',
+  // Disable the default throttling of IPC between renderer & browser processes.
+  '--disable-ipc-flooding-protection',
+  // Avoid potential instability of using Gnome Keyring or KDE wallet. crbug.com/571003 crbug.com/991424
+  '--password-store=basic',
+  // Use mock keychain on Mac to prevent blocking permissions dialogs
+  '--use-mock-keychain',
+  // Disable background tracing (aka slow reports & deep reports) to avoid 'Tracing already started'
+  '--force-fieldtrials=*BackgroundTracing/default/',
+];

--- a/incubator/chromium-edge-launcher/src/flags.ts
+++ b/incubator/chromium-edge-launcher/src/flags.ts
@@ -3,48 +3,48 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
-'use strict';
+"use strict";
 
 // https://github.com/cezaraugusto/chromium-edge-launcher/blob/master/docs/edge-flags-for-tools.md
 
 export const DEFAULT_FLAGS: readonly string[] = [
   // Disable built-in Google Translate service
-  '--disable-features=Translate',
+  "--disable-features=Translate",
   // Disable all edge extensions
-  '--disable-extensions',
+  "--disable-extensions",
   // Disable some extensions that aren't affected by --disable-extensions
-  '--disable-component-extensions-with-background-pages',
+  "--disable-component-extensions-with-background-pages",
   // Disable various background network services, including extension updating,
   //   safe browsing service, upgrade detector, translate, UMA
-  '--disable-background-networking',
+  "--disable-background-networking",
   // Don't update the browser 'components' listed at edge://components/
-  '--disable-component-update',
+  "--disable-component-update",
   // Disables client-side phishing detection.
-  '--disable-client-side-phishing-detection',
+  "--disable-client-side-phishing-detection",
   // Disable syncing to a Google account
-  '--disable-sync',
+  "--disable-sync",
   // Disable reporting to UMA, but allows for collection
-  '--metrics-recording-only',
+  "--metrics-recording-only",
   // Disable installation of default apps on first run
-  '--disable-default-apps',
+  "--disable-default-apps",
   // Mute any audio
-  '--mute-audio',
+  "--mute-audio",
   // Disable the default browser check, do not prompt to set it as such
-  '--no-default-browser-check',
+  "--no-default-browser-check",
   // Skip first run wizards
-  '--no-first-run',
+  "--no-first-run",
   // Disable backgrounding renders for occluded windows
-  '--disable-backgrounding-occluded-windows',
+  "--disable-backgrounding-occluded-windows",
   // Disable renderer process backgrounding
-  '--disable-renderer-backgrounding',
+  "--disable-renderer-backgrounding",
   // Disable task throttling of timer tasks from background pages.
-  '--disable-background-timer-throttling',
+  "--disable-background-timer-throttling",
   // Disable the default throttling of IPC between renderer & browser processes.
-  '--disable-ipc-flooding-protection',
+  "--disable-ipc-flooding-protection",
   // Avoid potential instability of using Gnome Keyring or KDE wallet. crbug.com/571003 crbug.com/991424
-  '--password-store=basic',
+  "--password-store=basic",
   // Use mock keychain on Mac to prevent blocking permissions dialogs
-  '--use-mock-keychain',
+  "--use-mock-keychain",
   // Disable background tracing (aka slow reports & deep reports) to avoid 'Tracing already started'
-  '--force-fieldtrials=*BackgroundTracing/default/',
+  "--force-fieldtrials=*BackgroundTracing/default/",
 ];

--- a/incubator/chromium-edge-launcher/src/index.ts
+++ b/incubator/chromium-edge-launcher/src/index.ts
@@ -1,0 +1,7 @@
+export { Launcher, killAll, launch } from "./edge-launcher";
+export type {
+  LaunchedEdge,
+  ModuleOverrides,
+  Options,
+  RimrafModule,
+} from "./edge-launcher";

--- a/incubator/chromium-edge-launcher/src/random-port.ts
+++ b/incubator/chromium-edge-launcher/src/random-port.ts
@@ -1,0 +1,24 @@
+/**
+ * @license Copyright 2016 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+import {createServer} from 'http';
+import type {AddressInfo} from 'net';
+
+/**
+ * Return a random, unused port.
+ */
+export function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0);
+    server.once('listening', () => {
+      const {port} = server.address() as AddressInfo;
+      server.close(() => resolve(port));
+    });
+    server.once('error', reject);
+  });
+}

--- a/incubator/chromium-edge-launcher/src/random-port.ts
+++ b/incubator/chromium-edge-launcher/src/random-port.ts
@@ -3,10 +3,10 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
-'use strict';
+"use strict";
 
-import {createServer} from 'http';
-import type {AddressInfo} from 'net';
+import { createServer } from "http";
+import type { AddressInfo } from "net";
 
 /**
  * Return a random, unused port.
@@ -15,10 +15,10 @@ export function getRandomPort(): Promise<number> {
   return new Promise((resolve, reject) => {
     const server = createServer();
     server.listen(0);
-    server.once('listening', () => {
-      const {port} = server.address() as AddressInfo;
+    server.once("listening", () => {
+      const { port } = server.address() as AddressInfo;
       server.close(() => resolve(port));
     });
-    server.once('error', reject);
+    server.once("error", reject);
   });
 }

--- a/incubator/chromium-edge-launcher/src/types.ts
+++ b/incubator/chromium-edge-launcher/src/types.ts
@@ -1,0 +1,1 @@
+export type FakeMethod = (message: string) => string;

--- a/incubator/chromium-edge-launcher/src/utils.ts
+++ b/incubator/chromium-edge-launcher/src/utils.ts
@@ -1,0 +1,115 @@
+/**
+ * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+"use strict";
+
+import { execSync } from "child_process";
+import * as mkdirp from "mkdirp";
+import { join } from "path";
+import isWsl = require("is-wsl");
+
+// eslint-disable-next-line @rnx-kit/no-const-enum
+export const enum LaunchErrorCodes {
+  ERR_LAUNCHER_PATH_NOT_SET = "ERR_LAUNCHER_PATH_NOT_SET",
+  ERR_LAUNCHER_INVALID_USER_DATA_DIRECTORY = "ERR_LAUNCHER_INVALID_USER_DATA_DIRECTORY",
+  ERR_LAUNCHER_UNSUPPORTED_PLATFORM = "ERR_LAUNCHER_UNSUPPORTED_PLATFORM",
+  ERR_LAUNCHER_NOT_INSTALLED = "ERR_LAUNCHER_NOT_INSTALLED",
+}
+
+export function defaults<T>(val: T | undefined, def: T): T {
+  return typeof val === "undefined" ? def : val;
+}
+
+export async function delay(time: number) {
+  return new Promise((resolve) => setTimeout(resolve, time));
+}
+
+export class LauncherError extends Error {
+  constructor(
+    public override message = "Unexpected error",
+    public code?: string
+  ) {
+    super();
+    this.stack = new Error().stack;
+    return this;
+  }
+}
+
+export class EdgePathNotSetError extends LauncherError {
+  override message =
+    "The EDGE_PATH environment variable must be set to a Edge/Chromium executable no older than Edge stable.";
+  override code = LaunchErrorCodes.ERR_LAUNCHER_PATH_NOT_SET;
+}
+
+export class InvalidUserDataDirectoryError extends LauncherError {
+  override message = "userDataDir must be false or a path.";
+  override code = LaunchErrorCodes.ERR_LAUNCHER_INVALID_USER_DATA_DIRECTORY;
+}
+
+export class UnsupportedPlatformError extends LauncherError {
+  override message = `Platform ${getPlatform()} is not supported.`;
+  override code = LaunchErrorCodes.ERR_LAUNCHER_UNSUPPORTED_PLATFORM;
+}
+
+export class EdgeNotInstalledError extends LauncherError {
+  override message = "No Edge installations found.";
+  override code = LaunchErrorCodes.ERR_LAUNCHER_NOT_INSTALLED;
+}
+
+export function getPlatform() {
+  return isWsl ? "wsl" : process.platform;
+}
+
+export function makeTmpDir() {
+  switch (getPlatform()) {
+    case "darwin":
+    case "linux":
+      return makeUnixTmpDir();
+    // @ts-expect-error - Fallthrough case in switch.
+    case "wsl":
+      // We populate the user's Windows temp dir so the folder is correctly created later
+      process.env.TEMP = getLocalAppDataPath(`${process.env.PATH}`);
+    // falls through
+    case "win32":
+      return makeWin32TmpDir();
+    default:
+      throw new UnsupportedPlatformError();
+  }
+}
+
+export function toWinDirFormat(dir = ""): string {
+  const results = /\/mnt\/([a-z])\//.exec(dir);
+  if (!results) {
+    return dir;
+  }
+
+  const driveLetter = results[1];
+  return dir
+    .replace(`/mnt/${driveLetter}/`, `${driveLetter.toUpperCase()}:\\`)
+    .replace(/\//g, "\\");
+}
+
+export function getLocalAppDataPath(path: string): string {
+  const userRegExp = /\/mnt\/([a-z])\/Users\/([^/:]+)\/AppData\//;
+  const results = userRegExp.exec(path) || [];
+
+  return `/mnt/${results[1]}/Users/${results[2]}/AppData/Local`;
+}
+
+function makeUnixTmpDir() {
+  return execSync("mktemp -d -t lighthouse.XXXXXXX").toString().trim();
+}
+
+function makeWin32TmpDir() {
+  const winTmpPath =
+    process.env.TEMP ||
+    process.env.TMP ||
+    (process.env.SystemRoot || process.env.windir) + "\\temp";
+  const randomNumber = Math.floor(Math.random() * 9e7 + 1e7);
+  const tmpdir = join(winTmpPath, "lighthouse." + randomNumber);
+
+  mkdirp.sync(tmpdir);
+  return tmpdir;
+}

--- a/incubator/chromium-edge-launcher/test/edge-launcher-test.ts
+++ b/incubator/chromium-edge-launcher/test/edge-launcher-test.ts
@@ -1,0 +1,198 @@
+/**
+ * @license Copyright 2016 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+"use strict";
+
+import { Launcher, Options, killAll, launch } from "../src/edge-launcher";
+import { DEFAULT_FLAGS } from "../src/flags";
+
+import * as assert from "assert";
+import { spy, stub } from "sinon";
+
+const log = require("lighthouse-logger");
+const fsMock = {
+  openSync: () => {},
+  closeSync: () => {},
+  writeFileSync: () => {},
+};
+
+// @ts-ignore
+const launchEdgeWithOpts = async (opts: Options = {}) => {
+  const spawnStub = stub().returns({ pid: "some_pid" });
+
+  const edgeInstance = new Launcher(opts, {
+    fs: fsMock as any,
+    rimraf: spy() as any,
+    spawn: spawnStub as any,
+  });
+  stub(edgeInstance, "waitUntilReady").returns(Promise.resolve());
+
+  edgeInstance.prepare();
+
+  try {
+    await edgeInstance.launch();
+    return Promise.resolve(spawnStub);
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};
+
+describe("Launcher", () => {
+  beforeEach(() => {
+    log.setLevel("error");
+  });
+
+  afterEach(() => {
+    log.setLevel("");
+  });
+
+  it("sets default launching flags", async () => {
+    const spawnStub = await launchEdgeWithOpts({ userDataDir: "some_path" });
+    const edgeFlags = spawnStub.getCall(0).args[1] as string[];
+    assert.ok(edgeFlags.find((f) => f.startsWith("--remote-debugging-port")));
+    assert.ok(
+      edgeFlags.find((f) => f.startsWith("--disable-background-networking"))
+    );
+    assert.strictEqual(edgeFlags[edgeFlags.length - 1], "about:blank");
+  });
+
+  it("accepts and uses a custom path", async () => {
+    const rimrafMock = spy();
+    const edgeInstance = new Launcher(
+      { userDataDir: "some_path" },
+      { fs: fsMock as any, rimraf: rimrafMock as any }
+    );
+
+    edgeInstance.prepare();
+
+    await edgeInstance.destroyTmp();
+    assert.strictEqual(rimrafMock.callCount, 0);
+  });
+
+  it("cleans up the tmp dir after closing", async () => {
+    const rimrafMock = stub().callsFake((_, done) => done());
+
+    const edgeInstance = new Launcher(
+      {},
+      { fs: fsMock as any, rimraf: rimrafMock as any }
+    );
+
+    edgeInstance.prepare();
+    await edgeInstance.destroyTmp();
+    assert.strictEqual(rimrafMock.callCount, 1);
+  });
+
+  it("does not delete created directory when custom path passed", () => {
+    const edgeInstance = new Launcher(
+      { userDataDir: "some_path" },
+      { fs: fsMock as any }
+    );
+
+    edgeInstance.prepare();
+    assert.strictEqual(edgeInstance.userDataDir, "some_path");
+  });
+
+  it("defaults to genering a tmp dir when no data dir is passed", () => {
+    const edgeInstance = new Launcher({}, { fs: fsMock as any });
+    const originalMakeTmp = edgeInstance.makeTmpDir;
+    edgeInstance.makeTmpDir = () => "tmp_dir";
+    edgeInstance.prepare();
+    assert.strictEqual(edgeInstance.userDataDir, "tmp_dir");
+
+    // Restore the original fn.
+    edgeInstance.makeTmpDir = originalMakeTmp;
+  });
+
+  it(
+    "doesn't fail when killed twice",
+    async () => {
+      const edgeInstance = new Launcher();
+      await edgeInstance.launch();
+      await edgeInstance.kill();
+      await edgeInstance.kill();
+    },
+    30 * 1000
+  );
+
+  it("doesn't fail when killing all instances", async () => {
+    await launch();
+    await launch();
+    const errors = await killAll();
+    assert.strictEqual(errors.length, 0);
+  });
+
+  it("doesn't launch multiple edge processes", async () => {
+    const edgeInstance = new Launcher();
+    await edgeInstance.launch();
+    let pid = edgeInstance.pid!;
+    await edgeInstance.launch();
+    assert.strictEqual(pid, edgeInstance.pid);
+    await edgeInstance.kill();
+  });
+
+  it("gets all default flags", async () => {
+    const flags = Launcher.defaultFlags();
+    assert.ok(flags.length);
+    assert.deepStrictEqual(flags, DEFAULT_FLAGS);
+  });
+
+  it("does not allow mutating default flags", async () => {
+    const flags = Launcher.defaultFlags();
+    flags.push("--new-flag");
+    const currentDefaultFlags = Launcher.defaultFlags().slice();
+    assert.notDeepStrictEqual(flags, currentDefaultFlags);
+  });
+
+  it("does not mutate default flags when launching", async () => {
+    const originalDefaultFlags = Launcher.defaultFlags().slice();
+    await launchEdgeWithOpts();
+    const currentDefaultFlags = Launcher.defaultFlags().slice();
+    assert.deepStrictEqual(originalDefaultFlags, currentDefaultFlags);
+  });
+
+  it("removes all default flags", async () => {
+    const spawnStub = await launchEdgeWithOpts({ ignoreDefaultFlags: true });
+    const edgeFlags = spawnStub.getCall(0).args[1] as string[];
+    assert.ok(!edgeFlags.includes("--disable-extensions"));
+  });
+
+  it("removes --user-data-dir if userDataDir is false", async () => {
+    const spawnStub = await launchEdgeWithOpts();
+    const edgeFlags = spawnStub.getCall(0).args[1] as string[];
+    assert.ok(!edgeFlags.includes("--user-data-dir"));
+  });
+
+  it("passes no env vars when none are passed", async () => {
+    const spawnStub = await launchEdgeWithOpts();
+    const spawnOptions = spawnStub.getCall(0).args[2] as { env: {} };
+    assert.deepStrictEqual(spawnOptions.env, Object.assign({}, process.env));
+  });
+
+  it("passes env vars when passed", async () => {
+    const envVars = { hello: "world" };
+    const spawnStub = await launchEdgeWithOpts({ envVars });
+    const spawnOptions = spawnStub.getCall(0).args[2] as { env: {} };
+    assert.deepStrictEqual(spawnOptions.env, envVars);
+  });
+
+  it("ensure specific flags are present when passed and defaults are ignored", async () => {
+    const spawnStub = await launchEdgeWithOpts({
+      ignoreDefaultFlags: true,
+      edgeFlags: ["--disable-extensions", "--mute-audio", "--no-first-run"],
+    });
+    const edgeFlags = spawnStub.getCall(0).args[1] as string[];
+    assert.ok(edgeFlags.includes("--mute-audio"));
+    assert.ok(edgeFlags.includes("--disable-extensions"));
+
+    // Make sure that default flags are not present
+    assert.ok(!edgeFlags.includes("--disable-background-networking"));
+    assert.ok(!edgeFlags.includes("--disable-default-app"));
+  });
+
+  it("throws an error when edgePath is empty", (done) => {
+    const edgeInstance = new Launcher({ edgePath: "" });
+    edgeInstance.launch().catch(() => done());
+  });
+});

--- a/incubator/chromium-edge-launcher/test/launch-signature-test.ts
+++ b/incubator/chromium-edge-launcher/test/launch-signature-test.ts
@@ -1,0 +1,30 @@
+/**
+ * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+"use strict";
+
+import * as assert from "assert";
+import { launch } from "../src";
+
+const log = require("lighthouse-logger");
+describe("Launcher", () => {
+  beforeEach(() => {
+    log.setLevel("error");
+  });
+
+  afterEach(() => {
+    log.setLevel("");
+  });
+
+  it("exposes expected interface when launched", async () => {
+    const edge = await launch();
+    assert.notStrictEqual(edge.process, undefined);
+    assert.notStrictEqual(edge.pid, undefined);
+    assert.notStrictEqual(edge.port, undefined);
+    assert.notStrictEqual(edge.kill, undefined);
+    await edge.kill();
+  }, 500000);
+});

--- a/incubator/chromium-edge-launcher/test/random-port.test.ts
+++ b/incubator/chromium-edge-launcher/test/random-port.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import * as assert from 'assert';
+import {getRandomPort} from '../src/random-port';
+
+describe('Random port generation', () => {
+  it('generates a valid random port number', async () => {
+    const port = await getRandomPort();
+    // Verify generated port number is valid integer.
+    assert.ok(Number.isInteger(port) && port > 0 && port <= 0xFFFF);
+  });
+});

--- a/incubator/chromium-edge-launcher/test/random-port.test.ts
+++ b/incubator/chromium-edge-launcher/test/random-port.test.ts
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
+"use strict";
 
-import * as assert from 'assert';
-import {getRandomPort} from '../src/random-port';
+import * as assert from "assert";
+import { getRandomPort } from "../src/random-port";
 
-describe('Random port generation', () => {
-  it('generates a valid random port number', async () => {
+describe("Random port generation", () => {
+  it("generates a valid random port number", async () => {
     const port = await getRandomPort();
     // Verify generated port number is valid integer.
-    assert.ok(Number.isInteger(port) && port > 0 && port <= 0xFFFF);
+    assert.ok(Number.isInteger(port) && port > 0 && port <= 0xffff);
   });
 });

--- a/incubator/chromium-edge-launcher/test/utils.test.ts
+++ b/incubator/chromium-edge-launcher/test/utils.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import * as assert from 'assert';
+import {toWinDirFormat, getLocalAppDataPath} from '../src/utils';
+
+describe('WSL path format to Windows', () => {
+  it('transforms basic path', () => {
+    const wsl = '/mnt/c/Users/user1/AppData/';
+    const windows = 'C:\\Users\\user1\\AppData\\';
+    assert.strictEqual(toWinDirFormat(wsl), windows);
+  });
+
+  it('transforms if drive letter is different than c', () => {
+    const wsl = '/mnt/d/Users/user1/AppData';
+    const windows = 'D:\\Users\\user1\\AppData';
+    assert.strictEqual(toWinDirFormat(wsl), windows);
+  });
+
+  it('getLocalAppDataPath returns a correct path', () => {
+    const path = '/mnt/c/Users/user1/.bin:/mnt/c/Users/user1:/mnt/c/Users/user1/AppData/';
+    const appDataPath = '/mnt/c/Users/user1/AppData/Local';
+    assert.strictEqual(getLocalAppDataPath(path), appDataPath);
+  });
+});

--- a/incubator/chromium-edge-launcher/test/utils.test.ts
+++ b/incubator/chromium-edge-launcher/test/utils.test.ts
@@ -13,27 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
+"use strict";
 
-import * as assert from 'assert';
-import {toWinDirFormat, getLocalAppDataPath} from '../src/utils';
+import * as assert from "assert";
+import { getLocalAppDataPath, toWinDirFormat } from "../src/utils";
 
-describe('WSL path format to Windows', () => {
-  it('transforms basic path', () => {
-    const wsl = '/mnt/c/Users/user1/AppData/';
-    const windows = 'C:\\Users\\user1\\AppData\\';
+describe("WSL path format to Windows", () => {
+  it("transforms basic path", () => {
+    const wsl = "/mnt/c/Users/user1/AppData/";
+    const windows = "C:\\Users\\user1\\AppData\\";
     assert.strictEqual(toWinDirFormat(wsl), windows);
   });
 
-  it('transforms if drive letter is different than c', () => {
-    const wsl = '/mnt/d/Users/user1/AppData';
-    const windows = 'D:\\Users\\user1\\AppData';
+  it("transforms if drive letter is different than c", () => {
+    const wsl = "/mnt/d/Users/user1/AppData";
+    const windows = "D:\\Users\\user1\\AppData";
     assert.strictEqual(toWinDirFormat(wsl), windows);
   });
 
-  it('getLocalAppDataPath returns a correct path', () => {
-    const path = '/mnt/c/Users/user1/.bin:/mnt/c/Users/user1:/mnt/c/Users/user1/AppData/';
-    const appDataPath = '/mnt/c/Users/user1/AppData/Local';
+  it("getLocalAppDataPath returns a correct path", () => {
+    const path =
+      "/mnt/c/Users/user1/.bin:/mnt/c/Users/user1:/mnt/c/Users/user1/AppData/";
+    const appDataPath = "/mnt/c/Users/user1/AppData/Local";
     assert.strictEqual(getLocalAppDataPath(path), appDataPath);
   });
 });

--- a/incubator/chromium-edge-launcher/tsconfig.json
+++ b/incubator/chromium-edge-launcher/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@rnx-kit/scripts/tsconfig-shared.json",
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3508,7 +3508,7 @@ __metadata:
     "@rnx-kit/jest-preset": "*"
     "@rnx-kit/scripts": "*"
     "@types/mkdirp": ^1.0.1
-    "@types/node": "*"
+    "@types/node": ^18.0.0
     "@types/rimraf": ^3.0.0
     "@types/sinon": ^9.0.1
     escape-string-regexp: ^4.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3500,6 +3500,30 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@rnx-kit/chromium-edge-launcher@workspace:incubator/chromium-edge-launcher":
+  version: 0.0.0-use.local
+  resolution: "@rnx-kit/chromium-edge-launcher@workspace:incubator/chromium-edge-launcher"
+  dependencies:
+    "@rnx-kit/eslint-config": "*"
+    "@rnx-kit/jest-preset": "*"
+    "@rnx-kit/scripts": "*"
+    "@types/mkdirp": ^1.0.1
+    "@types/node": "*"
+    "@types/rimraf": ^3.0.0
+    "@types/sinon": ^9.0.1
+    escape-string-regexp: ^4.0.0
+    eslint: ^8.0.0
+    is-wsl: ^2.2.0
+    jest: ^29.2.1
+    lighthouse-logger: ^1.0.0
+    mkdirp: ^1.0.4
+    prettier: ^3.0.0
+    rimraf: ^3.0.2
+    sinon: ^9.0.1
+    typescript: ^5.0.0
+  languageName: unknown
+  linkType: soft
+
 "@rnx-kit/cli@workspace:*, @rnx-kit/cli@workspace:packages/cli":
   version: 0.0.0-use.local
   resolution: "@rnx-kit/cli@workspace:packages/cli"
@@ -4340,6 +4364,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sinonjs/commons@npm:^1.6.0, @sinonjs/commons@npm:^1.7.0, @sinonjs/commons@npm:^1.8.1":
+  version: 1.8.6
+  resolution: "@sinonjs/commons@npm:1.8.6"
+  dependencies:
+    type-detect: 4.0.8
+  checksum: 7d3f8c1e85f30cd4e83594fc19b7a657f14d49eb8d95a30095631ce15e906c869e0eff96c5b93dffea7490c00418b07f54582ba49c6560feb2a8c34c0b16832d
+  languageName: node
+  linkType: hard
+
 "@sinonjs/commons@npm:^2.0.0":
   version: 2.0.0
   resolution: "@sinonjs/commons@npm:2.0.0"
@@ -4355,6 +4388,33 @@ __metadata:
   dependencies:
     "@sinonjs/commons": ^2.0.0
   checksum: c62aa98e7cefda8dedc101ce227abc888dc46b8ff9706c5f0a8dfd9c3ada97d0a5611384738d9ba0b26b59f99c2ba24efece8e779bb08329e9e87358fa309824
+  languageName: node
+  linkType: hard
+
+"@sinonjs/fake-timers@npm:^6.0.0, @sinonjs/fake-timers@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "@sinonjs/fake-timers@npm:6.0.1"
+  dependencies:
+    "@sinonjs/commons": ^1.7.0
+  checksum: 8e331aa1412d905ecc8efd63550f58a6f77dcb510f878172004e53be63eb82650623618763001a918fc5e21257b86c45041e4e97c454ed6a2d187de084abbd11
+  languageName: node
+  linkType: hard
+
+"@sinonjs/samsam@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "@sinonjs/samsam@npm:5.3.1"
+  dependencies:
+    "@sinonjs/commons": ^1.6.0
+    lodash.get: ^4.4.2
+    type-detect: ^4.0.8
+  checksum: 1c2c49d51b1840775980e9496707d68b936f443896f92e48150c4f7713d14904e576740e52660b602f8a53b665bd5f149c5c733758030758427ddb1621090279
+  languageName: node
+  linkType: hard
+
+"@sinonjs/text-encoding@npm:^0.7.1":
+  version: 0.7.2
+  resolution: "@sinonjs/text-encoding@npm:0.7.2"
+  checksum: fe690002a32ba06906cf87e2e8fe84d1590294586f2a7fd180a65355b53660c155c3273d8011a5f2b77209b819aa7306678ae6e4aea0df014bd7ffd4bbbcf1ab
   languageName: node
   linkType: hard
 
@@ -4466,6 +4526,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/glob@npm:*":
+  version: 8.1.0
+  resolution: "@types/glob@npm:8.1.0"
+  dependencies:
+    "@types/minimatch": ^5.1.2
+    "@types/node": "*"
+  checksum: 9101f3a9061e40137190f70626aa0e202369b5ec4012c3fabe6f5d229cce04772db9a94fa5a0eb39655e2e4ad105c38afbb4af56a56c0996a8c7d4fc72350e3d
+  languageName: node
+  linkType: hard
+
 "@types/graceful-fs@npm:^4.1.3":
   version: 4.1.6
   resolution: "@types/graceful-fs@npm:4.1.6"
@@ -4549,10 +4619,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/minimatch@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "@types/minimatch@npm:5.1.2"
+  checksum: 0391a282860c7cb6fe262c12b99564732401bdaa5e395bee9ca323c312c1a0f45efbf34dce974682036e857db59a5c9b1da522f3d6055aeead7097264c8705a8
+  languageName: node
+  linkType: hard
+
 "@types/minimist@npm:^1.2.0":
   version: 1.2.2
   resolution: "@types/minimist@npm:1.2.2"
   checksum: b8da83c66eb4aac0440e64674b19564d9d86c80ae273144db9681e5eeff66f238ade9515f5006ffbfa955ceff8b89ad2bd8ec577d7caee74ba101431fb07045d
+  languageName: node
+  linkType: hard
+
+"@types/mkdirp@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "@types/mkdirp@npm:1.0.2"
+  dependencies:
+    "@types/node": "*"
+  checksum: 72dedfb2d250f0e44ec964ac68ff6a4a03d7d9d6e83ae1d5ba6d212791af69cf051a5fac59846826242d099de56a18c8e0581861792fae8b845b3c9ad67ecdeb
   languageName: node
   linkType: hard
 
@@ -4633,6 +4719,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/rimraf@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "@types/rimraf@npm:3.0.2"
+  dependencies:
+    "@types/glob": "*"
+    "@types/node": "*"
+  checksum: b47fa302f46434cba704d20465861ad250df79467d3d289f9d6490d3aeeb41e8cb32dd80bd1a8fd833d1e185ac719fbf9be12e05ad9ce9be094d8ee8f1405347
+  languageName: node
+  linkType: hard
+
 "@types/scheduler@npm:*":
   version: 0.16.1
   resolution: "@types/scheduler@npm:0.16.1"
@@ -4644,6 +4740,22 @@ __metadata:
   version: 7.5.4
   resolution: "@types/semver@npm:7.5.4"
   checksum: 120c0189f6fec5f2d12d0d71ac8a4cfa952dc17fa3d842e8afddb82bba8828a4052f8799c1653e2b47ae1977435f38e8985658fde971905ce5afb8e23ee97ecf
+  languageName: node
+  linkType: hard
+
+"@types/sinon@npm:^9.0.1":
+  version: 9.0.11
+  resolution: "@types/sinon@npm:9.0.11"
+  dependencies:
+    "@types/sinonjs__fake-timers": "*"
+  checksum: 2074490973012283ec9ccb9f607fa12f36c78d8801f63ec437d3e8351dae161a018836cc02e8b039118ec9fb7680331594716ed0858075a11d381edd27faa75c
+  languageName: node
+  linkType: hard
+
+"@types/sinonjs__fake-timers@npm:*":
+  version: 8.1.4
+  resolution: "@types/sinonjs__fake-timers@npm:8.1.4"
+  checksum: f53fcb5cc6c77e064f8bf0772ddd82d5bbc8264167182cdb7209600d3580e09e71ca313925e6e8a3de0faad10518a8f803db8555762bca5a100cf5bcb5e13170
   languageName: node
   linkType: hard
 
@@ -6409,7 +6521,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:2.6.9, debug@npm:^2.2.0":
+"debug@npm:2.6.9, debug@npm:^2.2.0, debug@npm:^2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
   dependencies:
@@ -6665,6 +6777,13 @@ __metadata:
   version: 29.6.3
   resolution: "diff-sequences@npm:29.6.3"
   checksum: f4914158e1f2276343d98ff5b31fc004e7304f5470bf0f1adb2ac6955d85a531a6458d33e87667f98f6ae52ebd3891bb47d420bb48a5bd8b7a27ee25b20e33aa
+  languageName: node
+  linkType: hard
+
+"diff@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "diff@npm:4.0.2"
+  checksum: f2c09b0ce4e6b301c221addd83bf3f454c0bc00caa3dd837cf6c127d6edf7223aa2bbe3b688feea110b7f262adbfc845b757c44c8a9f8c0c5b15d8fa9ce9d20d
   languageName: node
   linkType: hard
 
@@ -8891,6 +9010,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isarray@npm:0.0.1":
+  version: 0.0.1
+  resolution: "isarray@npm:0.0.1"
+  checksum: 49191f1425681df4a18c2f0f93db3adb85573bcdd6a4482539d98eac9e705d8961317b01175627e860516a2fc45f8f9302db26e5a380a97a520e272e2a40a8d4
+  languageName: node
+  linkType: hard
+
 "isarray@npm:^2.0.5":
   version: 2.0.5
   resolution: "isarray@npm:2.0.5"
@@ -9699,6 +9825,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"just-extend@npm:^4.0.2":
+  version: 4.2.1
+  resolution: "just-extend@npm:4.2.1"
+  checksum: ff9fdede240fad313efeeeb68a660b942e5586d99c0058064c78884894a2690dc09bba44c994ad4e077e45d913fef01a9240c14a72c657b53687ac58de53b39c
+  languageName: node
+  linkType: hard
+
 "keyv@npm:^4.5.2":
   version: 4.5.2
   resolution: "keyv@npm:4.5.2"
@@ -9759,6 +9892,16 @@ __metadata:
     prelude-ls: ^1.2.1
     type-check: ~0.4.0
   checksum: 12c5021c859bd0f5248561bf139121f0358285ec545ebf48bb3d346820d5c61a4309535c7f387ed7d84361cf821e124ce346c6b7cef8ee09a67c1473b46d0fc4
+  languageName: node
+  linkType: hard
+
+"lighthouse-logger@npm:^1.0.0":
+  version: 1.4.2
+  resolution: "lighthouse-logger@npm:1.4.2"
+  dependencies:
+    debug: ^2.6.9
+    marky: ^1.2.2
+  checksum: ba6b73d93424318fab58b4e07c9ed246e3e969a3313f26b69515ed4c06457dd9a0b11bc706948398fdaef26aa4ba5e65cb848c37ce59f470d3c6c450b9b79a33
   languageName: node
   linkType: hard
 
@@ -9848,6 +9991,13 @@ __metadata:
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
   checksum: a3f527d22c548f43ae31c861ada88b2637eb48ac6aa3eb56e82d44917971b8aa96fbb37aa60efea674dc4ee8c42074f90f7b1f772e9db375435f6c83a19b3bc6
+  languageName: node
+  linkType: hard
+
+"lodash.get@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "lodash.get@npm:4.4.2"
+  checksum: e403047ddb03181c9d0e92df9556570e2b67e0f0a930fcbbbd779370972368f5568e914f913e93f3b08f6d492abc71e14d4e9b7a18916c31fa04bd2306efe545
   languageName: node
   linkType: hard
 
@@ -10082,6 +10232,13 @@ __metadata:
   bin:
     marked: bin/marked.js
   checksum: 0db6817893952c3ec710eb9ceafb8468bf5ae38cb0f92b7b083baa13d70b19774674be04db5b817681fa7c5c6a088f61300815e4dd75a59696f4716ad69f6260
+  languageName: node
+  linkType: hard
+
+"marky@npm:^1.2.2":
+  version: 1.2.5
+  resolution: "marky@npm:1.2.5"
+  checksum: 823b946677749551cdfc3b5221685478b5d1b9cc0dc03eff977c6f9a615fb05c67559f9556cb3c0fcb941a9ea0e195e37befd83026443396ccee8b724f54f4c5
   languageName: node
   linkType: hard
 
@@ -10786,6 +10943,19 @@ __metadata:
   version: 1.0.5
   resolution: "nice-try@npm:1.0.5"
   checksum: 0b4af3b5bb5d86c289f7a026303d192a7eb4417231fe47245c460baeabae7277bcd8fd9c728fb6bd62c30b3e15cd6620373e2cf33353b095d8b403d3e8a15aff
+  languageName: node
+  linkType: hard
+
+"nise@npm:^4.0.4":
+  version: 4.1.0
+  resolution: "nise@npm:4.1.0"
+  dependencies:
+    "@sinonjs/commons": ^1.7.0
+    "@sinonjs/fake-timers": ^6.0.0
+    "@sinonjs/text-encoding": ^0.7.1
+    just-extend: ^4.0.2
+    path-to-regexp: ^1.7.0
+  checksum: b2ea1c96a41c392adf746509904af565ebd667ad4e40267f6d73be3648f04267945624ba0ce6a991b779f3ae246181f71975152b93b4dafee1f62886fa897c32
   languageName: node
   linkType: hard
 
@@ -11535,6 +11705,15 @@ __metadata:
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
   checksum: 49abf3d81115642938a8700ec580da6e830dde670be21893c62f4e10bd7dd4c3742ddc603fe24f898cba7eb0c6bc1777f8d9ac14185d34540c6d4d80cd9cae8a
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^1.7.0":
+  version: 1.8.0
+  resolution: "path-to-regexp@npm:1.8.0"
+  dependencies:
+    isarray: 0.0.1
+  checksum: 709f6f083c0552514ef4780cb2e7e4cf49b0cc89a97439f2b7cc69a608982b7690fb5d1720a7473a59806508fc2dae0be751ba49f495ecf89fd8fbc62abccbcd
   languageName: node
   linkType: hard
 
@@ -12900,6 +13079,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sinon@npm:^9.0.1":
+  version: 9.2.4
+  resolution: "sinon@npm:9.2.4"
+  dependencies:
+    "@sinonjs/commons": ^1.8.1
+    "@sinonjs/fake-timers": ^6.0.1
+    "@sinonjs/samsam": ^5.3.1
+    diff: ^4.0.2
+    nise: ^4.0.4
+    supports-color: ^7.1.0
+  checksum: 34b881886daa4b491bb9147ccad43d662f58b45a1b6f1e8b26a405ad77041108306fac3648646335f00f702897f0ba12282588ab64de470f48f1a7678e08dc65
+  languageName: node
+  linkType: hard
+
 "sisteransi@npm:^1.0.5":
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
@@ -13637,7 +13830,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-detect@npm:4.0.8":
+"type-detect@npm:4.0.8, type-detect@npm:^4.0.8":
   version: 4.0.8
   resolution: "type-detect@npm:4.0.8"
   checksum: 62b5628bff67c0eb0b66afa371bd73e230399a8d2ad30d852716efcc4656a7516904570cd8631a49a3ce57c10225adf5d0cbdcb47f6b0255fe6557c453925a15


### PR DESCRIPTION
### Description

Recently metro took a dependency on chromium-edge-launcher to launch edge and attach it to a RN instance.

Unfortunately, there is a bug in chromium-edge-launcher which prevents it from correctly finding Edge on Windows machines.  There has not been response from the maintainer, so we're forking it here to allow metro to bring in the fix.


Includes some typings and formatting fixes to allow compilation within the rnx-kit repo.