### PR TITLE
feat(align-deps): Update profiles to versions with visionOS support

### DIFF
--- a/packages/align-deps/src/presets/microsoft/react-native/profile-0.73.ts
+++ b/packages/align-deps/src/presets/microsoft/react-native/profile-0.73.ts
@@ -110,7 +110,7 @@ export const profile: Profile = {
   },
   netinfo: {
     name: "@react-native-community/netinfo",
-    version: "^11.0.1",
+    version: "^11.3.1",
   },
   "safe-area": {
     name: "react-native-safe-area-context",


### PR DESCRIPTION
### Description

react-native-netinfo supports visionOS for version 11.3.1 and above. Let's update the dependency profile to show that. 

TODO:
- Figure out the rest of the community packages that support visionOS, and add here. 

### Test plan

CI should pass. 
