### PR TITLE
feat(align-deps) allow exact version within range according to semver…

### DIFF
--- a/packages/align-deps/src/commands/check.ts
+++ b/packages/align-deps/src/commands/check.ts
@@ -84,7 +84,7 @@ export function checkPackageManifest(
     kitType
   );
 
-  const allChanges = diff(manifest, updatedManifest);
+  const allChanges = diff(manifest, updatedManifest, options.diffMode);
   if (allChanges) {
     if (options.write) {
       // The config object may be passed to other commands, so we need to

--- a/packages/align-deps/src/types.ts
+++ b/packages/align-deps/src/types.ts
@@ -19,6 +19,8 @@ export type Changes = {
   capabilities: { type: "unmanaged"; dependency: string; capability: string }[];
 };
 
+export type DiffMode = "strict" | "allow-exact-version";
+
 export type Options = {
   presets: string[];
   loose: boolean;
@@ -28,6 +30,7 @@ export type Options = {
   write: boolean;
   excludePackages?: string[];
   requirements?: string[];
+  diffMode?: DiffMode;
 };
 
 export type Args = Pick<Options, "loose" | "verbose" | "write"> & {
@@ -39,6 +42,7 @@ export type Args = Pick<Options, "loose" | "verbose" | "write"> & {
   packages?: (string | number)[];
   presets?: string | number;
   requirements?: string | number;
+  "diff-mode"?: string;
 };
 
 export type DependencyType = "direct" | "development" | "peer";

--- a/packages/align-deps/test/check.app.test.ts
+++ b/packages/align-deps/test/check.app.test.ts
@@ -12,6 +12,7 @@ const defaultOptions = {
   noUnmanaged: false,
   verbose: false,
   write: true,
+  allowExactVersion: false,
 };
 
 function fixturePath(name: string) {

--- a/packages/align-deps/test/initialize.test.ts
+++ b/packages/align-deps/test/initialize.test.ts
@@ -11,6 +11,7 @@ const defaultOptions = {
   noUnmanaged: false,
   verbose: false,
   write: false,
+  diffMode: "strict",
 };
 
 describe("initializeConfig()", () => {

--- a/packages/align-deps/test/setVersion.test.ts
+++ b/packages/align-deps/test/setVersion.test.ts
@@ -38,6 +38,7 @@ describe("makeSetVersionCommand()", () => {
     noUnmanaged: false,
     verbose: false,
     write: false,
+    diffMode: "strict",
   };
 
   afterEach(() => {

--- a/packages/align-deps/test/vigilant.test.ts
+++ b/packages/align-deps/test/vigilant.test.ts
@@ -450,6 +450,7 @@ describe("checkPackageManifestUnconfigured()", () => {
     noUnmanaged: false,
     verbose: false,
     write: false,
+    diffMode: "strict",
   };
 
   beforeEach(() => {

--- a/packages/cli/src/align-deps.ts
+++ b/packages/cli/src/align-deps.ts
@@ -25,6 +25,7 @@ export function rnxAlignDeps(
     verbose: Boolean(args.verbose),
     write: Boolean(args.write),
     packages: argv,
+    "diff-mode": String(args.diffMode),
   });
 }
 
@@ -73,6 +74,10 @@ export const rnxAlignDepsCommand = {
     {
       name: "--write",
       description: cliOptions.write.description,
+    },
+    {
+      name: `--diff-mode [${cliOptions["diff-mode"].choices?.join("|")}]`,
+      description: cliOptions["diff-mode"].description,
     },
   ],
 };


### PR DESCRIPTION
…Satisfies

### Description

Add a new option (flag) `--diff-mode` to allow specifying two modes for diffing:

- `strict`: Same as before
- `allow-exact-versions`: Allow (don't throw an error) when exact versions are declared in `package.json` that are within range according to `semverSatisfies`.

Resolves #2983 

Remaining tasks:

- [x] Change to `diff-mode` options from a boolean flag
- [ ] Add information about what changed (_Changeset_)
- [ ] Add unit tests
- [ ] Update documentation

### Test plan

- CI should pass, including updated unit tests
- Declare a dependency to `package.json` with an _exact version_ that is within the range of what the built-in capabilities define. Run `align-deps` with the new  `--diff-mode` set to `allow-exact-version` and verify that **no error is thrown**.
- Declare a dependency to `package.json` with an _exact version_ that is within the range of what the built-in capabilities define. Run `align-deps` with the new  `--diff-mode` set to `allow-exact-version` and `--write` flag set and verify that **nothing changes** in package.json.
- Declare a dependency to `package.json` with an _exact version_ that is outside of the range of what the built-in capabilities define. Run `align-deps` with the new  `--diff-mode` set to `allow-exact-version` and verify that **an error is thrown** for not correct version.
- Declare a dependency to `package.json` with an _exact version_ that is within the range of what the built-in capabilities define. Run `align-deps` with the new  `--diff-mode` set to `strict` and verify that **an error is thrown** for not correct version.
- Declare a dependency to `package.json` with an _exact version_ that is within the range of what the built-in capabilities define. Run `align-deps` with the new  `--diff-mode` set to `strict` but **with** `--write` flag and verify that **the versions is overwritten** with what is defined in built-in capabilities.
- Declare a dependency to `package.json` with an _exact version_ that is outside of the range of what the built-in capabilities define. Run `align-deps` with the new  `--diff-mode` set to `strict` and verify that **an error is thrown** for not correct version.
- Declare a dependency to `package.json` with an _exact version_ that is within the range of what the built-in capabilities define. Run `align-deps` **without** the new  `--diff-mode` set and verify that **an error is thrown** for not correct version.
- Declare a dependency to `package.json` with an _exact version_ that is within the range of what the built-in capabilities define. Run `align-deps` **without** the new  `--diff-mode` set but **with** `--write` flag and verify that **the versions is overwritten** with what is defined in built-in capabilities.
- Declare a dependency to `package.json` with an _exact version_ that is outside of the range of what the built-in capabilities define. Run `align-deps` **without** the new  `--diff-mode` set and verify that **an error is thrown** for not correct version.
