### PR TITLE
Add typescript as a peerDependency in @rnx-kit/eslint-plugin

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -55,6 +55,11 @@
     "eslint": ">=8.56.0",
     "typescript": "^5.0.0"
   },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@microsoft/eslint-plugin-sdl": "^0.2.0",
     "@rnx-kit/eslint-config": "*",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -52,7 +52,8 @@
     "typescript-eslint": "^7.5.0"
   },
   "peerDependencies": {
-    "eslint": ">=8.56.0"
+    "eslint": ">=8.56.0",
+    "typescript": "^5.0.0"
   },
   "devDependencies": {
     "@microsoft/eslint-plugin-sdl": "^0.2.0",


### PR DESCRIPTION
### Description

Strict package managers need all dependencies to be fulfilled. This carries the typescript dependency from the consuming package over to `@typescript-eslint/eslint-plugin`, which would otherwise fail on missing typescript dependency.
