### PR TITLE
fix(metro-serializer-esbuild): include `ReactFabric-prod.js` by default

### DIFF
--- a/.changeset/itchy-chefs-bow.md
+++ b/.changeset/itchy-chefs-bow.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Include `ReactFabric-prod.js` by default

--- a/packages/metro-serializer-esbuild/README.md
+++ b/packages/metro-serializer-esbuild/README.md
@@ -137,7 +137,7 @@ Defaults to `hermes0.7.0`.
 When enabled, includes Fabric-enabled version of React. You can save some bytes
 by disabling this if you haven't migrated to Fabric yet.
 
-Defaults to `false`.
+Defaults to `true`.
 
 ### `drop`
 

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -155,7 +155,7 @@ export function MetroSerializer(
           // that we pass to `esbuild.build()` below. Since it doesn't work for
           // some reason, we'll filter them out here instead.
           if (
-            buildOptions?.fabric !== true &&
+            buildOptions?.fabric === false &&
             args.path.endsWith("ReactFabric-prod.js")
           ) {
             return { contents: "" };


### PR DESCRIPTION
### Description

Include `ReactFabric-prod.js` by default.

### Test plan

n/a