### PR TITLE
fix(tools-shell): allow `once` functions to take arguments

### DIFF
--- a/.changeset/spicy-rabbits-smash.md
+++ b/.changeset/spicy-rabbits-smash.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-shell": patch
+---
+
+Allow `once` functions to take arguments

--- a/packages/tools-shell/src/async.ts
+++ b/packages/tools-shell/src/async.ts
@@ -8,11 +8,13 @@ export function idle(ms: number): Promise<void> {
 /**
  * Wraps the function, making sure it only gets called once.
  */
-export function once<R>(func: () => R): () => R {
+export function once<R>(
+  func: (...args: unknown[]) => R
+): (...args: unknown[]) => R {
   let result: R | undefined;
-  return () => {
+  return (...args) => {
     if (!result) {
-      result = func();
+      result = func(...args);
     }
     return result;
   };

--- a/packages/tools-shell/src/async.ts
+++ b/packages/tools-shell/src/async.ts
@@ -9,11 +9,11 @@ export function idle(ms: number): Promise<void> {
  * Wraps the function, making sure it only gets called once.
  */
 export function once<R>(
-  func: (...args: unknown[]) => R
-): (...args: unknown[]) => R {
-  let result: R | undefined;
+  func: (...args: unknown[]) => NonNullable<R>
+): (...args: unknown[]) => NonNullable<R> {
+  let result: NonNullable<R>;
   return (...args) => {
-    if (!result) {
+    if (result != null) {
       result = func(...args);
     }
     return result;


### PR DESCRIPTION
### Description

Allow `once` functions to take arguments

### Test plan

n/a