### PR TITLE
fix(metro-resolver-symlinks): widen supported Metro version range

### DIFF
--- a/.changeset/honest-trainers-sparkle.md
+++ b/.changeset/honest-trainers-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Verified that `experimental_retryResolvingFromDisk` works with Metro 0.81

--- a/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
+++ b/packages/metro-resolver-symlinks/src/utils/patchMetro.ts
@@ -30,7 +30,7 @@ function supportsRetryResolvingFromDisk(): boolean {
   const { version } = importMetroModule("/package.json");
   const [major, minor] = version.split(".");
   const v = major * 1000 + minor;
-  return v >= 64 && v <= 80;
+  return v >= 64 && v <= 81;
 }
 
 export function shouldEnableRetryResolvingFromDisk({


### PR DESCRIPTION
### Description

Verified that `experimental_retryResolvingFromDisk` works with Metro 0.81

### Test plan

n/a