### PR TITLE
fix(tools-apple): make sure iPhone Pro simulators can be selected

### DIFF
--- a/.changeset/brown-walls-suffer.md
+++ b/.changeset/brown-walls-suffer.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-apple": patch
+---
+
+Make sure iPhone Pro simulators can be selected if none are specified

--- a/packages/tools-apple/src/ios.ts
+++ b/packages/tools-apple/src/ios.ts
@@ -170,7 +170,9 @@ export async function selectDevice(
   const device = deviceName
     ? devices.find(({ simulator, name }) => simulator && name === deviceName)
     : devices.reverse().find(({ simulator, available, modelName }) => {
-        return simulator && available && /^iPhone \d\d$/.test(modelName);
+        return (
+          simulator && available && /^iPhone \d\d(?: Pro)?$/.test(modelName)
+        );
       });
   if (!device) {
     const foundDevices = devices


### PR DESCRIPTION
### Description

Make sure iPhone Pro simulators can be selected if none are specified

### Test plan

n/a