### PR TITLE
fix(cli): fix `build` command missing additional context

### DIFF
--- a/.changeset/new-cougars-collect.md
+++ b/.changeset/new-cougars-collect.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Provide additional context for the `build` command

--- a/packages/cli/src/bin/context.ts
+++ b/packages/cli/src/bin/context.ts
@@ -11,7 +11,10 @@ import {
   getSavedState,
   saveConfigToCache,
 } from "@rnx-kit/tools-react-native/cache";
-import { resolveCommunityCLI } from "@rnx-kit/tools-react-native/context";
+import {
+  loadContext,
+  resolveCommunityCLI,
+} from "@rnx-kit/tools-react-native/context";
 import { reactNativeConfig } from "../index";
 
 type Command = BaseCommand<false> | BaseCommand<true>;
@@ -53,7 +56,10 @@ export function uniquify(commands: Command[]): Command[] {
   return Object.values(uniqueCommands);
 }
 
-export function loadContext(userCommand: string, root = process.cwd()): Config {
+export function loadContextForCommand(
+  userCommand: string,
+  root = process.cwd()
+): Config {
   // The fast path avoids traversing project dependencies because we know what
   // information our commands depend on.
   const coreCommands = getCoreCommands();
@@ -90,7 +96,8 @@ export function loadContext(userCommand: string, root = process.cwd()): Config {
         throw new Error("Unexpected access to `platforms`");
       },
       get project(): Config["project"] {
-        throw new Error("Unexpected access to `project`");
+        // Used by the build command
+        return loadContext(root).project;
       },
     };
   }

--- a/packages/cli/src/bin/rnx-cli.ts
+++ b/packages/cli/src/bin/rnx-cli.ts
@@ -1,12 +1,12 @@
 import { Command } from "commander";
 import * as path from "node:path";
-import { loadContext } from "./context";
+import { loadContextForCommand } from "./context";
 import { findExternalCommands } from "./externalCommands";
 
 export function main() {
   const [, , userCommand] = process.argv;
 
-  const context = loadContext(userCommand);
+  const context = loadContextForCommand(userCommand);
   const allCommands = context.commands.concat(findExternalCommands(context));
   const program = new Command(path.basename(__filename, ".js"));
 

--- a/packages/cli/test/bin/context.test.ts
+++ b/packages/cli/test/bin/context.test.ts
@@ -1,5 +1,9 @@
 import type { Command } from "@react-native-community/cli-types";
-import { getCoreCommands, loadContext, uniquify } from "../../src/bin/context";
+import {
+  getCoreCommands,
+  loadContextForCommand,
+  uniquify,
+} from "../../src/bin/context";
 import { reactNativeConfig } from "../../src/index";
 
 jest.mock("@rnx-kit/tools-react-native/context", () => ({
@@ -48,19 +52,19 @@ describe("bin/context/uniquify()", () => {
   });
 });
 
-describe("bin/context/loadContext()", () => {
+describe("bin/context/loadContextForCommand()", () => {
   afterAll(() => {
     jest.resetAllMocks();
   });
 
   it("uses fast code path for rnx commands", () => {
     for (const { name } of getCoreCommands()) {
-      expect(() => loadContext(name)).not.toThrow();
+      expect(() => loadContextForCommand(name)).not.toThrow();
     }
   });
 
   it("uses full code path for other commands", () => {
-    expect(() => loadContext("run-android")).toThrow();
-    expect(() => loadContext("run-ios")).toThrow();
+    expect(() => loadContextForCommand("run-android")).toThrow();
+    expect(() => loadContextForCommand("run-ios")).toThrow();
   });
 });

--- a/packages/test-app/react-native.config.js
+++ b/packages/test-app/react-native.config.js
@@ -1,23 +1,15 @@
-const project = (() => {
-  try {
-    const { configureProjects } = require("react-native-test-app");
-    return configureProjects({
-      android: {
-        sourceDir: "android",
-      },
-      ios: {
-        sourceDir: "ios",
-      },
-      windows: {
-        sourceDir: "windows",
-        solutionFile: "windows/SampleCrossApp.sln",
-      },
-    });
-  } catch (_) {
-    return undefined;
-  }
-})();
-
+const { configureProjects } = require("react-native-test-app");
 module.exports = {
-  ...(project ? { project } : undefined),
+  project: configureProjects({
+    android: {
+      sourceDir: "android",
+    },
+    ios: {
+      sourceDir: "ios",
+    },
+    windows: {
+      sourceDir: "windows",
+      solutionFile: "windows/SampleCrossApp.sln",
+    },
+  }),
 };


### PR DESCRIPTION
### Description

Provide additional context for the `build` command

### Test plan

1. Patch in the run command:
    ```diff
    diff --git a/packages/cli/src/index.ts b/packages/cli/src/index.ts
    index 00b83a26..e0c540ee 100644
    --- a/packages/cli/src/index.ts
    +++ b/packages/cli/src/index.ts
    @@ -4,6 +4,7 @@ import { rnxBundleCommand } from "./bundle";
     import { rnxCleanCommand } from "./clean";
     import { rnxCopyAssetsCommand } from "./copy-assets";
     import { rnxRamBundleCommand } from "./ram-bundle";
    +import { rnxRunCommand } from "./run";
     import { rnxStartCommand } from "./start";
     import { rnxTestCommand } from "./test";
     import { rnxWriteThirdPartyNoticesCommand } from "./write-third-party-notices";
    @@ -12,6 +13,7 @@ export const reactNativeConfig = {
       commands: [
         rnxBundleCommand,
         rnxRamBundleCommand,
    +    rnxRunCommand,
         rnxStartCommand,
         rnxCopyAssetsCommand,
         rnxAlignDepsCommand,
    ```
2. Build: `yarn nx build @rnx-kit/test-app`
3. Build iOS app:
    ```sh
    cd packages/test-app
    pod install --project-directory=ios
    yarn rnx run --platform ios
    ```