### PR TITLE
fix(react-native-host): Add visionOS as a supported platform

### DIFF
--- a/.changeset/chilly-elephants-pump.md
+++ b/.changeset/chilly-elephants-pump.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Add visionOS support

--- a/packages/react-native-host/ReactNativeHost.podspec
+++ b/packages/react-native-host/ReactNativeHost.podspec
@@ -33,6 +33,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'
+  s.visionos.deployment_target = '1.0'
 
   s.dependency 'React-Core'
   s.dependency 'React-cxxreact'


### PR DESCRIPTION
### Description

Add visionOS as a supported platform to ReactNativeHost, so that react-native-test-app can support visionOS. React Native host doesn't import UIKit anywhere, so I don't expect any of its' code to fail to compile on visionOS.

### Test plan

Once react native test app is unblocked, I can update the test app here.