### PR TITLE
fix(tools-react-native): add `loadContextAsync` to exported types

### DIFF
--- a/.changeset/afraid-paws-remain.md
+++ b/.changeset/afraid-paws-remain.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-react-native": patch
+---
+
+Add missing `loadContextAsync` to exported types

--- a/packages/tools-react-native/context.d.ts
+++ b/packages/tools-react-native/context.d.ts
@@ -1,1 +1,5 @@
-export { loadContext, resolveCommunityCLI } from "./lib/context";
+export {
+  loadContext,
+  loadContextAsync,
+  resolveCommunityCLI,
+} from "./lib/context";


### PR DESCRIPTION
### Description

Add missing `loadContextAsync` to exported types

### Test plan

n/a