### PR TITLE
Fix esbuild serializer on react-native 0.74

### DIFF
--- a/.changeset/stupid-kangaroos-think.md
+++ b/.changeset/stupid-kangaroos-think.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Handle updated exports for newer metro versions

--- a/packages/metro-serializer-esbuild/src/sourceMap.ts
+++ b/packages/metro-serializer-esbuild/src/sourceMap.ts
@@ -26,9 +26,13 @@ export function absolutizeSourceMap(outputPath: string, text: string): string {
 
 export function getInlineSourceMappingURL(modules: readonly Module[]): string {
   const metroPath = findMetroPath() || "metro";
-  const sourceMapString = require(
+  let sourceMapString = require(
     `${metroPath}/src/DeltaBundler/Serializers/sourceMapString`
   );
+  // Newer versions of metro export an object: https://github.com/facebook/metro/commit/34148e61200a508923315fbe387b26d1da27bf4b#diff-1b836d1729e527a725305eef0cec22e44605af2700fa413f4c2489ea1a03aebc
+  if (sourceMapString.sourceMapString) {
+    sourceMapString = sourceMapString.sourceMapString;
+  }
   const sourceMap = sourceMapString(modules, sourceMappingOptions);
   const base64 = Buffer.from(sourceMap).toString("base64");
   return `data:application/json;charset=utf-8;base64,${base64}`;


### PR DESCRIPTION
### Description
metro-serializer-esbuild uses a private export from metro, which changed in a recent release.  This updates the import to handle the newer metro version that is used in 0.74.

