### PR TITLE
fix(build): `gradle/actions/setup-gradle` is for setup only

### DIFF
--- a/.changeset/poor-planets-shop.md
+++ b/.changeset/poor-planets-shop.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/build": patch
+---
+
+Using `gradle/actions/setup-gradle` to execute Gradle is deprecated (see https://github.com/gradle/actions/blob/v3/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated)

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -36,18 +36,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@3.5.13
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@3.5.15
         with:
           platform: android
           cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Build Android app
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-version: wrapper
-          arguments: --no-daemon clean assembleDebug
-          build-root-directory: ${{ github.event.inputs.projectRoot }}/android
+        run: ./gradlew --no-daemon clean assembleDebug
+        shell: bash
+        working-directory: ${{ github.event.inputs.projectRoot }}/android
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
@@ -68,7 +66,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@3.5.13
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@3.5.15
         with:
           platform: ios
           project-root: ${{ github.event.inputs.projectRoot }}
@@ -122,7 +120,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@3.5.13
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@3.5.15
         with:
           platform: macos
           project-root: ${{ github.event.inputs.projectRoot }}
@@ -156,7 +154,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@3.5.13
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@3.5.15
         with:
           platform: windows
           cache-npm-dependencies: ${{ github.event.inputs.packageManager }}

--- a/incubator/build/workflows/github.yml
+++ b/incubator/build/workflows/github.yml
@@ -36,18 +36,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@3.5.13
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@3.5.15
         with:
           platform: android
           cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Build Android app
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-version: wrapper
-          arguments: --no-daemon clean assembleDebug
-          build-root-directory: ${{ github.event.inputs.projectRoot }}/android
+        run: ./gradlew --no-daemon clean assembleDebug
+        shell: bash
+        working-directory: ${{ github.event.inputs.projectRoot }}/android
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
@@ -68,7 +66,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@3.5.13
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@3.5.15
         with:
           platform: ios
           project-root: ${{ github.event.inputs.projectRoot }}
@@ -122,7 +120,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@3.5.13
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@3.5.15
         with:
           platform: macos
           project-root: ${{ github.event.inputs.projectRoot }}
@@ -156,7 +154,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@3.5.13
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@3.5.15
         with:
           platform: windows
           cache-npm-dependencies: ${{ github.event.inputs.packageManager }}


### PR DESCRIPTION
### Description

Using `gradle/actions/setup-gradle` to execute Gradle is deprecated (see https://github.com/gradle/actions/blob/v3/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated)

### Test plan

n/a