### PR TITLE
fix(metro-config): handle apps in nested folders

### DIFF
--- a/.changeset/twenty-gorillas-sneeze.md
+++ b/.changeset/twenty-gorillas-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Handle apps in nested folders

--- a/packages/metro-config/src/defaultConfig.js
+++ b/packages/metro-config/src/defaultConfig.js
@@ -1,7 +1,7 @@
 // @ts-check
+const { findUp } = require("@rnx-kit/tools-node/path");
 const { requireModuleFromMetro } = require("@rnx-kit/tools-react-native/metro");
 const fs = require("fs");
-const path = require("path");
 
 /**
  * @typedef {import("metro-config").MetroConfig} MetroConfig;
@@ -104,8 +104,12 @@ function outOfTreePlatformResolver(implementations, projectRoot) {
  * @returns {MetroConfig[]}
  */
 function getDefaultConfig(projectRoot) {
+  const pkgJson = findUp("package.json", { startDir: projectRoot });
+  if (!pkgJson) {
+    return [];
+  }
+
   try {
-    const pkgJson = path.join(projectRoot, "package.json");
     const manifest = fs.readFileSync(pkgJson, { encoding: "utf-8" });
     if (manifest.includes("@react-native/metro-config")) {
       const metroConfigPath = require.resolve("@react-native/metro-config", {

--- a/packages/metro-config/src/defaultConfig.js
+++ b/packages/metro-config/src/defaultConfig.js
@@ -109,9 +109,9 @@ function getDefaultConfig(projectRoot) {
     return [];
   }
 
-  try {
-    const manifest = fs.readFileSync(pkgJson, { encoding: "utf-8" });
-    if (manifest.includes("@react-native/metro-config")) {
+  const manifest = fs.readFileSync(pkgJson, { encoding: "utf-8" });
+  if (manifest.includes("@react-native/metro-config")) {
+    try {
       const metroConfigPath = require.resolve("@react-native/metro-config", {
         paths: [projectRoot],
       });
@@ -133,10 +133,11 @@ function getDefaultConfig(projectRoot) {
       };
 
       return [defaultConfig];
+    } catch (_) {
+      // Ignore
     }
-  } catch (_) {
-    // Ignore
   }
+
   return [];
 }
 


### PR DESCRIPTION
### Description

Handle apps in nested folders e.g.:

```
my-awesome-component
├── example  <-- Note no `package.json`
│   └── App.js
├── package.json
└── src
```

### Test plan

n/a