### PR TITLE
feat(metro-serializer-esbuild): add `drop` and `pure` options

### DIFF
--- a/.changeset/popular-meals-dance.md
+++ b/.changeset/popular-meals-dance.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Added [`drop`](https://esbuild.github.io/api/#drop) and [`pure`](https://esbuild.github.io/api/#pure) options

--- a/packages/metro-serializer-esbuild/README.md
+++ b/packages/metro-serializer-esbuild/README.md
@@ -139,6 +139,16 @@ by disabling this if you haven't migrated to Fabric yet.
 
 Defaults to `false`.
 
+### `drop`
+
+Tells esbuild to edit your source code before building to drop certain
+constructs. There are currently two possible things that can be dropped:
+`debugger` and `console`.
+
+See the full documentation at https://esbuild.github.io/api/#drop.
+
+By default, this option is not set.
+
 ### `minify`
 
 When enabled, the generated code will be minified instead of pretty-printed.
@@ -168,6 +178,15 @@ By default, this option is not set.
 Same as `minify` but only rewrites syntax to be more compact.
 
 See the full documentation at https://esbuild.github.io/api/#minify.
+
+By default, this option is not set.
+
+### `pure`
+
+Add `/* @__PURE__ */` annotation to the specified new or call expressions. This
+tells esbuild they can be removed if the resulting value is unused.
+
+See the full documentation at https://esbuild.github.io/api/#pure.
 
 By default, this option is not set.
 

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -19,11 +19,13 @@ export { esbuildTransformerConfig } from "./esbuildTransformerConfig";
 
 export type Options = Pick<
   BuildOptions,
+  | "drop"
   | "logLevel"
   | "minify"
   | "minifyWhitespace"
   | "minifyIdentifiers"
   | "minifySyntax"
+  | "pure"
   | "target"
 > & {
   analyze?: boolean | "verbose";
@@ -380,6 +382,7 @@ export function MetroSerializer(
           __METRO_GLOBAL_PREFIX__: "''",
           global: "global",
         },
+        drop: buildOptions?.drop,
         entryPoints: [entryPoint],
         inject: [
           /**
@@ -402,6 +405,7 @@ export function MetroSerializer(
         minifySyntax: buildOptions?.minifySyntax,
         outfile,
         plugins,
+        pure: buildOptions?.pure,
         sourcemap: Boolean(options.sourceMapUrl) && "linked",
         target,
         supported: (() => {


### PR DESCRIPTION
### Description

Added [`drop`](https://esbuild.github.io/api/#drop) and [`pure`](https://esbuild.github.io/api/#pure) options

### Test plan

n/a