### PR TITLE
fix(react-native-host): fix building with `use_frameworks!`

### DIFF
--- a/.changeset/gorgeous-snails-speak.md
+++ b/.changeset/gorgeous-snails-speak.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Fixed building with `use_frameworks!`

--- a/packages/react-native-host/ReactNativeHost.podspec
+++ b/packages/react-native-host/ReactNativeHost.podspec
@@ -10,12 +10,7 @@ repo_dir = repository['directory']
 
 new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 preprocessor_definitions = [
-  'FOLLY_CFG_NO_COROUTINES=1',
-  'FOLLY_HAVE_CLOCK_GETTIME=1',
-  'FOLLY_HAVE_PTHREAD=1',
-  'FOLLY_MOBILE=1',
-  'FOLLY_NO_CONFIG=1',
-  'FOLLY_USE_LIBCPP=1',
+  '$(inherit)',
   "USE_HERMES=#{ENV['USE_HERMES'] || '0'}",
 ]
 if new_arch_enabled
@@ -51,17 +46,13 @@ Pod::Spec.new do |s|
   end
 
   s.pod_target_xcconfig = {
-    'CLANG_CXX_LANGUAGE_STANDARD' => 'gnu++20',
+    'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20',
     'DEFINES_MODULE' => 'YES',
     'GCC_PREPROCESSOR_DEFINITIONS' => preprocessor_definitions,
     'HEADER_SEARCH_PATHS' => [
-      '$(PODS_ROOT)/boost',
-      '$(PODS_ROOT)/boost-for-react-native',
-      '$(PODS_ROOT)/RCT-Folly',
-      '$(PODS_ROOT)/DoubleConversion',
       '$(PODS_ROOT)/Headers/Private/React-Core',
-      '$(PODS_ROOT)/Headers/Private/Yoga',
-    ],
+      '$(PODS_CONFIGURATION_BUILD_DIR)/React-runtimescheduler/React_runtimescheduler.framework/Headers',
+    ].join(' '),
   }
 
   # Include both package and repository relative paths to allow the podspec to
@@ -71,4 +62,6 @@ Pod::Spec.new do |s|
                            "#{repo_dir}/#{source_files}"         # :podspec
   s.public_header_files  = public_header_files,                  # :path
                            "#{repo_dir}/#{public_header_files}"  # :podspec
+
+  install_modules_dependencies(s)
 end

--- a/packages/react-native-host/cocoa/RNXHostReleaser.mm
+++ b/packages/react-native-host/cocoa/RNXHostReleaser.mm
@@ -34,9 +34,9 @@
 #if !TARGET_OS_OSX
     // This may initialize `RCTAccessibilityManager` and must therefore be run
     // on the main queue.
-    __weak typeof(self) weakSelf = self;
+    __weak __typeof(self) weakSelf = self;
     RCTExecuteOnMainQueue(^{
-      typeof(self) strongSelf = weakSelf;
+      __typeof(self) strongSelf = weakSelf;
       if (strongSelf == nil) {
           return;
       }
@@ -50,7 +50,7 @@
       RCTExecuteOnUIManagerQueue(^{
         [manager addUIBlock:^(RCTUIManager *uiManager,
                               NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-          typeof(self) strongSelf = weakSelf;
+          __typeof(self) strongSelf = weakSelf;
           if (strongSelf == nil) {
               return;
           }

--- a/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
+++ b/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
@@ -13,23 +13,36 @@
 #if __has_include(<React/RCTAppSetupUtils.h>)  // <0.72
 #import <React/RCTAppSetupUtils.h>
 #else
+
+#if __has_include(<React-RCTAppDelegate/RCTAppSetupUtils.h>)
 #import <React-RCTAppDelegate/RCTAppSetupUtils.h>
+#elif __has_include(<React_RCTAppDelegate/RCTAppSetupUtils.h>)  // use_frameworks!
+#import <React_RCTAppDelegate/RCTAppSetupUtils.h>
+#endif  // __has_include(<React-RCTAppDelegate/RCTAppSetupUtils.h>)
+
 #import <React/RCTSurfacePresenterBridgeAdapter.h>
 
 // We still get into this path because react-native-macos 0.71 picked up some
 // 0.72 bits. AFAICT, `SchedulerPriorityUtils.h` is a new addition in 0.72 in
 // both react-native and react-native-macos.
 #if __has_include(<react/renderer/runtimescheduler/SchedulerPriorityUtils.h>)
+
 #if __has_include(<React-RCTAppDelegate/RCTLegacyInteropComponents.h>)  // <0.74
 #import <React-RCTAppDelegate/RCTLegacyInteropComponents.h>
 #define MANUALLY_REGISTER_LEGACY_COMPONENTS 1
+#elif __has_include(<React_RCTAppDelegate/RCTLegacyInteropComponents.h>)  // use_frameworks!
+#import <React_RCTAppDelegate/RCTLegacyInteropComponents.h>
+#define MANUALLY_REGISTER_LEGACY_COMPONENTS 1
 #endif  // __has_include(<React-RCTAppDelegate/RCTLegacyInteropComponents.h>)
+
 #import <React/RCTLegacyViewManagerInteropComponentView.h>
 #import <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
+
 #if __has_include(<React/RCTRuntimeExecutorFromBridge.h>)
 #import <React/RCTRuntimeExecutorFromBridge.h>
 #endif  // __has_include(<React/RCTRuntimeExecutorFromBridge.h>)
+
 #define USE_RUNTIME_SCHEDULER 1
 #endif  // __has_include(<react/renderer/runtimescheduler/SchedulerPriorityUtils.h>)
 


### PR DESCRIPTION
### Description

Fixed building with `use_frameworks!`

Resolves #3034.

### Test plan

This needs to be tested in RNTA because `use_frameworks!` seems to be broken in 0.73.

1. Setup
    ```sh
    npm run set-react-version 0.72 -- --core-only
    yarn
    cd example
    rm ios/Podfile.lock
    ```
2. Locally apply the patch under `../node_modules/@rnx-kit/react-native-host`
3. Add `use_frameworks!` to `ios/Podfile`:
    ```diff
    diff --git a/example/ios/Podfile b/example/ios/Podfile
    index 55a670f..8242b91 100644
    --- a/example/ios/Podfile
    +++ b/example/ios/Podfile
    @@ -6,6 +6,8 @@ require "#{ws_dir}/node_modules/react-native-test-app/test_app.rb"
    
     workspace 'Example.xcworkspace'
    
    +use_frameworks! :linkage => :static
    +
     options = {
       :fabric_enabled => false,
       :hermes_enabled => false,
    ```
4. Run: `pod install --project-directory=ios`
5. Build: `yarn react-native build-ios`
6. Clean: `git clean -dfqx ios`
7. Repeat steps 4-6, but with New Architecture enabled