### PR TITLE
fix(eslint-plugin): prepare `no-export-all` for ESLint v9

### DIFF
--- a/.changeset/brave-goats-smoke.md
+++ b/.changeset/brave-goats-smoke.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/eslint-plugin": patch
+---
+
+Prepare `no-export-all` for ESLint v9

--- a/packages/eslint-plugin/src/rules/no-export-all.js
+++ b/packages/eslint-plugin/src/rules/no-export-all.js
@@ -150,17 +150,12 @@ const resolveFrom =
  * @returns {RuleContext}
  */
 function toRuleContext(context) {
-  /** @type {RuleContext["options"]} */
-  const defaultOptions = {
-    debug: false,
-    expand: "all",
-    maxDepth: 5,
-  };
-
   return {
     id: context.id,
     options: {
-      ...defaultOptions,
+      debug: false,
+      expand: "all",
+      maxDepth: 5,
       ...(context.options && context.options[0]),
     },
     filename: context.filename || context.getFilename(),


### PR DESCRIPTION
### Description

Prepare `no-export-all` for ESLint v9: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/

### Test plan

Modify `align-deps` to trigger the rule:

```diff
diff --git a/packages/align-deps/src/index.ts b/packages/align-deps/src/index.ts
index 21280853..910e2b52 100644
--- a/packages/align-deps/src/index.ts
+++ b/packages/align-deps/src/index.ts
@@ -9,15 +9,4 @@ export { cli, cliOptions } from "./cli";
 export { checkPackageManifest } from "./commands/check";
 export { checkPackageManifestUnconfigured } from "./commands/vigilant";
 export { updatePackageManifest } from "./manifest";
-export type {
-  Args,
-  Command,
-  DependencyType,
-  ExcludedPackage,
-  ManifestProfile,
-  MetaPackage,
-  Options,
-  Package,
-  Preset,
-  Profile,
-} from "./types";
+export type * from "./types";
```

Then run lint:

```
yarn lint
```