### PR TITLE
fix(tools-workspaces): fix findWorkspacePackagesSync lerna 7+ incompatibility

### DIFF
--- a/.changeset/smart-poems-carry.md
+++ b/.changeset/smart-poems-carry.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-workspaces": patch
+---
+
+fix findWorkspacePackagesSync lerna 7+ incompatibility

--- a/packages/tools-workspaces/src/lerna.ts
+++ b/packages/tools-workspaces/src/lerna.ts
@@ -44,7 +44,9 @@ export async function findWorkspacePackages(
 
 export function findWorkspacePackagesSync(configFile: string): string[] {
   const { packages, useWorkspaces } = readJSONSync(configFile);
-  if (!useWorkspaces) {
+  // `useWorkspaces` was deprecated: https://github.com/lerna/lerna/releases/tag/7.0.0
+  // respect Lerna `packages` property
+  if (packages && useWorkspaces !== true) {
     return findPackagesSync(packages, path.dirname(configFile));
   }
 


### PR DESCRIPTION
### Description
Sync findWorkspacePackages Compatibility Adapter for lerna 7+ to findWorkspacePackagesSync

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
