### PR TITLE
fix(cli): invalidate state if `pod install` was not run

### DIFF
--- a/.changeset/ninety-islands-shop.md
+++ b/.changeset/ninety-islands-shop.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/tools-react-native": patch
+"@rnx-kit/cli": patch
+---
+
+Fix context cache not taking `pod install` state into account

--- a/packages/cli/src/build/android.ts
+++ b/packages/cli/src/build/android.ts
@@ -13,7 +13,7 @@ export function buildAndroid(
 ): Promise<BuildResult> {
   const { sourceDir } = config.project.android ?? {};
   if (!sourceDir) {
-    invalidateState(process.cwd());
+    invalidateState();
     process.exitCode = 1;
     logger.fail("No Android project was found");
     return Promise.resolve(null);

--- a/packages/cli/src/build/android.ts
+++ b/packages/cli/src/build/android.ts
@@ -1,4 +1,5 @@
 import type { Config } from "@react-native-community/cli-types";
+import { invalidateState } from "@rnx-kit/tools-react-native/cache";
 import ora from "ora";
 import type { AndroidBuildParams } from "./types";
 import { watch } from "./watcher";
@@ -12,8 +13,9 @@ export function buildAndroid(
 ): Promise<BuildResult> {
   const { sourceDir } = config.project.android ?? {};
   if (!sourceDir) {
-    logger.fail("No Android project was found");
+    invalidateState(process.cwd());
     process.exitCode = 1;
+    logger.fail("No Android project was found");
     return Promise.resolve(null);
   }
 

--- a/packages/cli/src/build/ios.ts
+++ b/packages/cli/src/build/ios.ts
@@ -1,4 +1,5 @@
 import type { Config } from "@react-native-community/cli-types";
+import { invalidateState } from "@rnx-kit/tools-react-native/cache";
 import * as path from "node:path";
 import ora from "ora";
 import type { BuildResult } from "./apple";
@@ -13,20 +14,22 @@ export function buildIOS(
   const { platform } = buildParams;
   const { sourceDir, xcodeProject } = config.project[platform] ?? {};
   if (!sourceDir || !xcodeProject) {
+    invalidateState(process.cwd());
+    process.exitCode = 1;
     const root = platform.substring(0, platform.length - 2);
     logger.fail(
       `No ${root}OS project was found; did you forget to run 'pod install'?`
     );
-    process.exitCode = 1;
     return Promise.resolve(1);
   }
 
   const { name, path: projectDir } = xcodeProject;
   if (!name?.endsWith(".xcworkspace")) {
+    invalidateState(process.cwd());
+    process.exitCode = 1;
     logger.fail(
       "No Xcode workspaces were found; did you forget to run `pod install`?"
     );
-    process.exitCode = 1;
     return Promise.resolve(1);
   }
 

--- a/packages/cli/src/build/ios.ts
+++ b/packages/cli/src/build/ios.ts
@@ -14,7 +14,7 @@ export function buildIOS(
   const { platform } = buildParams;
   const { sourceDir, xcodeProject } = config.project[platform] ?? {};
   if (!sourceDir || !xcodeProject) {
-    invalidateState(process.cwd());
+    invalidateState();
     process.exitCode = 1;
     const root = platform.substring(0, platform.length - 2);
     logger.fail(
@@ -25,7 +25,7 @@ export function buildIOS(
 
   const { name, path: projectDir } = xcodeProject;
   if (!name?.endsWith(".xcworkspace")) {
-    invalidateState(process.cwd());
+    invalidateState();
     process.exitCode = 1;
     logger.fail(
       "No Xcode workspaces were found; did you forget to run `pod install`?"

--- a/packages/cli/src/build/macos.ts
+++ b/packages/cli/src/build/macos.ts
@@ -1,4 +1,5 @@
 import type { Config } from "@react-native-community/cli-types";
+import { invalidateState } from "@rnx-kit/tools-react-native/cache";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import ora from "ora";
@@ -24,10 +25,11 @@ export function buildMacOS(
   const sourceDir = "macos";
   const workspaces = findXcodeWorkspaces(sourceDir);
   if (workspaces.length === 0) {
+    invalidateState(process.cwd());
+    process.exitCode = 1;
     logger.fail(
       "No Xcode workspaces were found; specify an Xcode workspace with `--workspace`"
     );
-    process.exitCode = 1;
     return Promise.resolve(1);
   }
 

--- a/packages/cli/src/build/macos.ts
+++ b/packages/cli/src/build/macos.ts
@@ -25,7 +25,7 @@ export function buildMacOS(
   const sourceDir = "macos";
   const workspaces = findXcodeWorkspaces(sourceDir);
   if (workspaces.length === 0) {
-    invalidateState(process.cwd());
+    invalidateState();
     process.exitCode = 1;
     logger.fail(
       "No Xcode workspaces were found; specify an Xcode workspace with `--workspace`"

--- a/packages/tools-react-native/src/cache.ts
+++ b/packages/tools-react-native/src/cache.ts
@@ -68,7 +68,7 @@ export function getSavedState(
 }
 
 export function invalidateState(
-  projectRoot: string,
+  projectRoot = process.cwd(),
   /** @internal */ fs = nodefs
 ) {
   fs.rmSync(configCachePath(projectRoot));

--- a/packages/tools-react-native/src/cache.ts
+++ b/packages/tools-react-native/src/cache.ts
@@ -67,6 +67,14 @@ export function getSavedState(
   return fs.existsSync(stateFile) && fs.readFileSync(stateFile, UTF8);
 }
 
+export function invalidateState(
+  projectRoot: string,
+  /** @internal */ fs = nodefs
+) {
+  fs.rmSync(configCachePath(projectRoot));
+  fs.rmSync(cacheStatePath(projectRoot));
+}
+
 export function loadConfigFromCache(
   projectRoot: string,
   /** @internal */ fs = nodefs


### PR DESCRIPTION
### Description

Fix context cache not taking `pod install` state into account.

### Test plan

n/a