### PR TITLE
fix(cli): don't throw if Jest is not installed

### DIFF
--- a/.changeset/clever-donkeys-guess.md
+++ b/.changeset/clever-donkeys-guess.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Don't throw if Jest is not installed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,11 +49,11 @@
     "readline": "^1.3.0"
   },
   "peerDependencies": {
-    "jest-cli": ">=26.0",
+    "jest": ">=26.0",
     "react-native": ">=0.64"
   },
   "peerDependenciesMeta": {
-    "jest-cli": {
+    "jest": {
       "optional": true
     },
     "react-native": {
@@ -68,6 +68,8 @@
     "@rnx-kit/scripts": "*",
     "@types/connect": "^3.4.36",
     "@types/fs-extra": "^9.0.0",
+    "@types/jest": "^29.2.1",
+    "@types/node": "^18.0.0",
     "@types/node-fetch": "^2.6.5",
     "@types/qrcode": "^1.4.2",
     "eslint": "^8.0.0",
@@ -83,6 +85,7 @@
   "depcheck": {
     "ignoreMatches": [
       "connect",
+      "jest-cli",
       "readline"
     ]
   },

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -22,7 +22,7 @@ type Options = {
 };
 
 const COMMAND_NAME = "rnx-test";
-const DEP_CHAIN = ["jest", "jest-cli"];
+const JEST_CLI = ["jest", "jest-cli"];
 
 export function rnxTest(
   _argv: string[],
@@ -31,7 +31,7 @@ export function rnxTest(
 ): void {
   const runJest: (argv: string[]) => void = (() => {
     try {
-      const { run } = require(resolveDependencyChain(DEP_CHAIN, root));
+      const { run } = require(resolveDependencyChain(JEST_CLI, root));
       return run;
     } catch (e) {
       error("'rnx-test' is unavailable because 'jest' is not installed");
@@ -64,7 +64,7 @@ export function jestOptions(): Options[] {
   const options = (() => {
     const jestCliPath = (() => {
       try {
-        return resolveDependencyChain(DEP_CHAIN);
+        return resolveDependencyChain(JEST_CLI);
       } catch (_) {
         return undefined;
       }

--- a/packages/cli/test/test.test.ts
+++ b/packages/cli/test/test.test.ts
@@ -1,4 +1,4 @@
-import { jestOptions, resolveJestCli } from "../src/test";
+import { jestOptions } from "../src/test";
 
 describe("rnx-test", () => {
   test("retrieves options from 'jest-cli'", () => {
@@ -7,11 +7,5 @@ describe("rnx-test", () => {
 
     const updateSnapshot = options.find(({ name }) => name.startsWith("-u,"));
     expect(updateSnapshot).toBeDefined();
-  });
-
-  test("resolves 'jest-cli' starting from 'jest'", () => {
-    expect(resolveJestCli()).toMatch(
-      /node_modules[/\\]jest-cli[/\\]build[/\\]index.js$/
-    );
   });
 });

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -55,7 +55,7 @@
     "@rnx-kit/third-party-notices": "workspace:*",
     "@types/react": "^18.0.0",
     "eslint": "^8.0.0",
-    "jest-cli": "^29.2.1",
+    "jest": "^29.2.1",
     "metro-react-native-babel-preset": "^0.76.5",
     "prettier": "^3.0.0",
     "react-native-test-app": "^2.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,6 +3551,8 @@ __metadata:
     "@rnx-kit/tools-react-native": ^1.3.4
     "@types/connect": ^3.4.36
     "@types/fs-extra": ^9.0.0
+    "@types/jest": ^29.2.1
+    "@types/node": ^18.0.0
     "@types/node-fetch": ^2.6.5
     "@types/qrcode": ^1.4.2
     chalk: ^4.1.0
@@ -3570,10 +3572,10 @@ __metadata:
     type-fest: ^4.0.0
     typescript: ^5.0.0
   peerDependencies:
-    jest-cli: ">=26.0"
+    jest: ">=26.0"
     react-native: ">=0.64"
   peerDependenciesMeta:
-    jest-cli:
+    jest:
       optional: true
     react-native:
       optional: true
@@ -4208,7 +4210,7 @@ __metadata:
     "@rnx-kit/third-party-notices": "workspace:*"
     "@types/react": ^18.0.0
     eslint: ^8.0.0
-    jest-cli: ^29.2.1
+    jest: ^29.2.1
     metro-react-native-babel-preset: ^0.76.5
     prettier: ^3.0.0
     react: 18.2.0


### PR DESCRIPTION
### Description

Don't throw if Jest is not installed.

### Test plan

```
cd packages/test-app
yarn build --dependencies
yarn react-native rnx-test --help
# Expect: Jest options
```

Now open `packages/cli/lib/test.js` and introduce a typo to force Jest resolution to fail:

```diff
-const JEST_CLI = ["jest", "jest-cli"];
+const JEST_CLI = ["jest", "jestcli"];
```

Then in `packages/test-app`, re-run `yarn react-native rnx-test --help`. This should show significantly less options.