### PR TITLE
docs: use populated github token link

### DIFF
--- a/incubator/rn-changelog-generator/README.md
+++ b/incubator/rn-changelog-generator/README.md
@@ -89,6 +89,6 @@ parameter which may be necessary in case Github API rate-limits your requests.
 
 Instructions to create a GitHub ‘personal access token’:
 
-1. Visit the [token settings page](https://github.com/settings/tokens).
+1. Visit the [token settings page](https://github.com/settings/tokens/new?description=rnx-kit%20changelog%20generator&scopes=public_repo).
 1. Generate a new token and **only** give it the `public_repo` scope.
 1. Store this token somewhere secure for future usage.


### PR DESCRIPTION
Set all the requirements through the url to the Github token generator page.

### Description

https://github.com/microsoft/rnx-kit/assets/49578/593a448a-0a74-4789-9857-25559160dc17

### Test plan

See video.
