### PR TITLE
fix(react-native-host): handle `RCTHost` interface changes

### DIFF
--- a/.changeset/orange-days-design.md
+++ b/.changeset/orange-days-design.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Handle `launchOptions` being added to `RCTHost` initializer in 0.74 (see https://github.com/facebook/react-native/pull/43757)

--- a/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
+++ b/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
@@ -23,6 +23,21 @@ using SharedJSRuntimeFactory = std::shared_ptr<facebook::react::JSRuntimeFactory
 @interface RCTHost (Compatibility)
 @property (nonatomic, readonly) RCTModuleRegistry *moduleRegistry;      // Introduced in 0.74
 @property (nonatomic, readonly) RCTSurfacePresenter *surfacePresenter;  // Introduced in 0.74
+
+// Introduced in 0.74
+- (instancetype)initWithBundleURLProvider:(RCTHostBundleURLProvider)provider
+                             hostDelegate:(id<RCTHostDelegate>)hostDelegate
+               turboModuleManagerDelegate:
+                   (id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
+                         jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider
+                            launchOptions:(nullable NSDictionary *)launchOptions;
+
+// Deprecated in 0.74
+- (instancetype)initWithBundleURL:(NSURL *)bundleURL
+                     hostDelegate:(id<RCTHostDelegate>)hostDelegate
+       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
+                 jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider;
+
 - (RCTModuleRegistry *)getModuleRegistry;      // Deprecated in 0.74, and removed in 0.75
 - (RCTSurfacePresenter *)getSurfacePresenter;  // Deprecated in 0.74, and removed in 0.75
 @end

--- a/packages/react-native-host/cocoa/ReactNativeHost.h
+++ b/packages/react-native-host/cocoa/ReactNativeHost.h
@@ -24,8 +24,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithConfig:(id<RNXHostConfig>)config NS_DESIGNATED_INITIALIZER
-    NS_SWIFT_NAME(init(_:));
+- (instancetype)initWithConfig:(id<RNXHostConfig>)config NS_SWIFT_NAME(init(_:));
+
+- (instancetype)initWithConfig:(id<RNXHostConfig>)config
+                 launchOptions:(nullable NSDictionary *)launchOptions NS_DESIGNATED_INITIALIZER
+    NS_SWIFT_NAME(init(_:launchOptions:));
 
 - (void)shutdown;
 

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -31,6 +31,7 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 
 @implementation ReactNativeHost {
     __weak id<RNXHostConfig> _config;
+    NSDictionary *_launchOptions;
     RNXTurboModuleAdapter *_turboModuleAdapter;
     RCTSurfacePresenterBridgeAdapter *_surfacePresenterBridgeAdapter;
     RCTBridge *_bridge;
@@ -41,6 +42,11 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 }
 
 - (instancetype)initWithConfig:(id<RNXHostConfig>)config
+{
+    return [self initWithConfig:config launchOptions:nil];
+}
+
+- (instancetype)initWithConfig:(id<RNXHostConfig>)config launchOptions:(NSDictionary *)launchOptions
 {
     if (self = [super init]) {
         if ([config respondsToSelector:@selector(isDevLoadingViewEnabled)]) {
@@ -64,6 +70,7 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
         }
 
         _config = config;
+        _launchOptions = launchOptions;
         [self enableTurboModule];
         _isShuttingDown = [[NSLock alloc] init];
 
@@ -90,7 +97,7 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 
     @try {
         if (_bridge == nil) {
-            _bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:nil];
+            _bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:_launchOptions];
             _surfacePresenterBridgeAdapter = RNXInstallSurfacePresenterBridgeAdapter(_bridge);
             [_hostReleaser setBridge:_bridge];
         }
@@ -262,7 +269,7 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
                           hostDelegate:nil
             turboModuleManagerDelegate:_turboModuleAdapter
                       jsEngineProvider:jsEngineProvider
-                         launchOptions:nil];
+                         launchOptions:_launchOptions];
     } else {
         _reactHost = [[RCTHost alloc] initWithBundleURL:[self sourceURLForBridge:nil]
                                            hostDelegate:nil

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -250,12 +250,26 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 #endif  // USE_HERMES
     };
 
-    _reactHost = [[RCTHost alloc] initWithBundleURL:[self sourceURLForBridge:nil]
-                                       hostDelegate:nil
-                         turboModuleManagerDelegate:_turboModuleAdapter
-                                   jsEngineProvider:jsEngineProvider];
-
     __weak __typeof(self) weakSelf = self;
+    if ([RCTHost instancesRespondToSelector:@selector
+                 (initWithBundleURLProvider:
+                               hostDelegate:turboModuleManagerDelegate:jsEngineProvider
+                                           :launchOptions:)]) {
+        _reactHost = [[RCTHost alloc]
+             initWithBundleURLProvider:^{
+               return [weakSelf sourceURLForBridge:nil];
+             }
+                          hostDelegate:nil
+            turboModuleManagerDelegate:_turboModuleAdapter
+                      jsEngineProvider:jsEngineProvider
+                         launchOptions:nil];
+    } else {
+        _reactHost = [[RCTHost alloc] initWithBundleURL:[self sourceURLForBridge:nil]
+                                           hostDelegate:nil
+                             turboModuleManagerDelegate:_turboModuleAdapter
+                                       jsEngineProvider:jsEngineProvider];
+    }
+
     [_reactHost setBundleURLProvider:^NSURL *() {
       return [weakSelf sourceURLForBridge:nil];
     }];


### PR DESCRIPTION
### Description

Handle `launchOptions` being added to `RCTHost` initializer in 0.74 (see https://github.com/facebook/react-native/commit/cb2d93ea50e62024d5238cccfc7242f7fd75d3b2)

### Test plan

In RNTA:

```
npm run set-react-version 0.74
yarn
# Manually modify node_modules/@rnx-kit/react-native-host
cd example
RCT_NEW_ARCH_ENABLED=1 USE_BRIDGELESS=1 pod install --project-directory=ios
yarn ios

# In a separate terminal
yarn start
```

![image](https://github.com/microsoft/rnx-kit/assets/4123478/3c822fe7-989c-4604-a069-1257bf6f0374)
