### PR TITLE
fix(cli): fix `EINVAL` running `clean` on Windows with latest Node

### DIFF
--- a/.changeset/large-pears-jog.md
+++ b/.changeset/large-pears-jog.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Fix `EINVAL` error when running `clean` on Windows with Node 18.20.2+ or 20.12.2+

--- a/packages/cli/src/clean.ts
+++ b/packages/cli/src/clean.ts
@@ -174,6 +174,7 @@ function execute(command: string, args: string[], cwd: string): Promise<void> {
     const process = spawn(command, args, {
       cwd,
       stdio: ["inherit", null, null],
+      shell: command.endsWith(".bat") || command.endsWith(".cmd"),
     });
 
     const stderr: Buffer[] = [];


### PR DESCRIPTION
### Description

Fix `EINVAL` error when running `clean` on Windows with Node 18.20.2+ or 20.12.2+

### Test plan

```sh
cd packages/test-app
yarn build --dependencies
yarn react-native rnx-clean --include android
```