### PR TITLE
feat(align-deps): add flag to make unmanaged capabilities errors

### DIFF
--- a/.changeset/friendly-peas-sneeze.md
+++ b/.changeset/friendly-peas-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": minor
+---
+
+Added a flag, `--no-unmanaged`, to make unmanaged capabilities errors

--- a/.changeset/tidy-windows-relate.md
+++ b/.changeset/tidy-windows-relate.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+align-deps: Added a flag, `--no-unmanaged`, to make unmanaged capabilities errors

--- a/packages/align-deps/README.md
+++ b/packages/align-deps/README.md
@@ -100,6 +100,20 @@ cumbersome to manually add all capabilities yourself. You can run this tool with
 `--init`, and it will try to add a sensible configuration based on what is
 currently defined in the specified `package.json`.
 
+### `--loose`
+
+Determines how strict the React Native version requirement should be. Useful for
+apps that depend on a newer React Native version than their dependencies declare
+support for.
+
+Default: `false`
+
+### `--no-unmanaged`
+
+Whether unmanaged capabilities should be treated as errors.
+
+Default: `false`
+
 ### `--presets`
 
 Comma-separated list of presets. This can be names to built-in presets, or paths
@@ -170,9 +184,17 @@ If the version numbers are omitted, an _interactive prompt_ will appear.
 > made. As such, this flag will fail if changes are needed before making any
 > modifications.
 
+### `--verbose`
+
+Specify to increase logging verbosity.
+
+Default: `false`
+
 ### `--write`
 
 Writes all proposed changes to the specified `package.json`.
+
+Default: `false`
 
 ## Configure
 

--- a/packages/align-deps/src/cli.ts
+++ b/packages/align-deps/src/cli.ts
@@ -42,6 +42,12 @@ export const cliOptions = {
       "Determines whether align-deps should try to update the config in 'package.json'.",
     type: "boolean",
   },
+  "no-unmanaged": {
+    default: false,
+    description:
+      "Determines whether align-deps should treat unmanaged capabilities as errors.",
+    type: "boolean",
+  },
   presets: {
     description:
       "Comma-separated list of presets. This can be names to built-in presets, or paths to external presets.",
@@ -157,6 +163,7 @@ async function makeCommand(args: Args): Promise<Command | undefined> {
     init,
     loose,
     "migrate-config": migrateConfig,
+    "no-unmanaged": noUnmanaged,
     presets,
     requirements,
     "set-version": setVersion,
@@ -168,6 +175,7 @@ async function makeCommand(args: Args): Promise<Command | undefined> {
     presets: presets?.toString()?.split(",") ?? defaultConfig.presets,
     loose,
     migrateConfig,
+    noUnmanaged,
     verbose,
     write,
     excludePackages: excludePackages?.toString()?.split(","),

--- a/packages/align-deps/src/types.ts
+++ b/packages/align-deps/src/types.ts
@@ -22,6 +22,7 @@ export type Options = {
   presets: string[];
   loose: boolean;
   migrateConfig: boolean;
+  noUnmanaged: boolean;
   verbose: boolean;
   write: boolean;
   excludePackages?: string[];
@@ -31,6 +32,7 @@ export type Options = {
 export type Args = Pick<Options, "loose" | "verbose" | "write"> & {
   "exclude-packages"?: string | number;
   "migrate-config": boolean;
+  "no-unmanaged": boolean;
   "set-version"?: string | number;
   init?: string;
   packages?: (string | number)[];
@@ -48,6 +50,7 @@ export type ErrorCode =
   | "invalid-manifest"
   | "missing-react-native"
   | "not-configured"
+  | "unmanaged-capabilities"
   | "unsatisfied";
 
 export type Command = (manifest: string) => ErrorCode;

--- a/packages/align-deps/test/check.app.test.ts
+++ b/packages/align-deps/test/check.app.test.ts
@@ -9,6 +9,7 @@ const defaultOptions = {
   presets: defaultConfig.presets,
   loose: false,
   migrateConfig: false,
+  noUnmanaged: false,
   verbose: false,
   write: true,
 };

--- a/packages/align-deps/test/check.test.ts
+++ b/packages/align-deps/test/check.test.ts
@@ -11,6 +11,7 @@ const defaultOptions = {
   presets: defaultConfig.presets,
   loose: false,
   migrateConfig: false,
+  noUnmanaged: false,
   verbose: false,
   write: false,
 };
@@ -26,6 +27,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
 
   const consoleLogSpy = jest.spyOn(global.console, "log");
   const consoleWarnSpy = jest.spyOn(global.console, "warn");
+  const consoleErrorSpy = jest.spyOn(global.console, "error");
 
   const mockManifest = {
     name: "@rnx-kit/align-deps",
@@ -49,6 +51,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     rnxKitConfig.__setMockConfig();
     consoleLogSpy.mockReset();
     consoleWarnSpy.mockReset();
+    consoleErrorSpy.mockReset();
   });
 
   afterAll(() => {
@@ -60,6 +63,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(result).toBe("invalid-manifest");
     expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   test("returns early if 'rnx-kit' is missing from the manifest", () => {
@@ -73,6 +77,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(result).toBe("not-configured");
     expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   test("prints warnings when detecting bad packages", () => {
@@ -95,6 +100,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(result).toBe("success");
     expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   test("prints warnings when detecting bad packages (with version range)", () => {
@@ -111,6 +117,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(result).toBe("success");
     expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   test("returns early if no capabilities are defined", () => {
@@ -124,6 +131,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(result).toBe("success");
     expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   test("returns if no changes are needed", () => {
@@ -150,6 +158,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(result).toBe("success");
     expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   test("prints additional information with `--verbose`", () => {
@@ -179,6 +188,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(result).toBe("success");
     expect(consoleLogSpy).toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   test("returns if no changes are needed (write: true)", () => {
@@ -209,6 +219,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(didWriteToPath).toBe(false);
     expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   test("returns error code if changes are needed", () => {
@@ -239,6 +250,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(result).not.toBe("success");
     expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   test("writes changes back to 'package.json'", () => {
@@ -259,6 +271,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(didWriteToPath).toBe("package.json");
     expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   test("preserves indentation in 'package.json'", () => {
@@ -279,6 +292,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(output).toMatchSnapshot();
     expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   test("returns appropriate error code if package is excluded", () => {
@@ -298,6 +312,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(result).toBe("excluded");
     expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   test("uses minimum supported version as development version", () => {
@@ -324,6 +339,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(result).toBe("success");
     expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   test("uses declared development version", () => {
@@ -353,6 +369,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(result).toBe("success");
     expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   test("handles development version ranges", () => {
@@ -382,6 +399,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
     expect(result).toBe("success");
     expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/align-deps/test/initialize.test.ts
+++ b/packages/align-deps/test/initialize.test.ts
@@ -8,6 +8,7 @@ const defaultOptions = {
   presets: defaultConfig.presets,
   loose: false,
   migrateConfig: false,
+  noUnmanaged: false,
   verbose: false,
   write: false,
 };
@@ -190,13 +191,25 @@ describe("initializeConfig()", () => {
 describe("makeInitializeCommand()", () => {
   const options = { ...defaultOptions, presets: [] };
 
+  const consoleErrorSpy = jest.spyOn(global.console, "error");
+
+  beforeEach(() => {
+    consoleErrorSpy.mockReset();
+  });
+
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
   test("returns undefined for invalid kit types", () => {
     const command = makeInitializeCommand("random", options);
     expect(command).toBeUndefined();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
   });
 
   test("returns command for kit types", () => {
     expect(makeInitializeCommand("app", options)).toBeDefined();
     expect(makeInitializeCommand("library", options)).toBeDefined();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/align-deps/test/setVersion.test.ts
+++ b/packages/align-deps/test/setVersion.test.ts
@@ -35,6 +35,7 @@ describe("makeSetVersionCommand()", () => {
     presets: defaultConfig.presets,
     loose: false,
     migrateConfig: false,
+    noUnmanaged: false,
     verbose: false,
     write: false,
   };

--- a/packages/align-deps/test/vigilant.test.ts
+++ b/packages/align-deps/test/vigilant.test.ts
@@ -423,7 +423,7 @@ describe("checkPackageManifestUnconfigured()", () => {
           },
         },
         ["core"]
-      ),
+      )
     );
     expect(result).toBe("unmanaged-capabilities");
     expect(didWrite).toBe(false);
@@ -450,7 +450,7 @@ describe("checkPackageManifestUnconfigured()", () => {
           },
         },
         ["test-app"]
-      ),
+      )
     );
     expect(result).toBe("unmanaged-capabilities");
     expect(didWrite).toBe(true);

--- a/packages/cli/src/align-deps.ts
+++ b/packages/cli/src/align-deps.ts
@@ -21,6 +21,7 @@ export function rnxAlignDeps(
     ...pickValues(args, Object.values(optionsMap), Object.keys(optionsMap)),
     loose: Boolean(args.loose),
     "migrate-config": Boolean(args.migrateConfig),
+    "no-unmanaged": Boolean(args.noUnmanaged),
     verbose: Boolean(args.verbose),
     write: Boolean(args.write),
     packages: argv,
@@ -48,6 +49,10 @@ export const rnxAlignDepsCommand = {
     {
       name: "--migrate-config",
       description: cliOptions["migrate-config"].description,
+    },
+    {
+      name: "--no-unmanaged",
+      description: cliOptions["no-unmanaged"].description,
     },
     {
       name: "--presets [presets]",


### PR DESCRIPTION
### Description

Added a flag, `--no-unmanaged`, to make unmanaged capabilities errors

### Test plan

1. Remove a random capability from `test-app/package.json`
2. Run `yarn rnx-align-deps`:
    ```
    warn packages/test-app/package.json: Found dependencies that are currently missing from capabilities:
    	  - react-native-test-app can be managed by 'test-app'
    ```
3. Enable `no-unmanaged`:
    ```diff
    diff --git a/scripts/rnx-align-deps.js b/scripts/rnx-align-deps.js
    index 9f56ed11..b92792f6 100755
    --- a/scripts/rnx-align-deps.js
    +++ b/scripts/rnx-align-deps.js
    @@ -11,4 +11,5 @@ cli({
       requirements: ["react-native@0.73"],
       write: process.argv.includes("--write"),
       "exclude-packages": ["@rnx-kit/build", "@rnx-kit/metro-plugin-typescript"],
    +  "no-unmanaged": true,
     });
    ```
4. Run `yarn rnx-align-deps`:
    ```
    error packages/test-app/package.json: Found dependencies that are currently missing from capabilities:
    	  - react-native-test-app can be managed by 'test-app'
    ```