### PR TITLE
fix(web-storage): add TurboModule support

### DIFF
--- a/.changeset/gentle-carpets-smash.md
+++ b/.changeset/gentle-carpets-smash.md
@@ -1,0 +1,5 @@
+---
+"@react-native-webapis/web-storage": patch
+---
+
+Add support for New Architecture

--- a/incubator/@react-native-webapis/web-storage/RNWWebStorage.podspec
+++ b/incubator/@react-native-webapis/web-storage/RNWWebStorage.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'
+  s.visionos.deployment_target = '1.0'
 
   s.dependency 'React-Core'
 
@@ -23,8 +24,10 @@ Pod::Spec.new do |s|
   # Include both package and repository relative paths to allow the podspec to
   # be consumed from both a local path, and as a podspec outside a spec
   # repository.
-  s.source_files         = 'ios/*.{h,m}',                              # :path
-                           "#{repository['directory']}/ios/*.{h,m}"    # :podspec
-  s.public_header_files  = 'ios/*.h',                                  # :path
-                           "#{repository['directory']}/ios/*.h"        # :podspec
+  s.source_files         = 'ios/*.{h,m,mm}',                              # :path
+                           "#{repository['directory']}/ios/*.{h,m,mm}"    # :podspec
+  s.public_header_files  = 'ios/*.h',                                     # :path
+                           "#{repository['directory']}/ios/*.h"           # :podspec
+
+  install_modules_dependencies(s) if defined?(install_modules_dependencies)
 end

--- a/incubator/@react-native-webapis/web-storage/android/build.gradle
+++ b/incubator/@react-native-webapis/web-storage/android/build.gradle
@@ -42,6 +42,15 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
+def enableNewArchitecture = (project.hasProperty("react.newArchEnabled") &&
+                             project.getProperty("react.newArchEnabled") == "true") ||
+                            (project.hasProperty("newArchEnabled") &&
+                             project.getProperty("newArchEnabled") == "true")
+
+if (enableNewArchitecture) {
+    apply(plugin: "com.facebook.react")
+}
+
 repositories {
     maven {
         url("${findNodeModulesPath('react-native')}/android")
@@ -59,6 +68,15 @@ android {
     }
     lintOptions {
         abortOnError false
+    }
+    sourceSets {
+        main {
+            if (enableNewArchitecture) {
+                java.srcDirs += ['src/newarch/java']
+            } else {
+                java.srcDirs += ['src/oldarch/java']
+            }
+        }
     }
 }
 

--- a/incubator/@react-native-webapis/web-storage/android/src/main/java/org/reactnativewebapis/webstorage/WebStoragePackage.kt
+++ b/incubator/@react-native-webapis/web-storage/android/src/main/java/org/reactnativewebapis/webstorage/WebStoragePackage.kt
@@ -5,9 +5,10 @@ import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
+import com.facebook.react.turbomodule.core.interfaces.TurboModule
 
 class WebStoragePackage : TurboReactPackage() {
-    override fun getModule(name: String?, reactContext: ReactApplicationContext?): NativeModule {
+    override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule {
         return when (name) {
             WebStorageModule.NAME -> WebStorageModule(reactContext)
             else -> throw IllegalArgumentException("No module named '$name'")
@@ -22,7 +23,7 @@ class WebStoragePackage : TurboReactPackage() {
             false,
             false,
             false,
-            false
+            TurboModule::class.java.isAssignableFrom(WebStorageModule::class.java)
         )
         mapOf(info.name() to info).toMutableMap()
     }

--- a/incubator/@react-native-webapis/web-storage/android/src/newarch/java/org/reactnativewebapis/webstorage/WebStorageModule.kt
+++ b/incubator/@react-native-webapis/web-storage/android/src/newarch/java/org/reactnativewebapis/webstorage/WebStorageModule.kt
@@ -1,0 +1,48 @@
+package org.reactnativewebapis.webstorage
+
+import android.content.Context.MODE_PRIVATE
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.facebook.react.bridge.ReactApplicationContext
+
+class WebStorageModule(context: ReactApplicationContext) : NativeWebStorageSpec(context) {
+
+    companion object {
+        const val NAME = NativeWebStorageSpec.NAME
+    }
+
+    private val sharedPreferences: SharedPreferences =
+        reactApplicationContext.getSharedPreferences(
+            reactApplicationContext.packageName,
+            MODE_PRIVATE
+        )
+
+    override fun length(): Double {
+        return sharedPreferences.all.size.toDouble()
+    }
+
+    override fun key(index: Double): String? {
+        // The order of the elements in `SharedPreferences` is not defined.
+        // https://developer.android.com/reference/android/content/SharedPreferences#getAll()
+        return null
+    }
+
+    override fun getItem(key: String): String? {
+        return sharedPreferences.getString(key, null)
+    }
+
+    override fun setItem(key: String, value: String): Boolean {
+        sharedPreferences.edit { putString(key, value) }
+        return false
+    }
+
+    override fun removeItem(key: String): Boolean {
+        sharedPreferences.edit { remove(key) }
+        return false
+    }
+
+    override fun clear(): Boolean {
+        sharedPreferences.edit { clear() }
+        return false
+    }
+}

--- a/incubator/@react-native-webapis/web-storage/android/src/oldarch/java/org/reactnativewebapis/webstorage/WebStorageModule.kt
+++ b/incubator/@react-native-webapis/web-storage/android/src/oldarch/java/org/reactnativewebapis/webstorage/WebStorageModule.kt
@@ -8,7 +8,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReactModuleWithSpec
 
-class WebStorageModule(context: ReactApplicationContext?) :
+class WebStorageModule(context: ReactApplicationContext) :
     ReactContextBaseJavaModule(context), ReactModuleWithSpec {
 
     companion object {

--- a/incubator/@react-native-webapis/web-storage/ios/RNWWebStorage+TurboModule.h
+++ b/incubator/@react-native-webapis/web-storage/ios/RNWWebStorage+TurboModule.h
@@ -1,0 +1,14 @@
+#if __has_include(<RNWWebStorageSpec/RNWWebStorageSpec.h>)
+
+#include <RNWWebStorageSpec/RNWWebStorageSpec.h>
+
+#define RNW_USE_NEW_ARCH 1
+
+@interface RNWWebStorage () <NativeWebStorageSpec>
+@end
+
+#else
+
+#define RNW_USE_NEW_ARCH 0
+
+#endif  // __has_include(<RNWWebStorageSpec/RNWWebStorageSpec.h>)

--- a/incubator/@react-native-webapis/web-storage/ios/RNWWebStorage.mm
+++ b/incubator/@react-native-webapis/web-storage/ios/RNWWebStorage.mm
@@ -1,5 +1,7 @@
 #import "RNWWebStorage.h"
 
+#import "RNWWebStorage+TurboModule.h"
+
 @implementation RNWWebStorage
 
 RCT_EXPORT_MODULE(RNWWebStorage)
@@ -32,7 +34,7 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSNumber *, length)
 }
 
 // clang-format off
-RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, key:(NSNumber *)index)
+RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, key:(double)index)
 // clang-format on
 {
     // The order of the elements in `NSUserDefaults` is not defined.
@@ -48,27 +50,37 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, getItem:(NSString *)key)
 }
 
 // clang-format off
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(setItem:(NSString *)key value:(NSString *)value)
+RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSNumber *, setItem:(NSString *)key value:(NSString *)value)
 // clang-format on
 {
     [[self userDefaults] setObject:value forKey:key];
-    return nil;
+    return @NO;
 }
 
 // clang-format off
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(removeItem:(NSString *)key)
+RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSNumber *, removeItem:(NSString *)key)
 // clang-format on
 {
     [[self userDefaults] removeObjectForKey:key];
-    return nil;
+    return @NO;
 }
 
 // clang-format off
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(clear)
+RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSNumber *, clear)
 // clang-format on
 {
     [[self userDefaults] removePersistentDomainForName:[self appDomain]];
-    return nil;
+    return @NO;
 }
+
+#if RNW_USE_NEW_ARCH
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+    return std::make_shared<facebook::react::NativeWebStorageSpecJSI>(params);
+}
+
+#endif  // RNW_USE_NEW_ARCH
 
 @end

--- a/incubator/@react-native-webapis/web-storage/package.json
+++ b/incubator/@react-native-webapis/web-storage/package.json
@@ -53,5 +53,13 @@
     "react-native": "^0.72.0",
     "typescript": "^5.0.0"
   },
+  "codegenConfig": {
+    "name": "RNWWebStorageSpec",
+    "type": "all",
+    "jsSrcsDir": "./src",
+    "android": {
+      "javaPackageName": "org.reactnativewebapis.webstorage"
+    }
+  },
   "experimental": true
 }

--- a/incubator/@react-native-webapis/web-storage/src/NativeWebStorage.ts
+++ b/incubator/@react-native-webapis/web-storage/src/NativeWebStorage.ts
@@ -5,11 +5,11 @@ import { TurboModuleRegistry } from "react-native";
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface Spec extends TurboModule {
   length: () => number;
-  key: Storage["key"];
-  getItem: Storage["getItem"];
-  setItem: Storage["setItem"];
-  removeItem: Storage["removeItem"];
-  clear: Storage["clear"];
+  key(index: number): string | null;
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): boolean; // can't use `void` because sync methods must return something
+  removeItem(key: string): boolean; // can't use `void` because sync methods must return something
+  clear(): boolean; // can't use `void` because sync methods must return something
 }
 
 export const NativeWebStorage =

--- a/incubator/@react-native-webapis/web-storage/src/sessionStorage.ts
+++ b/incubator/@react-native-webapis/web-storage/src/sessionStorage.ts
@@ -33,7 +33,10 @@ export function makeSessionStorage() {
       writable: false,
     },
     setItem: {
-      value: (key: string, value: string) => store.set(key, value),
+      value: (key: string, value: string) => {
+        store.set(key, value);
+        return false;
+      },
       writable: false,
     },
     removeItem: {
@@ -41,7 +44,10 @@ export function makeSessionStorage() {
       writable: false,
     },
     clear: {
-      value: () => store.clear(),
+      value: () => {
+        store.clear();
+        return false;
+      },
       writable: false,
     },
   };


### PR DESCRIPTION
### Description

Add TurboModule support

### Test plan

This must be tested in the RNTA repository.

1. Switch to the `tido/replace-safe-area` branch
2. Run `yarn`
3. Link `@react-native-webapis/web-storage`: `yarn link -r /~/rnx-kit/incubator/@react-native-webapis/web-storage`
4. Update `metro.config.js`:
    ```diff
    diff --git a/example/metro.config.js b/example/metro.config.js
    index 2c321b4..d546a19 100644
    --- a/example/metro.config.js
    +++ b/example/metro.config.js
    @@ -1,4 +1,5 @@
     const { makeMetroConfig } = require("@rnx-kit/metro-config");
    +const path = require("node:path");
     module.exports = makeMetroConfig({
       transformer: {
         getTransformOptions: async () => ({
    @@ -8,4 +9,7 @@ module.exports = makeMetroConfig({
           },
         }),
       },
    +  watchFolders: [
    +    path.dirname(require.resolve("@react-native-webapis/web-storage/package.json")),
    +  ]
     });
    ```
5. Enable New Architecture:
    ```diff
    diff --git a/example/android/gradle.properties b/example/android/gradle.properties
    index c65407b..c18fdf9 100644
    --- a/example/android/gradle.properties
    +++ b/example/android/gradle.properties
    @@ -40,7 +40,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
     # to write custom TurboModules/Fabric components OR use libraries that
     # are providing them.
     # Note that this is incompatible with web debugging.
    -#newArchEnabled=true
    +newArchEnabled=true

     # Uncomment the line below if building react-native from source
     #ANDROID_NDK_VERSION=26.1.10909125
    diff --git a/example/ios/Podfile b/example/ios/Podfile
    index 9809ada..ee8888b 100644
    --- a/example/ios/Podfile
    +++ b/example/ios/Podfile
    @@ -3,7 +3,7 @@ require_relative '../node_modules/react-native-test-app/test_app'
     workspace 'Example.xcworkspace'

     options = {
    -  :fabric_enabled => false,
    +  :fabric_enabled => true,
       :hermes_enabled => false,
     }

    ```
6. In a separate terminal, start the dev server: `yarn start`
7. Run Android: `yarn android`
8. Run iOS: `pod install --project-directory=ios && yarn ios`

### Screenshots

| Android | iOS |
| :-: | :-: |
| ![Screenshot_1706795556](https://github.com/microsoft/rnx-kit/assets/4123478/5e7ff91b-d3cd-45f3-b0f7-80dba7f729a2) | ![image](https://github.com/microsoft/rnx-kit/assets/4123478/26f1d4cc-772f-485d-9f14-5759eac38052) |
