### PR TITLE
fix(eslint-plugin): handle packages missing `default` in their exports map

### DIFF
--- a/.changeset/twelve-fireants-hammer.md
+++ b/.changeset/twelve-fireants-hammer.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/eslint-plugin": patch
+---
+
+Properly handle packages that are missing a default entry in their exports map

--- a/packages/eslint-plugin/src/rules/no-export-all.js
+++ b/packages/eslint-plugin/src/rules/no-export-all.js
@@ -105,6 +105,11 @@ const resolveFrom =
       const resolve = require("enhanced-resolve").create.sync({
         extensions: [".ts", ".tsx", ".js", ".jsx"],
         mainFields: ["module", "main"],
+
+        // Add `require` to handle packages that are missing `default`
+        // conditional. See
+        // https://github.com/webpack/enhanced-resolve/issues/313
+        conditionNames: ["typescript", "import", "require", "node"],
       });
 
       return (fromDir, moduleId) => {


### PR DESCRIPTION
### Description

Properly handle packages that are missing a default entry in their exports map.

### Test plan

1. In [Fluent UI](https://github.com/microsoft/fluentui), create a file, `packages/react-components/react-components/src/icons.ts`, with the following content:
    ```ts
    export * from "@fluentui/react-icons";
    ```
2. Run ESLint: `yarn workspace @fluentui/react-components eslint --ext .ts src/icons.ts`
3. Verify that at least 1 error is fixable with `--fix`