### PR TITLE
fix(cli): fix `rnx-align-deps` command not working

### DIFF
--- a/.changeset/plenty-onions-whisper.md
+++ b/.changeset/plenty-onions-whisper.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Fix `rnx-align-deps` not working

--- a/packages/cli/src/align-deps.ts
+++ b/packages/cli/src/align-deps.ts
@@ -13,7 +13,7 @@ const optionsMap: Partial<Record<keyof typeof cliOptions, string>> = {
 };
 
 export function rnxAlignDeps(
-  argv: string[],
+  _argv: string[],
   _config: CLIConfig,
   args: CLIArgs
 ): void {
@@ -25,7 +25,6 @@ export function rnxAlignDeps(
     "no-unmanaged": Boolean(args.noUnmanaged),
     verbose: Boolean(args.verbose),
     write: Boolean(args.write),
-    packages: argv,
   });
 }
 


### PR DESCRIPTION
### Description

The `rnx-align-deps` command has been broken ever since we renamed `dep-check` to `align-deps`, but it was never caught because CI never ran it (fix for that here: https://github.com/microsoft/rnx-kit/pull/3243).

### Test plan

```
cd packages/test-app
yarn build --dependencies
yarn react-native rnx-align-deps
```