### PR TITLE
fix(web-storage): fix old arch code being included in new arch

### DIFF
--- a/.changeset/breezy-impalas-compete.md
+++ b/.changeset/breezy-impalas-compete.md
@@ -1,5 +1,5 @@
 ---
-"@react-native-webapis/web-storage": patch
+"@react-native-webapis/web-storage": minor
 ---
 
 Fix old arch code being included when new arch is enabled. Also had to bump `react-native` requirement because changes in `@react-native/codegen` 0.72 are not backwards-compatible with 0.71.

--- a/.changeset/breezy-impalas-compete.md
+++ b/.changeset/breezy-impalas-compete.md
@@ -1,0 +1,5 @@
+---
+"@react-native-webapis/web-storage": patch
+---
+
+Fix old arch code being included when new arch is enabled. Also had to bump `react-native` requirement because changes in `@react-native/codegen` 0.72 are not backwards-compatible with 0.71.

--- a/incubator/@react-native-webapis/web-storage/android/build.gradle
+++ b/incubator/@react-native-webapis/web-storage/android/build.gradle
@@ -70,13 +70,9 @@ android {
         abortOnError false
     }
     sourceSets {
-        main {
-            if (enableNewArchitecture) {
-                java.srcDirs += ['src/newarch/java']
-            } else {
-                java.srcDirs += ['src/oldarch/java']
-            }
-        }
+        main.java.srcDirs += [
+            enableNewArchitecture ? "src/newarch/java" : "src/oldarch/java"
+        ]
     }
 }
 

--- a/incubator/@react-native-webapis/web-storage/android/src/oldarch/java/org/reactnativewebapis/webstorage/WebStorageModule.kt
+++ b/incubator/@react-native-webapis/web-storage/android/src/oldarch/java/org/reactnativewebapis/webstorage/WebStorageModule.kt
@@ -6,10 +6,8 @@ import androidx.core.content.edit
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
-import com.facebook.react.bridge.ReactModuleWithSpec
 
-class WebStorageModule(context: ReactApplicationContext) :
-    ReactContextBaseJavaModule(context), ReactModuleWithSpec {
+class WebStorageModule(context: ReactApplicationContext) : ReactContextBaseJavaModule(context) {
 
     companion object {
         const val NAME = "RNWWebStorage"
@@ -29,7 +27,7 @@ class WebStorageModule(context: ReactApplicationContext) :
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
-    fun key(index: Int): String? {
+    fun key(@Suppress("UNUSED_PARAMETER") index: Int): String? {
         // The order of the elements in `SharedPreferences` is not defined.
         // https://developer.android.com/reference/android/content/SharedPreferences#getAll()
         return null

--- a/incubator/@react-native-webapis/web-storage/package.json
+++ b/incubator/@react-native-webapis/web-storage/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "react": ">=18.2.0",
-    "react-native": ">=0.71.0-0"
+    "react-native": ">=0.72.0-0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3193,7 +3193,7 @@ __metadata:
     typescript: ^5.0.0
   peerDependencies:
     react: ">=18.2.0"
-    react-native: ">=0.71.0-0"
+    react-native: ">=0.72.0-0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

Fix old arch code being included when new arch is enabled. Also had to bump `react-native` requirement because changes in `@react-native/codegen` 0.72 are not backwards-compatible with 0.71.

### Test plan

In `react-native-test-app`, run:

```sh
npm run set-react-version 0.72 -- --core-only
yarn
```

Patch `TestApp.kt`:

```diff
diff --git a/android/app/src/reactapplication-pre-0.73/java/com/microsoft/reacttestapp/TestApp.kt b/android/app/src/reactapplication-pre-0.73/java/com/microsoft/reacttestapp/TestApp.kt
index d009132..5f56191 100644
--- a/android/app/src/reactapplication-pre-0.73/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/reactapplication-pre-0.73/java/com/microsoft/reacttestapp/TestApp.kt
@@ -22,7 +22,7 @@ class TestApp : Application(), ReactApplication {
     private lateinit var reactNativeBundleNameProvider: ReactBundleNameProvider
     private lateinit var reactNativeHostInternal: TestAppReactNativeHost

-    fun reloadJSFromServer(activity: Activity?, bundleURL: String) {
+    fun reloadJSFromServer(activity: Activity, bundleURL: String) {
         reactNativeHostInternal.reloadJSFromServer(activity, bundleURL)
     }

```

Apply the changes in this PR:

```sh
cp /~/rnx-kit/incubator/@react-native-webapis/web-storage/android/build.gradle example/node_modules/@react-native-webapis/web-storage/android/build.gradle
cp /~/rnx-kit/incubator/@react-native-webapis/web-storage/android/src/oldarch/java/org/reactnativewebapis/webstorage/WebStorageModule.kt example/node_modules/@react-native-webapis/web-storage/android/src/oldarch/java/org/reactnativewebapis/webstorage/WebStorageModule.kt
```

Start the dev server:

```sh
cd example
yarn start
```

Build the Android app:

```sh
yarn android
```

Verify that it works. Then close and uninstall the app.

Next, enable New Arch:

```diff
diff --git a/example/android/gradle.properties b/example/android/gradle.properties
index ad74fd3..71c6ec7 100644
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -40,7 +40,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
 # Note that this is incompatible with web debugging.
-#newArchEnabled=true
+newArchEnabled=true
 #bridgelessEnabled=true

 # Uncomment the line below if building react-native from source
```

Remove build artifacts, and build the Android app:

```sh
cd example
git clean -dfqx
cd ..
yarn android
```