### PR TITLE
[align-deps] Update react-native-svg min versions

### DIFF
--- a/packages/align-deps/src/presets/microsoft/react-native/profile-0.64.ts
+++ b/packages/align-deps/src/presets/microsoft/react-native/profile-0.64.ts
@@ -191,7 +191,7 @@ export const profile: Profile = {
   },
   svg: {
     name: "react-native-svg",
-    version: "^12.1.1",
+    version: "^12.3.0",
   },
   webview: {
     name: "react-native-webview",

--- a/packages/align-deps/src/presets/microsoft/react-native/profile-0.68.ts
+++ b/packages/align-deps/src/presets/microsoft/react-native/profile-0.68.ts
@@ -119,10 +119,6 @@ export const profile: Profile = {
     name: "@react-native-async-storage/async-storage",
     version: "^1.17.3",
   },
-  svg: {
-    name: "react-native-svg",
-    version: "^12.3.0",
-  },
   "test-app": {
     name: "react-native-test-app",
     version: "^1.3.5",

--- a/packages/align-deps/src/presets/microsoft/react-native/profile-0.70.ts
+++ b/packages/align-deps/src/presets/microsoft/react-native/profile-0.70.ts
@@ -124,6 +124,10 @@ export const profile: Profile = {
     name: "@react-native-async-storage/async-storage",
     version: "^1.17.10",
   },
+  svg: {
+    name: "react-native-svg",
+    version: "^15.0.0",
+  },
   "test-app": {
     name: "react-native-test-app",
     version: "^1.6.9",

--- a/packages/align-deps/src/presets/microsoft/react-native/profile-0.71.ts
+++ b/packages/align-deps/src/presets/microsoft/react-native/profile-0.71.ts
@@ -132,10 +132,6 @@ export const profile: Profile = {
     name: "@react-native-async-storage/async-storage",
     version: "^1.17.11",
   },
-  svg: {
-    name: "react-native-svg",
-    version: "^13.14.0",
-  },
   "test-app": {
     name: "react-native-test-app",
     version: "^2.2.1",

--- a/packages/align-deps/src/presets/microsoft/react-native/profile-0.73.ts
+++ b/packages/align-deps/src/presets/microsoft/react-native/profile-0.73.ts
@@ -138,10 +138,6 @@ export const profile: Profile = {
     name: "@react-native-async-storage/async-storage",
     version: "^1.22.0",
   },
-  svg: {
-    name: "react-native-svg",
-    version: "^15.0.0",
-  },
   "test-app": {
     name: "react-native-test-app",
     version: "^2.5.34",


### PR DESCRIPTION
Referencing [react-native-svg's supported versions](https://github.com/software-mansion/react-native-svg#supported-react-native-versions), updating some values here.

I'm on RN 0.72 for example and react-native-svg 15.4.0 works fine for me, but align-deps tells me I need to be using ^13.14.0