### PR TITLE
fix(ios): collected data types declaration is required

### DIFF
--- a/.changeset/poor-garlics-brake.md
+++ b/.changeset/poor-garlics-brake.md
@@ -1,0 +1,5 @@
+---
+"@react-native-webapis/web-storage": patch
+---
+
+`NSPrivacyCollectedDataTypes` needs to be present even if we don't collect any data

--- a/incubator/@react-native-webapis/web-storage/ios/PrivacyInfo.xcprivacy
+++ b/incubator/@react-native-webapis/web-storage/ios/PrivacyInfo.xcprivacy
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>
@@ -13,7 +19,5 @@
 			</array>
 		</dict>
 	</array>
-	<key>NSPrivacyCollectedDataTypes</key>
-	<array/>
 </dict>
 </plist>

--- a/incubator/@react-native-webapis/web-storage/ios/PrivacyInfo.xcprivacy
+++ b/incubator/@react-native-webapis/web-storage/ios/PrivacyInfo.xcprivacy
@@ -5,13 +5,15 @@
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>CA92.1</string>
 			</array>
-			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
 		</dict>
 	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
### Description

`NSPrivacyCollectedDataTypes` needs to be present even if we don't collect any data.

See https://github.com/react-native-async-storage/async-storage/pull/1076

### Test plan

n/a