### PR TITLE
fix(cli): automatically compose source maps for Hermes bundle

### DIFF
--- a/.changeset/afraid-suns-live.md
+++ b/.changeset/afraid-suns-live.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-react-native": patch
+---
+
+Allow importing `metro-source-map` via `metro`

--- a/.changeset/red-turkeys-trade.md
+++ b/.changeset/red-turkeys-trade.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Automatically compose source maps of the JS and Hermes bytecode bundles

--- a/packages/tools-react-native/package.json
+++ b/packages/tools-react-native/package.json
@@ -59,6 +59,7 @@
     "metro-config": "^0.76.5",
     "metro-core": "^0.76.5",
     "metro-resolver": "^0.76.5",
+    "metro-source-map": "^0.76.5",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"
   },

--- a/packages/tools-react-native/src/metro.ts
+++ b/packages/tools-react-native/src/metro.ts
@@ -10,7 +10,8 @@ type MetroImport =
   | typeof import("metro/src/shared/output/bundle")
   | typeof import("metro-config")
   | typeof import("metro-core")
-  | typeof import("metro-resolver");
+  | typeof import("metro-resolver")
+  | typeof import("metro-source-map");
 
 type MetroModule =
   | "metro"
@@ -19,7 +20,8 @@ type MetroModule =
   | "metro/src/shared/output/bundle"
   | "metro-config"
   | "metro-core"
-  | "metro-resolver";
+  | "metro-resolver"
+  | "metro-source-map";
 
 function resolveFrom(name: string, startDir: string): string | undefined {
   return findPackageDependencyDir(name, {
@@ -109,6 +111,11 @@ export function requireModuleFromMetro(
   moduleName: "metro-resolver",
   fromDir?: string
 ): typeof import("metro-resolver");
+
+export function requireModuleFromMetro(
+  moduleName: "metro-source-map",
+  fromDir?: string
+): typeof import("metro-source-map");
 
 /**
  * Imports specified module starting from the installation directory of the

--- a/yarn.lock
+++ b/yarn.lock
@@ -4386,6 +4386,7 @@ __metadata:
     metro-config: ^0.76.5
     metro-core: ^0.76.5
     metro-resolver: ^0.76.5
+    metro-source-map: ^0.76.5
     prettier: ^3.0.0
     typescript: ^5.0.0
   languageName: unknown
@@ -10638,7 +10639,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-source-map@npm:0.76.8, metro-source-map@npm:^0.76.8":
+"metro-source-map@npm:0.76.8, metro-source-map@npm:^0.76.5, metro-source-map@npm:^0.76.8":
   version: 0.76.8
   resolution: "metro-source-map@npm:0.76.8"
   dependencies:


### PR DESCRIPTION
### Description

Automatically compose source maps of the JS bundle and Hermes bytecode bundle.

### Test plan

```
cd packages/test-app
yarn build --dependencies
yarn bundle+esbuild --dev false --platform android
```

Verify that `dist/main+esbuild.android.hbc.map` points to source files instead of `dist/main+esbuild.android.bundle`