### PR TITLE
fix(eslint-plugin): migrate to `typescript-eslint`

### DIFF
--- a/.changeset/thick-chairs-drop.md
+++ b/.changeset/thick-chairs-drop.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/eslint-plugin": patch
+---
+
+Migrate to `typescript-eslint`

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -11,10 +11,8 @@ const compat = new FlatCompat({
 
 module.exports = [
   ...rnx.configs.strict,
-  ...compat.extends(
-    "plugin:@microsoft/sdl/required",
-    "plugin:@typescript-eslint/stylistic"
-  ),
+  ...rnx.configs.stylistic,
+  ...compat.extends("plugin:@microsoft/sdl/required"),
   {
     rules: {
       "@typescript-eslint/consistent-type-definitions": ["error", "type"],

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -46,11 +46,10 @@
     "@eslint/eslintrc": "^2.1.4",
     "@eslint/js": "^8.56.0",
     "@react-native/eslint-plugin": "^0.74.0",
-    "@typescript-eslint/eslint-plugin": "^7.0.0",
-    "@typescript-eslint/parser": "^7.0.0",
     "enhanced-resolve": "^5.8.3",
     "eslint-plugin-react": "^7.33.0",
-    "eslint-plugin-react-hooks": "^4.6.0"
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "typescript-eslint": "^7.5.0"
   },
   "peerDependencies": {
     "eslint": ">=8.56.0"
@@ -67,6 +66,7 @@
     "@types/estree": "*",
     "@types/jest": "^29.2.1",
     "@types/node": "^20.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
     "@typescript-eslint/types": "^7.0.0",
     "eslint": "^8.56.0",
     "eslint-plugin-node": "11.1.0",

--- a/packages/eslint-plugin/src/configs/recommended.js
+++ b/packages/eslint-plugin/src/configs/recommended.js
@@ -3,6 +3,7 @@
 
 const { FlatCompat } = require("@eslint/eslintrc");
 const js = require("@eslint/js");
+const tseslint = require("typescript-eslint");
 
 const compat = new FlatCompat({
   baseDirectory: __dirname,
@@ -22,18 +23,14 @@ function isInstalled(spec) {
 }
 
 const usesReact = isInstalled("react");
-const configs = ["plugin:@typescript-eslint/recommended"];
-if (usesReact) {
-  configs.push("plugin:react-hooks/recommended", "plugin:react/recommended");
-}
+const reactConfigs = usesReact
+  ? compat.extends("plugin:react-hooks/recommended", "plugin:react/recommended")
+  : [];
 
 module.exports = [
-  ...compat.extends(...configs),
+  ...tseslint.configs.recommended,
+  ...reactConfigs,
   {
-    languageOptions: {
-      // @ts-expect-error No declaration file for module
-      parser: require("@typescript-eslint/parser"),
-    },
     plugins: {
       // @ts-expect-error No declaration file for module
       "@react-native": require("@react-native/eslint-plugin"),

--- a/packages/eslint-plugin/src/index.js
+++ b/packages/eslint-plugin/src/index.js
@@ -10,6 +10,7 @@ module.exports = {
   configs: {
     recommended: require("./configs/recommended"),
     strict: require("./configs/strict"),
+    stylistic: require("typescript-eslint").configs.stylistic,
   },
   rules: require("./rules").rules,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3859,7 +3859,6 @@ __metadata:
     "@types/estree": "npm:*"
     "@types/jest": "npm:^29.2.1"
     "@types/node": "npm:^20.0.0"
-    "@typescript-eslint/eslint-plugin": "npm:^7.0.0"
     "@typescript-eslint/parser": "npm:^7.0.0"
     "@typescript-eslint/types": "npm:^7.0.0"
     enhanced-resolve: "npm:^5.8.3"
@@ -3870,6 +3869,7 @@ __metadata:
     jest: "npm:^29.2.1"
     prettier: "npm:^3.0.0"
     typescript: "npm:^5.0.0"
+    typescript-eslint: "npm:^7.5.0"
   peerDependencies:
     eslint: ">=8.56.0"
   languageName: unknown
@@ -4921,7 +4921,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^7.0.0":
+"@typescript-eslint/eslint-plugin@npm:7.5.0":
   version: 7.5.0
   resolution: "@typescript-eslint/eslint-plugin@npm:7.5.0"
   dependencies:
@@ -4946,7 +4946,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^7.0.0":
+"@typescript-eslint/parser@npm:7.5.0, @typescript-eslint/parser@npm:^7.0.0":
   version: 7.5.0
   resolution: "@typescript-eslint/parser@npm:7.5.0"
   dependencies:
@@ -13846,6 +13846,22 @@ __metadata:
   bin:
     typedoc: bin/typedoc
   checksum: 10c0/35157a90954ed67243bc1ad430781de381431959c62e24f8a8688c4ebae62c2ee11d404002dfd43a0df3bf96721d94fce928423fe1f91f1ed40c99f29c5276aa
+  languageName: node
+  linkType: hard
+
+"typescript-eslint@npm:^7.5.0":
+  version: 7.5.0
+  resolution: "typescript-eslint@npm:7.5.0"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": "npm:7.5.0"
+    "@typescript-eslint/parser": "npm:7.5.0"
+    "@typescript-eslint/utils": "npm:7.5.0"
+  peerDependencies:
+    eslint: ^8.56.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/5b40508de65bf8398e006dd7e0cd83962720ffad6b4854a7fa5e5be00d67fd4a0e2fc37592c54e29847d8b4d38cf9aecb8a25dc8b7f3203eca232fe5dfe962df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

`typescript-eslint` is the new main entry point for the flat config format: https://typescript-eslint.io/getting-started/

### Test plan

n/a