### PR TITLE
fix(web-storage): migrate away from `com.facebook.react.turbomodule.core.interfaces.TurboModule`

### DIFF
--- a/.changeset/early-zebras-laugh.md
+++ b/.changeset/early-zebras-laugh.md
@@ -1,0 +1,5 @@
+---
+"@react-native-webapis/web-storage": patch
+---
+
+Migrate away from `com.facebook.react.turbomodule.core.interfaces.TurboModule` as it has been moved/renamed in 0.74 and will break TurboModule detection

--- a/incubator/@react-native-webapis/web-storage/android/src/main/java/org/reactnativewebapis/webstorage/WebStoragePackage.kt
+++ b/incubator/@react-native-webapis/web-storage/android/src/main/java/org/reactnativewebapis/webstorage/WebStoragePackage.kt
@@ -5,7 +5,6 @@ import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
-import com.facebook.react.turbomodule.core.interfaces.TurboModule
 
 class WebStoragePackage : TurboReactPackage() {
     override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule {
@@ -23,7 +22,7 @@ class WebStoragePackage : TurboReactPackage() {
             false,
             false,
             false,
-            TurboModule::class.java.isAssignableFrom(WebStorageModule::class.java)
+            WebStorageModule.IS_TURBO_MODULE
         )
         mapOf(info.name() to info).toMutableMap()
     }

--- a/incubator/@react-native-webapis/web-storage/android/src/newarch/java/org/reactnativewebapis/webstorage/WebStorageModule.kt
+++ b/incubator/@react-native-webapis/web-storage/android/src/newarch/java/org/reactnativewebapis/webstorage/WebStorageModule.kt
@@ -8,6 +8,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 class WebStorageModule(context: ReactApplicationContext) : NativeWebStorageSpec(context) {
 
     companion object {
+        const val IS_TURBO_MODULE = true
         const val NAME = NativeWebStorageSpec.NAME
     }
 

--- a/incubator/@react-native-webapis/web-storage/android/src/oldarch/java/org/reactnativewebapis/webstorage/WebStorageModule.kt
+++ b/incubator/@react-native-webapis/web-storage/android/src/oldarch/java/org/reactnativewebapis/webstorage/WebStorageModule.kt
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.ReactMethod
 class WebStorageModule(context: ReactApplicationContext) : ReactContextBaseJavaModule(context) {
 
     companion object {
+        const val IS_TURBO_MODULE = false
         const val NAME = "RNWWebStorage"
     }
 


### PR DESCRIPTION
### Description

Migrate away from `com.facebook.react.turbomodule.core.interfaces.TurboModule` as it has been moved in 0.74 and will break TurboModule detection.

### Test plan

```
cd packages/test-app
yarn build --dependencies
yarn android

# In a separate terminal
yarn start
```