### PR TITLE
fix(align-deps): `--write` should add capabilities when used with `--no-unmanaged`

### DIFF
--- a/.changeset/popular-beers-shop.md
+++ b/.changeset/popular-beers-shop.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": patch
+---
+
+`--write` should add capabilities when used with `--no-unmanaged`

--- a/packages/align-deps/src/commands/vigilant.ts
+++ b/packages/align-deps/src/commands/vigilant.ts
@@ -208,7 +208,7 @@ export function inspect(
 
   const { unmanagedCapabilities } = profile;
 
-  const changesCount = dependencySections.reduce((count, section) => {
+  const errorCount = dependencySections.reduce((count, section) => {
     const dependencies = manifest[section];
     if (!dependencies) {
       return count;
@@ -268,8 +268,8 @@ export function inspect(
   }
 
   return {
-    errors: errors,
-    errorCount: changesCount + errors.capabilities.length,
+    errors,
+    errorCount: errorCount + errors.capabilities.length,
     warnings,
   };
 }

--- a/packages/align-deps/src/diff.ts
+++ b/packages/align-deps/src/diff.ts
@@ -1,5 +1,5 @@
-import { keysOf } from "@rnx-kit/tools-language";
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
+import { dependencySections } from "./helpers";
 import type { Changes } from "./types";
 
 export function diff(
@@ -10,9 +10,10 @@ export function diff(
     dependencies: [],
     peerDependencies: [],
     devDependencies: [],
+    capabilities: [],
   };
 
-  const numChanges = keysOf(allChanges).reduce((count, section) => {
+  const numChanges = dependencySections.reduce((count, section) => {
     const changes = allChanges[section];
     const currentDeps = manifest[section] ?? {};
     const updatedDeps = updatedManifest[section] ?? {};
@@ -38,7 +39,10 @@ export function diff(
   return numChanges > 0 ? allChanges : undefined;
 }
 
-export function stringify(allChanges: Changes, output: string[] = []): string {
+export function stringify(
+  allChanges: Partial<Changes>,
+  output: string[] = []
+): string {
   const prefix = "\t  - ";
 
   for (const [section, changes] of Object.entries(allChanges)) {
@@ -57,6 +61,11 @@ export function stringify(allChanges: Changes, output: string[] = []): string {
             break;
           case "removed":
             output.push(`${prefix}${dependency} should be removed`);
+            break;
+          case "unmanaged":
+            output.push(
+              `${prefix}${dependency} can be managed by '${change.capability}'`
+            );
             break;
         }
       }

--- a/packages/align-deps/src/helpers.ts
+++ b/packages/align-deps/src/helpers.ts
@@ -4,6 +4,12 @@ import detectIndent from "detect-indent";
 import fs from "fs";
 import semverValidRange from "semver/ranges/valid";
 
+export const dependencySections = [
+  "dependencies",
+  "peerDependencies",
+  "devDependencies",
+] as const;
+
 export function compare<T>(lhs: T, rhs: T): -1 | 0 | 1 {
   if (lhs === rhs) {
     return 0;
@@ -59,8 +65,7 @@ export function modifyManifest(
 }
 
 export function omitEmptySections(manifest: PackageManifest): PackageManifest {
-  const sections = ["dependencies", "peerDependencies", "devDependencies"];
-  for (const sectionName of sections) {
+  for (const sectionName of dependencySections) {
     const section = manifest[sectionName];
     if (typeof section === "object" && Object.keys(section).length === 0) {
       delete manifest[sectionName];

--- a/packages/align-deps/src/types.ts
+++ b/packages/align-deps/src/types.ts
@@ -16,6 +16,7 @@ export type Changes = {
   dependencies: Change[];
   peerDependencies: Change[];
   devDependencies: Change[];
+  capabilities: { type: "unmanaged"; dependency: string; capability: string }[];
 };
 
 export type Options = {
@@ -50,7 +51,6 @@ export type ErrorCode =
   | "invalid-manifest"
   | "missing-react-native"
   | "not-configured"
-  | "unmanaged-capabilities"
   | "unsatisfied";
 
 export type Command = (manifest: string) => ErrorCode;

--- a/packages/align-deps/test/vigilant.test.ts
+++ b/packages/align-deps/test/vigilant.test.ts
@@ -1,4 +1,3 @@
-import type { Capability } from "@rnx-kit/config";
 import {
   buildManifestProfile,
   checkPackageManifestUnconfigured,
@@ -14,15 +13,14 @@ function makeConfig(
   manifest: AlignDepsConfig["manifest"] = {
     name: "@rnx-kit/align-deps",
     version: "1.0.0-test",
-  },
-  capabilities: Capability[] = []
+  }
 ): AlignDepsConfig {
   return {
     kitType: "library" as const,
     alignDeps: {
       presets: ["microsoft/react-native"],
       requirements,
-      capabilities,
+      capabilities: [],
     },
     manifest,
   };
@@ -93,13 +91,13 @@ describe("inspect()", () => {
     name: "@rnx-kit/align-deps",
     version: "1.0.0",
     dependencies: {
-      "react-native": "^0.63.2",
+      "react-native": "^0.73.6",
     },
     peerDependencies: {
-      "react-native": "^0.63 || ^0.64",
+      "react-native": "^0.72 || ^0.73",
     },
     devDependencies: {
-      "react-native": "^0.63.2",
+      "react-native": "^0.73.6",
     },
     unmanagedCapabilities: {
       "react-native": "core",
@@ -111,30 +109,42 @@ describe("inspect()", () => {
       name: "@rnx-kit/align-deps",
       version: "1.0.0",
     };
-    expect(inspect(manifest, mockManifestProfile, false)).toEqual({
-      changes: {
+    expect(
+      inspect(manifest, mockManifestProfile, {
+        noUnmanaged: false,
+        write: false,
+      })
+    ).toEqual({
+      errors: {
         dependencies: [],
         peerDependencies: [],
         devDependencies: [],
+        capabilities: [],
       },
-      changesCount: 0,
-      unmanagedDependencies: [],
+      errorCount: 0,
+      warnings: [],
     });
-    expect(inspect(manifest, mockManifestProfile, true)).toEqual({
-      changes: {
+    expect(
+      inspect(manifest, mockManifestProfile, {
+        noUnmanaged: false,
+        write: true,
+      })
+    ).toEqual({
+      errors: {
         dependencies: [],
         peerDependencies: [],
         devDependencies: [],
+        capabilities: [],
       },
-      changesCount: 0,
-      unmanagedDependencies: [],
+      errorCount: 0,
+      warnings: [],
     });
   });
 
   test("ignores unmanaged dependencies", () => {
     const dependencies = {
       "@babel/core": "^7.0.0",
-      "react-native": "0.63.2",
+      "react-native": "0.73.6",
     };
     const manifest = {
       name: "@rnx-kit/align-deps",
@@ -143,7 +153,7 @@ describe("inspect()", () => {
     };
 
     const expected = {
-      changes: {
+      errors: {
         dependencies: [
           {
             type: "changed",
@@ -154,12 +164,18 @@ describe("inspect()", () => {
         ],
         peerDependencies: [],
         devDependencies: [],
+        capabilities: [],
       },
-      changesCount: 1,
-      unmanagedDependencies: [["react-native", "core"]],
+      errorCount: 1,
+      warnings: [],
     };
 
-    expect(inspect(manifest, mockManifestProfile, false)).toEqual(expected);
+    expect(
+      inspect(manifest, mockManifestProfile, {
+        noUnmanaged: false,
+        write: false,
+      })
+    ).toEqual(expected);
     expect(manifest.dependencies).toEqual(dependencies);
   });
 
@@ -171,15 +187,15 @@ describe("inspect()", () => {
         "@babel/core": "^7.0.0",
       },
       peerDependencies: {
-        "react-native": "0.63.2",
+        "react-native": "0.73.6",
       },
       devDependencies: {
-        "react-native": "0.63.2",
+        "react-native": "0.73.6",
       },
     };
 
     const expected = {
-      changes: {
+      errors: {
         dependencies: [],
         peerDependencies: [
           {
@@ -197,18 +213,24 @@ describe("inspect()", () => {
             current: manifest.devDependencies["react-native"],
           },
         ],
+        capabilities: [],
       },
-      changesCount: 2,
-      unmanagedDependencies: [["react-native", "core"]],
+      errorCount: 2,
+      warnings: [],
     };
 
-    expect(inspect(manifest, mockManifestProfile, false)).toEqual(expected);
+    expect(
+      inspect(manifest, mockManifestProfile, {
+        noUnmanaged: false,
+        write: false,
+      })
+    ).toEqual(expected);
   });
 
   test("modifies the manifest when `write: true`", () => {
     const dependencies = {
       "@babel/core": "^7.0.0",
-      "react-native": "0.63.2",
+      "react-native": "0.73.6",
     };
     const manifest = {
       name: "@rnx-kit/align-deps",
@@ -217,7 +239,7 @@ describe("inspect()", () => {
     };
 
     const expected = {
-      changes: {
+      errors: {
         dependencies: [
           {
             type: "changed",
@@ -228,12 +250,18 @@ describe("inspect()", () => {
         ],
         peerDependencies: [],
         devDependencies: [],
+        capabilities: [],
       },
-      changesCount: 1,
-      unmanagedDependencies: [["react-native", "core"]],
+      errorCount: 1,
+      warnings: [],
     };
 
-    expect(inspect(manifest, mockManifestProfile, true)).toEqual(expected);
+    expect(
+      inspect(manifest, mockManifestProfile, {
+        noUnmanaged: false,
+        write: true,
+      })
+    ).toEqual(expected);
     expect(manifest.dependencies).not.toEqual(dependencies);
   });
 
@@ -268,7 +296,7 @@ describe("inspect()", () => {
       },
     };
     const expected = {
-      changes: {
+      errors: {
         dependencies: [
           {
             type: "changed",
@@ -279,12 +307,133 @@ describe("inspect()", () => {
         ],
         peerDependencies: [],
         devDependencies: [],
+        capabilities: [],
       },
-      changesCount: 1,
-      unmanagedDependencies: [["react", "react"]],
+      errorCount: 1,
+      warnings: [],
     };
 
-    expect(inspect(manifest, profile, false)).toEqual(expected);
+    expect(
+      inspect(manifest, profile, { noUnmanaged: false, write: false })
+    ).toEqual(expected);
+  });
+
+  test("warns about unmanaged dependencies", () => {
+    const dependencies = {
+      "react-native": "^0.73.6",
+    };
+    const manifest = {
+      name: "@rnx-kit/align-deps",
+      version: "1.0.0",
+      dependencies,
+      "rnx-kit": {
+        kitType: "app",
+        alignDeps: {
+          capabilities: [],
+        },
+      },
+    };
+
+    expect(
+      inspect(manifest, mockManifestProfile, {
+        noUnmanaged: false,
+        write: false,
+      })
+    ).toEqual({
+      errors: {
+        dependencies: [],
+        peerDependencies: [],
+        devDependencies: [],
+        capabilities: [],
+      },
+      errorCount: 0,
+      warnings: [
+        {
+          type: "unmanaged",
+          dependency: "react-native",
+          capability: "core",
+        },
+      ],
+    });
+  });
+
+  test("treats unmanaged dependencies as errors", () => {
+    const dependencies = {
+      "react-native": "^0.73.6",
+    };
+    const manifest = {
+      name: "@rnx-kit/align-deps",
+      version: "1.0.0",
+      dependencies,
+      "rnx-kit": {
+        kitType: "app",
+        alignDeps: {
+          capabilities: [],
+        },
+      },
+    };
+
+    expect(
+      inspect(manifest, mockManifestProfile, {
+        noUnmanaged: true,
+        write: false,
+      })
+    ).toEqual({
+      errors: {
+        dependencies: [],
+        peerDependencies: [],
+        devDependencies: [],
+        capabilities: [
+          {
+            type: "unmanaged",
+            dependency: "react-native",
+            capability: "core",
+          },
+        ],
+      },
+      errorCount: 1,
+      warnings: [],
+    });
+  });
+
+  test("writes capabilities if `--no-unamaged` is specified", () => {
+    const dependencies = {
+      "react-native": "^0.73.6",
+    };
+    const manifest = {
+      name: "@rnx-kit/align-deps",
+      version: "1.0.0",
+      dependencies,
+      "rnx-kit": {
+        kitType: "app",
+        alignDeps: {
+          capabilities: [],
+        },
+      },
+    };
+
+    expect(
+      inspect(manifest, mockManifestProfile, {
+        noUnmanaged: true,
+        write: true,
+      })
+    ).toEqual({
+      errors: {
+        dependencies: [],
+        peerDependencies: [],
+        devDependencies: [],
+        capabilities: [
+          {
+            type: "unmanaged",
+            dependency: "react-native",
+            capability: "core",
+          },
+        ],
+      },
+      errorCount: 1,
+      warnings: [],
+    });
+    expect(manifest["rnx-kit"].alignDeps.capabilities).toEqual(["core"]);
   });
 });
 
@@ -410,22 +559,23 @@ describe("checkPackageManifestUnconfigured()", () => {
     });
 
     const result = checkPackageManifestUnconfigured(
-      "package.json",
+      "test-app/package.json",
       { ...defaultOptions, noUnmanaged: true },
-      makeConfig(
-        ["react-native@0.73"],
-        {
-          name: "@rnx-kit/align-deps",
-          version: "1.0.0",
-          dependencies: {
-            "react-native": "^0.73.0",
-            "react-native-test-app": "^2.5.34",
+      makeConfig(["react-native@0.73"], {
+        name: "@rnx-kit/align-deps",
+        version: "1.0.0",
+        dependencies: {
+          "react-native": "^0.73.0",
+          "react-native-test-app": "^2.5.34",
+        },
+        "rnx-kit": {
+          alignDeps: {
+            capabilities: ["core"],
           },
         },
-        ["core"]
-      )
+      })
     );
-    expect(result).toBe("unmanaged-capabilities");
+    expect(result).toBe("unsatisfied");
     expect(didWrite).toBe(false);
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
   });
@@ -437,24 +587,25 @@ describe("checkPackageManifestUnconfigured()", () => {
     });
 
     const result = checkPackageManifestUnconfigured(
-      "package.json",
+      "test-app/package.json",
       { ...defaultOptions, noUnmanaged: true, write: true },
-      makeConfig(
-        ["react-native@0.73"],
-        {
-          name: "@rnx-kit/align-deps",
-          version: "1.0.0",
-          dependencies: {
-            "react-native": "1000.0.0",
-            "react-native-test-app": "^2.5.34",
+      makeConfig(["react-native@0.73"], {
+        name: "@rnx-kit/align-deps",
+        version: "1.0.0",
+        dependencies: {
+          "react-native": "^0.73.0",
+          "react-native-test-app": "^2.5.34",
+        },
+        "rnx-kit": {
+          alignDeps: {
+            capabilities: ["core"],
           },
         },
-        ["test-app"]
-      )
+      })
     );
-    expect(result).toBe("unmanaged-capabilities");
+    expect(result).toBe("success");
     expect(didWrite).toBe(true);
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(0);
   });
 
   test("uses package-specific custom profiles", () => {

--- a/packages/align-deps/test/vigilant.test.ts
+++ b/packages/align-deps/test/vigilant.test.ts
@@ -559,7 +559,7 @@ describe("checkPackageManifestUnconfigured()", () => {
     });
 
     const result = checkPackageManifestUnconfigured(
-      "test-app/package.json",
+      "package.json",
       { ...defaultOptions, noUnmanaged: true },
       makeConfig(["react-native@0.73"], {
         name: "@rnx-kit/align-deps",
@@ -587,7 +587,7 @@ describe("checkPackageManifestUnconfigured()", () => {
     });
 
     const result = checkPackageManifestUnconfigured(
-      "test-app/package.json",
+      "package.json",
       { ...defaultOptions, noUnmanaged: true, write: true },
       makeConfig(["react-native@0.73"], {
         name: "@rnx-kit/align-deps",


### PR DESCRIPTION
### Description

`--write` should add capabilities when used with `--no-unmanaged`

> [!NOTE]
> We should restart the check if capabilities were added. This will be implemented in a separate PR. Until then, users will have to run align-deps twice.

### Test plan

1. Ensure there are no alignment warnings:
    ```sh
    % yarn rnx-align-deps
    info incubator/build/package.json was ignored
    warn Known bad packages are found in 'packages/babel-preset-metro-react-native/package.json':
    	metro-react-native-babel-preset@*: This package was renamed to '@react-native/babel-preset' in react-native 0.73. Replace this package when you're on react-native 0.73 or higher.
    info packages/metro-plugin-typescript/package.json was ignored
    ```
2. Remove `test-app` capability from `packages/test-app/package.json`
3. align-deps should warn about missing `test-app` capability:
    ```sh
    % yarn rnx-align-deps
    info incubator/build/package.json was ignored
    warn Known bad packages are found in 'packages/babel-preset-metro-react-native/package.json':
    	metro-react-native-babel-preset@*: This package was renamed to '@react-native/babel-preset' in react-native 0.73. Replace this package when you're on react-native 0.73 or higher.
    info packages/metro-plugin-typescript/package.json was ignored
    warn packages/test-app/package.json: Found dependencies that are currently missing from capabilities:
    	In capabilities:
    	  - react-native-test-app can be managed by 'test-app'
    ```
4. Enable `noUnmanaged`:
    ```diff
    diff --git a/scripts/rnx-align-deps.js b/scripts/rnx-align-deps.js
    index 9f56ed11..b92792f6 100755
    --- a/scripts/rnx-align-deps.js
    +++ b/scripts/rnx-align-deps.js
    @@ -11,4 +11,5 @@ cli({
       requirements: ["react-native@0.73"],
       write: process.argv.includes("--write"),
       "exclude-packages": ["@rnx-kit/build", "@rnx-kit/metro-plugin-typescript"],
    +  "no-unmanaged": true,
     });
    ```
5. align-deps should output an error about missing `test-app` capability:
    ```sh
    % yarn rnx-align-deps
    info incubator/build/package.json was ignored
    warn Known bad packages are found in 'packages/babel-preset-metro-react-native/package.json':
    	metro-react-native-babel-preset@*: This package was renamed to '@react-native/babel-preset' in react-native 0.73. Replace this package when you're on react-native 0.73 or higher.
    info packages/metro-plugin-typescript/package.json was ignored
    error packages/test-app/package.json: Found 1 violation(s) outside of capabilities.
    	In capabilities:
    	  - react-native-test-app can be managed by 'test-app'
    error Re-run with '--write' to fix them.
    info Visit https://aka.ms/align-deps for more information about align-deps.
    ```
6. Run again with `--write`:
    ```sh
    % yarn rnx-align-deps --write
    info incubator/build/package.json was ignored
    warn Known bad packages are found in 'packages/babel-preset-metro-react-native/package.json':
    	metro-react-native-babel-preset@*: This package was renamed to '@react-native/babel-preset' in react-native 0.73. Replace this package when you're on react-native 0.73 or higher.
    info packages/metro-plugin-typescript/package.json was ignored
    ```
7. Verify that `test-app` was re-added:
    ```diff
    diff --git a/packages/test-app/package.json b/packages/test-app/package.json
    index 9b8e9068..6078ecb0 100644
    --- a/packages/test-app/package.json
    +++ b/packages/test-app/package.json
    @@ -203,8 +203,8 @@
             "eslint",
             "prettier",
             "react",
    -        "test-app",
    -        "typescript"
    +        "typescript",
    +        "test-app"
           ]
         }
       }
    ```