### PR TITLE
fix(rnx-native-auth): make Android error type string actually work

### DIFF
--- a/.changeset/orange-hornets-yawn.md
+++ b/.changeset/orange-hornets-yawn.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-auth": patch
+---
+
+fix(rnx-native-auth): make Android error type from native work

--- a/packages/react-native-auth/android/src/main/java/com/microsoft/reactnativesdk/auth/AuthError.kt
+++ b/packages/react-native-auth/android/src/main/java/com/microsoft/reactnativesdk/auth/AuthError.kt
@@ -32,7 +32,7 @@ data class AuthError(
 
     fun toWritableMap(): WritableMap {
         return Arguments.createMap().also { map ->
-            map.putString("type", type.toString())
+            map.putString("type", type.type)
             map.putString("correlationId", correlationId)
             message?.let {
                 map.putString("message", it)

--- a/packages/react-native-auth/android/src/main/java/com/microsoft/reactnativesdk/auth/ReactNativeAuthModule.kt
+++ b/packages/react-native-auth/android/src/main/java/com/microsoft/reactnativesdk/auth/ReactNativeAuthModule.kt
@@ -77,7 +77,7 @@ abstract class ReactNativeAuthModule(context: ReactApplicationContext?) :
             AccountType.from(accountType)
         ) { result, error ->
             when {
-                error != null -> promise.reject(error.type.toString(), error.toWritableMap())
+                error != null -> promise.reject(error.type.type, error.toWritableMap())
                 result == null -> promise.reject(
                     AuthErrorType.UNKNOWN.toString(),
                     AuthError.unknown().toWritableMap()
@@ -100,7 +100,7 @@ abstract class ReactNativeAuthModule(context: ReactApplicationContext?) :
             AccountType.from(accountType)
         ) { result, error ->
             when {
-                error != null -> promise.reject(error.type.toString(), error.toWritableMap())
+                error != null -> promise.reject(error.type.type, error.toWritableMap())
                 result == null -> promise.reject(
                     AuthErrorType.UNKNOWN.toString(),
                     AuthError.unknown().toWritableMap()

--- a/packages/react-native-auth/android/src/main/java/com/microsoft/reactnativesdk/auth/ReactNativeAuthModule.kt
+++ b/packages/react-native-auth/android/src/main/java/com/microsoft/reactnativesdk/auth/ReactNativeAuthModule.kt
@@ -79,7 +79,7 @@ abstract class ReactNativeAuthModule(context: ReactApplicationContext?) :
             when {
                 error != null -> promise.reject(error.type.type, error.toWritableMap())
                 result == null -> promise.reject(
-                    AuthErrorType.UNKNOWN.toString(),
+                    AuthErrorType.UNKNOWN.type,
                     AuthError.unknown().toWritableMap()
                 )
                 else -> promise.resolve(result.toWritableMap())
@@ -102,7 +102,7 @@ abstract class ReactNativeAuthModule(context: ReactApplicationContext?) :
             when {
                 error != null -> promise.reject(error.type.type, error.toWritableMap())
                 result == null -> promise.reject(
-                    AuthErrorType.UNKNOWN.toString(),
+                    AuthErrorType.UNKNOWN.type,
                     AuthError.unknown().toWritableMap()
                 )
                 else -> promise.resolve(result.toWritableMap())


### PR DESCRIPTION
### Description

The string that is created in the map that goes to React Native must be on the form of e.g. "BadRefreshToken" rather than "BAD_REFRESH_TOKEN".

instead of .toString(), let's use the actual type of type.type for the proper representation in the map that gets passed to RN.

### Test plan

NA
