### PR TITLE
feat(config): add helper for loading kit config in the case where package.json has been parsed already

### DIFF
--- a/.changeset/cuddly-carrots-carry.md
+++ b/.changeset/cuddly-carrots-carry.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/config": patch
+---
+
+Add helper to load the kit config from an already parsed package.json file

--- a/packages/config/src/getKitConfig.ts
+++ b/packages/config/src/getKitConfig.ts
@@ -76,7 +76,7 @@ export function getKitConfig(
  * @param packageDir The directory containing the package.json file.
  * @returns The rnx-kit configuration for this package, merged with any base configuration.
  */
-export function getKitConfigFromPackageJson(
+export function getKitConfigFromPackageManifest(
   packageJson: PackageManifest,
   packageDir: string
 ): KitConfig | undefined {

--- a/packages/config/src/getKitConfig.ts
+++ b/packages/config/src/getKitConfig.ts
@@ -69,3 +69,16 @@ export function getKitConfig(
     return undefined;
   }
 }
+
+/**
+ * Helper for loading the KitConfig for cases where the package.json has already been loaded for other reasons.
+ * @param packageJson The loaded and parsed package.json file for this package.
+ * @param packageDir The directory containing the package.json file.
+ * @returns The rnx-kit configuration for this package, merged with any base configuration.
+ */
+export function getKitConfigFromPackageJson(
+  packageJson: PackageManifest,
+  packageDir: string
+): KitConfig | undefined {
+  return loadBaseConfig(packageJson["rnx-kit"], packageDir);
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -11,7 +11,7 @@ export { getBundleConfig, getPlatformBundleConfig } from "./getBundleConfig";
 export { getKitCapabilities } from "./getKitCapabilities";
 export type { KitCapabilities } from "./getKitCapabilities";
 
-export { getKitConfig, getKitConfigFromPackageJson } from "./getKitConfig";
+export { getKitConfig, getKitConfigFromPackageManifest } from "./getKitConfig";
 export type { GetKitConfigOptions } from "./getKitConfig";
 
 export type {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -11,7 +11,7 @@ export { getBundleConfig, getPlatformBundleConfig } from "./getBundleConfig";
 export { getKitCapabilities } from "./getKitCapabilities";
 export type { KitCapabilities } from "./getKitCapabilities";
 
-export { getKitConfig } from "./getKitConfig";
+export { getKitConfig, getKitConfigFromPackageJson } from "./getKitConfig";
 export type { GetKitConfigOptions } from "./getKitConfig";
 
 export type {


### PR DESCRIPTION
### Description

This is a quick helper function to load the kit config (resolving with the base config) in the case where package.json has already been loaded for a different purpose. This just routes to the internal call `loadBaseConfig` but makes it more generic by taking the `PackageManifest` type instead.

### Test plan

Purely additive code, routing to existing codepaths that are already in use. Just unit tests.