### PR TITLE
fix(rnta-msal): address deprecations

### DIFF
--- a/.changeset/twelve-jeans-wait.md
+++ b/.changeset/twelve-jeans-wait.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-test-app-msal": patch
+---
+
+Migrate away from deprecated `acquireTokenSilent(Array<(out) String!>, IAccount, String): IAuthenticationResult!`

--- a/incubator/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MicrosoftAccountsActivity.kt
+++ b/incubator/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MicrosoftAccountsActivity.kt
@@ -76,7 +76,7 @@ class MicrosoftAccountsActivity : AppCompatActivity() {
 
         val sharedPreferences = getPreferences(MODE_PRIVATE)
 
-        val selectedAccountObserver = Observer<Account> { account ->
+        val selectedAccountObserver = Observer<Account?> { account ->
             withTokenBroker { tokenBroker ->
                 if (tokenBroker.selectedAccount == account) {
                     return@withTokenBroker


### PR DESCRIPTION
### Description

Migrate away from deprecated `acquireTokenSilent(Array<(out) String!>, IAccount, String): IAuthenticationResult!`

### Test plan

n/a