### PR TITLE
fix(tools-node): avoid additional stat call when resolving symlinks

### DIFF
--- a/.changeset/hip-shrimps-serve.md
+++ b/.changeset/hip-shrimps-serve.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-node": patch
+---
+
+Avoid an additional stat call when trying to resolve symlinks

--- a/packages/tools-node/src/package.ts
+++ b/packages/tools-node/src/package.ts
@@ -184,22 +184,20 @@ export type FindPackageDependencyOptions = {
  */
 export function findPackageDependencyDir(
   ref: string | PackageRef,
-  options?: FindPackageDependencyOptions
+  {
+    startDir,
+    allowSymlinks,
+    resolveSymlinks,
+  }: FindPackageDependencyOptions = {}
 ): string | undefined {
   const pkgName =
     typeof ref === "string" ? ref : path.join(ref.scope ?? "", ref.name);
-  const packageDir = findUp(path.join("node_modules", pkgName), {
-    startDir: options?.startDir,
+  return findUp(path.join("node_modules", pkgName), {
     type: "directory",
-    allowSymlinks: options?.allowSymlinks,
+    startDir,
+    allowSymlinks,
+    resolveSymlinks,
   });
-  if (!packageDir || !options?.resolveSymlinks) {
-    return packageDir;
-  }
-
-  return fs.lstatSync(packageDir).isSymbolicLink()
-    ? path.resolve(path.dirname(packageDir), fs.readlinkSync(packageDir))
-    : packageDir;
 }
 
 /**


### PR DESCRIPTION
### Description

Avoid an additional stat call when trying to resolve symlinks

### Test plan

Existing tests should pass.