### PR TITLE
feat(typescript-service): Pick up the writeFile override from the LanguageServiceHost when it is overridden

### DIFF
--- a/.changeset/serious-olives-relate.md
+++ b/.changeset/serious-olives-relate.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/typescript-service": patch
+---
+
+Projects should use the writeFile set in the LanguageServiceHost to write files
+if it is overridden.

--- a/packages/typescript-service/src/project.ts
+++ b/packages/typescript-service/src/project.ts
@@ -10,6 +10,7 @@ export class Project {
   private externalFiles: ExternalFileCache;
 
   private languageService: ts.LanguageService;
+  private writeFile: (fileName: string, content: string) => void;
 
   constructor(
     documentRegistry: ts.DocumentRegistry,
@@ -93,6 +94,8 @@ export class Project {
     if (enhanceLanguageServiceHost) {
       enhanceLanguageServiceHost(languageServiceHost);
     }
+    // if someone replaces writeFile when they enhance the language service host, use that for writing
+    this.writeFile = languageServiceHost.writeFile || ts.sys.writeFile;
 
     this.languageService = ts.createLanguageService(
       languageServiceHost,
@@ -157,7 +160,7 @@ export class Project {
       return false;
     }
     output.outputFiles.forEach((o) => {
-      ts.sys.writeFile(o.name, o.text);
+      this.writeFile(o.name, o.text);
     });
     return true;
   }


### PR DESCRIPTION
### Description

Typescript allows plugging the writeFile implementation in the LanguageServiceHost when using a language service. It will use this override internally but in our Project code we were ignoring that setting and falling back to the default implementation. This will use the override value to write files out in `EmitFile` if it is set, otherwise using the system version.

### Test plan

This has been tested with a custom writer in a separate change, but for this change just rely on unit testing. There will be no behavioral change unless the writeFile value is set, and by default it is not.