### PR TITLE
fix(react-native-host): update feature flags for 0.77

### DIFF
--- a/.changeset/itchy-cameras-breathe.md
+++ b/.changeset/itchy-cameras-breathe.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Updated feature flags and other build fixes for 0.77

--- a/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
+++ b/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
@@ -49,10 +49,36 @@ using SharedJSRuntimeFactory = std::shared_ptr<facebook::react::JSRuntimeFactory
 @end
 
 #ifdef USE_FEATURE_FLAGS
+#if __has_include(<React-RCTAppDelegate/RCTArchConfiguratorProtocol.h>) || __has_include(<React_RCTAppDelegate/RCTArchConfiguratorProtocol.h>)
+#define USE_UNIFIED_FEATURE_FLAGS 1
+#endif  // __has_include(<React-RCTAppDelegate/RCTArchConfiguratorProtocol.h>)
+
 // https://github.com/facebook/react-native/blob/0.74-stable/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm#L272-L286
 class RNXBridgelessFeatureFlags : public facebook::react::ReactNativeFeatureFlagsDefaults
 {
 public:
+#ifdef USE_UNIFIED_FEATURE_FLAGS  // >= 0.77
+    bool enableBridgelessArchitecture() override
+    {
+        return true;
+    }
+    bool enableFabricRenderer() override
+    {
+        return true;
+    }
+    bool useTurboModules() override
+    {
+        return true;
+    }
+    bool useNativeViewConfigsInBridgelessMode() override
+    {
+        return true;
+    }
+    bool enableFixForViewCommandRace() override
+    {
+        return true;
+    }
+#else   // < 0.77
     bool useModernRuntimeScheduler() override
     {
         return true;
@@ -67,6 +93,7 @@ public:
     {
         return true;
     }
+#endif  // USE_UNIFIED_FEATURE_FLAGS
 };
 #endif  // USE_FEATURE_FLAGS
 

--- a/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
+++ b/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
@@ -98,7 +98,11 @@
 
 - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
 {
+#if __has_include(<React-RCTAppDelegate/RCTDependencyProvider.h>) || __has_include(<React_RCTAppDelegate/RCTDependencyProvider.h>)
+    return RCTAppSetupDefaultModuleFromClass(moduleClass, nil);
+#else
     return RCTAppSetupDefaultModuleFromClass(moduleClass);
+#endif  // __has_include(<React-RCTAppDelegate/RCTArchConfiguratorProtocol.h>)
 }
 
 // MARK: - Private

--- a/packages/react-native-host/cocoa/ReactNativeHost+View.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost+View.mm
@@ -59,10 +59,7 @@ static NSString *const kReactConcurrentRoot = @"concurrentRoot";
 #elif USE_BRIDGELESS
     RCTFabricSurface *surface = [self.reactHost createSurfaceWithModuleName:moduleName
                                                           initialProperties:initialProps];
-    RCTSurfaceSizeMeasureMode sizeMeasureMode =
-        RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact;
-    return [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface
-                                                   sizeMeasureMode:sizeMeasureMode];
+    return [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
 #else
     RCTFabricSurface *surface =
         [[RCTFabricSurface alloc] initWithSurfacePresenter:self.surfacePresenter

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -248,7 +248,9 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
     }
 
 #if USE_BRIDGELESS
+#ifndef USE_UNIFIED_FEATURE_FLAGS
     RCTSetUseNativeViewConfigsInBridgelessMode(YES);
+#endif
     RCTEnableTurboModuleInterop(YES);
     RCTEnableTurboModuleInteropBridgeProxy(YES);
 


### PR DESCRIPTION
### Description

Updated feature flags and other build fixes for 0.77

### Test plan

In [RNTA](https://github.com/microsoft/react-native-test-app):

```sh
npm run set-react-version 0.77 -- --core-only
yarn

# Manually patch the changes in node_modules/@rnx-kit/react-native-host

cd example
pod install --project-directory=ios
yarn ios
```

Build should succeed.

### Screenshots

![image](https://github.com/user-attachments/assets/87167ebf-fade-416c-9f10-8e2e35821022)
