### PR TITLE
ci: fix publish failing in pnpm mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,10 @@ jobs:
           fetch-depth: 0
       - name: Setup the toolchain
         uses: ./.github/actions/setup-toolchain
+        with:
+          # `npm pack` fails in pnpm mode when using npm 9+ (bundled with Node 18+)
+          # See also: https://github.com/npm/cli/issues/5007
+          node-version: "16"
       - name: Install package dependencies
         run: |
           yarn


### PR DESCRIPTION
### Description

`npm pack` fails in pnpm mode when using npm 9+ 

```
34 timing arborist:ctor Completed in 0ms
35 timing command:pack Completed in 1016ms
36 verbose stack TypeError: Cannot set properties of null (setting 'peer')
36 verbose stack     at visit (~/.local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/calc-dep-flags.js:101:54)
36 verbose stack     at visitNode (~/.local/lib/node_modules/npm/node_modules/treeverse/lib/depth-descent.js:58:25)
36 verbose stack     at next (~/.local/lib/node_modules/npm/node_modules/treeverse/lib/depth-descent.js:44:19)
36 verbose stack     at depth (~/.local/lib/node_modules/npm/node_modules/treeverse/lib/depth-descent.js:83:10)
36 verbose stack     at depth (~/.local/lib/node_modules/npm/node_modules/treeverse/lib/depth.js:27:12)
36 verbose stack     at unsetFlag (~/.local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/calc-dep-flags.js:96:5)
36 verbose stack     at ~/.local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/calc-dep-flags.js:63:7
36 verbose stack     at Map.forEach (<anonymous>)
36 verbose stack     at calcDepFlagsStep (~/.local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/calc-dep-flags.js:41:17)
36 verbose stack     at visit (~/.local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/calc-dep-flags.js:12:20)
37 verbose cwd ~/Source/rnx-kit/packages/eslint-plugin
38 verbose Darwin 23.1.0
39 verbose node v20.9.0
40 verbose npm  v10.1.0
41 error Cannot set properties of null (setting 'peer')
42 verbose exit 1
```

### Test plan

Switch to Node 16, run `npm pack` in one of the packages.