### PR TITLE
fix(react-native-host): prevent unintentional autolinking

### DIFF
--- a/.changeset/strange-lions-own.md
+++ b/.changeset/strange-lions-own.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Prevent unintentional autolinking

--- a/packages/react-native-host/package.json
+++ b/packages/react-native-host/package.json
@@ -13,7 +13,8 @@
     "android/build.gradle",
     "android/gradle.properties",
     "android/src",
-    "cocoa"
+    "cocoa",
+    "react-native.config.js"
   ],
   "repository": {
     "type": "git",

--- a/packages/react-native-host/react-native.config.js
+++ b/packages/react-native-host/react-native.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: null,
+      ios: null,
+      macos: null,
+      visionos: null,
+      windows: null,
+    },
+  },
+};


### PR DESCRIPTION
### Description

Prevent unintentional autolinking.

### Test plan

```
cd packages/test-app
yarn react-native config
```

Verify that `@rnx-kit/react-native-host` is not present.