### PR TITLE
fix(third-party-notices): use license URL if no copyright info is found

### DIFF
--- a/.changeset/loud-trains-double.md
+++ b/.changeset/loud-trains-double.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/third-party-notices": patch
+---
+
+Use licenseURL as placeholder if no copyright or package author is found

--- a/packages/third-party-notices/src/output/json.ts
+++ b/packages/third-party-notices/src/output/json.ts
@@ -27,7 +27,7 @@ function parseCopyright(
       return packageAuthor;
     }
 
-    if (licenseURLs.length > 0) {
+    if (licenseURLs && licenseURLs.length > 0) {
       return `${license} (${licenseURLs.join(" ")})`;
     }
 

--- a/packages/third-party-notices/src/output/json.ts
+++ b/packages/third-party-notices/src/output/json.ts
@@ -16,11 +16,22 @@ function getPackageAuthor(modulePath: string): string | undefined {
 
 function parseCopyright(
   modulePath: string,
-  licenseText: string | undefined
+  licenseText: string | undefined,
+  license: string | undefined,
+  licenseURLs: string[]
 ): string {
   const m = licenseText?.match(/^Copyright .*$/m);
   if (!m) {
-    return getPackageAuthor(modulePath) || "No copyright notice";
+    const packageAuthor = getPackageAuthor(modulePath);
+    if (packageAuthor) {
+      return packageAuthor;
+    }
+
+    if (licenseURLs.length > 0) {
+      return `${license} (${licenseURLs.join(" ")})`;
+    }
+
+    return "No copyright notice";
   }
 
   return m[0].trim();
@@ -33,7 +44,14 @@ export function createLicenseJSON(
   return JSON.stringify(
     {
       packages: licenses.map(
-        ({ name, path: modulePath, version, license, licenseText }) => {
+        ({
+          name,
+          path: modulePath,
+          version,
+          license,
+          licenseText,
+          licenseURLs,
+        }) => {
           if (!license) {
             throw new Error(`No license for ${name}`);
           }
@@ -41,7 +59,12 @@ export function createLicenseJSON(
             name,
             version,
             license,
-            copyright: parseCopyright(modulePath, licenseText),
+            copyright: parseCopyright(
+              modulePath,
+              licenseText,
+              license,
+              licenseURLs
+            ),
           };
 
           if (fullLicenseText) {

--- a/packages/third-party-notices/src/output/json.ts
+++ b/packages/third-party-notices/src/output/json.ts
@@ -27,7 +27,7 @@ function parseCopyright(
       return packageAuthor;
     }
 
-    if (licenseURLs && licenseURLs.length > 0) {
+    if (licenseURLs?.length > 0) {
       return `${license} (${licenseURLs.join(" ")})`;
     }
 

--- a/packages/third-party-notices/test/__snapshots__/licence.test.ts.snap
+++ b/packages/third-party-notices/test/__snapshots__/licence.test.ts.snap
@@ -7,6 +7,12 @@ MIT (https://spdx.org/licenses/MIT.html)
 
 ========================================================================
 
+metro-source-map 1.2.3-fixedVersionForTesting
+--
+MIT (https://spdx.org/licenses/MIT.html)
+
+========================================================================
+
 yargs 1.2.3-fixedVersionForTesting
 --
 MIT License
@@ -43,6 +49,12 @@ Preamble 2
 ========================================================================
 
 @rnx-kit/console 1.2.3-fixedVersionForTesting
+--
+MIT (https://spdx.org/licenses/MIT.html)
+
+========================================================================
+
+metro-source-map 1.2.3-fixedVersionForTesting
 --
 MIT (https://spdx.org/licenses/MIT.html)
 

--- a/packages/third-party-notices/test/licence.test.ts
+++ b/packages/third-party-notices/test/licence.test.ts
@@ -9,12 +9,18 @@ const rnxConsoleDir = path.dirname(
 );
 const yargsDir = path.dirname(require.resolve("yargs/package.json"));
 
+const metroSourceMapDir = path.dirname(
+  require.resolve("metro-source-map/package.json")
+);
+
 async function getSampleLicenseData(): Promise<License[]> {
   const map = new Map([
     // License data in package.json
     ["@rnx-kit/console", rnxConsoleDir],
     // License data package.json and LICENCE file
     ["yargs", yargsDir],
+    // No license data
+    ["metro-source-map", metroSourceMapDir],
   ]);
 
   const licenses = await extractLicenses(map);
@@ -47,6 +53,13 @@ describe("license", () => {
         name: "@rnx-kit/console",
         path: rnxConsoleDir,
         version: "1.2.3-fixedVersionForTesting",
+      },
+      {
+        name: "metro-source-map",
+        path: metroSourceMapDir,
+        version: "1.2.3-fixedVersionForTesting",
+        licenseURLs: ["https://spdx.org/licenses/MIT.html"],
+        license: "MIT",
       },
       {
         license: "MIT",
@@ -101,6 +114,12 @@ describe("license", () => {
           version: "1.2.3-fixedVersionForTesting",
         },
         {
+          name: "metro-source-map",
+          version: "1.2.3-fixedVersionForTesting",
+          license: "MIT",
+          copyright: "MIT (https://spdx.org/licenses/MIT.html)",
+        },
+        {
           copyright:
             "Copyright 2010 James Halliday (mail@substack.net); Modified work Copyright 2014 Contributors (ben@npmjs.com)",
           license: "MIT",
@@ -132,6 +151,12 @@ describe("license", () => {
           license: "MIT",
           name: "@rnx-kit/console",
           version: "1.2.3-fixedVersionForTesting",
+        },
+        {
+          name: "metro-source-map",
+          version: "1.2.3-fixedVersionForTesting",
+          license: "MIT",
+          copyright: "MIT (https://spdx.org/licenses/MIT.html)",
         },
         {
           copyright:


### PR DESCRIPTION
### Description
If no copyright or package author information is found then set license and license URL information instead of the default "No copyright notice" placeholder. This ensures that the JSON and text information is more similar. 

### Test plan
Unit tests

| Before | After  |
| ------ | --------- |
| <pre>{<br>  "name": "deprecated-react-native-prop-types",<br>  "version": "2.3.0",<br>  "license": "MIT",<br>  "copyright": "No copyright notice"<br>}</pre>    | <pre>{<br>  "name": "deprecated-react-native-prop-types",<br>  "version": "2.3.0",<br>  "license": "MIT",<br>  "copyright": "MIT (https://spdx.org/licenses/MIT.html)"<br>}</pre>|
