### PR TITLE
fix(react-native-host): handle refactorings in 0.74

### DIFF
--- a/.changeset/late-kids-fry.md
+++ b/.changeset/late-kids-fry.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Handle refactorings in 0.74

--- a/packages/react-native-host/ReactNativeHost.podspec
+++ b/packages/react-native-host/ReactNativeHost.podspec
@@ -8,7 +8,7 @@ version = package['version']
 repository = package['repository']
 repo_dir = repository['directory']
 
-new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1' && ENV['USE_NEW_ARCH'] != '0'
 preprocessor_definitions = [
   'FOLLY_CFG_NO_COROUTINES=1',
   'FOLLY_HAVE_CLOCK_GETTIME=1',


### PR DESCRIPTION
### Description

Handle refactorings in 0.74

### Test plan

In `react-native-test-app`:

```
npm run set-react-version 0.74
yarn
cd example
pod install --project-directory=ios
yarn ios

# New Architecture
RCT_NEW_ARCH_ENABLED=1 pod install --project-directory=ios
yarn ios
```

| Old Arch | New Arch |
| :-: | :-: |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-01-11 at 14 12 20](https://github.com/microsoft/rnx-kit/assets/4123478/a18edfb3-84b2-4f6c-b0d5-fd70fd340df2) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-11 at 14 08 57](https://github.com/microsoft/rnx-kit/assets/4123478/14c8be02-aede-4426-87f4-973a1427fd14) |