### PR TITLE
fix(babel-preset): deprecate `looseClassTransform`

### DIFF
--- a/.changeset/spotty-guests-explain.md
+++ b/.changeset/spotty-guests-explain.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/babel-preset-metro-react-native": patch
+---
+
+Deprecate `looseClassTransform`

--- a/packages/babel-preset-metro-react-native/package.json
+++ b/packages/babel-preset-metro-react-native/package.json
@@ -24,6 +24,7 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules rnx-kit-scripts test"
   },
   "dependencies": {
+    "@rnx-kit/console": "^1.0.12",
     "babel-plugin-const-enum": "^1.0.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3549,6 +3549,7 @@ __metadata:
     "@babel/core": "npm:^7.20.0"
     "@babel/plugin-transform-typescript": "npm:^7.20.0"
     "@rnx-kit/babel-plugin-import-path-remapper": "npm:*"
+    "@rnx-kit/console": "npm:^1.0.12"
     "@rnx-kit/eslint-config": "npm:*"
     "@rnx-kit/scripts": "npm:*"
     "@rnx-kit/tsconfig": "npm:*"


### PR DESCRIPTION
### Description

Deprecate `looseClassTransform` and redirect to compiler assumptions.

### Test plan

n/a