### PR TITLE
feat(cli): add Ccache support

### DIFF
--- a/.changeset/bright-mayflies-hide.md
+++ b/.changeset/bright-mayflies-hide.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Add Ccache support

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -24,21 +24,6 @@ runs:
       run: |
         podfile_lock="packages/test-app/${{ inputs.platform }}/Podfile.lock"
         if [[ -f $(git rev-parse --show-toplevel)/.ccache/ccache.conf ]] && [[ -f "$podfile_lock" ]]; then
-          if ! command -v ccache 1> /dev/null; then
-            brew install ccache
-          fi
-
-          CCACHE_HOME=$(dirname $(dirname $(which ccache)))/opt/ccache
-
-          echo "CCACHE_DIR=$(git rev-parse --show-toplevel)/.ccache" >> $GITHUB_ENV
-
-          echo "CC=${CCACHE_HOME}/libexec/clang" >> $GITHUB_ENV
-          echo "CXX=${CCACHE_HOME}/libexec/clang++" >> $GITHUB_ENV
-          echo "CMAKE_C_COMPILER_LAUNCHER=$(which ccache)" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)" >> $GITHUB_ENV
-
-          ccache --zero-stats 1> /dev/null
-
           clang --version > .clang-version
           input=$(find . -maxdepth 1 -name .clang-version -o -name .yarnrc.yml | sort)
           echo "cache-key=$(cat "$podfile_lock" $input | shasum -a 256 | awk '{ print $1 }')" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -138,6 +138,10 @@ jobs:
           if [[ "$(yarn show-affected --base origin/${{ github.base_ref }})" = *"@rnx-kit/test-app"* ]]; then
             echo 'ios=true' >> $GITHUB_OUTPUT
           fi
+      - name: Install Ccache
+        if: ${{ steps.affected-projects.outputs.ios != '' }}
+        run: |
+          brew install ccache
       - name: Build @rnx-kit/cli
         if: ${{ steps.affected-projects.outputs.ios != '' }}
         run: |
@@ -151,7 +155,10 @@ jobs:
       - name: Build iOS app
         if: ${{ steps.affected-projects.outputs.ios != '' }}
         run: |
-          yarn build:ios | xcbeautify
+          export CCACHE_DIR="$(git rev-parse --show-toplevel)/.ccache"
+          ccache --zero-stats 1> /dev/null
+          yarn build:ios --ccache-dir "$CCACHE_DIR" --ccache-home /opt/homebrew/opt/ccache | xcbeautify
+          ccache --show-stats --verbose
         working-directory: packages/test-app
   build-website:
     name: "Build the website"

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -1,6 +1,7 @@
 import type { Config } from "@react-native-community/cli-types";
 import { InvalidArgumentError } from "commander";
 import { buildAndroid } from "./build/android";
+import { setCcacheDir, setCcacheHome } from "./build/ccache";
 import { buildIOS } from "./build/ios";
 import { buildMacOS } from "./build/macos";
 import type {
@@ -99,6 +100,16 @@ export const rnxBuildCommand = {
         "Destination of the built app; 'device', 'emulator', or 'simulator'",
       default: "simulator",
       parse: asDestination,
+    },
+    {
+      name: "--ccache-dir <string>",
+      description: "Path to Ccache config",
+      parse: setCcacheDir,
+    },
+    {
+      name: "--ccache-home <string>",
+      description: "Path to Ccache installation",
+      parse: setCcacheHome,
     },
   ],
 };

--- a/packages/cli/src/build/ccache.ts
+++ b/packages/cli/src/build/ccache.ts
@@ -1,0 +1,23 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export function setCcacheDir(dir: string): string | undefined {
+  if (!fs.existsSync(dir)) {
+    return undefined;
+  }
+
+  process.env["CCACHE_DIR"] = dir;
+  return dir;
+}
+
+export function setCcacheHome(dir: string): string | undefined {
+  if (!fs.existsSync(dir)) {
+    return undefined;
+  }
+
+  process.env["CC"] = path.join(dir, "libexec", "clang");
+  process.env["CXX"] = path.join(dir, "libexec", "clang++");
+  process.env["CMAKE_C_COMPILER_LAUNCHER"] = path.join(dir, "bin", "ccache");
+  process.env["CMAKE_CXX_COMPILER_LAUNCHER"] = path.join(dir, "bin", "ccache");
+  return dir;
+}


### PR DESCRIPTION
### Description

Add Ccache support

### Test plan

CI should pass.

Stats from last run:
```
Cache directory:            /Users/runner/work/rnx-kit/rnx-kit/.ccache
Config file:                /Users/runner/work/rnx-kit/rnx-kit/.ccache/ccache.conf
System config file:         /opt/homebrew/Cellar/ccache/4.10.2_1/etc/ccache.conf
Stats updated:              Tue Oct  1 11:20:34 2024
Cacheable calls:            2216 / 2227 (99.51%)
  Hits:                     2216 / 2216 (100.0%)
    Direct:                 2216 / 2216 (100.0%)
    Preprocessed:              0 / 2216 ( 0.00%)
  Misses:                      0 / 2216 ( 0.00%)
Uncacheable calls:            11 / 2227 ( 0.49%)
  Called for preprocessing:   11 /   11 (100.0%)
Successful lookups:
  Direct:                   2216 / 2216 (100.0%)
  Preprocessed:                0
Local storage:
  Cache size (GB):           0.7 /  1.0 (74.96%)
  Files:                    6648
  Hits:                     2216 / 2216 (100.0%)
  Misses:                      0 / 2216 ( 0.00%)
  Reads:                    4432
  Writes:                      0
```