### PR TITLE
ci: fix publish failing because Yarn config is reset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Create release PR or publish to npm
         uses: changesets/action@v1
         with:
-          publish: yarn publish:changesets
-          version: yarn version:changesets
+          publish: npm run publish:changesets
+          version: npm run version:changesets
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Description

Changesets does a hard reset before publishing. This makes Yarn complain because the config and the install state becomes inconsistent.

```
setting git user
/usr/bin/git config user.name "github-actions[bot]"
/usr/bin/git config user.email "github-actions[bot]@users.noreply.github.com"
setting GitHub credentials
/usr/bin/git checkout changeset-release/main
error: pathspec 'changeset-release/main' did not match any file(s) known to git
/usr/bin/git checkout -b changeset-release/main
Switched to a new branch 'changeset-release/main'
/usr/bin/git reset --hard b9625034adee83ae3b28b326[11](https://github.com/microsoft/rnx-kit/actions/runs/8326410145/job/22782037380#step:7:12)79e39bfe6bf3ea
HEAD is now at b9625034 ci: bump Node to v20 to satisfy Yarn (#3007)
/usr/local/bin/yarn version:changesets
Usage Error: Couldn't find @changesets/cli@npm:2.27.1 in the currently installed pnpm map - running an install might help
$ yarn run [--inspect] [--inspect-brk] [-T,--top-level] [-B,--binaries-only] [--require #0] <scriptName> ...
Error: Error: The process '/usr/local/bin/yarn' failed with exit code 1
Error: The process '/usr/local/bin/yarn' failed with exit code 1
```

### Test plan

n/a