### PR TITLE
fix(typescript-service): unset unused loggers

### DIFF
--- a/.changeset/late-cheetahs-raise.md
+++ b/.changeset/late-cheetahs-raise.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/typescript-service": patch
+---
+
+Unset unused loggers

--- a/packages/typescript-service/package.json
+++ b/packages/typescript-service/package.json
@@ -26,8 +26,7 @@
     "test": "rnx-kit-scripts test"
   },
   "dependencies": {
-    "@rnx-kit/tools-node": "^2.0.0",
-    "chalk": "^4.1.0"
+    "@rnx-kit/tools-node": "^2.0.0"
   },
   "peerDependencies": {
     "typescript": ">=4.0"

--- a/packages/typescript-service/src/project.ts
+++ b/packages/typescript-service/src/project.ts
@@ -1,4 +1,3 @@
-import chalk from "chalk";
 import ts from "typescript";
 import { ExternalFileCache, ProjectFileCache } from "./cache";
 import type { DiagnosticWriter } from "./diagnostics";
@@ -41,9 +40,9 @@ export class Project {
       //getCancellationToken?(): HostCancellationToken;
       getCurrentDirectory: () => process.cwd(),
       getDefaultLibFileName: (o) => ts.getDefaultLibFilePath(o),
-      log: (s: string): void => console.log(chalk.cyanBright(s)),
-      trace: (s: string): void => console.log(chalk.greenBright(s)),
-      error: (s: string): void => console.error(chalk.redBright(s)),
+      //log: (s: string): void;
+      //trace: (s: string): void;
+      //error: (s: string): void;
       //useCaseSensitiveFileNames?(): boolean;
 
       /*

--- a/yarn.lock
+++ b/yarn.lock
@@ -4488,7 +4488,6 @@ __metadata:
     "@rnx-kit/tools-node": "npm:^2.0.0"
     "@rnx-kit/tsconfig": "npm:*"
     "@types/node": "npm:^20.0.0"
-    chalk: "npm:^4.1.0"
     eslint: "npm:^8.56.0"
     jest: "npm:^29.2.1"
     prettier: "npm:^3.0.0"


### PR DESCRIPTION
### Description

I'm not entirely sure what the loggers are used for. It doesn't look like they get used upstream either: https://github.com/search?q=repo%3Amicrosoft%2FTypeScript+createLanguageService&type=code

### Test plan

```sh
cd packages/test-app
yarn build --dependencies
yarn start

# In a separate terminal, run the following command every time you make changes to `App.native.tsx`
curl -v 'http://localhost:8081/index.bundle?platform=ios' > /dev/null
```

Example output:

![image](https://github.com/microsoft/rnx-kit/assets/4123478/23a3e68a-4604-48fb-80f0-d27eaeb81ce4)