### PR TITLE
fix(lazy-index): fix "Preset requires a filename to be set" error

### DIFF
--- a/.changeset/wicked-tools-camp.md
+++ b/.changeset/wicked-tools-camp.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-lazy-index": patch
+---
+
+Fix "Preset requires a filename to be set" error when an older version of `babel-plugin-codegen` is used

--- a/packages/react-native-lazy-index/package.json
+++ b/packages/react-native-lazy-index/package.json
@@ -35,7 +35,7 @@
     "test": "rnx-kit-scripts test"
   },
   "dependencies": {
-    "babel-plugin-codegen": "^4.0.0"
+    "babel-plugin-codegen": "^4.1.5"
   },
   "peerDependencies": {
     "react-native": ">=0.59"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4276,7 +4276,7 @@ __metadata:
     "@rnx-kit/tsconfig": "*"
     "@types/jest": ^29.2.1
     "@types/node": ^20.0.0
-    babel-plugin-codegen: ^4.0.0
+    babel-plugin-codegen: ^4.1.5
     eslint: ^8.23.0
     jest: ^29.2.1
     prettier: ^3.0.0
@@ -5710,7 +5710,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-codegen@npm:^4.0.0":
+"babel-plugin-codegen@npm:^4.1.5":
   version: 4.1.5
   resolution: "babel-plugin-codegen@npm:4.1.5"
   dependencies:


### PR DESCRIPTION
### Description

Fix "Preset requires a filename to be set" error when an older version of `babel-plugin-codegen` is used.

### Test plan

n/a