### PR TITLE
fix(metro-serializer-esbuild): polyfill `Symbol.asyncIterator` as necessary

### DIFF
--- a/.changeset/early-hounds-hide.md
+++ b/.changeset/early-hounds-hide.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+esbuild [0.19.6](https://github.com/evanw/esbuild/releases/tag/v0.19.6) no longer throws when a `Symbol` is missing

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -26,8 +26,7 @@
     "@rnx-kit/tools-react-native": "^1.3.4",
     "esbuild": "^0.19.0",
     "esbuild-plugin-lodash": "^1.2.0",
-    "fast-glob": "^3.2.7",
-    "semver": "^7.0.0"
+    "fast-glob": "^3.2.7"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
@@ -44,7 +43,6 @@
     "@rnx-kit/scripts": "*",
     "@types/jest": "^29.2.1",
     "@types/node": "^20.0.0",
-    "@types/semver": "^7.0.0",
     "eslint": "^8.0.0",
     "jest": "^29.2.1",
     "lodash-es": "^4.17.21",

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -1,19 +1,15 @@
 import { info, warn } from "@rnx-kit/console";
 import type { MetroPlugin } from "@rnx-kit/metro-serializer";
-import { findPackage, readPackage } from "@rnx-kit/tools-node/package";
-import {
-  findMetroPath,
-  getMetroVersion,
-} from "@rnx-kit/tools-react-native/metro";
+import { findMetroPath } from "@rnx-kit/tools-react-native/metro";
 import type { BuildOptions, BuildResult, Plugin } from "esbuild";
 import * as esbuild from "esbuild";
 import * as fs from "fs";
-import type { Module, ReadOnlyDependencies } from "metro";
 import type { SerializerConfigT } from "metro-config";
 import * as path from "path";
-import * as semver from "semver";
+import { getModulePath, getSideEffects, isImporting, outputOf } from "./module";
 import { polyfillAsyncIteratorSymbol } from "./polyfills";
-import { absolutizeSourceMap, generateSourceMappingURL } from "./sourceMap";
+import { absolutizeSourceMap } from "./sourceMap";
+import { assertVersion } from "./version";
 
 export { esbuildTransformerConfig } from "./esbuildTransformerConfig";
 
@@ -35,134 +31,14 @@ export type Options = Pick<
   strictMode?: boolean;
 };
 
-function assertVersion(requiredVersion: string): void {
-  const version = getMetroVersion();
-  if (!version) {
-    throw new Error(`Metro version ${requiredVersion} is required`);
-  }
-
-  if (!semver.satisfies(version, requiredVersion)) {
-    throw new Error(
-      `Metro version ${requiredVersion} is required; got ${version}`
-    );
-  }
-}
-
 function escapePath(path: string): string {
   return path.replace(/\\+/g, "\\\\");
-}
-
-function getModulePath(moduleName: string, parent: Module): string | undefined {
-  const p = parent.dependencies.get(moduleName)?.absolutePath;
-  if (p) {
-    return p;
-  }
-
-  // In Metro 0.72.0, the key changed from module name to a unique key in order
-  // to support features such as `require.context`. For more details, see
-  // https://github.com/facebook/metro/commit/52e1a00ffb124914a95e78e9f60df1bc2e2e7bf0.
-  for (const [, value] of parent.dependencies) {
-    if (value.data.name === moduleName) {
-      return value.absolutePath;
-    }
-  }
-
-  return undefined;
-}
-
-/**
- * Returns whether the specified module has any side effects.
- *
- * For details on how this field works, please see
- * https://webpack.js.org/guides/tree-shaking/.
- *
- * @param modulePath Absolute path to a module
- * @returns Whether the specified module has any side effects.
- */
-const getSideEffects = (() => {
-  const pkgCache: Record<string, boolean | string[] | undefined> = {};
-  const getSideEffectsFromCache = (pkgJson: string) => {
-    if (!(pkgJson in pkgCache)) {
-      const { sideEffects } = readPackage(pkgJson);
-      if (Array.isArray(sideEffects)) {
-        const fg = require("fast-glob");
-        pkgCache[pkgJson] = fg
-          .sync(sideEffects, {
-            cwd: path.dirname(pkgJson),
-            absolute: true,
-          })
-          .map((p: string) => p.replace(/[/\\]/g, path.sep));
-      } else if (typeof sideEffects === "boolean") {
-        pkgCache[pkgJson] = sideEffects;
-      } else {
-        pkgCache[pkgJson] = undefined;
-      }
-    }
-    return pkgCache[pkgJson];
-  };
-  return (modulePath: string): boolean | undefined => {
-    const pkgJson = findPackage(modulePath);
-    if (!pkgJson) {
-      return undefined;
-    }
-
-    const sideEffects = getSideEffectsFromCache(pkgJson);
-    return Array.isArray(sideEffects)
-      ? sideEffects.includes(modulePath)
-      : sideEffects;
-  };
-})();
-
-function isImporting(
-  moduleName: string,
-  dependencies: ReadOnlyDependencies
-): boolean {
-  const iterator = dependencies.keys();
-  for (let key = iterator.next(); !key.done; key = iterator.next()) {
-    if (key.value.includes(moduleName)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 function isRedundantPolyfill(modulePath: string): boolean {
   // __prelude__: The content of `__prelude__` is passed to esbuild with `define`
   // polyfills/require.js: `require` is already provided by esbuild
   return /(?:__prelude__|[/\\]polyfills[/\\]require.js)$/.test(modulePath);
-}
-
-function outputOf(
-  module: Module | undefined,
-  logLevel: BuildOptions["logLevel"]
-): string | undefined {
-  if (!module) {
-    return undefined;
-  }
-
-  const jsModules = module.output.filter(({ type }) => type.startsWith("js/"));
-  if (jsModules.length !== 1) {
-    throw new Error(
-      `Modules must have exactly one JS output, but ${module.path} has ${jsModules.length}`
-    );
-  }
-
-  const code = jsModules[0].data.code;
-  const moduleWithModuleNameOnly = {
-    ...module,
-    // esbuild only needs the base file name. It derives the path from the
-    // imported path, and appends the file name to it. If we don't trim the path
-    // here, we will end up with "double" paths, e.g.
-    // `src/Users/<user>/Source/rnx-kit/packages/test-app/src/App.native.tsx`.
-    path: path.basename(module.path),
-  };
-
-  if (logLevel === "debug" && code.includes("export * from")) {
-    const modulePath = path.relative(process.cwd(), module.path);
-    warn(`Found uses of 'export *' in ${modulePath}`);
-  }
-
-  return `${code}\n${generateSourceMappingURL([moduleWithModuleNameOnly])}\n`;
 }
 
 /**
@@ -172,7 +48,7 @@ export function MetroSerializer(
   metroPlugins: MetroPlugin[] = [],
   buildOptions?: Options
 ): SerializerConfigT["customSerializer"] {
-  assertVersion(">=0.66.1");
+  assertVersion("0.66.1");
 
   // Signal to every plugin that we're using esbuild.
   process.env["RNX_METRO_SERIALIZER_ESBUILD"] = "true";
@@ -348,7 +224,7 @@ export function MetroSerializer(
                  * @see https://github.com/evanw/esbuild/pull/3194
                  * @see https://github.com/facebook/hermes/issues/820
                  */
-                polyfillAsyncIteratorSymbol(target),
+                polyfillAsyncIteratorSymbol(esbuild, target),
               ].join("\n"),
             };
           }

--- a/packages/metro-serializer-esbuild/src/module.ts
+++ b/packages/metro-serializer-esbuild/src/module.ts
@@ -1,0 +1,116 @@
+import { warn } from "@rnx-kit/console";
+import { findPackage, readPackage } from "@rnx-kit/tools-node/package";
+import type { BuildOptions } from "esbuild";
+import type { Module, ReadOnlyDependencies } from "metro";
+import * as path from "path";
+import { generateSourceMappingURL } from "./sourceMap";
+
+export function getModulePath(
+  moduleName: string,
+  parent: Module
+): string | undefined {
+  const p = parent.dependencies.get(moduleName)?.absolutePath;
+  if (p) {
+    return p;
+  }
+
+  // In Metro 0.72.0, the key changed from module name to a unique key in order
+  // to support features such as `require.context`. For more details, see
+  // https://github.com/facebook/metro/commit/52e1a00ffb124914a95e78e9f60df1bc2e2e7bf0.
+  for (const [, value] of parent.dependencies) {
+    if (value.data.name === moduleName) {
+      return value.absolutePath;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Returns whether the specified module has any side effects.
+ *
+ * For details on how this field works, please see
+ * https://webpack.js.org/guides/tree-shaking/.
+ *
+ * @param modulePath Absolute path to a module
+ * @returns Whether the specified module has any side effects.
+ */
+export const getSideEffects = (() => {
+  const pkgCache: Record<string, boolean | string[] | undefined> = {};
+  const getSideEffectsFromCache = (pkgJson: string) => {
+    if (!(pkgJson in pkgCache)) {
+      const { sideEffects } = readPackage(pkgJson);
+      if (Array.isArray(sideEffects)) {
+        const fg = require("fast-glob");
+        pkgCache[pkgJson] = fg
+          .sync(sideEffects, {
+            cwd: path.dirname(pkgJson),
+            absolute: true,
+          })
+          .map((p: string) => p.replace(/[/\\]/g, path.sep));
+      } else if (typeof sideEffects === "boolean") {
+        pkgCache[pkgJson] = sideEffects;
+      } else {
+        pkgCache[pkgJson] = undefined;
+      }
+    }
+    return pkgCache[pkgJson];
+  };
+  return (modulePath: string): boolean | undefined => {
+    const pkgJson = findPackage(modulePath);
+    if (!pkgJson) {
+      return undefined;
+    }
+
+    const sideEffects = getSideEffectsFromCache(pkgJson);
+    return Array.isArray(sideEffects)
+      ? sideEffects.includes(modulePath)
+      : sideEffects;
+  };
+})();
+
+export function isImporting(
+  moduleName: string,
+  dependencies: ReadOnlyDependencies
+): boolean {
+  const iterator = dependencies.keys();
+  for (let key = iterator.next(); !key.done; key = iterator.next()) {
+    if (key.value.includes(moduleName)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function outputOf(
+  module: Module | undefined,
+  logLevel: BuildOptions["logLevel"]
+): string | undefined {
+  if (!module) {
+    return undefined;
+  }
+
+  const jsModules = module.output.filter(({ type }) => type.startsWith("js/"));
+  if (jsModules.length !== 1) {
+    throw new Error(
+      `Modules must have exactly one JS output, but ${module.path} has ${jsModules.length}`
+    );
+  }
+
+  const code = jsModules[0].data.code;
+  const moduleWithModuleNameOnly = {
+    ...module,
+    // esbuild only needs the base file name. It derives the path from the
+    // imported path, and appends the file name to it. If we don't trim the path
+    // here, we will end up with "double" paths, e.g.
+    // `src/Users/<user>/Source/rnx-kit/packages/test-app/src/App.native.tsx`.
+    path: path.basename(module.path),
+  };
+
+  if (logLevel === "debug" && code.includes("export * from")) {
+    const modulePath = path.relative(process.cwd(), module.path);
+    warn(`Found uses of 'export *' in ${modulePath}`);
+  }
+
+  return `${code}\n${generateSourceMappingURL([moduleWithModuleNameOnly])}\n`;
+}

--- a/packages/metro-serializer-esbuild/src/polyfills.ts
+++ b/packages/metro-serializer-esbuild/src/polyfills.ts
@@ -1,10 +1,18 @@
+import { v } from "./version";
+
 function isHermes(target: string | string[]): boolean {
   const isHermes = (t: string) => t.startsWith("hermes");
   return Array.isArray(target) ? target.some(isHermes) : isHermes(target);
 }
 
-export function polyfillAsyncIteratorSymbol(target: string | string[]): string {
-  return isHermes(target)
+export function polyfillAsyncIteratorSymbol(
+  esbuild: { version: string },
+  target: string | string[]
+): string {
+  // No longer needed in 0.19.6:
+  // https://github.com/evanw/esbuild/releases/tag/v0.19.6
+  const isNeeded = v(esbuild.version) < v("0.19.6");
+  return isNeeded && isHermes(target)
     ? `if (!Symbol.asyncIterator) { Symbol.asyncIterator = Symbol.for("Symbol.asyncIterator"); }`
     : "";
 }

--- a/packages/metro-serializer-esbuild/src/version.ts
+++ b/packages/metro-serializer-esbuild/src/version.ts
@@ -1,0 +1,19 @@
+import { getMetroVersion } from "@rnx-kit/tools-react-native/metro";
+
+export function v(version: string): number {
+  const [major, minor = 0, patch = 0] = version.split("-")[0].split(".");
+  return Number(major) * 1000000 + Number(minor) * 1000 + Number(patch);
+}
+
+export function assertVersion(requiredVersion: string): void {
+  const version = getMetroVersion();
+  if (!version) {
+    throw new Error(`Metro version >=${requiredVersion} is required`);
+  }
+
+  if (v(version) < v(requiredVersion)) {
+    throw new Error(
+      `Metro version >=${requiredVersion} is required; got ${version}`
+    );
+  }
+}

--- a/packages/metro-serializer-esbuild/test/polyfillAsyncIteratorSymbol.test.ts
+++ b/packages/metro-serializer-esbuild/test/polyfillAsyncIteratorSymbol.test.ts
@@ -1,18 +1,64 @@
 import { polyfillAsyncIteratorSymbol } from "../src/polyfills";
 
 describe("polyfillAsyncIteratorSymbol()", () => {
+  const esbuild = {
+    "0.18.8": { version: "0.18.8" }, // Lowering `async` generator functions introduced
+    "0.19.5": { version: "0.19.5" },
+    "0.19.6": { version: "0.19.6" }, // `Symbol.asyncIterator` introduced
+  };
+
   test("returns empty string for non-Hermes targets", () => {
-    expect(polyfillAsyncIteratorSymbol("es5")).toBeFalsy();
-    expect(polyfillAsyncIteratorSymbol("es6")).toBeFalsy();
+    expect(polyfillAsyncIteratorSymbol(esbuild["0.18.8"], "es5")).toBeFalsy();
+    expect(polyfillAsyncIteratorSymbol(esbuild["0.18.8"], "es6")).toBeFalsy();
+
+    expect(polyfillAsyncIteratorSymbol(esbuild["0.19.5"], "es5")).toBeFalsy();
+    expect(polyfillAsyncIteratorSymbol(esbuild["0.19.5"], "es6")).toBeFalsy();
+
+    expect(polyfillAsyncIteratorSymbol(esbuild["0.19.6"], "es5")).toBeFalsy();
+    expect(polyfillAsyncIteratorSymbol(esbuild["0.19.6"], "es6")).toBeFalsy();
   });
 
   test("returns polyfill for Hermes targets", () => {
-    expect(polyfillAsyncIteratorSymbol("hermes")).toBeTruthy();
-    expect(polyfillAsyncIteratorSymbol("hermes0.7.0")).toBeTruthy();
-    expect(polyfillAsyncIteratorSymbol("hermes0.12.0")).toBeTruthy();
+    expect(
+      polyfillAsyncIteratorSymbol(esbuild["0.18.8"], "hermes")
+    ).toBeTruthy();
+    expect(
+      polyfillAsyncIteratorSymbol(esbuild["0.18.8"], "hermes0.7.0")
+    ).toBeTruthy();
+    expect(
+      polyfillAsyncIteratorSymbol(esbuild["0.18.8"], "hermes0.12.0")
+    ).toBeTruthy();
+
+    expect(
+      polyfillAsyncIteratorSymbol(esbuild["0.19.5"], "hermes")
+    ).toBeTruthy();
+    expect(
+      polyfillAsyncIteratorSymbol(esbuild["0.19.5"], "hermes0.7.0")
+    ).toBeTruthy();
+    expect(
+      polyfillAsyncIteratorSymbol(esbuild["0.19.5"], "hermes0.12.0")
+    ).toBeTruthy();
+
+    expect(
+      polyfillAsyncIteratorSymbol(esbuild["0.19.6"], "hermes")
+    ).toBeFalsy();
+    expect(
+      polyfillAsyncIteratorSymbol(esbuild["0.19.6"], "hermes0.7.0")
+    ).toBeFalsy();
+    expect(
+      polyfillAsyncIteratorSymbol(esbuild["0.19.6"], "hermes0.12.0")
+    ).toBeFalsy();
   });
 
   test("returns polyfill if Hermes is one of the targets", () => {
-    expect(polyfillAsyncIteratorSymbol(["es6", "hermes0.7.0"])).toBeTruthy();
+    expect(
+      polyfillAsyncIteratorSymbol(esbuild["0.18.8"], ["es6", "hermes0.7.0"])
+    ).toBeTruthy();
+    expect(
+      polyfillAsyncIteratorSymbol(esbuild["0.19.5"], ["es6", "hermes0.7.0"])
+    ).toBeTruthy();
+    expect(
+      polyfillAsyncIteratorSymbol(esbuild["0.19.6"], ["es6", "hermes0.7.0"])
+    ).toBeFalsy();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3937,7 +3937,6 @@ __metadata:
     "@rnx-kit/tools-react-native": ^1.3.4
     "@types/jest": ^29.2.1
     "@types/node": ^20.0.0
-    "@types/semver": ^7.0.0
     esbuild: ^0.19.0
     esbuild-plugin-lodash: ^1.2.0
     eslint: ^8.0.0
@@ -3951,7 +3950,6 @@ __metadata:
     prettier: ^3.0.0
     react: 18.2.0
     react-native: ^0.72.0
-    semver: ^7.0.0
     typescript: ^5.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Description

esbuild [0.19.6](https://github.com/evanw/esbuild/releases/tag/v0.19.6) no longer throws when a `Symbol` is missing

### Test plan

n/a