### PR TITLE
fix(cli): print the command being invoked during build

### DIFF
--- a/.changeset/wise-pumpkins-happen.md
+++ b/.changeset/wise-pumpkins-happen.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Print the command being invoked during build

--- a/packages/cli/src/build/android.ts
+++ b/packages/cli/src/build/android.ts
@@ -1,39 +1,26 @@
 import type { Config } from "@react-native-community/cli-types";
 import ora from "ora";
 import type { AndroidBuildParams } from "./types";
+import { watch } from "./watcher";
 
-export async function buildAndroid(
+export type BuildResult = string | number | null;
+
+export function buildAndroid(
   config: Config,
   buildParams: AndroidBuildParams,
   logger = ora()
-): Promise<string | number | null> {
+): Promise<BuildResult> {
   const { sourceDir } = config.project.android ?? {};
   if (!sourceDir) {
     logger.fail("No Android project was found");
     process.exitCode = 1;
-    return null;
+    return Promise.resolve(null);
   }
 
   return import("@rnx-kit/tools-android").then(({ assemble }) => {
-    return new Promise((resolve) => {
-      logger.start("Building");
-
-      const errors: Buffer[] = [];
+    return new Promise<BuildResult>((resolve) => {
       const gradle = assemble(sourceDir, buildParams);
-
-      gradle.stdout.on("data", () => (logger.text += "."));
-      gradle.stderr.on("data", (data) => errors.push(data));
-
-      gradle.on("close", (code) => {
-        if (code === 0) {
-          logger.succeed("Build succeeded");
-          resolve(sourceDir);
-        } else {
-          logger.fail(Buffer.concat(errors).toString());
-          process.exitCode = code ?? 1;
-          resolve(code);
-        }
-      });
+      watch(gradle, logger, () => resolve(sourceDir), resolve);
     });
   });
 }

--- a/packages/cli/src/build/watcher.ts
+++ b/packages/cli/src/build/watcher.ts
@@ -1,0 +1,28 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import type { Ora } from "ora";
+
+export function watch(
+  subproc: ChildProcessWithoutNullStreams,
+  logger: Ora,
+  onSuccess: () => void,
+  onFail: (exitCode: number | null) => void
+) {
+  subproc.stdout.on("data", () => (logger.text += "."));
+
+  const errors: Buffer[] = [];
+  subproc.stderr.on("data", (data) => errors.push(data));
+
+  subproc.on("close", (code) => {
+    if (code === 0) {
+      logger.succeed("Build succeeded");
+      onSuccess();
+    } else {
+      logger.fail(Buffer.concat(errors).toString());
+      process.exitCode = code ?? 1;
+      onFail(code);
+    }
+  });
+
+  logger.info(`Command: ${subproc.spawnargs.join(" ")}`);
+  logger.start("Building");
+}


### PR DESCRIPTION
### Description

Print the command being invoked during build.

### Test plan

Patch:

```diff
diff --git a/packages/cli/src/index.ts b/packages/cli/src/index.ts
index 00b83a26..e89dffee 100644
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,12 +4,14 @@ import { rnxBundleCommand } from "./bundle";
 import { rnxCleanCommand } from "./clean";
 import { rnxCopyAssetsCommand } from "./copy-assets";
 import { rnxRamBundleCommand } from "./ram-bundle";
+import { rnxRunCommand } from "./run";
 import { rnxStartCommand } from "./start";
 import { rnxTestCommand } from "./test";
 import { rnxWriteThirdPartyNoticesCommand } from "./write-third-party-notices";

 export const reactNativeConfig = {
   commands: [
+    rnxRunCommand,
     rnxBundleCommand,
     rnxRamBundleCommand,
     rnxStartCommand,
```

Build:

```
cd packages/test-app
yarn build --dependencies
yarn rnx run --platform ios
```

Example output:

```
ℹ Multiple schemes were found; picking the first one: ReactTestApp, SampleCrossApp
ℹ If this is wrong, specify another scheme with `--scheme`
ℹ Command: xcodebuild -workspace /~/packages/test-app/ios/SampleCrossApp.xcworkspace -scheme ReactTestApp -configuration Debug -derivedDataPath /~/packages/test-app/ios/DerivedData -sdk iphonesimulator -destination generic/platform=iOS Simulator CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build
⠇ Building...
```