### PR TITLE
fix(web-storage): workaround autolinking issues

### DIFF
--- a/.changeset/tricky-comics-obey.md
+++ b/.changeset/tricky-comics-obey.md
@@ -1,0 +1,5 @@
+---
+"@react-native-webapis/web-storage": patch
+---
+
+Workaround for autolinking not including macOS or Windows as target platforms (see https://github.com/react-native-community/cli/issues/2419)

--- a/incubator/@react-native-webapis/web-storage/package.json
+++ b/incubator/@react-native-webapis/web-storage/package.json
@@ -66,6 +66,8 @@
     "prettier": "^3.0.0",
     "react": "18.2.0",
     "react-native": "^0.73.0",
+    "react-native-macos": "^0.73.0",
+    "react-native-windows": "^0.73.0",
     "typescript": "^5.0.0"
   },
   "codegenConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3305,6 +3305,8 @@ __metadata:
     prettier: "npm:^3.0.0"
     react: "npm:18.2.0"
     react-native: "npm:^0.73.0"
+    react-native-macos: "npm:^0.73.0"
+    react-native-windows: "npm:^0.73.0"
     typescript: "npm:^5.0.0"
   peerDependencies:
     "@callstack/react-native-visionos": ">=0.73"


### PR DESCRIPTION
### Description

Workaround for autolinking not including macOS or Windows as target platforms (see https://github.com/react-native-community/cli/issues/2419)

### Test plan

In RNTA:

```
yarn
cd node_modules/@react-native-webapis/web-storage
yarn react-native codegen-windows

# This command will fail as is
# Now add `react-native-windows` to `package.json`

yarn react-native codegen-windows

# This should succeed
```