### PR TITLE
fix(react-native-host): enable `concurrentRoot` when Fabric is

### DIFF
--- a/.changeset/nine-rules-refuse.md
+++ b/.changeset/nine-rules-refuse.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Enable `concurrentRoot` by default when New Architecture is enabled

--- a/.changeset/nine-rules-refuse.md
+++ b/.changeset/nine-rules-refuse.md
@@ -2,4 +2,11 @@
 "@rnx-kit/react-native-host": patch
 ---
 
-Enable `concurrentRoot` by default when New Architecture is enabled
+Enable `concurrentRoot` by default when New Architecture is enabled.
+
+Having `concurrentRoot` disabled when Fabric is enabled is not
+recommended:
+https://github.com/facebook/react-native/commit/7eaabfb174b14a30c30c7017195e8110348e5f44
+
+As of 0.74, it won't be possible to opt-out:
+https://github.com/facebook/react-native/commit/30d186c3683228d4fb7a42f804eb2fdfa7c8ac03

--- a/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
+++ b/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
@@ -67,13 +67,13 @@
 
 // MARK: - RCTTurboModuleManagerDelegate details
 
-- (Class)getModuleClassFromName:(const char *)name
+- (Class)getModuleClassFromName:(char const *)name
 {
     return RCTCoreModulesClassProvider(name);
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)
-    getTurboModule:(const std::string &)name
+    getTurboModule:(std::string const &)name
          jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
 {
     return nullptr;

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -126,7 +126,7 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 
 - (void)usingModule:(Class)moduleClass block:(void (^)(id<RCTBridgeModule> _Nullable))block
 {
-    const BOOL requiresMainQueueSetup =
+    BOOL const requiresMainQueueSetup =
         [moduleClass respondsToSelector:@selector(requiresMainQueueSetup)] &&
         [moduleClass requiresMainQueueSetup];
     if (requiresMainQueueSetup && !RCTIsMainQueue()) {


### PR DESCRIPTION
### Description

Enable `concurrentRoot` by default when New Architecture is enabled.

### Test plan

1. Patch `packages/test-app/node_modules/react-native/scripts/codegen/generate-artifacts-executor.js`
    - Replace line 35 with `const CODEGEN_NPM_PATH = path.dirname(require.resolve(path.join(CODEGEN_DEPENDENCY_NAME, "package.json"), { paths: [REACT_NATIVE_PACKAGE_ROOT_FOLDER] }));`
2. Open `packages/test-app/ios/Podfile` and enable Fabric
3. Build:
    ```
    cd packages/test-app
    yarn build --dependencies
    pod install --project-directory=ios
    yarn ios

    # In a separate terminal
    yarn start
    ```
4. Verify that `Concurrent React` is **on**
5. Opt-out:
    ```diff
    diff --git a/packages/test-app/app.json b/packages/test-app/app.json
    index 452770f3..c25fb418 100644
    --- a/packages/test-app/app.json
    +++ b/packages/test-app/app.json
    @@ -4,7 +4,10 @@
       "components": [
         {
           "appKey": "SampleCrossApp",
    -      "displayName": "SampleCrossApp"
    +      "displayName": "SampleCrossApp",
    +      "initialProperties": {
    +        "concurrentRoot": false
    +      }
         },
         {
           "appKey": "com.microsoft.reacttestapp.msal.MicrosoftAccountsActivity",
    ```
6. Rebuild the app: `yarn ios`
7. Verify that `Concurrent React` is **off**

### Screenshot

![Simulator Screenshot - iPhone 15 Pro - 2024-02-09 at 13 48 10](https://github.com/microsoft/rnx-kit/assets/4123478/cdd07c49-9c55-4235-87cd-c24f6f11a568)