### PR TITLE
fix(web-storage): migrate away from deprecated `TurboReactPackage`

### DIFF
--- a/.changeset/short-dolphins-tap.md
+++ b/.changeset/short-dolphins-tap.md
@@ -1,0 +1,6 @@
+---
+"@react-native-webapis/web-storage": minor
+---
+
+Migrate away from deprecated `TurboReactPackage`. This is a requirement for
+supporting 0.77 and above.

--- a/.changeset/short-dolphins-tap.md
+++ b/.changeset/short-dolphins-tap.md
@@ -1,5 +1,7 @@
 ---
+"@react-native-webapis/battery-status": minor
 "@react-native-webapis/web-storage": minor
+"@rnx-kit/react-native-test-app-msal": major
 ---
 
 Migrate away from deprecated `TurboReactPackage`. This is a requirement for

--- a/incubator/@react-native-webapis/battery-status/android/src/main/java/org/reactnativewebapis/batterystatus/BatteryStatusPackage.kt
+++ b/incubator/@react-native-webapis/battery-status/android/src/main/java/org/reactnativewebapis/batterystatus/BatteryStatusPackage.kt
@@ -1,30 +1,28 @@
 package org.reactnativewebapis.batterystatus
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class BatteryStatusPackage : TurboReactPackage() {
-    override fun getModule(name: String?, reactContext: ReactApplicationContext?): NativeModule {
-        return when (name) {
+class BatteryStatusPackage : BaseReactPackage() {
+    override fun getModule(name: String?, reactContext: ReactApplicationContext?): NativeModule =
+        when (name) {
             BatteryStatusModule.NAME -> BatteryStatusModule(reactContext)
             else -> throw IllegalArgumentException("No module named '$name'")
         }
-    }
 
-    override fun getReactModuleInfoProvider(): ReactModuleInfoProvider =
-        ReactModuleInfoProvider {
-            val info = ReactModuleInfo(
-                BatteryStatusModule.NAME,
-                BatteryStatusModule::class.java.name,
-                false,
-                false,
-                false,
-                false,
-                false
-            )
-            mapOf(info.name() to info).toMutableMap()
-        }
+    override fun getReactModuleInfoProvider(): ReactModuleInfoProvider = ReactModuleInfoProvider {
+        val info = ReactModuleInfo(
+            BatteryStatusModule.NAME,
+            BatteryStatusModule::class.java.name,
+            false,
+            false,
+            false,
+            false,
+            false
+        )
+        mapOf(info.name() to info).toMutableMap()
+    }
 }

--- a/incubator/@react-native-webapis/battery-status/package.json
+++ b/incubator/@react-native-webapis/battery-status/package.json
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "react": ">=18.2.0",
-    "react-native": ">=0.71.0-0"
+    "react-native": ">=0.74.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/incubator/@react-native-webapis/web-storage/android/src/main/java/org/reactnativewebapis/webstorage/WebStoragePackage.kt
+++ b/incubator/@react-native-webapis/web-storage/android/src/main/java/org/reactnativewebapis/webstorage/WebStoragePackage.kt
@@ -1,18 +1,17 @@
 package org.reactnativewebapis.webstorage
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class WebStoragePackage : TurboReactPackage() {
-    override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule {
-        return when (name) {
+class WebStoragePackage : BaseReactPackage() {
+    override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule =
+        when (name) {
             WebStorageModule.NAME -> WebStorageModule(reactContext)
             else -> throw IllegalArgumentException("No module named '$name'")
         }
-    }
 
     override fun getReactModuleInfoProvider(): ReactModuleInfoProvider = ReactModuleInfoProvider {
         val info = ReactModuleInfo(

--- a/incubator/@react-native-webapis/web-storage/package.json
+++ b/incubator/@react-native-webapis/web-storage/package.json
@@ -35,11 +35,11 @@
     "lint:kt": "ktlint --relative 'android/src/**/*.kt'"
   },
   "peerDependencies": {
-    "@callstack/react-native-visionos": ">=0.73",
+    "@callstack/react-native-visionos": ">=0.74",
     "react": ">=18.2.0",
-    "react-native": ">=0.72",
-    "react-native-macos": ">=0.72",
-    "react-native-windows": ">=0.72"
+    "react-native": ">=0.74",
+    "react-native-macos": ">=0.74",
+    "react-native-windows": ">=0.74"
   },
   "peerDependenciesMeta": {
     "@callstack/react-native-visionos": {

--- a/incubator/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MsalPackage.kt
+++ b/incubator/react-native-test-app-msal/android/src/main/java/com/microsoft/reacttestapp/msal/MsalPackage.kt
@@ -1,11 +1,11 @@
 package com.microsoft.reacttestapp.msal
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class MsalPackage : TurboReactPackage() {
+class MsalPackage : BaseReactPackage() {
     override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule {
         val info = ReactNativeAuthModuleProvider.info()
             ?: throw IllegalArgumentException("No modules were ever registered")

--- a/yarn.lock
+++ b/yarn.lock
@@ -3296,11 +3296,11 @@ __metadata:
     react-native-windows: "npm:^0.75.0"
     typescript: "npm:^5.0.0"
   peerDependencies:
-    "@callstack/react-native-visionos": ">=0.73"
+    "@callstack/react-native-visionos": ">=0.74"
     react: ">=18.2.0"
-    react-native: ">=0.72"
-    react-native-macos: ">=0.72"
-    react-native-windows: ">=0.72"
+    react-native: ">=0.74"
+    react-native-macos: ">=0.74"
+    react-native-windows: ">=0.74"
   peerDependenciesMeta:
     "@callstack/react-native-visionos":
       optional: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -3274,7 +3274,7 @@ __metadata:
     typescript: "npm:^5.0.0"
   peerDependencies:
     react: ">=18.2.0"
-    react-native: ">=0.71.0-0"
+    react-native: ">=0.74.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

`TurboReactPackage` was deprecated in favor of `BaseReactPackage` in [0.74](https://github.com/facebook/react-native/commit/7a31ecd6653f673edca2e9bfd01b9059bfe3d869), and finally removed in [latest nightly](https://github.com/facebook/react-native/commit/bf5c98cf5e1ce5c041d3d9321a0ba2fd3c755b46).

### Test plan

CI should pass.