### PR TITLE
fix(react-native-host): implement `RCTHost` 0.74/0.75 compatibility layer

### DIFF
--- a/.changeset/thin-numbers-sniff.md
+++ b/.changeset/thin-numbers-sniff.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Implemented an `RCTHost` compatibility layer for deprecated methods, `-getModuleRegistry` and `-getSurfacePresenter`, and their replacements, `-moduleRegistry` and `-surfacePresenter` (see https://github.com/facebook/react-native/commit/c3b0a8f1626939cf5c7b3864a5acf9d3dad26fb3 for details)

--- a/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
+++ b/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
@@ -18,6 +18,15 @@ using SharedJSRuntimeFactory = std::shared_ptr<facebook::react::JSEngineInstance
 using SharedJSRuntimeFactory = std::shared_ptr<facebook::react::JSRuntimeFactory>;
 #endif  // __has_include(<react/runtime/JSEngineInstance.h>)
 
+// For details, see
+// https://github.com/facebook/react-native/commit/c3b0a8f1626939cf5c7b3864a5acf9d3dad26fb3
+@interface RCTHost (Compatibility)
+@property (nonatomic, readonly) RCTModuleRegistry *moduleRegistry;      // Introduced in 0.74
+@property (nonatomic, readonly) RCTSurfacePresenter *surfacePresenter;  // Introduced in 0.74
+- (RCTModuleRegistry *)getModuleRegistry;      // Deprecated in 0.74, and removed in 0.75
+- (RCTSurfacePresenter *)getSurfacePresenter;  // Deprecated in 0.74, and removed in 0.75
+@end
+
 #elif USE_FABRIC
 
 #import <React/RCTSurfacePresenterBridgeAdapter.h>

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -104,7 +104,9 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 - (RCTSurfacePresenter *)surfacePresenter
 {
 #if USE_BRIDGELESS
-    return [_reactHost getSurfacePresenter];
+    return [_reactHost respondsToSelector:@selector(surfacePresenter)]
+               ? _reactHost.surfacePresenter
+               : [_reactHost getSurfacePresenter];
 #elif USE_FABRIC
     return [_surfacePresenterBridgeAdapter surfacePresenter];
 #else
@@ -144,7 +146,10 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 
 #if USE_BRIDGELESS
     const char *moduleName = RCTBridgeModuleNameForClass(moduleClass).UTF8String;
-    block([[_reactHost getModuleRegistry] moduleForName:moduleName]);
+    RCTModuleRegistry *moduleRegistry = [_reactHost respondsToSelector:@selector(moduleRegistry)]
+                                            ? _reactHost.moduleRegistry
+                                            : [_reactHost getModuleRegistry];
+    block([moduleRegistry moduleForName:moduleName]);
 #endif  // USE_BRIDGELESS
 }
 

--- a/packages/test-app/ios/Podfile.lock
+++ b/packages/test-app/ios/Podfile.lock
@@ -1063,7 +1063,7 @@ PODS:
   - ReactTestApp-MSAL (2.1.8):
     - MSAL
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNWWebStorage (0.2.1):
+  - RNWWebStorage (0.2.2):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - RCTRequired
@@ -1271,9 +1271,9 @@ SPEC CHECKSUMS:
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: 56e0e498dbb513b96c40bac6284729ba4e62672d
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
+  glog: 79d13cd7c34b5d0cea5f4ca72c0e6b462ef8fb4d
   MSAL: 75402959845e55146583efbf37ff4ad90b408630
-  RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
+  RCT-Folly: 082c31bb88ae3582d685f8923b9938147be587b3
   RCTRequired: 2544c0f1081a5fa12e108bb8cb40e5f4581ccd87
   RCTTypeSafety: 50efabe2b115c11ed03fbf3fd79e2f163ddb5d7c
   React: 84221d5e0ce297bc57c4b6af539a62d812d89f10
@@ -1321,7 +1321,7 @@ SPEC CHECKSUMS:
   ReactTestApp-DevSupport: 300a04c076acd40b00a1f2160fb1229854934040
   ReactTestApp-MSAL: f41794214b301ab1e969a95112e276acc7204a7a
   ReactTestApp-Resources: ecfced6249be8a1d032cc75c6339538214e2bab1
-  RNWWebStorage: 431bdd2c52091626ac84e1bf4653e6268817144b
+  RNWWebStorage: 6dca525e55525aa59b6f81d7330d5727d8f0ad5c
   RNXAuth: da888a17b9a0f54908f6daa8b2e020d3585f91cc
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: a716eea57d0d3430219c0a5a233e1e93ee931eb7


### PR DESCRIPTION
### Description

Implemented an `RCTHost` compatibility layer for deprecated methods, `-getModuleRegistry` and `-getSurfacePresenter`, and their replacements, `-moduleRegistry` and `-surfacePresenter` (see https://github.com/facebook/react-native/commit/c3b0a8f1626939cf5c7b3864a5acf9d3dad26fb3 for details)

### Test plan

CI should pass.