### PR TITLE
fix(react-native-host): add support for bridgeless mode

### DIFF
--- a/.changeset/old-bottles-clean.md
+++ b/.changeset/old-bottles-clean.md
@@ -1,0 +1,12 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Added support for Bridgeless Mode
+
+Bridgeless mode can now be enabled by setting the environment variable
+`USE_BRIDGELESS=1`. This build flag will enable bridgeless bits, but you can
+still disable it at runtime by implementing `RNXHostConfig.isBridgelessEnabled`.
+
+See the full announcement here:
+https://reactnative.dev/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#new-architecture-updates

--- a/packages/react-native-host/ReactNativeHost.podspec
+++ b/packages/react-native-host/ReactNativeHost.podspec
@@ -16,10 +16,12 @@ preprocessor_definitions = [
   'FOLLY_MOBILE=1',
   'FOLLY_NO_CONFIG=1',
   'FOLLY_USE_LIBCPP=1',
+  "USE_HERMES=#{ENV['USE_HERMES'] || '0'}",
 ]
 if new_arch_enabled
   preprocessor_definitions << 'RCT_NEW_ARCH_ENABLED=1'
   preprocessor_definitions << 'USE_FABRIC=1'
+  preprocessor_definitions << 'USE_BRIDGELESS=1' if ENV['USE_BRIDGELESS'] == '1'
 end
 
 Pod::Spec.new do |s|

--- a/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
+++ b/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
@@ -1,0 +1,32 @@
+#if USE_BRIDGELESS
+
+#import <React/RCTSurfacePresenterBridgeAdapter.h>
+#import <ReactCommon/RCTHost+Internal.h>
+#import <ReactCommon/RCTHost.h>
+
+#if USE_HERMES
+#import <ReactCommon/RCTHermesInstance.h>
+#else
+#import <ReactCommon/RCTJscInstance.h>
+#endif  // USE_HERMES
+
+#import <react/config/ReactNativeConfig.h>
+
+#if __has_include(<react/runtime/JSEngineInstance.h>)
+using SharedJSRuntimeFactory = std::shared_ptr<facebook::react::JSEngineInstance>;
+#else
+using SharedJSRuntimeFactory = std::shared_ptr<facebook::react::JSRuntimeFactory>;
+#endif  // __has_include(<react/runtime/JSEngineInstance.h>)
+
+#elif USE_FABRIC
+
+#import <React/RCTSurfacePresenterBridgeAdapter.h>
+
+@class RCTHost;
+
+#else
+
+@class RCTHost;
+@class RCTSurfacePresenterBridgeAdapter;
+
+#endif  // USE_BRIDGELESS

--- a/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
+++ b/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
@@ -21,6 +21,7 @@ using SharedJSRuntimeFactory = std::shared_ptr<facebook::react::JSRuntimeFactory
 #elif USE_FABRIC
 
 #import <React/RCTSurfacePresenterBridgeAdapter.h>
+#import <react/config/ReactNativeConfig.h>
 
 @class RCTHost;
 
@@ -28,5 +29,12 @@ using SharedJSRuntimeFactory = std::shared_ptr<facebook::react::JSRuntimeFactory
 
 @class RCTHost;
 @class RCTSurfacePresenterBridgeAdapter;
+
+namespace facebook::react
+{
+    class EmptyReactNativeConfig
+    {
+    };
+}  // namespace facebook::react
 
 #endif  // USE_BRIDGELESS

--- a/packages/react-native-host/cocoa/RNXFabricAdapter.h
+++ b/packages/react-native-host/cocoa/RNXFabricAdapter.h
@@ -1,9 +1,11 @@
 #import <Foundation/Foundation.h>
 
 @class RCTBridge;
+@class RCTSurfacePresenterBridgeAdapter;
 
 NS_ASSUME_NONNULL_BEGIN
 
-NSObject *RNXInstallSurfacePresenterBridgeAdapter(RCTBridge *bridge);
+RCTSurfacePresenterBridgeAdapter *_Nullable RNXInstallSurfacePresenterBridgeAdapter(
+    RCTBridge *bridge);
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native-host/cocoa/RNXFabricAdapter.mm
+++ b/packages/react-native-host/cocoa/RNXFabricAdapter.mm
@@ -1,6 +1,6 @@
 #import "RNXFabricAdapter.h"
 
-#ifdef USE_FABRIC
+#if USE_FABRIC && !USE_BRIDGELESS
 #include "FollyConfig.h"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcomma"
@@ -9,11 +9,11 @@
 #import <React/RCTSurfacePresenterBridgeAdapter.h>
 #import <react/config/ReactNativeConfig.h>
 #pragma clang diagnostic pop
-#endif  // USE_FABRIC
+#endif  // USE_FABRIC && !USE_BRIDGELESS
 
-NSObject *RNXInstallSurfacePresenterBridgeAdapter(RCTBridge *bridge)
+RCTSurfacePresenterBridgeAdapter *RNXInstallSurfacePresenterBridgeAdapter(RCTBridge *bridge)
 {
-#ifdef USE_FABRIC
+#if USE_FABRIC && !USE_BRIDGELESS
     auto contextContainer = std::make_shared<facebook::react::ContextContainer const>();
     auto reactNativeConfig = std::make_shared<facebook::react::EmptyReactNativeConfig const>();
     contextContainer->insert("ReactNativeConfig", reactNativeConfig);
@@ -24,5 +24,5 @@ NSObject *RNXInstallSurfacePresenterBridgeAdapter(RCTBridge *bridge)
     return bridgeAdapter;
 #else
     return nil;
-#endif  // USE_FABRIC
+#endif  // USE_FABRIC && !USE_BRIDGELESS
 }

--- a/packages/react-native-host/cocoa/RNXHostConfig.h
+++ b/packages/react-native-host/cocoa/RNXHostConfig.h
@@ -10,6 +10,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @optional
 
+/// Returns whether the new initialization layer is enabled.
+@property (nonatomic, readonly) BOOL isBridgelessEnabled;
+
 /// Returns whether the loading view should be visible while loading JavaScript.
 @property (nonatomic, readonly) BOOL isDevLoadingViewEnabled;
 

--- a/packages/react-native-host/cocoa/ReactNativeHost+Private.h
+++ b/packages/react-native-host/cocoa/ReactNativeHost+Private.h
@@ -1,0 +1,16 @@
+#import "ReactNativeHost.h"
+
+@class RCTSurfacePresenter;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ReactNativeHost (Private)
+
+/// Returns the current ``RCTSurfacePresenter`` instance.
+///
+/// - Note: Returns `nil` if New Architecture is not enabled.
+@property (nonatomic, readonly, nullable) RCTSurfacePresenter *surfacePresenter;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native-host/cocoa/ReactNativeHost+View.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost+View.mm
@@ -1,4 +1,4 @@
-#import "ReactNativeHost.h"
+#import "ReactNativeHost+Private.h"
 
 #ifdef USE_FABRIC
 #if __has_include(<React/RCTFabricSurfaceHostingProxyRootView.h>)

--- a/packages/react-native-host/cocoa/ReactNativeHost+View.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost+View.mm
@@ -41,9 +41,10 @@
                                                              moduleName:moduleName
                                                       initialProperties:initialProperties];
 #else
-    RCTFabricSurface *surface = [[RCTFabricSurface alloc] initWithBridge:self.bridge
-                                                              moduleName:moduleName
-                                                       initialProperties:initialProperties];
+    RCTFabricSurface *surface =
+        [[RCTFabricSurface alloc] initWithSurfacePresenter:self.surfacePresenter
+                                                moduleName:moduleName
+                                         initialProperties:initialProperties];
     return [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
 #endif  // __has_include(<React/RCTFabricSurfaceHostingProxyRootView.h>)
 #else

--- a/packages/react-native-host/cocoa/ReactNativeHost.h
+++ b/packages/react-native-host/cocoa/ReactNativeHost.h
@@ -4,8 +4,6 @@
 
 #import "RNXHostConfig.h"
 
-@class RCTSurfacePresenter;
-
 #if TARGET_OS_OSX
 @class NSView;
 typedef NSView RNXView;
@@ -23,11 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// - Note: This is not forwards compatible and will be removed in the future.
 @property (nonatomic, readonly, nullable) RCTBridge *bridge;
-
-/// Returns the current ``RCTSurfacePresenter`` instance.
-///
-/// - Note: Returns `nil` if New Architecture is not enabled.
-@property (nonatomic, readonly, nullable) RCTSurfacePresenter *surfacePresenter;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/packages/react-native-host/cocoa/ReactNativeHost.h
+++ b/packages/react-native-host/cocoa/ReactNativeHost.h
@@ -4,6 +4,8 @@
 
 #import "RNXHostConfig.h"
 
+@class RCTSurfacePresenter;
+
 #if TARGET_OS_OSX
 @class NSView;
 typedef NSView RNXView;
@@ -21,6 +23,11 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// - Note: This is not forwards compatible and will be removed in the future.
 @property (nonatomic, readonly, nullable) RCTBridge *bridge;
+
+/// Returns the current `RCTSurfacePresenter` instance.
+///
+/// - Note: Returns `nil` if New Architecture is not enabled.
+@property (nonatomic, readonly, nullable) RCTSurfacePresenter *surfacePresenter;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/packages/react-native-host/cocoa/ReactNativeHost.h
+++ b/packages/react-native-host/cocoa/ReactNativeHost.h
@@ -19,12 +19,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// Hosts a React Native instance.
 @interface ReactNativeHost : NSObject <RCTBridgeDelegate>
 
-/// Returns the current `RCTBridge` instance.
+/// Returns the current ``RCTBridge`` instance.
 ///
 /// - Note: This is not forwards compatible and will be removed in the future.
 @property (nonatomic, readonly, nullable) RCTBridge *bridge;
 
-/// Returns the current `RCTSurfacePresenter` instance.
+/// Returns the current ``RCTSurfacePresenter`` instance.
 ///
 /// - Note: Returns `nil` if New Architecture is not enabled.
 @property (nonatomic, readonly, nullable) RCTSurfacePresenter *surfacePresenter;

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -12,17 +12,6 @@
 #import <React/RCTDevLoadingViewSetEnabled.h>
 #import <React/RCTUtils.h>
 
-#if __has_include(<react/config/ReactNativeConfig.h>)
-#import <react/config/ReactNativeConfig.h>
-#else
-namespace facebook::react
-{
-    class EmptyReactNativeConfig
-    {
-    };
-}  // namespace facebook::react
-#endif  // __has_include(<react/config/ReactNativeConfig.h>)
-
 #import "RNXBridgelessHeaders.h"
 #import "RNXFabricAdapter.h"
 #import "RNXHostConfig.h"

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -18,6 +18,8 @@
 #import "RNXHostReleaser.h"
 #import "RNXTurboModuleAdapter.h"
 
+@class RCTSurfacePresenter;
+
 using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 
 #if USE_BRIDGELESS

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -11,7 +11,17 @@
 #import <React/RCTCxxBridgeDelegate.h>
 #import <React/RCTDevLoadingViewSetEnabled.h>
 #import <React/RCTUtils.h>
+
+#if __has_include(<react/config/ReactNativeConfig.h>)
 #import <react/config/ReactNativeConfig.h>
+#else
+namespace facebook::react
+{
+    class EmptyReactNativeConfig
+    {
+    };
+}  // namespace facebook::react
+#endif  // __has_include(<react/config/ReactNativeConfig.h>)
 
 #import "RNXBridgelessHeaders.h"
 #import "RNXFabricAdapter.h"


### PR DESCRIPTION
### Description

Bridgeless mode can now be enabled by setting the environment variable `USE_BRIDGELESS=1`. This build flag will enable bridgeless bits, but you can still disable it at runtime by implementing `RNXHostConfig.isBridgelessEnabled`.

See the full announcement here: https://reactnative.dev/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#new-architecture-updates

### Test plan

1. If necessary, clone `react-native-test-app`, then link in `react-native-host`
   ```
   cd ../react-native-test-app
   git checkout tido/bridgeless
   yarn clean
   yarn
   yarn link -r ../rnx-kit/packages/react-native-host
   cd example
   ```
2. In a separate terminal, start Metro server and keep it running for the rest of the session
   ```
   yarn start
   ```
3. Test old architecture
   ```
   pod install --project-directory=ios
   yarn ios
   ```
4. Test new architecture
   - In `ios/Podfile`, change `:fabric_enabled` to `true`
   - Repeat commands in step 2
   - Verify that "Fabric" is on
5. Test new architecture + bridgeless
   - In `ios/Podfile`, change `:bridgeless_enabled` to `true`
   - Repeat commands in step 2
   - Verify that "Bridgeless" is on
6. Test Hermes
   - In `ios/Podfile`, change `:hermes_enabled` to `true`
   - Repeat commands in step 2
   - Verify that "Hermes" is on

### Screenshots

| New Architecture | + Bridgeless | + Hermes |
| :-: | :-: | :-: |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-01-25 at 09 45 06](https://github.com/microsoft/rnx-kit/assets/4123478/a704cc13-70d5-44c7-9e1d-bae89d26c3f2) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-24 at 21 07 40](https://github.com/microsoft/rnx-kit/assets/4123478/cca45e09-1321-4bcf-b73a-b21f0317248a) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-25 at 09 32 59](https://github.com/microsoft/rnx-kit/assets/4123478/89649ca5-7b00-44d3-bb6a-da32457462b0) |