### PR TITLE
feat(cli): clean Xcode Simulator cache

### DIFF
--- a/.changeset/late-cheetahs-heal.md
+++ b/.changeset/late-cheetahs-heal.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Add ability to clean Xcode Simulator cache. Fixes issues with `launchd_sim`
+crashing or not responding when trying to boot a simulator.

--- a/packages/cli/src/clean.ts
+++ b/packages/cli/src/clean.ts
@@ -123,6 +123,13 @@ export async function rnxClean(
         action: () => execute("watchman", ["watch-del-all"]),
       },
     ],
+    xcode: [
+      {
+        label: "Clean Xcode Simulator cache",
+        action: () =>
+          cleanDir(`${os.homedir()}/Library/Developer/CoreSimulator/Caches`),
+      },
+    ],
     yarn: [
       {
         label: "Clean Yarn cache",
@@ -180,7 +187,7 @@ export const rnxCleanCommand = {
   description: "Clears React Native project related caches",
   options: [
     {
-      name: "--include <android,cocoapods,metro,npm,watchman,yarn>",
+      name: "--include <android,cocoapods,metro,npm,watchman,xcode,yarn>",
       description: "Comma-separated flag of caches to clear e.g., `npm,yarn`",
       default: "metro,watchman",
     },


### PR DESCRIPTION
### Description

Add ability to clean Xcode Simulator cache. Fixes issues with `launchd_sim` crashing or not responding when trying to boot a simulator.

### Test plan

n/a