### PR TITLE
fix(react-native-host): fix New Arch not building

### DIFF
--- a/.changeset/thin-dragons-invite.md
+++ b/.changeset/thin-dragons-invite.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Fix New Arch not building because `folly::coro` was unintentionally enabled

--- a/packages/react-native-host/cocoa/FollyConfig.h
+++ b/packages/react-native-host/cocoa/FollyConfig.h
@@ -1,0 +1,7 @@
+#include <folly/Portability.h>
+#if FOLLY_HAS_COROUTINES
+// TODO: `FOLLY_CFG_NO_COROUTINES` was added in 0.73. We can drop this block
+// when we drop support for 0.72:
+// https://github.com/facebook/react-native/commit/17154a661fe06ed25bf599f47bd4193eba011971
+#define FOLLY_HAS_COROUTINES 0
+#endif

--- a/packages/react-native-host/cocoa/RNXFabricAdapter.mm
+++ b/packages/react-native-host/cocoa/RNXFabricAdapter.mm
@@ -1,6 +1,7 @@
 #import "RNXFabricAdapter.h"
 
 #ifdef USE_FABRIC
+#include "FollyConfig.h"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcomma"
 #pragma clang diagnostic ignored "-Wdocumentation"

--- a/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
+++ b/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
@@ -1,12 +1,6 @@
 #import "RNXTurboModuleAdapter.h"
 
-#include <folly/Portability.h>
-#if FOLLY_HAS_COROUTINES
-// TODO: `FOLLY_CFG_NO_COROUTINES` was added in 0.73. We can drop this block
-// when we drop support for 0.72:
-// https://github.com/facebook/react-native/commit/17154a661fe06ed25bf599f47bd4193eba011971
-#define FOLLY_HAS_COROUTINES 0
-#endif
+#include "FollyConfig.h"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcomma"
 #import <cxxreact/JSExecutor.h>
@@ -90,7 +84,8 @@
 
 // MARK: - Private
 
-- (std::unique_ptr<facebook::react::JSExecutorFactory>)initJsExecutorFactoryWithBridge:(RCTBridge *)bridge
+- (std::unique_ptr<facebook::react::JSExecutorFactory>)initJsExecutorFactoryWithBridge:
+    (RCTBridge *)bridge
 {
 #if USE_RUNTIME_SCHEDULER
     _runtimeScheduler =

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -1,12 +1,6 @@
 #import "ReactNativeHost.h"
 
-#include <folly/Portability.h>
-#if FOLLY_HAS_COROUTINES
-// TODO: `FOLLY_CFG_NO_COROUTINES` was added in 0.73. We can drop this block
-// when we drop support for 0.72:
-// https://github.com/facebook/react-native/commit/17154a661fe06ed25bf599f47bd4193eba011971
-#define FOLLY_HAS_COROUTINES 0
-#endif
+#include "FollyConfig.h"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcomma"
 #import <cxxreact/JSExecutor.h>


### PR DESCRIPTION
### Description

Fix New Arch not building because `folly::coro` was unintentionally enabled.

### Test plan

See https://github.com/microsoft/react-native-test-app/pull/1600.