### PR TITLE
fix(tools-node): allow empty scope in package names

### DIFF
--- a/.changeset/beige-otters-dream.md
+++ b/.changeset/beige-otters-dream.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/metro-plugin-typescript": patch
+"@rnx-kit/tools-node": patch
+---
+
+Allow empty scope in package names

--- a/packages/test-app/jest.config.js
+++ b/packages/test-app/jest.config.js
@@ -10,6 +10,7 @@ function isPnpmMode() {
 const config = {
   preset: "@rnx-kit/jest-preset/private",
   moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/internal/$1",
     "^internal(.*)$": "<rootDir>/src/internal$1",
   },
 };

--- a/packages/test-app/metro.config.js
+++ b/packages/test-app/metro.config.js
@@ -16,6 +16,7 @@ const blockList = exclusionList([
 module.exports = makeMetroConfig({
   resolver: {
     extraNodeModules: {
+      "@/hermes": path.resolve(__dirname, "src", "internal", "hermes.ts"),
       internal: path.resolve(__dirname, "src", "internal"),
       ...(useAuthMock
         ? {

--- a/packages/test-app/src/Home.tsx
+++ b/packages/test-app/src/Home.tsx
@@ -1,13 +1,13 @@
 // Both `internal` imports are used to verify that `metro-resolver-symlinks`
 // resolves them correctly when `experimental_retryResolvingFromDisk` is
 // enabled.
+import { getHermesVersion } from "@/hermes";
 import {
   getReactNativeVersion,
   isBridgeless,
   isFabricInstance,
   isRemoteDebuggingAvailable,
 } from "internal";
-import { getHermesVersion } from "internal/hermes";
 import type { PropsWithChildren } from "react";
 import React, { useCallback, useState } from "react";
 import type { NativeSyntheticEvent } from "react-native";

--- a/packages/test-app/tsconfig.json
+++ b/packages/test-app/tsconfig.json
@@ -4,8 +4,8 @@
     "checkJs": false,
     "noEmit": true,
     "paths": {
-      "internal": ["./src/internal"],
-      "internal/*": ["./src/internal/*"]
+      "@/*": ["./src/internal/*"],
+      "internal": ["./src/internal"]
     }
   },
   "include": ["src"]

--- a/packages/tools-node/src/package.ts
+++ b/packages/tools-node/src/package.ts
@@ -22,11 +22,11 @@ export function parsePackageRef(r: string): PackageRef {
     // If `/` is not found, the reference could be a path alias.
     const indexSeparator = r.indexOf("/");
     if (indexSeparator >= 0) {
-      // The separator must start from position >= 2 to ensure that it is '@'
-      // and at least one other character. Further, the separator must have
-      // at least 1 character following it, before the end of the string.
-      if (indexSeparator < 2 || indexSeparator + 2 >= r.length) {
-        throw new Error(`Invalid package reference: "${r}"`);
+      // The separator must have at least 1 character following it, before the
+      // end of the string. Note that the scope may be an empty string.
+      // TypeScript does not place any restrictions on import re-mappings.
+      if (indexSeparator + 1 >= r.length) {
+        throw new Error(`Invalid package reference: ${r}`);
       }
 
       return {

--- a/packages/tools-node/test/package.test.ts
+++ b/packages/tools-node/test/package.test.ts
@@ -50,6 +50,10 @@ describe("Node > Package", () => {
     deepEqual(parsePackageRef("@alias"), { name: "@alias" });
   });
 
+  it("parsePackageRef(@/core) is allowed", () => {
+    deepEqual(parsePackageRef("@/core"), { scope: "@", name: "core" });
+  });
+
   it("parsePackageRef(undefined) throws an Error", () => {
     // @ts-expect-error Argument of type 'undefined' is not assignable to parameter of type 'string'
     throws(() => parsePackageRef(undefined));
@@ -57,10 +61,6 @@ describe("Node > Package", () => {
 
   it("parsePackageRef(@babel/) throws an Error", () => {
     throws(() => parsePackageRef("@babel/"));
-  });
-
-  it("parsePackageRef(@/core) throws an Error", () => {
-    throws(() => parsePackageRef("@/core"));
   });
 
   it("readPackage() loads package.json when given its containing directory", () => {


### PR DESCRIPTION
### Description

Allow empty scope in package names.

Resolves #3307.

### Test plan

- A test was modified.
- Test app has been configured to import a package with an empty scope.

CI should pass.