### PR TITLE
fix(ios): add privacy manifest

### DIFF
--- a/.changeset/tall-eagles-type.md
+++ b/.changeset/tall-eagles-type.md
@@ -1,0 +1,5 @@
+---
+"@react-native-webapis/web-storage": patch
+---
+
+Added privacy manifest as required by Apple for app submissions

--- a/incubator/@react-native-webapis/web-storage/RNWWebStorage.podspec
+++ b/incubator/@react-native-webapis/web-storage/RNWWebStorage.podspec
@@ -28,6 +28,12 @@ Pod::Spec.new do |s|
                            "#{repository['directory']}/ios/*.{h,m,mm}"    # :podspec
   s.public_header_files  = 'ios/*.h',                                     # :path
                            "#{repository['directory']}/ios/*.h"           # :podspec
+  s.resource_bundles = {
+    "#{s.name}" => [
+      'ios/PrivacyInfo.xcprivacy',                              # :path
+      "#{repository['directory']}/ios/PrivacyInfo.xcprivacy"    # :podspec
+    ]
+  }
 
   install_modules_dependencies(s) if defined?(install_modules_dependencies)
 end

--- a/incubator/@react-native-webapis/web-storage/ios/PrivacyInfo.xcprivacy
+++ b/incubator/@react-native-webapis/web-storage/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/packages/test-app/ios/Podfile.lock
+++ b/packages/test-app/ios/Podfile.lock
@@ -1321,7 +1321,7 @@ SPEC CHECKSUMS:
   ReactTestApp-DevSupport: 7996b78090b3d5e2e2a49b8ab7fdd84ff91be30f
   ReactTestApp-MSAL: f41794214b301ab1e969a95112e276acc7204a7a
   ReactTestApp-Resources: a4cc1f968cd26bdbd18ee0bfbd0ab8dd0ea90101
-  RNWWebStorage: 6dca525e55525aa59b6f81d7330d5727d8f0ad5c
+  RNWWebStorage: d94fb5551bfcd36a60235243951a8f1947054d1e
   RNXAuth: da888a17b9a0f54908f6daa8b2e020d3585f91cc
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: a716eea57d0d3430219c0a5a233e1e93ee931eb7

--- a/packages/test-app/macos/Podfile.lock
+++ b/packages/test-app/macos/Podfile.lock
@@ -1266,7 +1266,7 @@ SPEC CHECKSUMS:
   ReactTestApp-DevSupport: 7996b78090b3d5e2e2a49b8ab7fdd84ff91be30f
   ReactTestApp-MSAL: f41794214b301ab1e969a95112e276acc7204a7a
   ReactTestApp-Resources: 23ebf203a76bfaa5b08de3118ae3daa2baa25478
-  RNWWebStorage: 1b0a56ca5a3994c88a46f69e26374787f0b0bf87
+  RNWWebStorage: b74da0c3b7f05e2fa959be41ea1eb3bfc4b9bd3b
   RNXAuth: da888a17b9a0f54908f6daa8b2e020d3585f91cc
   SocketRocket: f6c6249082c011e6de2de60ed641ef8bbe0cfac9
   Yoga: be49bbfe083338605b543c38aba44c90ac3a18a5


### PR DESCRIPTION
### Description

Privacy manifest files are required as of May 1 for app submissions: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api

### Test plan

```
cd packages/test-app
pod install --project-directory=ios
open ios/SampleCrossApp.xcworkspace
```

Verify that `PrivacyInfo.xcprivacy` is included.

<img width="1512" alt="Screenshot 2024-03-16 at 10 02 40" src="https://github.com/microsoft/rnx-kit/assets/4123478/e0c31cd2-8b55-432a-8a40-7be3b67c31af">
