### PR TITLE
fix(react-native-host): override feature flags for bridgeless mode

### DIFF
--- a/.changeset/plenty-moose-live.md
+++ b/.changeset/plenty-moose-live.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Override feature flags for bridgeless mode

--- a/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
+++ b/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
@@ -11,6 +11,8 @@
 #endif  // USE_HERMES
 
 #import <react/config/ReactNativeConfig.h>
+#import <react/featureflags/ReactNativeFeatureFlags.h>
+#import <react/featureflags/ReactNativeFeatureFlagsDefaults.h>
 
 #if __has_include(<react/runtime/JSEngineInstance.h>)
 using SharedJSRuntimeFactory = std::shared_ptr<facebook::react::JSEngineInstance>;
@@ -41,6 +43,26 @@ using SharedJSRuntimeFactory = std::shared_ptr<facebook::react::JSRuntimeFactory
 - (RCTModuleRegistry *)getModuleRegistry;      // Deprecated in 0.74, and removed in 0.75
 - (RCTSurfacePresenter *)getSurfacePresenter;  // Deprecated in 0.74, and removed in 0.75
 @end
+
+// https://github.com/facebook/react-native/blob/0.74-stable/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm#L272-L286
+class RNXBridgelessFeatureFlags : public facebook::react::ReactNativeFeatureFlagsDefaults
+{
+public:
+    bool useModernRuntimeScheduler() override
+    {
+        return true;
+    }
+
+    bool enableMicrotasks() override
+    {
+        return true;
+    }
+
+    bool batchRenderingUpdatesInEventLoop() override
+    {
+        return true;
+    }
+};
 
 #elif USE_FABRIC
 

--- a/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
+++ b/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
@@ -11,8 +11,12 @@
 #endif  // USE_HERMES
 
 #import <react/config/ReactNativeConfig.h>
+
+#if __has_include(<react/featureflags/ReactNativeFeatureFlags.h>)
 #import <react/featureflags/ReactNativeFeatureFlags.h>
 #import <react/featureflags/ReactNativeFeatureFlagsDefaults.h>
+#define USE_FEATURE_FLAGS
+#endif  // __has_include(<react/featureflags/ReactNativeFeatureFlags.h>)
 
 #if __has_include(<react/runtime/JSEngineInstance.h>)
 using SharedJSRuntimeFactory = std::shared_ptr<facebook::react::JSEngineInstance>;
@@ -44,6 +48,7 @@ using SharedJSRuntimeFactory = std::shared_ptr<facebook::react::JSRuntimeFactory
 - (RCTSurfacePresenter *)getSurfacePresenter;  // Deprecated in 0.74, and removed in 0.75
 @end
 
+#ifdef USE_FEATURE_FLAGS
 // https://github.com/facebook/react-native/blob/0.74-stable/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm#L272-L286
 class RNXBridgelessFeatureFlags : public facebook::react::ReactNativeFeatureFlagsDefaults
 {
@@ -63,6 +68,7 @@ public:
         return true;
     }
 };
+#endif  // USE_FEATURE_FLAGS
 
 #elif USE_FABRIC
 

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -59,12 +59,12 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
             _hostReleaser = [[RNXHostReleaser alloc] initWithHost:self];
         }
 
-#if USE_BRIDGELESS
+#ifdef USE_FEATURE_FLAGS
         if (self.isBridgelessEnabled) {
             facebook::react::ReactNativeFeatureFlags::override(
                 std::make_unique<RNXBridgelessFeatureFlags>());
         }
-#endif  // USE_BRIDGELESS
+#endif  // USE_FEATURE_FLAGS
 
         if ([config respondsToSelector:@selector(isDevLoadingViewEnabled)]) {
             RCTDevLoadingViewSetEnabled([config isDevLoadingViewEnabled]);

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -49,6 +49,23 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 - (instancetype)initWithConfig:(id<RNXHostConfig>)config launchOptions:(NSDictionary *)launchOptions
 {
     if (self = [super init]) {
+        _config = config;
+        _launchOptions = launchOptions;
+        [self enableTurboModule];
+        _isShuttingDown = [[NSLock alloc] init];
+
+        if ([config respondsToSelector:@selector(shouldReleaseBridgeWhenBackgrounded)] &&
+            [config shouldReleaseBridgeWhenBackgrounded]) {
+            _hostReleaser = [[RNXHostReleaser alloc] initWithHost:self];
+        }
+
+#if USE_BRIDGELESS
+        if (self.isBridgelessEnabled) {
+            facebook::react::ReactNativeFeatureFlags::override(
+                std::make_unique<RNXBridgelessFeatureFlags>());
+        }
+#endif  // USE_BRIDGELESS
+
         if ([config respondsToSelector:@selector(isDevLoadingViewEnabled)]) {
             RCTDevLoadingViewSetEnabled([config isDevLoadingViewEnabled]);
         }
@@ -67,16 +84,6 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
             RCTSetFatalHandler(^(NSError *error) {
               [config onFatalError:error];
             });
-        }
-
-        _config = config;
-        _launchOptions = launchOptions;
-        [self enableTurboModule];
-        _isShuttingDown = [[NSLock alloc] init];
-
-        if ([config respondsToSelector:@selector(shouldReleaseBridgeWhenBackgrounded)] &&
-            [config shouldReleaseBridgeWhenBackgrounded]) {
-            _hostReleaser = [[RNXHostReleaser alloc] initWithHost:self];
         }
 
         [self initializeReactHost];


### PR DESCRIPTION
### Description

Override feature flags for bridgeless mode.

### Test plan

This needs to be tested in RNTA:

```sh
npm run set-react-version 0.74 -- --core-only
yarn clean
yarn

# Manually apply changes under node_modules/@rnx-kit/react-native-host/

cd example
RCT_NEW_ARCH_ENABLED=1 pod install --project-directory=ios
yarn ios

# In a separate terminal
yarn start
```

### Screenshots

![Simulator Screenshot - iPhone 15 Pro - 2024-06-19 at 11 47 40](https://github.com/microsoft/rnx-kit/assets/4123478/7b7b2c30-c823-4dff-a07d-11c6620553ba)
