### PR TITLE
docs: use the new alerts syntax

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # The `rnx-kit` roadmap
 
-> **Disclaimer**
+> [!IMPORTANT]
 >
 > This document conveys what we (the maintainers of `rnx-kit`) want to achieve
 > with it. Whether we have resources to fund all the efforts to reach these
@@ -178,7 +178,7 @@ same folks maintaining `rnx-kit`. It currently does not support/target web.
 In the long term, we want `react-native-test-app` to be the best choice for
 developers, whether they are working on a library or a standalone app.
 
-> **Note**
+> [!NOTE]
 >
 > - For efforts towards making it easier to build, see
 >   [Building native](#building-native).
@@ -203,7 +203,7 @@ write one yourself. We want to shift the mindset from "what packages to use" to
 Standard APIs is what will make the "web browser" effort truly ubiquitous. We
 cannot provide a complete downloadable app for development without this.
 
-> **Note**
+> [!NOTE]
 >
 > - The RFC for this effort is here: [React Native WebAPIs][]
 > - This section only relates to the Web APIs. For the DOM counterpart of this

--- a/incubator/@react-native-webapis/battery-status/README.md
+++ b/incubator/@react-native-webapis/battery-status/README.md
@@ -12,7 +12,7 @@
 [Battery Status API](https://developer.mozilla.org/en-US/docs/Web/API/Battery_Status_API)
 for React Native.
 
-> **Note**
+> [!NOTE]
 >
 > This is purely a prototype for the
 > [React Native WebAPIs RFC](https://github.com/microsoft/rnx-kit/pull/2504). It

--- a/packages/metro-resolver-symlinks/README.md
+++ b/packages/metro-resolver-symlinks/README.md
@@ -67,7 +67,9 @@ everything in their main JS file.
  });
 ```
 
-> **Sidenote:** When Metro releases a version with the ability to set a
+> [!TIP]
+>
+> When Metro releases a version with the ability to set a
 > [custom resolver for Haste requests](https://github.com/facebook/metro/commit/96fb6e904e1660b37f4d1f5353ca1e5477c4afbf),
 > this way of remapping modules is preferable over
 > `@rnx-kit/babel-plugin-import-path-remapper`. The Babel plugin mutates the AST


### PR DESCRIPTION
### Description

Use the new [alerts syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).

### Test plan

n/a