### PR TITLE
fix(metro-serializer-esbuild): do not lower template literals

### DIFF
--- a/.changeset/gentle-eggs-type.md
+++ b/.changeset/gentle-eggs-type.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Do not lower template literals. Template literals are partially supported by
+Hermes for most of the use cases we care about (e.g., `styled-components`).

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -289,7 +289,7 @@ export function MetroSerializer(
             return undefined;
           }
 
-          // The following features should be safe to enable if we take into
+          // `arrow` and `generator` should be safe to enable if we take into
           // consideration that Hermes does not support classes. They were
           // disabled in esbuild 0.14.49 after the feature compatibility table
           // generator was fixed (see
@@ -297,6 +297,7 @@ export function MetroSerializer(
           return {
             arrow: true,
             generator: true,
+            "template-literal": true, // Used heavily by `styled-components`
           };
         })(),
         write: false,

--- a/packages/metro-serializer-esbuild/test/__fixtures__/templateLiterals.ts
+++ b/packages/metro-serializer-esbuild/test/__fixtures__/templateLiterals.ts
@@ -1,0 +1,1 @@
+console.log`Hello`;

--- a/packages/metro-serializer-esbuild/test/index.test.ts
+++ b/packages/metro-serializer-esbuild/test/index.test.ts
@@ -48,6 +48,7 @@ describe("metro-serializer-esbuild", () => {
           require.resolve("react-native/package.json")
         ),
         dependencies: {},
+        assets: [],
         commands: [],
         healthChecks: [],
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -307,5 +308,19 @@ describe("metro-serializer-esbuild", () => {
         "var __BUNDLE_START_TIME__=this.nativePerformanceNow?nativePerformanceNow():Date.now(),__DEV__=true,process=this.process||{},__METRO_GLOBAL_PREFIX__=''"
       )
     );
+  });
+
+  it("preserves template literals", async () => {
+    const result = await bundle("test/__fixtures__/templateLiterals.ts");
+    deepEqual(result, [
+      "(() => {",
+      "  // virtual:metro:__rnx_prelude__",
+      '  var global = new Function("return this;")();',
+      "",
+      "  // test/__fixtures__/templateLiterals.ts",
+      "  console.log`Hello`;",
+      "})();",
+      "",
+    ]);
   });
 });


### PR DESCRIPTION
### Description

Do not lower template literals. Template literals are partially supported by Hermes for most of the use cases we care about (e.g., `styled-components`).

Partially addresses #3361.

### Test plan

n/a