### PR TITLE
fix(eslint-plugin): bump `typescript-eslint` to v7

### DIFF
--- a/.changeset/young-fishes-warn.md
+++ b/.changeset/young-fishes-warn.md
@@ -1,0 +1,10 @@
+---
+"@rnx-kit/eslint-plugin": minor
+---
+
+Bumped `@typescript-eslint/eslint-plugin` to v7. This brings the following breaking changes:
+
+- Update Node.js engine requirement to ^18.18.0 || >=20.0.0. This means we are dropping support for Node 16, 19, and Node 18 versions prior to 18.18.0. Note that this is the same requirement that ESLint v9 will impose.
+- Update the ESLint peer dependency requirement to ^8.56.0.
+
+For more details, check their blog post: https://typescript-eslint.io/blog/announcing-typescript-eslint-v7/

--- a/incubator/@react-native-webapis/battery-status/package.json
+++ b/incubator/@react-native-webapis/battery-status/package.json
@@ -48,7 +48,7 @@
     "@rnx-kit/scripts": "*",
     "@rnx-kit/tsconfig": "*",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "react": "18.2.0",

--- a/incubator/@react-native-webapis/web-storage/package.json
+++ b/incubator/@react-native-webapis/web-storage/package.json
@@ -47,7 +47,7 @@
     "@rnx-kit/eslint-config": "*",
     "@rnx-kit/scripts": "*",
     "@rnx-kit/tsconfig": "*",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "react": "18.2.0",

--- a/incubator/build-plugin-firebase/package.json
+++ b/incubator/build-plugin-firebase/package.json
@@ -39,7 +39,7 @@
     "@rnx-kit/jest-preset": "*",
     "@rnx-kit/scripts": "*",
     "@rnx-kit/tsconfig": "*",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"
   },

--- a/incubator/build/package.json
+++ b/incubator/build/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^20.0.0",
     "@types/qrcode": "^1.4.2",
     "@types/yargs": "^16.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"

--- a/incubator/chromium-edge-launcher/package.json
+++ b/incubator/chromium-edge-launcher/package.json
@@ -43,7 +43,7 @@
     "@types/mkdirp": "^1.0.1",
     "@types/rimraf": "^3.0.0",
     "@types/sinon": "^9.0.1",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "sinon": "^9.0.1",

--- a/incubator/commitlint-lite/package.json
+++ b/incubator/commitlint-lite/package.json
@@ -37,7 +37,7 @@
     "@rnx-kit/scripts": "*",
     "@rnx-kit/tsconfig": "*",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"

--- a/incubator/esbuild-bundle-analyzer/package.json
+++ b/incubator/esbuild-bundle-analyzer/package.json
@@ -47,7 +47,7 @@
     "@types/jest": "^29.2.1",
     "@types/node": "^20.0.0",
     "@types/yargs": "^16.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"

--- a/incubator/patcher-rnmacos/package.json
+++ b/incubator/patcher-rnmacos/package.json
@@ -38,7 +38,7 @@
     "@types/fs-extra": "^9.0.0",
     "@types/istextorbinary": "^2.3.0",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"

--- a/incubator/polyfills/package.json
+++ b/incubator/polyfills/package.json
@@ -52,7 +52,7 @@
     "@types/babel__template": "^7.0.0",
     "@types/node": "^20.0.0",
     "chalk": "^4.1.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "metro-config": "^0.80.0",
     "prettier": "^3.0.0",

--- a/incubator/react-native-error-trace-decorator/package.json
+++ b/incubator/react-native-error-trace-decorator/package.json
@@ -35,7 +35,7 @@
     "@rnx-kit/tsconfig": "*",
     "@types/node": "^20.0.0",
     "@types/yargs": "^16.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"

--- a/incubator/rn-changelog-generator/package.json
+++ b/incubator/rn-changelog-generator/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^20.0.0",
     "chalk": "^4.1.0",
     "deepmerge": "^4.2.2",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "fast-levenshtein": "^3.0.0",
     "jest": "^29.2.1",
     "p-limit": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@changesets/cli": "^2.22.0",
     "@types/jest": "^29.2.1",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "metro": "^0.80.0",
     "nx": "~17.2.0",
     "prettier": "^3.0.0",

--- a/packages/align-deps/package.json
+++ b/packages/align-deps/package.json
@@ -43,7 +43,7 @@
     "@types/yargs": "^16.0.0",
     "chalk": "^4.1.0",
     "detect-indent": "^6.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "markdown-table": "^3.0.0",
     "package-json": "^8.1.1",

--- a/packages/babel-plugin-import-path-remapper/package.json
+++ b/packages/babel-plugin-import-path-remapper/package.json
@@ -33,7 +33,7 @@
     "@types/babel__helper-plugin-utils": "^7.0.0",
     "@types/jest": "^29.2.1",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"

--- a/packages/babel-preset-metro-react-native/package.json
+++ b/packages/babel-preset-metro-react-native/package.json
@@ -49,7 +49,7 @@
     "@types/babel__core": "^7.0.0",
     "@types/jest": "^29.2.1",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "metro-react-native-babel-preset": "^0.76.5",
     "prettier": "^3.0.0",

--- a/packages/bundle-diff/package.json
+++ b/packages/bundle-diff/package.json
@@ -30,7 +30,7 @@
     "@rnx-kit/tsconfig": "*",
     "@types/jest": "^29.2.1",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -74,7 +74,7 @@
     "@types/node": "^20.0.0",
     "@types/node-fetch": "^2.6.5",
     "@types/qrcode": "^1.4.2",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "memfs": "^4.0.0",
     "metro": "^0.80.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -46,7 +46,7 @@
     "@rnx-kit/tsconfig": "*",
     "@types/node": "^20.0.0",
     "@types/semver": "^7.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "metro": "^0.80.0",
     "prettier": "^3.0.0",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -39,7 +39,7 @@
     "@rnx-kit/tsconfig": "*",
     "@types/jest": "^29.2.1",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"

--- a/packages/esbuild-plugin-import-path-remapper/package.json
+++ b/packages/esbuild-plugin-import-path-remapper/package.json
@@ -27,7 +27,7 @@
     "@rnx-kit/tsconfig": "*",
     "@types/node": "^20.0.0",
     "esbuild": "^0.20.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -18,12 +18,12 @@
     "format": "prettier --write --log-level error README.md index.js package.json"
   },
   "dependencies": {
-    "@eslint/eslintrc": "^2.1.2",
-    "@eslint/js": "^8.33.0",
+    "@eslint/eslintrc": "^2.1.4",
+    "@eslint/js": "^8.56.0",
     "@rnx-kit/eslint-plugin": "workspace:*"
   },
   "peerDependencies": {
-    "eslint": ">=6.0.0"
+    "eslint": ">=8.56.0"
   },
   "devDependencies": {
     "prettier": "^3.0.0"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -39,8 +39,8 @@
     "test": "rnx-kit-scripts test"
   },
   "dependencies": {
-    "@eslint/eslintrc": "^2.1.2",
-    "@eslint/js": "^8.33.0",
+    "@eslint/eslintrc": "^2.1.4",
+    "@eslint/js": "^8.56.0",
     "@react-native/eslint-plugin": "^0.74.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -42,14 +42,14 @@
     "@eslint/eslintrc": "^2.1.2",
     "@eslint/js": "^8.33.0",
     "@react-native/eslint-plugin": "^0.74.0",
-    "@typescript-eslint/eslint-plugin": "^6.0.0",
-    "@typescript-eslint/parser": "^6.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
     "enhanced-resolve": "^5.8.3",
     "eslint-plugin-react": "^7.33.0",
     "eslint-plugin-react-hooks": "^4.6.0"
   },
   "peerDependencies": {
-    "eslint": ">=8.23.0"
+    "eslint": ">=8.56.0"
   },
   "devDependencies": {
     "@microsoft/eslint-plugin-sdl": "^0.2.0",
@@ -63,8 +63,8 @@
     "@types/estree": "*",
     "@types/jest": "^29.2.1",
     "@types/node": "^20.0.0",
-    "@typescript-eslint/types": "^6.0.0",
-    "eslint": "^8.23.0",
+    "@typescript-eslint/types": "^7.0.0",
+    "eslint": "^8.56.0",
     "eslint-plugin-node": "11.1.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -42,7 +42,7 @@
     "@rnx-kit/tsconfig": "*",
     "@types/jest": "^29.2.1",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "react": "18.2.0",

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -45,7 +45,7 @@
     "@types/babel__core": "^7.0.0",
     "@types/connect": "^3.4.36",
     "@types/jest": "^29.2.1",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "metro": "^0.80.0",
     "metro-config": "^0.80.0",

--- a/packages/metro-plugin-cyclic-dependencies-detector/package.json
+++ b/packages/metro-plugin-cyclic-dependencies-detector/package.json
@@ -32,7 +32,7 @@
     "@rnx-kit/tsconfig": "*",
     "@types/jest": "^29.2.1",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "metro": "^0.80.0",
     "prettier": "^3.0.0",

--- a/packages/metro-plugin-duplicates-checker/package.json
+++ b/packages/metro-plugin-duplicates-checker/package.json
@@ -35,7 +35,7 @@
     "@rnx-kit/tsconfig": "*",
     "@types/jest": "^29.2.1",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "memfs": "^4.0.0",
     "metro": "^0.80.0",

--- a/packages/metro-plugin-typescript/package.json
+++ b/packages/metro-plugin-typescript/package.json
@@ -43,7 +43,7 @@
     "@rnx-kit/tsconfig": "*",
     "@types/node": "^20.0.0",
     "@types/semver": "^7.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "metro": "^0.80.0",
     "prettier": "^3.0.0"

--- a/packages/metro-resolver-symlinks/package.json
+++ b/packages/metro-resolver-symlinks/package.json
@@ -34,7 +34,7 @@
     "@rnx-kit/tsconfig": "*",
     "@types/jest": "^29.2.1",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "metro-resolver": "^0.80.0",
     "prettier": "^3.0.0",

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -46,7 +46,7 @@
     "@rnx-kit/tsconfig": "*",
     "@types/jest": "^29.2.1",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "lodash-es": "^4.17.21",
     "metro": "^0.80.0",

--- a/packages/metro-serializer/package.json
+++ b/packages/metro-serializer/package.json
@@ -31,7 +31,7 @@
     "@rnx-kit/tsconfig": "*",
     "@types/node": "^20.0.0",
     "@types/semver": "^7.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "metro": "^0.80.0",
     "prettier": "^3.0.0",

--- a/packages/metro-service/package.json
+++ b/packages/metro-service/package.json
@@ -56,7 +56,7 @@
     "@rnx-kit/tsconfig": "*",
     "@types/node": "^20.0.0",
     "@types/node-fetch": "^2.6.5",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "flow-remove-types": "~2.229.0",
     "jest": "^29.2.1",
     "metro": "^0.80.0",

--- a/packages/react-native-auth/package.json
+++ b/packages/react-native-auth/package.json
@@ -40,7 +40,7 @@
     "@rnx-kit/eslint-config": "*",
     "@rnx-kit/scripts": "*",
     "@rnx-kit/tsconfig": "*",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "prettier": "^3.0.0",
     "react": "18.2.0",
     "react-native": "^0.73.0",

--- a/packages/react-native-lazy-index/package.json
+++ b/packages/react-native-lazy-index/package.json
@@ -48,7 +48,7 @@
     "@rnx-kit/tsconfig": "*",
     "@types/jest": "^29.2.1",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -33,7 +33,7 @@
     "@rnx-kit/jest-preset": "*",
     "@rnx-kit/scripts": "*",
     "@rnx-kit/tsconfig": "*",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -59,7 +59,7 @@
     "@rnx-kit/tsconfig": "workspace:*",
     "@testing-library/react-native": "^12.4.3",
     "@types/react": "^18.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "react-native-test-app": "^3.0.0",

--- a/packages/third-party-notices/package.json
+++ b/packages/third-party-notices/package.json
@@ -39,7 +39,7 @@
     "@types/jest": "^29.2.1",
     "@types/node": "^20.0.0",
     "@types/yargs": "^16.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "metro-source-map": "^0.80.0",
     "prettier": "^3.0.0",

--- a/packages/tools-language/package.json
+++ b/packages/tools-language/package.json
@@ -43,7 +43,7 @@
     "@rnx-kit/scripts": "*",
     "@rnx-kit/tsconfig": "*",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"

--- a/packages/tools-node/package.json
+++ b/packages/tools-node/package.json
@@ -57,7 +57,7 @@
     "@rnx-kit/scripts": "*",
     "@rnx-kit/tsconfig": "*",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"

--- a/packages/tools-react-native/package.json
+++ b/packages/tools-react-native/package.json
@@ -53,7 +53,7 @@
     "@rnx-kit/scripts": "*",
     "@rnx-kit/tsconfig": "*",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "metro": "^0.80.0",
     "metro-config": "^0.80.0",

--- a/packages/tools-workspaces/package.json
+++ b/packages/tools-workspaces/package.json
@@ -46,7 +46,7 @@
     "@rnx-kit/scripts": "*",
     "@rnx-kit/tsconfig": "*",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"

--- a/packages/typescript-service/package.json
+++ b/packages/typescript-service/package.json
@@ -33,7 +33,7 @@
     "@rnx-kit/scripts": "*",
     "@rnx-kit/tsconfig": "*",
     "@types/node": "^20.0.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"

--- a/scripts/align-deps-preset.cjs
+++ b/scripts/align-deps-preset.cjs
@@ -65,7 +65,7 @@ const profile = {
   },
   eslint: {
     name: "eslint",
-    version: "^8.23.0",
+    version: "^8.56.0",
     devOnly: true,
   },
   "find-up": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "depcheck": "^1.0.0",
     "esbuild": "^0.20.0",
-    "eslint": "^8.23.0",
+    "eslint": "^8.56.0",
     "jest": "^29.2.1",
     "markdown-table": "^3.0.0",
     "prettier": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2168,10 +2168,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:8.56.0, @eslint/js@npm:^8.33.0":
-  version: 8.56.0
-  resolution: "@eslint/js@npm:8.56.0"
-  checksum: 5804130574ef810207bdf321c265437814e7a26f4e6fac9b496de3206afd52f533e09ec002a3be06cd9adcc9da63e727f1883938e663c4e4751c007d5b58e539
+"@eslint/js@npm:8.57.0, @eslint/js@npm:^8.33.0":
+  version: 8.57.0
+  resolution: "@eslint/js@npm:8.57.0"
+  checksum: 315dc65b0e9893e2bff139bddace7ea601ad77ed47b4550e73da8c9c2d2766c7a575c3cddf17ef85b8fd6a36ff34f91729d0dcca56e73ca887c10df91a41b0bb
   languageName: node
   linkType: hard
 
@@ -2242,14 +2242,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/config-array@npm:^0.11.13":
-  version: 0.11.13
-  resolution: "@humanwhocodes/config-array@npm:0.11.13"
+"@humanwhocodes/config-array@npm:^0.11.14":
+  version: 0.11.14
+  resolution: "@humanwhocodes/config-array@npm:0.11.14"
   dependencies:
-    "@humanwhocodes/object-schema": ^2.0.1
-    debug: ^4.1.1
+    "@humanwhocodes/object-schema": ^2.0.2
+    debug: ^4.3.1
     minimatch: ^3.0.5
-  checksum: f8ea57b0d7ed7f2d64cd3944654976829d9da91c04d9c860e18804729a33f7681f78166ef4c761850b8c324d362f7d53f14c5c44907a6b38b32c703ff85e4805
+  checksum: 861ccce9eaea5de19546653bccf75bf09fe878bc39c3aab00aeee2d2a0e654516adad38dd1098aab5e3af0145bbcbf3f309bdf4d964f8dab9dcd5834ae4c02f2
   languageName: node
   linkType: hard
 
@@ -2260,10 +2260,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/object-schema@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@humanwhocodes/object-schema@npm:2.0.1"
-  checksum: 24929487b1ed48795d2f08346a0116cc5ee4634848bce64161fb947109352c562310fd159fc64dda0e8b853307f5794605191a9547f7341158559ca3c8262a45
+"@humanwhocodes/object-schema@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@humanwhocodes/object-schema@npm:2.0.2"
+  checksum: 2fc11503361b5fb4f14714c700c02a3f4c7c93e9acd6b87a29f62c522d90470f364d6161b03d1cc618b979f2ae02aed1106fd29d302695d8927e2fc8165ba8ee
   languageName: node
   linkType: hard
 
@@ -3162,7 +3162,7 @@ __metadata:
     "@rnx-kit/scripts": "*"
     "@rnx-kit/tsconfig": "*"
     "@types/node": ^20.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     prettier: ^3.0.0
     react: 18.2.0
@@ -3183,7 +3183,7 @@ __metadata:
     "@rnx-kit/eslint-config": "*"
     "@rnx-kit/scripts": "*"
     "@rnx-kit/tsconfig": "*"
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     prettier: ^3.0.0
     react: 18.2.0
@@ -3513,7 +3513,7 @@ __metadata:
     "@types/yargs": ^16.0.0
     chalk: ^4.1.0
     detect-indent: ^6.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     markdown-table: ^3.0.0
     package-json: ^8.1.1
@@ -3542,7 +3542,7 @@ __metadata:
     "@types/babel__helper-plugin-utils": ^7.0.0
     "@types/jest": ^29.2.1
     "@types/node": ^20.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     prettier: ^3.0.0
     typescript: ^5.0.0
@@ -3563,7 +3563,7 @@ __metadata:
     "@types/jest": ^29.2.1
     "@types/node": ^20.0.0
     babel-plugin-const-enum: ^1.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     metro-react-native-babel-preset: ^0.76.5
     prettier: ^3.0.0
@@ -3592,7 +3592,7 @@ __metadata:
     "@rnx-kit/jest-preset": "*"
     "@rnx-kit/scripts": "*"
     "@rnx-kit/tsconfig": "*"
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     prettier: ^3.0.0
     typescript: ^5.0.0
   peerDependencies:
@@ -3618,7 +3618,7 @@ __metadata:
     "@types/qrcode": ^1.4.2
     "@types/yargs": ^16.0.0
     env-paths: ^3.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     fast-xml-parser: ^4.0.0
     jest: ^29.2.1
     node-fetch: ^3.3.2
@@ -3643,7 +3643,7 @@ __metadata:
     "@rnx-kit/tsconfig": "*"
     "@types/jest": ^29.2.1
     "@types/node": ^20.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     prettier: ^3.0.0
     typescript: ^5.0.0
@@ -3665,7 +3665,7 @@ __metadata:
     "@types/rimraf": ^3.0.0
     "@types/sinon": ^9.0.1
     escape-string-regexp: ^4.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     is-wsl: ^2.2.0
     jest: ^29.2.1
     lighthouse-logger: ^1.0.0
@@ -3709,7 +3709,7 @@ __metadata:
     "@types/node-fetch": ^2.6.5
     "@types/qrcode": ^1.4.2
     chalk: ^4.1.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     fs-extra: ^10.0.0
     jest: ^29.2.1
     memfs: ^4.0.0
@@ -3745,7 +3745,7 @@ __metadata:
     "@rnx-kit/scripts": "*"
     "@rnx-kit/tsconfig": "*"
     "@types/node": ^20.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     prettier: ^3.0.0
     typescript: ^5.0.0
@@ -3770,7 +3770,7 @@ __metadata:
     "@rnx-kit/tsconfig": "*"
     "@types/node": ^20.0.0
     "@types/semver": ^7.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     metro: ^0.80.0
     prettier: ^3.0.0
@@ -3790,7 +3790,7 @@ __metadata:
     "@types/jest": ^29.2.1
     "@types/node": ^20.0.0
     chalk: ^4.1.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     prettier: ^3.0.0
     typescript: ^5.0.0
@@ -3813,7 +3813,7 @@ __metadata:
     "@types/node": ^20.0.0
     "@types/yargs": ^16.0.0
     chalk: ^4.1.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     prettier: ^3.0.0
     typescript: ^5.0.0
@@ -3833,7 +3833,7 @@ __metadata:
     "@rnx-kit/tsconfig": "*"
     "@types/node": ^20.0.0
     esbuild: ^0.20.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     prettier: ^3.0.0
     typescript: ^5.0.0
@@ -3871,11 +3871,11 @@ __metadata:
     "@types/estree": "*"
     "@types/jest": ^29.2.1
     "@types/node": ^20.0.0
-    "@typescript-eslint/eslint-plugin": ^6.0.0
-    "@typescript-eslint/parser": ^6.0.0
-    "@typescript-eslint/types": ^6.0.0
+    "@typescript-eslint/eslint-plugin": ^7.0.0
+    "@typescript-eslint/parser": ^7.0.0
+    "@typescript-eslint/types": ^7.0.0
     enhanced-resolve: ^5.8.3
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     eslint-plugin-node: 11.1.0
     eslint-plugin-react: ^7.33.0
     eslint-plugin-react-hooks: ^4.6.0
@@ -3883,7 +3883,7 @@ __metadata:
     prettier: ^3.0.0
     typescript: ^5.0.0
   peerDependencies:
-    eslint: ">=8.23.0"
+    eslint: ">=8.56.0"
   languageName: unknown
   linkType: soft
 
@@ -3907,7 +3907,7 @@ __metadata:
     "@rnx-kit/tsconfig": "*"
     "@types/jest": ^29.2.1
     "@types/node": ^20.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     find-up: ^5.0.0
     jest: ^29.2.1
     prettier: ^3.0.0
@@ -3939,7 +3939,7 @@ __metadata:
     "@types/babel__core": ^7.0.0
     "@types/connect": ^3.4.36
     "@types/jest": ^29.2.1
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     metro: ^0.80.0
     metro-config: ^0.80.0
@@ -3972,7 +3972,7 @@ __metadata:
     "@rnx-kit/tsconfig": "*"
     "@types/jest": ^29.2.1
     "@types/node": ^20.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     metro: ^0.80.0
     prettier: ^3.0.0
@@ -3993,7 +3993,7 @@ __metadata:
     "@rnx-kit/tsconfig": "*"
     "@types/jest": ^29.2.1
     "@types/node": ^20.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     memfs: ^4.0.0
     metro: ^0.80.0
@@ -4020,7 +4020,7 @@ __metadata:
     "@rnx-kit/typescript-service": ^1.5.7
     "@types/node": ^20.0.0
     "@types/semver": ^7.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     metro: ^0.80.0
     prettier: ^3.0.0
@@ -4043,7 +4043,7 @@ __metadata:
     "@types/jest": ^29.2.1
     "@types/node": ^20.0.0
     enhanced-resolve: ^5.8.3
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     metro-resolver: ^0.80.0
     prettier: ^3.0.0
@@ -4077,7 +4077,7 @@ __metadata:
     "@types/node": ^20.0.0
     esbuild: ^0.20.0
     esbuild-plugin-lodash: ^1.2.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     fast-glob: ^3.2.7
     jest: ^29.2.1
     lodash-es: ^4.17.21
@@ -4102,7 +4102,7 @@ __metadata:
     "@rnx-kit/tsconfig": "*"
     "@types/node": ^20.0.0
     "@types/semver": ^7.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     metro: ^0.80.0
     prettier: ^3.0.0
@@ -4127,7 +4127,7 @@ __metadata:
     "@types/node": ^20.0.0
     "@types/node-fetch": ^2.6.5
     chalk: ^4.1.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     flow-remove-types: ~2.229.0
     jest: ^29.2.1
     metro: ^0.80.0
@@ -4165,7 +4165,7 @@ __metadata:
     "@types/istextorbinary": ^2.3.0
     "@types/node": ^20.0.0
     commander: ^4.1.1
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     fs-extra: ^10.0.0
     istextorbinary: ^3.3.0
     jest: ^29.2.1
@@ -4195,7 +4195,7 @@ __metadata:
     "@types/babel__template": ^7.0.0
     "@types/node": ^20.0.0
     chalk: ^4.1.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     metro-config: ^0.80.0
     prettier: ^3.0.0
@@ -4218,7 +4218,7 @@ __metadata:
     "@rnx-kit/eslint-config": "*"
     "@rnx-kit/scripts": "*"
     "@rnx-kit/tsconfig": "*"
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     prettier: ^3.0.0
     react: 18.2.0
     react-native: ^0.73.0
@@ -4240,7 +4240,7 @@ __metadata:
     "@rnx-kit/tsconfig": "*"
     "@types/node": ^20.0.0
     "@types/yargs": ^16.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     metro-symbolicate: ^0.80.0
     prettier: ^3.0.0
@@ -4276,7 +4276,7 @@ __metadata:
     "@types/jest": ^29.2.1
     "@types/node": ^20.0.0
     babel-plugin-codegen: ^4.1.5
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     prettier: ^3.0.0
     typescript: ^5.0.0
@@ -4309,7 +4309,7 @@ __metadata:
     "@types/node": ^20.0.0
     chalk: ^4.1.0
     deepmerge: ^4.2.2
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     fast-levenshtein: ^3.0.0
     jest: ^29.2.1
     p-limit: ^3.1.0
@@ -4332,7 +4332,7 @@ __metadata:
     "@types/yargs": ^16.0.0
     depcheck: ^1.0.0
     esbuild: ^0.20.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     markdown-table: ^3.0.0
     prettier: ^3.0.0
@@ -4352,7 +4352,7 @@ __metadata:
     "@rnx-kit/jest-preset": "*"
     "@rnx-kit/scripts": "*"
     "@rnx-kit/tsconfig": "*"
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     prettier: ^3.0.0
     typescript: ^5.0.0
@@ -4391,7 +4391,7 @@ __metadata:
     "@rnx-kit/tsconfig": "workspace:*"
     "@testing-library/react-native": ^12.4.3
     "@types/react": ^18.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     prettier: ^3.0.0
     react: 18.2.0
@@ -4418,7 +4418,7 @@ __metadata:
     "@types/jest": ^29.2.1
     "@types/node": ^20.0.0
     "@types/yargs": ^16.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     metro-source-map: ^0.80.0
     prettier: ^3.0.0
@@ -4439,7 +4439,7 @@ __metadata:
     "@rnx-kit/scripts": "*"
     "@rnx-kit/tsconfig": "*"
     "@types/node": ^20.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     prettier: ^3.0.0
     typescript: ^5.0.0
@@ -4455,7 +4455,7 @@ __metadata:
     "@rnx-kit/scripts": "*"
     "@rnx-kit/tsconfig": "*"
     "@types/node": ^20.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     prettier: ^3.0.0
     typescript: ^5.0.0
@@ -4472,7 +4472,7 @@ __metadata:
     "@rnx-kit/tools-node": ^2.0.1
     "@rnx-kit/tsconfig": "*"
     "@types/node": ^20.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     metro: ^0.80.0
     metro-config: ^0.80.0
@@ -4493,7 +4493,7 @@ __metadata:
     "@rnx-kit/scripts": "*"
     "@rnx-kit/tsconfig": "*"
     "@types/node": ^20.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     fast-glob: ^3.2.7
     find-up: ^5.0.0
     jest: ^29.2.1
@@ -4523,7 +4523,7 @@ __metadata:
     "@rnx-kit/tsconfig": "*"
     "@types/node": ^20.0.0
     chalk: ^4.1.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     jest: ^29.2.1
     prettier: ^3.0.0
     typescript: ^5.0.0
@@ -5049,15 +5049,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^6.0.0":
-  version: 6.21.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:6.21.0"
+"@typescript-eslint/eslint-plugin@npm:^7.0.0":
+  version: 7.2.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:7.2.0"
   dependencies:
     "@eslint-community/regexpp": ^4.5.1
-    "@typescript-eslint/scope-manager": 6.21.0
-    "@typescript-eslint/type-utils": 6.21.0
-    "@typescript-eslint/utils": 6.21.0
-    "@typescript-eslint/visitor-keys": 6.21.0
+    "@typescript-eslint/scope-manager": 7.2.0
+    "@typescript-eslint/type-utils": 7.2.0
+    "@typescript-eslint/utils": 7.2.0
+    "@typescript-eslint/visitor-keys": 7.2.0
     debug: ^4.3.4
     graphemer: ^1.4.0
     ignore: ^5.2.4
@@ -5065,73 +5065,73 @@ __metadata:
     semver: ^7.5.4
     ts-api-utils: ^1.0.1
   peerDependencies:
-    "@typescript-eslint/parser": ^6.0.0 || ^6.0.0-alpha
-    eslint: ^7.0.0 || ^8.0.0
+    "@typescript-eslint/parser": ^7.0.0
+    eslint: ^8.56.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 5ef2c502255e643e98051e87eb682c2a257e87afd8ec3b9f6274277615e1c2caf3131b352244cfb1987b8b2c415645eeacb9113fa841fc4c9b2ac46e8aed6efd
+  checksum: 1f6e1d12774f4a2cbe585fdaa0e74982c6b553281624c23646e043547736d2893c4a55fbbee4f7d9d596291f3b94b1856f11c4d71cf6b5bce988945f0fad60d4
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^6.0.0":
-  version: 6.21.0
-  resolution: "@typescript-eslint/parser@npm:6.21.0"
+"@typescript-eslint/parser@npm:^7.0.0":
+  version: 7.2.0
+  resolution: "@typescript-eslint/parser@npm:7.2.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 6.21.0
-    "@typescript-eslint/types": 6.21.0
-    "@typescript-eslint/typescript-estree": 6.21.0
-    "@typescript-eslint/visitor-keys": 6.21.0
+    "@typescript-eslint/scope-manager": 7.2.0
+    "@typescript-eslint/types": 7.2.0
+    "@typescript-eslint/typescript-estree": 7.2.0
+    "@typescript-eslint/visitor-keys": 7.2.0
     debug: ^4.3.4
   peerDependencies:
-    eslint: ^7.0.0 || ^8.0.0
+    eslint: ^8.56.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 162fe3a867eeeffda7328bce32dae45b52283c68c8cb23258fb9f44971f761991af61f71b8c9fe1aa389e93dfe6386f8509c1273d870736c507d76dd40647b68
+  checksum: 21deb2e7ad1fc730f637af08f5c549f30ef5b50f424639f57f5bc01274e648db47c696bb994bb24e87424b593d4084e306447c9431a0c0e4807952996db306f4
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:6.21.0":
-  version: 6.21.0
-  resolution: "@typescript-eslint/scope-manager@npm:6.21.0"
+"@typescript-eslint/scope-manager@npm:7.2.0":
+  version: 7.2.0
+  resolution: "@typescript-eslint/scope-manager@npm:7.2.0"
   dependencies:
-    "@typescript-eslint/types": 6.21.0
-    "@typescript-eslint/visitor-keys": 6.21.0
-  checksum: 71028b757da9694528c4c3294a96cc80bc7d396e383a405eab3bc224cda7341b88e0fc292120b35d3f31f47beac69f7083196c70616434072fbcd3d3e62d3376
+    "@typescript-eslint/types": 7.2.0
+    "@typescript-eslint/visitor-keys": 7.2.0
+  checksum: b4ef8e35a56f590fa56cf769e111907828abb4793f482bf57e3fc8c987294ec119acb96359aa4b0150eea7416816e0b2d8635dccd1e4a5c2b02678b0f74def94
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:6.21.0":
-  version: 6.21.0
-  resolution: "@typescript-eslint/type-utils@npm:6.21.0"
+"@typescript-eslint/type-utils@npm:7.2.0":
+  version: 7.2.0
+  resolution: "@typescript-eslint/type-utils@npm:7.2.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": 6.21.0
-    "@typescript-eslint/utils": 6.21.0
+    "@typescript-eslint/typescript-estree": 7.2.0
+    "@typescript-eslint/utils": 7.2.0
     debug: ^4.3.4
     ts-api-utils: ^1.0.1
   peerDependencies:
-    eslint: ^7.0.0 || ^8.0.0
+    eslint: ^8.56.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 77025473f4d80acf1fafcce99c5c283e557686a61861febeba9c9913331f8a41e930bf5cd8b7a54db502a57b6eb8ea6d155cbd4f41349ed00e3d7aeb1f477ddc
+  checksum: d38b91ce2c3ffced243948e4778c3b015cf6a4fe988f35000977bf611c33edf455a92a78e69efe1ffa68257110a286c9c5593553bc32e19170410a1f730efed6
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:6.21.0, @typescript-eslint/types@npm:^6.0.0":
-  version: 6.21.0
-  resolution: "@typescript-eslint/types@npm:6.21.0"
-  checksum: 9501b47d7403417af95fc1fb72b2038c5ac46feac0e1598a46bcb43e56a606c387e9dcd8a2a0abe174c91b509f2d2a8078b093786219eb9a01ab2fbf9ee7b684
+"@typescript-eslint/types@npm:7.2.0, @typescript-eslint/types@npm:^7.0.0":
+  version: 7.2.0
+  resolution: "@typescript-eslint/types@npm:7.2.0"
+  checksum: 237acd24aa55b762ee98904e4f422ba86579325200dcd058b3cbfe70775926e7f00ee0295788d81eb728f3a6326fe4401c648aee9eb1480d9030a441c17520e8
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:6.21.0":
-  version: 6.21.0
-  resolution: "@typescript-eslint/typescript-estree@npm:6.21.0"
+"@typescript-eslint/typescript-estree@npm:7.2.0":
+  version: 7.2.0
+  resolution: "@typescript-eslint/typescript-estree@npm:7.2.0"
   dependencies:
-    "@typescript-eslint/types": 6.21.0
-    "@typescript-eslint/visitor-keys": 6.21.0
+    "@typescript-eslint/types": 7.2.0
+    "@typescript-eslint/visitor-keys": 7.2.0
     debug: ^4.3.4
     globby: ^11.1.0
     is-glob: ^4.0.3
@@ -5141,34 +5141,34 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: dec02dc107c4a541e14fb0c96148f3764b92117c3b635db3a577b5a56fc48df7a556fa853fb82b07c0663b4bf2c484c9f245c28ba3e17e5cb0918ea4cab2ea21
+  checksum: fe882195cad45bb67e7e127efa9c31977348d0ca923ef26bb9fbd03a2ab64e6772e6e60954ba07a437684fae8e35897d71f0e6a1ef8fbf3f0025cd314960cd9d
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:6.21.0":
-  version: 6.21.0
-  resolution: "@typescript-eslint/utils@npm:6.21.0"
+"@typescript-eslint/utils@npm:7.2.0":
+  version: 7.2.0
+  resolution: "@typescript-eslint/utils@npm:7.2.0"
   dependencies:
     "@eslint-community/eslint-utils": ^4.4.0
     "@types/json-schema": ^7.0.12
     "@types/semver": ^7.5.0
-    "@typescript-eslint/scope-manager": 6.21.0
-    "@typescript-eslint/types": 6.21.0
-    "@typescript-eslint/typescript-estree": 6.21.0
+    "@typescript-eslint/scope-manager": 7.2.0
+    "@typescript-eslint/types": 7.2.0
+    "@typescript-eslint/typescript-estree": 7.2.0
     semver: ^7.5.4
   peerDependencies:
-    eslint: ^7.0.0 || ^8.0.0
-  checksum: b129b3a4aebec8468259f4589985cb59ea808afbfdb9c54f02fad11e17d185e2bf72bb332f7c36ec3c09b31f18fc41368678b076323e6e019d06f74ee93f7bf2
+    eslint: ^8.56.0
+  checksum: 1d333bdc50c52de5757d860512db0dde5748c5fbf8c66a8a984a3bff10d4cd492878c9d5ca3a49d869fdf8d6cf415594be8e7c3cfb4dfe9e3f3f5db297877ad4
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:6.21.0":
-  version: 6.21.0
-  resolution: "@typescript-eslint/visitor-keys@npm:6.21.0"
+"@typescript-eslint/visitor-keys@npm:7.2.0":
+  version: 7.2.0
+  resolution: "@typescript-eslint/visitor-keys@npm:7.2.0"
   dependencies:
-    "@typescript-eslint/types": 6.21.0
+    "@typescript-eslint/types": 7.2.0
     eslint-visitor-keys: ^3.4.1
-  checksum: 67c7e6003d5af042d8703d11538fca9d76899f0119130b373402819ae43f0bc90d18656aa7add25a24427ccf1a0efd0804157ba83b0d4e145f06107d7d1b7433
+  checksum: d9b11b52737450f213cea5c6e07e4672684da48325905c096ee09302b6b261c0bb226e1e350011bdf127c0cbbdd9e6474c905befdfa0a2118fc89ece16770f2b
   languageName: node
   linkType: hard
 
@@ -7631,15 +7631,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^8.23.0":
-  version: 8.56.0
-  resolution: "eslint@npm:8.56.0"
+"eslint@npm:^8.56.0":
+  version: 8.57.0
+  resolution: "eslint@npm:8.57.0"
   dependencies:
     "@eslint-community/eslint-utils": ^4.2.0
     "@eslint-community/regexpp": ^4.6.1
     "@eslint/eslintrc": ^2.1.4
-    "@eslint/js": 8.56.0
-    "@humanwhocodes/config-array": ^0.11.13
+    "@eslint/js": 8.57.0
+    "@humanwhocodes/config-array": ^0.11.14
     "@humanwhocodes/module-importer": ^1.0.1
     "@nodelib/fs.walk": ^1.2.8
     "@ungap/structured-clone": ^1.2.0
@@ -7675,7 +7675,7 @@ __metadata:
     text-table: ^0.2.0
   bin:
     eslint: bin/eslint.js
-  checksum: 883436d1e809b4a25d9eb03d42f584b84c408dbac28b0019f6ea07b5177940bf3cca86208f749a6a1e0039b63e085ee47aca1236c30721e91f0deef5cc5a5136
+  checksum: 3a48d7ff85ab420a8447e9810d8087aea5b1df9ef68c9151732b478de698389ee656fd895635b5f2871c89ee5a2652b3f343d11e9db6f8486880374ebc74a2d9
   languageName: node
   linkType: hard
 
@@ -12984,7 +12984,7 @@ __metadata:
     "@changesets/cli": ^2.22.0
     "@types/jest": ^29.2.1
     "@types/node": ^20.0.0
-    eslint: ^8.23.0
+    eslint: ^8.56.0
     metro: ^0.80.0
     nx: ~17.2.0
     prettier: ^3.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,7 +2151,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^2.1.2, @eslint/eslintrc@npm:^2.1.4":
+"@eslint/eslintrc@npm:^2.1.4":
   version: 2.1.4
   resolution: "@eslint/eslintrc@npm:2.1.4"
   dependencies:
@@ -2168,7 +2168,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:8.57.0, @eslint/js@npm:^8.33.0":
+"@eslint/js@npm:8.57.0, @eslint/js@npm:^8.33.0, @eslint/js@npm:^8.56.0":
   version: 8.57.0
   resolution: "@eslint/js@npm:8.57.0"
   checksum: 315dc65b0e9893e2bff139bddace7ea601ad77ed47b4550e73da8c9c2d2766c7a575c3cddf17ef85b8fd6a36ff34f91729d0dcca56e73ca887c10df91a41b0bb
@@ -3844,12 +3844,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rnx-kit/eslint-config@workspace:packages/eslint-config"
   dependencies:
-    "@eslint/eslintrc": ^2.1.2
-    "@eslint/js": ^8.33.0
+    "@eslint/eslintrc": ^2.1.4
+    "@eslint/js": ^8.56.0
     "@rnx-kit/eslint-plugin": "workspace:*"
     prettier: ^3.0.0
   peerDependencies:
-    eslint: ">=6.0.0"
+    eslint: ">=8.56.0"
   languageName: unknown
   linkType: soft
 
@@ -3857,8 +3857,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rnx-kit/eslint-plugin@workspace:packages/eslint-plugin"
   dependencies:
-    "@eslint/eslintrc": ^2.1.2
-    "@eslint/js": ^8.33.0
+    "@eslint/eslintrc": ^2.1.4
+    "@eslint/js": ^8.56.0
     "@microsoft/eslint-plugin-sdl": ^0.2.0
     "@react-native/eslint-plugin": ^0.74.0
     "@rnx-kit/eslint-config": "*"


### PR DESCRIPTION
### Description

Bumped `@typescript-eslint/eslint-plugin` to v7. This brings the following breaking changes:

- Update Node.js engine requirement to ^18.18.0 || >=20.0.0. This means we are dropping support for Node 16, 19, and Node 18 versions prior to 18.18.0. Note that this is the same requirement that ESLint v9 will impose.
- Update the ESLint peer dependency requirement to ^8.56.0.

For more details, check their blog post: https://typescript-eslint.io/blog/announcing-typescript-eslint-v7/

### Test plan

CI should pass.