### PR TITLE
feat(react-native-host): bump C++ language standard to C++20

### DIFF
--- a/.changeset/slimy-bees-attend.md
+++ b/.changeset/slimy-bees-attend.md
@@ -1,0 +1,8 @@
+---
+"@rnx-kit/react-native-host": minor
+---
+
+Bump C++ language standard to C++20
+
+This will unfortunately break `react-native` versions 0.65 and below, but is
+neccessary to support 0.74 and above.

--- a/packages/react-native-host/ReactNativeHost.podspec
+++ b/packages/react-native-host/ReactNativeHost.podspec
@@ -9,7 +9,14 @@ repository = package['repository']
 repo_dir = repository['directory']
 
 new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
-preprocessor_definitions = ['FOLLY_NO_CONFIG=1', 'FOLLY_MOBILE=1', 'FOLLY_USE_LIBCPP=1']
+preprocessor_definitions = [
+  'FOLLY_CFG_NO_COROUTINES=1',
+  'FOLLY_HAVE_CLOCK_GETTIME=1',
+  'FOLLY_HAVE_PTHREAD=1',
+  'FOLLY_MOBILE=1',
+  'FOLLY_NO_CONFIG=1',
+  'FOLLY_USE_LIBCPP=1',
+]
 if new_arch_enabled
   preprocessor_definitions << 'RCT_NEW_ARCH_ENABLED=1'
   preprocessor_definitions << 'USE_FABRIC=1'
@@ -42,7 +49,7 @@ Pod::Spec.new do |s|
   end
 
   s.pod_target_xcconfig = {
-    'CLANG_CXX_LANGUAGE_STANDARD' => 'gnu++17',
+    'CLANG_CXX_LANGUAGE_STANDARD' => 'gnu++20',
     'DEFINES_MODULE' => 'YES',
     'GCC_PREPROCESSOR_DEFINITIONS' => preprocessor_definitions,
     'HEADER_SEARCH_PATHS' => [

--- a/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
+++ b/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
@@ -1,6 +1,12 @@
 #import "RNXTurboModuleAdapter.h"
 
-#define FOLLY_NO_CONFIG 1
+#include <folly/Portability.h>
+#if FOLLY_HAS_COROUTINES
+// TODO: `FOLLY_CFG_NO_COROUTINES` was added in 0.73. We can drop this block
+// when we drop support for 0.72:
+// https://github.com/facebook/react-native/commit/17154a661fe06ed25bf599f47bd4193eba011971
+#define FOLLY_HAS_COROUTINES 0
+#endif
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcomma"
 #import <cxxreact/JSExecutor.h>

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -1,6 +1,12 @@
 #import "ReactNativeHost.h"
 
-#define FOLLY_NO_CONFIG 1
+#include <folly/Portability.h>
+#if FOLLY_HAS_COROUTINES
+// TODO: `FOLLY_CFG_NO_COROUTINES` was added in 0.73. We can drop this block
+// when we drop support for 0.72:
+// https://github.com/facebook/react-native/commit/17154a661fe06ed25bf599f47bd4193eba011971
+#define FOLLY_HAS_COROUTINES 0
+#endif
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcomma"
 #import <cxxreact/JSExecutor.h>

--- a/packages/react-native-host/package.json
+++ b/packages/react-native-host/package.json
@@ -24,7 +24,7 @@
     "lint:kt": "ktlint --relative 'android/src/**/*.kt'"
   },
   "peerDependencies": {
-    "react-native": ">=0.64"
+    "react-native": ">=0.66"
   },
   "devDependencies": {
     "@rnx-kit/scripts": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4136,7 +4136,7 @@ __metadata:
     "@rnx-kit/scripts": "*"
     prettier: ^3.0.0
   peerDependencies:
-    react-native: ">=0.64"
+    react-native: ">=0.66"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

`react-native` has updated Folly and bumped C++ language standard. This will break 0.65 and below.

See also https://github.com/microsoft/react-native-test-app/pull/1714.

### Test plan

In `react-native-test-app`, verify that nightly builds:

```sh
git checkout tido/3.0
npm run set-react-version nightly
yarn clean
yarn
# Copy changes into node_modules/@rnx-kit/react-native-host/ReactNativeHost.podspec
cd example
rm ios/Podfile.lock
pod install --project-directory=ios
yarn ios
```

Verify that 0.66 still works:

```sh
npm run set-react-version 0.66
yarn clean
yarn
# Copy changes into node_modules/@rnx-kit/react-native-host/ReactNativeHost.podspec
cd example
rm ios/Podfile.lock
pod install --project-directory=ios
yarn ios
```