### PR TITLE
fix(react-native-host): implement `usingModule:block:` for bridgeless mode

### DIFF
--- a/.changeset/purple-cats-cheat.md
+++ b/.changeset/purple-cats-cheat.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Implement `usingModule:block:` for bridgeless mode

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -137,7 +137,12 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
         return;
     }
 
+#if USE_BRIDGELESS
+    const char *moduleName = RCTBridgeModuleNameForClass(moduleClass).UTF8String;
+    id<RCTBridgeModule> bridgeModule = [[_reactHost getModuleRegistry] moduleForName:moduleName];
+#else
     id<RCTBridgeModule> bridgeModule = [self.bridge moduleForClass:moduleClass];
+#endif  // USE_BRIDGELESS
     block(bridgeModule);
 }
 


### PR DESCRIPTION
### Description

Implement `usingModule:block:` for bridgeless mode.

### Test plan

Test this in RNTA:

```
git checkout tido/fix-bridgeless-dev-menu
cd example

# Enable Fabric + Bridgeless
sed -i '' 's/:bridgeless_enabled => false/:bridgeless_enabled => true/' ios/Podfiile
sed -i '' 's/:fabric_enabled => false/:fabric_enabled => true/' ios/Podfiile

pod install --project-directory=ios
yarn ios

# In a separate terminal
yarn start
```

Verify that dev menu contains a menu entry "Load Embedded JS Bundle".