### PR TITLE
fix(metro-config): workaround for Expo unintentionally overwriting fields

### DIFF
--- a/.changeset/healthy-ducks-greet.md
+++ b/.changeset/healthy-ducks-greet.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Let users know if they're missing `@react-native/metro-config` when on React
+Native 0.72+

--- a/.changeset/unlucky-bikes-push.md
+++ b/.changeset/unlucky-bikes-push.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Workaround for Expo unintentionally overwriting our Metro config

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -24,7 +24,6 @@
     "test": "rnx-kit-scripts test"
   },
   "dependencies": {
-    "@rnx-kit/console": "^1.0.0",
     "@rnx-kit/tools-node": "^2.0.0",
     "@rnx-kit/tools-react-native": "^1.3.4",
     "@rnx-kit/tools-workspaces": "^0.1.3"

--- a/packages/metro-config/src/expoConfig.js
+++ b/packages/metro-config/src/expoConfig.js
@@ -1,0 +1,65 @@
+// @ts-check
+
+/** @typedef {import("metro-config").MetroConfig} MetroConfig */
+
+/**
+ * Determines whether this is an Expo config.
+ * @param {MetroConfig=} config
+ * @returns {boolean}
+ */
+function isExpoConfig(config) {
+  if (!config) {
+    return false;
+  }
+
+  // https://github.com/expo/expo/blob/sdk-51/packages/%40expo/metro-config/src/ExpoMetroConfig.ts#L256
+  const transformer = config.transformer;
+  if (transformer) {
+    if (
+      "_expoRelativeProjectRoot" in transformer ||
+      transformer.babelTransformerPath?.includes("@expo")
+    ) {
+      return true;
+    }
+  }
+
+  return Boolean(config.transformerPath?.includes("@expo"));
+}
+
+/**
+ * Applies workarounds to make the Expo config work.
+ * @param {MetroConfig} config
+ * @param {MetroConfig} defaultConfig
+ * @returns {void}
+ */
+function applyExpoWorkarounds(config, defaultConfig) {
+  // Expo's default config is based on Metro's default config, and Metro's
+  // default config sets some fields (like `resolveRequest`) to `null`, which
+  // then overwrites our fields.
+  // https://github.com/facebook/metro/blob/v0.80.10/packages/metro-config/src/defaults/index.js#L51
+  if (config.resolver?.resolveRequest === null) {
+    delete config.resolver.resolveRequest;
+  }
+
+  // Expo _always_ sets to `getModulesRunBeforeMainModule`.
+  // https://github.com/expo/expo/blob/sdk-51/packages/%40expo/metro-config/src/ExpoMetroConfig.ts#L207
+  const getModulesRunBeforeMainModule =
+    config.serializer?.getModulesRunBeforeMainModule;
+  if (getModulesRunBeforeMainModule) {
+    const core = /Libraries[/\\]Core[/\\]InitializeCore/;
+    const prelude =
+      defaultConfig.serializer?.getModulesRunBeforeMainModule?.("") ?? [];
+    config.serializer.getModulesRunBeforeMainModule = (entryFilePath) => {
+      const modules = prelude.slice();
+      for (const m of getModulesRunBeforeMainModule(entryFilePath)) {
+        if (!core.test(m)) {
+          modules.push(m);
+        }
+      }
+      return modules;
+    };
+  }
+}
+
+exports.applyExpoWorkarounds = applyExpoWorkarounds;
+exports.isExpoConfig = isExpoConfig;

--- a/packages/metro-config/src/expoConfig.js
+++ b/packages/metro-config/src/expoConfig.js
@@ -35,13 +35,13 @@ function isExpoConfig(config) {
 function applyExpoWorkarounds(config, defaultConfig) {
   // Expo's default config is based on Metro's default config, and Metro's
   // default config sets some fields (like `resolveRequest`) to `null`, which
-  // then overwrites our fields.
+  // then overwrites our fields:
   // https://github.com/facebook/metro/blob/v0.80.10/packages/metro-config/src/defaults/index.js#L51
   if (config.resolver?.resolveRequest === null) {
     delete config.resolver.resolveRequest;
   }
 
-  // Expo _always_ sets to `getModulesRunBeforeMainModule`.
+  // Expo _always_ sets `getModulesRunBeforeMainModule`:
   // https://github.com/expo/expo/blob/sdk-51/packages/%40expo/metro-config/src/ExpoMetroConfig.ts#L207
   const getModulesRunBeforeMainModule =
     config.serializer?.getModulesRunBeforeMainModule;

--- a/packages/metro-config/test/expoConfig.test.ts
+++ b/packages/metro-config/test/expoConfig.test.ts
@@ -1,0 +1,69 @@
+import type { MetroConfig } from "metro-config";
+import { deepEqual, ok } from "node:assert/strict";
+import { describe, it } from "node:test";
+import { applyExpoWorkarounds, isExpoConfig } from "../src/expoConfig";
+
+describe("isExpoConfig()", () => {
+  it("returns true when it's likely a config comes from Expo", () => {
+    ok(!isExpoConfig());
+    ok(!isExpoConfig({}));
+    ok(
+      !isExpoConfig({
+        transformer: { babelTransformerPath: "metro-babel-transformer" },
+      })
+    );
+    ok(!isExpoConfig({ transformerPath: "metro-transform-worker" }));
+
+    ok(
+      isExpoConfig({
+        transformer: { _expoRelativeProjectRoot: null },
+      } as MetroConfig)
+    );
+    ok(isExpoConfig({ transformer: { babelTransformerPath: "@expo" } }));
+    ok(isExpoConfig({ transformerPath: "@expo" }));
+  });
+});
+
+describe("applyExpoWorkarounds()", () => {
+  it("removes `config.resolver.resolveRequest` when it's `null`", () => {
+    const config = { resolver: { resolveRequest: null } };
+
+    ok("resolveRequest" in config.resolver);
+
+    applyExpoWorkarounds(config, {});
+
+    ok(!("resolveRequest" in config.resolver));
+  });
+
+  it("replaces `config.serializer.getModulesRunBeforeMainModule`", () => {
+    const expoConfig = {
+      serializer: {
+        getModulesRunBeforeMainModule: () => [
+          "react-native/Libraries/Core/InitializeCore.js",
+          "expo/build/winter",
+          "@expo/metro-runtime",
+        ],
+      },
+    };
+
+    const defaultConfig = {
+      serializer: {
+        getModulesRunBeforeMainModule: () => [
+          "react-native/Libraries/Core/InitializeCore.js",
+          "react-native-macos/Libraries/Core/InitializeCore.js",
+          "react-native-windows/Libraries/Core/InitializeCore.js",
+        ],
+      },
+    };
+
+    applyExpoWorkarounds(expoConfig, defaultConfig);
+
+    deepEqual(expoConfig.serializer.getModulesRunBeforeMainModule(), [
+      "react-native/Libraries/Core/InitializeCore.js",
+      "react-native-macos/Libraries/Core/InitializeCore.js",
+      "react-native-windows/Libraries/Core/InitializeCore.js",
+      "expo/build/winter",
+      "@expo/metro-runtime",
+    ]);
+  });
+});

--- a/packages/metro-config/test/index.test.ts
+++ b/packages/metro-config/test/index.test.ts
@@ -405,6 +405,7 @@ describe("makeMetroConfig", () => {
 
   it("sets both `blacklistRE` and `blockList`", () => {
     const configWithBlacklist = makeMetroConfig({
+      projectRoot,
       resolver: {
         blacklistRE: /.*/,
       },
@@ -415,6 +416,7 @@ describe("makeMetroConfig", () => {
     equal(blacklistRE, configWithBlacklist.resolver?.blockList);
 
     const configWithBlockList = makeMetroConfig({
+      projectRoot,
       resolver: {
         blockList: /.*/,
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4008,7 +4008,6 @@ __metadata:
   dependencies:
     "@babel/core": "npm:^7.20.0"
     "@babel/preset-env": "npm:^7.20.0"
-    "@rnx-kit/console": "npm:^1.0.0"
     "@rnx-kit/eslint-config": "npm:*"
     "@rnx-kit/scripts": "npm:*"
     "@rnx-kit/tools-node": "npm:^2.0.0"


### PR DESCRIPTION
### Description

Workaround for Expo unintentionally overwriting our Metro config

### Test plan

Reconfigure `test-app` to use `@expo/metro-config`:

```diff
diff --git a/.yarnrc.yml b/.yarnrc.yml
index f4dcdc46..dbde6a63 100644
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,6 +15,12 @@ logFilters:
 nodeLinker: pnpm
 npmRegistryServer: "https://registry.npmjs.org"
 packageExtensions:
+  "@expo/metro-config@*":
+    dependencies:
+      metro-cache: 0.80.9
+      metro-config: 0.80.9
+      metro-source-map: 0.80.9
+      metro-transform-plugins: 0.80.9
   "@fluentui/utilities@*":
     peerDependenciesMeta:
       # https://github.com/microsoft/fluentui/pull/30964
diff --git a/packages/test-app/metro.config.js b/packages/test-app/metro.config.js
index 585167ef..3c94188a 100644
--- a/packages/test-app/metro.config.js
+++ b/packages/test-app/metro.config.js
@@ -1,36 +1,5 @@
-const { exclusionList, makeMetroConfig } = require("@rnx-kit/metro-config");
-const MetroSymlinksResolver = require("@rnx-kit/metro-resolver-symlinks");
-const path = require("node:path");
+const { getDefaultConfig } = require("@expo/metro-config");
+const { makeMetroConfig } = require("@rnx-kit/metro-config");

-// If USE_AUTH_MOCK=1, exclude the real module to enable the mock.
-const useAuthMock = process.env["USE_AUTH_MOCK"];
-
-const blockList = exclusionList([
-  // Metro will pick up react-native-macos/-windows mocks if we don't exclude them
-  /.*__fixtures__.*/,
-
-  // If USE_AUTH_MOCK=1, exclude the real module to enable the mock.
-  ...(useAuthMock ? [/.*packages[/\\]react-native-auth.*/] : []),
-]);
-
-module.exports = makeMetroConfig({
-  resolver: {
-    extraNodeModules: {
-      internal: path.resolve(__dirname, "src", "internal"),
-      ...(useAuthMock
-        ? {
-            "@rnx-kit/react-native-auth": path.join(
-              __dirname,
-              "test",
-              "__mocks__",
-              "@rnx-kit",
-              "react-native-auth.js"
-            ),
-          }
-        : {}),
-    },
-    resolveRequest: MetroSymlinksResolver(),
-    blacklistRE: blockList,
-    blockList,
-  },
-});
+const defaultConfig = getDefaultConfig(__dirname);
+module.exports = makeMetroConfig(defaultConfig);
diff --git a/packages/test-app/package.json b/packages/test-app/package.json
index 01d82304..621c82c5 100644
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -41,6 +41,7 @@
     "@babel/plugin-transform-react-jsx-source": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
+    "@expo/metro-config": "*",
     "@jridgewell/trace-mapping": "^0.3.18",
     "@react-native/babel-preset": "^0.73.0",
     "@react-native/metro-config": "^0.73.0",
@@ -65,6 +66,7 @@
     "@testing-library/react-native": "^12.4.3",
     "@types/react": "^18.0.0",
     "eslint": "^8.56.0",
+    "expo-asset": "*",
     "jest": "^29.2.1",
     "prettier": "^3.0.0",
     "react-native-test-app": "^3.3.5",
```

Run `yarn install` to install the new dependencies.

To verify the config, run: `node --print 'require("./metro.config.js")'`

You should see that `resolveRequest` is set to `[Function: platformResolver]`.