### PR TITLE
fix(cli): check Pods Manifest.lock earlier

### DIFF
--- a/.changeset/lovely-bats-pull.md
+++ b/.changeset/lovely-bats-pull.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Check Pods Manifest.lock earlier

--- a/.changeset/wet-carrots-happen.md
+++ b/.changeset/wet-carrots-happen.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/tools-apple": patch
+---
+
+Added a new function, `checkPodsManifestLock`, for checking whether the
+CocoaPods sandbox is in sync with its `Podfile.lock`

--- a/packages/cli/src/build/watcher.ts
+++ b/packages/cli/src/build/watcher.ts
@@ -25,7 +25,7 @@ export function watch<T>(
         logger.succeed("Build succeeded");
         resolve(onSuccess());
       } else {
-        logger.fail(Buffer.concat(errors).toString());
+        logger.fail(Buffer.concat(errors).toString().trim());
         process.exitCode = code ?? 1;
         resolve(code);
       }

--- a/packages/tools-apple/README.md
+++ b/packages/tools-apple/README.md
@@ -15,18 +15,19 @@ import * as tools from "@rnx-kit/tools-apple";
 <!-- The following table can be updated by running `yarn update-readme` -->
 <!-- @rnx-kit/api start -->
 
-| Category | Function                                                           | Description                                                                               |
-| -------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
-| ios      | `bootSimulator(simulator)`                                         | Boots the simulator with the specified UDID.                                              |
-| ios      | `getAvailableSimulators(search)`                                   | Returns a list of available iOS simulators.                                               |
-| ios      | `getDevices()`                                                     | Returns a list of available iOS simulators and physical devices.                          |
-| ios      | `install(device, app)`                                             | Installs the specified app bundle on specified simulator or physical device.              |
-| ios      | `launch(device, app)`                                              | Launches the specified app bundle on specified simulator or physical device.              |
-| ios      | `selectDevice(deviceNameOrPlatformIdentifier, deviceType, logger)` | Returns the simulator or physical device with the specified name.                         |
-| xcode    | `getBuildSettings(xcworkspace, params)`                            | Returns build settings for specified Xcode workspace and the parameters used to build it. |
-| xcode    | `getDeveloperDirectory()`                                          | Returns the path to the active developer directory.                                       |
-| xcode    | `getDevicePlatformIdentifier(buildParams)`                         | Returns device platform identifier for specified platform and destination.                |
-| xcode    | `parsePlist(app)`                                                  | Parses and returns the information property list of specified bundle.                     |
-| xcode    | `xcodebuild(xcworkspace, params, log)`                             | Builds the specified `.xcworkspace`.                                                      |
+| Category  | Function                                                           | Description                                                                               |
+| --------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| cocoapods | `checkPodsManifestLock(xcworkspace)`                               | Returns whether the CocoaPods sandbox is in sync with its `Podfile.lock`.                 |
+| ios       | `bootSimulator(simulator)`                                         | Boots the simulator with the specified UDID.                                              |
+| ios       | `getAvailableSimulators(search)`                                   | Returns a list of available iOS simulators.                                               |
+| ios       | `getDevices()`                                                     | Returns a list of available iOS simulators and physical devices.                          |
+| ios       | `install(device, app)`                                             | Installs the specified app bundle on specified simulator or physical device.              |
+| ios       | `launch(device, app)`                                              | Launches the specified app bundle on specified simulator or physical device.              |
+| ios       | `selectDevice(deviceNameOrPlatformIdentifier, deviceType, logger)` | Returns the simulator or physical device with the specified name.                         |
+| xcode     | `getBuildSettings(xcworkspace, params)`                            | Returns build settings for specified Xcode workspace and the parameters used to build it. |
+| xcode     | `getDeveloperDirectory()`                                          | Returns the path to the active developer directory.                                       |
+| xcode     | `getDevicePlatformIdentifier(buildParams)`                         | Returns device platform identifier for specified platform and destination.                |
+| xcode     | `parsePlist(app)`                                                  | Parses and returns the information property list of specified bundle.                     |
+| xcode     | `xcodebuild(xcworkspace, params, log)`                             | Builds the specified `.xcworkspace`.                                                      |
 
 <!-- @rnx-kit/api end -->

--- a/packages/tools-apple/package.json
+++ b/packages/tools-apple/package.json
@@ -20,6 +20,11 @@
       "typescript": "./src/index.ts",
       "default": "./lib/index.js"
     },
+    "./cocoapods": {
+      "types": "./lib/cocoapods.d.ts",
+      "typescript": "./src/cocoapods.ts",
+      "default": "./lib/cocoapods.js"
+    },
     "./ios": {
       "types": "./lib/ios.d.ts",
       "typescript": "./src/ios.ts",

--- a/packages/tools-apple/src/cocoapods.ts
+++ b/packages/tools-apple/src/cocoapods.ts
@@ -1,0 +1,45 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+function equalFiles(aPath: string, bPath: string): boolean {
+  if (fs.lstatSync(aPath).size !== fs.lstatSync(bPath).size) {
+    return false;
+  }
+
+  const af = fs.openSync(aPath, "r");
+  const bf = fs.openSync(bPath, "r");
+
+  const bufsize = 16 * 1024;
+  const aBuf = Buffer.alloc(bufsize);
+  const bBuf = Buffer.alloc(bufsize);
+
+  try {
+    let aRead = 0;
+    do {
+      aRead = fs.readSync(af, aBuf, 0, aBuf.length, null);
+      const bRead = fs.readSync(bf, bBuf, 0, bBuf.length, null);
+      if (aRead !== bRead || !aBuf.equals(bBuf)) {
+        return false;
+      }
+    } while (aRead > 0);
+  } finally {
+    fs.closeSync(af);
+    fs.closeSync(bf);
+  }
+
+  return true;
+}
+
+/**
+ * Returns whether the CocoaPods sandbox is in sync with its `Podfile.lock`.
+ */
+export function checkPodsManifestLock(xcworkspace: string): boolean {
+  const workspaceDir = path.dirname(xcworkspace);
+  const podfileLock = path.join(workspaceDir, "Podfile.lock");
+  const manifestLock = path.join(workspaceDir, "Pods", "Manifest.lock");
+  return (
+    fs.existsSync(podfileLock) &&
+    fs.existsSync(manifestLock) &&
+    equalFiles(podfileLock, manifestLock)
+  );
+}

--- a/packages/tools-apple/src/index.ts
+++ b/packages/tools-apple/src/index.ts
@@ -1,3 +1,4 @@
+export { checkPodsManifestLock } from "./cocoapods.js";
 export {
   bootSimulator,
   getAvailableSimulators,


### PR DESCRIPTION
### Description

Check Pods Manifest.lock earlier so we can fail earlier if they're not in sync.

### Test plan

```
cd packages/test-app
yarn build --dependencies
pod install --project-directory=ios
rm ios/Pods/Manifest.lock
yarn ios
```