### PR TITLE
fix(babel-preset): fix `@babel/runtime` not being found in pnpm setups

### DIFF
--- a/.changeset/olive-starfishes-itch.md
+++ b/.changeset/olive-starfishes-itch.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/babel-preset-metro-react-native": patch
+---
+
+Ensure `@babel/runtime` can be found in a pnpm environment

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -37,22 +37,9 @@ packageExtensions:
   "@react-native/metro-config@*":
     peerDependencies:
       "@babel/preset-env": ^7.20.0
-  "@react-native/virtualized-lists@*":
-    peerDependencies:
-      "@babel/runtime": ^7.20.0
   babel-plugin-transform-flow-enums@*:
     peerDependencies:
       "@babel/core": ^7.20.0
-  memfs@4.x:
-    peerDependenciesMeta:
-      memfs:
-        optional: true
-      quill-delta:
-        optional: true
-      rxjs:
-        optional: true
-      tslib:
-        optional: true
   metro-config@*:
     dependencies:
       # `metro-config` fails to resolve `JsTransformerConfig` because it's in another package
@@ -68,9 +55,6 @@ packageExtensions:
     peerDependencies:
       "@babel/preset-env": ^7.1.6
   react-native@*:
-    dependencies:
-      # Implicit dependency introduced by Babel
-      "@babel/runtime": ^7.20.0
     peerDependencies:
       "@babel/preset-env": ^7.1.6
 plugins:

--- a/packages/babel-preset-metro-react-native/package.json
+++ b/packages/babel-preset-metro-react-native/package.json
@@ -28,8 +28,9 @@
     "babel-plugin-const-enum": "^1.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0",
-    "@babel/plugin-transform-typescript": "^7.0.0",
+    "@babel/core": "^7.20.0",
+    "@babel/plugin-transform-typescript": "^7.20.0",
+    "@babel/runtime": "^7.20.0",
     "@react-native/babel-preset": "*",
     "metro-react-native-babel-preset": "*"
   },
@@ -47,6 +48,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@babel/plugin-transform-typescript": "^7.20.0",
+    "@babel/runtime": "^7.20.0",
     "@rnx-kit/babel-plugin-import-path-remapper": "*",
     "@rnx-kit/eslint-config": "*",
     "@rnx-kit/scripts": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3555,6 +3555,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:^7.20.0"
     "@babel/plugin-transform-typescript": "npm:^7.20.0"
+    "@babel/runtime": "npm:^7.20.0"
     "@rnx-kit/babel-plugin-import-path-remapper": "npm:*"
     "@rnx-kit/console": "npm:^1.0.13"
     "@rnx-kit/eslint-config": "npm:*"
@@ -3570,8 +3571,9 @@ __metadata:
     prettier: "npm:^3.0.0"
     typescript: "npm:^5.0.0"
   peerDependencies:
-    "@babel/core": ^7.0.0
-    "@babel/plugin-transform-typescript": ^7.0.0
+    "@babel/core": ^7.20.0
+    "@babel/plugin-transform-typescript": ^7.20.0
+    "@babel/runtime": ^7.20.0
     "@react-native/babel-preset": "*"
     metro-react-native-babel-preset: "*"
   peerDependenciesMeta:


### PR DESCRIPTION
### Description

Use [`absoluteRuntime`](https://babel.dev/docs/babel-plugin-transform-runtime#absoluteruntime) to ensure `@babel/runtime` can be found in a pnpm environment

### Test plan

n/a