### PR TITLE
fix(metro-service): lazy-load `node-fetch` to avoid `punycode` warning

### DIFF
--- a/.changeset/many-flies-sleep.md
+++ b/.changeset/many-flies-sleep.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-service": patch
+---
+
+Lazy-load `node-fetch` to avoid `punycode` warning

--- a/packages/metro-service/src/server.ts
+++ b/packages/metro-service/src/server.ts
@@ -1,6 +1,6 @@
 import { requireModuleFromMetro } from "@rnx-kit/tools-react-native/metro";
 import type { runServer } from "metro";
-import net from "net";
+import net from "node:net";
 import { ensureBabelConfig } from "./babel";
 
 type ServerStatus = "not_running" | "already_running" | "in_use" | "unknown";
@@ -11,8 +11,9 @@ function getFetchImpl(): (url: string | URL) => Promise<Response> {
   }
 
   // TODO: Remove `node-fetch` when we drop support for Node 16
-  // @ts-expect-error To be removed when Node 16 is no longer supported
-  return (...args) => import("node-fetch").then(({ default: fetch }) => fetch(...args));
+  return (...args) =>
+    // @ts-expect-error To be removed when Node 16 is no longer supported
+    import("node-fetch").then(({ default: fetch }) => fetch(...args));
 }
 
 /**

--- a/packages/metro-service/src/server.ts
+++ b/packages/metro-service/src/server.ts
@@ -1,10 +1,19 @@
 import { requireModuleFromMetro } from "@rnx-kit/tools-react-native/metro";
 import type { runServer } from "metro";
 import net from "net";
-import nodeFetch from "node-fetch";
 import { ensureBabelConfig } from "./babel";
 
 type ServerStatus = "not_running" | "already_running" | "in_use" | "unknown";
+
+function getFetchImpl(): (url: string | URL) => Promise<Response> {
+  if ("fetch" in globalThis) {
+    return fetch;
+  }
+
+  // TODO: Remove `node-fetch` when we drop support for Node 16
+  // @ts-expect-error To be removed when Node 16 is no longer supported
+  return (...args) => import("node-fetch").then(({ default: fetch }) => fetch(...args));
+}
 
 /**
  * Returns whether the specified host:port is occupied.
@@ -49,8 +58,7 @@ export async function isDevServerRunning(
       return "not_running";
     }
 
-    // TODO: Remove `node-fetch` when we drop support for Node 16
-    const ftch = "fetch" in globalThis ? fetch : nodeFetch;
+    const ftch = getFetchImpl();
     const statusUrl = `${scheme}://${host || "localhost"}:${port}/status`;
     const statusResponse = await ftch(statusUrl);
     const body = await statusResponse.text();


### PR DESCRIPTION
### Description

Lazy-load `node-fetch` to avoid `punycode` warning

### Test plan

```sh
cd packages/metro-service
yarn build --dependencies
yarn test
```

There should be no `punycode` deprecation warning.