### PR TITLE
fix(web-storage): fix missing peer dependencies

### DIFF
--- a/.changeset/stupid-peaches-invent.md
+++ b/.changeset/stupid-peaches-invent.md
@@ -1,0 +1,5 @@
+---
+"@react-native-webapis/web-storage": patch
+---
+
+Fix missing `react-native-macos` and `-windows` under peer dependencies

--- a/incubator/@react-native-webapis/web-storage/package.json
+++ b/incubator/@react-native-webapis/web-storage/package.json
@@ -38,8 +38,22 @@
     "lint:kt": "ktlint --relative 'android/src/**/*.kt'"
   },
   "peerDependencies": {
+    "@callstack/react-native-visionos": ">=0.73",
     "react": ">=18.2.0",
-    "react-native": ">=0.72.0-0"
+    "react-native": ">=0.72",
+    "react-native-macos": ">=0.72",
+    "react-native-windows": ">=0.72"
+  },
+  "peerDependenciesMeta": {
+    "@callstack/react-native-visionos": {
+      "optional": true
+    },
+    "react-native-macos": {
+      "optional": true
+    },
+    "react-native-windows": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3307,8 +3307,18 @@ __metadata:
     react-native: "npm:^0.73.0"
     typescript: "npm:^5.0.0"
   peerDependencies:
+    "@callstack/react-native-visionos": ">=0.73"
     react: ">=18.2.0"
-    react-native: ">=0.72.0-0"
+    react-native: ">=0.72"
+    react-native-macos: ">=0.72"
+    react-native-windows: ">=0.72"
+  peerDependenciesMeta:
+    "@callstack/react-native-visionos":
+      optional: true
+    react-native-macos:
+      optional: true
+    react-native-windows:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

Fix missing `react-native-macos` and `-windows` under peer dependencies

### Test plan

n/a