### PR TITLE
fix(web-storage): fix build errors when targeting RNW canaries

### DIFF
--- a/.changeset/real-stingrays-jam.md
+++ b/.changeset/real-stingrays-jam.md
@@ -1,0 +1,5 @@
+---
+"@react-native-webapis/web-storage": patch
+---
+
+Fixed build errors when targeting canary builds of `react-native-windows`

--- a/incubator/@react-native-webapis/web-storage/windows/NuGet.Config
+++ b/incubator/@react-native-webapis/web-storage/windows/NuGet.Config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="repositoryPath" value="packages" />
+  </config>
+  <packageSources>
+    <clear />
+    <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
+    <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>


### PR DESCRIPTION
### Description

Fixed build errors when targeting canary builds of `react-native-windows`.

`@react-native-webapis/web-storage` was missing a NuGet config file, making VS unable to reference canary builds.

### Test plan

See https://github.com/microsoft/react-native-test-app/pull/1936