### PR TITLE
feat(tools-node): Add a destructureModuleRef function that does all the module reference parsing at the same time

### DIFF
--- a/.changeset/tough-buckets-shave.md
+++ b/.changeset/tough-buckets-shave.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/tools-node": patch
+---
+
+add a full module destructuring function, route other routines to use this new
+function.

--- a/packages/tools-node/README.md
+++ b/packages/tools-node/README.md
@@ -25,25 +25,27 @@ import * as pathTools from "@rnx-kit/tools-node/path";
 | -------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | module   | FileModuleRef                | Module reference rooted to a file system location, either relative to a directory, or as an absolute path. For example, `./index` or `/repos/rnx-kit/packages/tools/src/index`. |
 | module   | PackageModuleRef             | Module reference relative to a package, such as `react-native` or `@rnx-kit/tools/node/index`.                                                                                  |
+| package  | DestructuredModuleRef        | Module reference with the package name and optional sub-module path included as path                                                                                            |
 | package  | FindPackageDependencyOptions | Options which control how package dependecies are located.                                                                                                                      |
 | package  | PackageManifest              | Schema for the contents of a `package.json` manifest file.                                                                                                                      |
 | package  | PackagePerson                | Schema for a reference to a person in `package.json`.                                                                                                                           |
 | package  | PackageRef                   | Components of a package reference.                                                                                                                                              |
 
-| Category | Function                                        | Description                                                                                                                    |
-| -------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| module   | `getPackageModuleRefFromModulePath(modulePath)` | Convert a module path to a package module reference.                                                                           |
-| module   | `isFileModuleRef(r)`                            | Is the module reference relative to a file location?                                                                           |
-| module   | `isPackageModuleRef(r)`                         | Is the module reference a package module reference?                                                                            |
-| module   | `parseModuleRef(r)`                             | Parse a module reference into either a package module reference or a file module reference.                                    |
-| package  | `findPackage(startDir)`                         | Find the nearest `package.json` manifest file. Search upward through all parent directories.                                   |
-| package  | `findPackageDependencyDir(ref, options)`        | Find the package dependency's directory, starting from the given directory and moving outward, through all parent directories. |
-| package  | `findPackageDir(startDir)`                      | Find the parent directory of the nearest `package.json` manifest file. Search upward through all parent directories.           |
-| package  | `parsePackageRef(r)`                            | Parse a package reference string. An example reference is the `name` property found in `package.json`.                         |
-| package  | `readPackage(pkgPath)`                          | Read a `package.json` manifest from a file.                                                                                    |
-| package  | `resolveDependencyChain(chain, startDir)`       | Resolve the path to a dependency given a chain of dependencies leading up to it.                                               |
-| package  | `writePackage(pkgPath, manifest, space)`        | Write a `package.json` manifest to a file.                                                                                     |
-| path     | `findUp(names, options)`                        | Finds the specified file(s) or directory(s) by walking up parent directories.                                                  |
-| path     | `normalizePath(p)`                              | Normalize the separators in a path, converting each backslash ('\\') to a foreward slash ('/').                                |
+| Category | Function                                        | Description                                                                                                                                         |
+| -------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| module   | `getPackageModuleRefFromModulePath(modulePath)` | Convert a module path to a package module reference.                                                                                                |
+| module   | `isFileModuleRef(r)`                            | Is the module reference relative to a file location?                                                                                                |
+| module   | `isPackageModuleRef(r)`                         | Is the module reference a package module reference?                                                                                                 |
+| module   | `parseModuleRef(r)`                             | Parse a module reference into either a package module reference or a file module reference. If there are any sub-paths, they are returned in paths. |
+| package  | `destructureModuleRef(r)`                       | Destructure a module reference into its component par                                                                                               |
+| package  | `findPackage(startDir)`                         | Find the nearest `package.json` manifest file. Search upward through all parent directories.                                                        |
+| package  | `findPackageDependencyDir(ref, options)`        | Find the package dependency's directory, starting from the given directory and moving outward, through all parent directories.                      |
+| package  | `findPackageDir(startDir)`                      | Find the parent directory of the nearest `package.json` manifest file. Search upward through all parent directories.                                |
+| package  | `parsePackageRef(r)`                            | Parse a package reference string. An example reference is the `name` property found in `package.json`.                                              |
+| package  | `readPackage(pkgPath)`                          | Read a `package.json` manifest from a file.                                                                                                         |
+| package  | `resolveDependencyChain(chain, startDir)`       | Resolve the path to a dependency given a chain of dependencies leading up to it.                                                                    |
+| package  | `writePackage(pkgPath, manifest, space)`        | Write a `package.json` manifest to a file.                                                                                                          |
+| path     | `findUp(names, options)`                        | Finds the specified file(s) or directory(s) by walking up parent directories.                                                                       |
+| path     | `normalizePath(p)`                              | Normalize the separators in a path, converting each backslash ('\\') to a foreward slash ('/').                                                     |
 
 <!-- @rnx-kit/api end -->

--- a/packages/tools-node/src/index.ts
+++ b/packages/tools-node/src/index.ts
@@ -7,6 +7,7 @@ export {
 export type { FileModuleRef, PackageModuleRef } from "./module";
 
 export {
+  destructureModuleRef,
   findPackage,
   findPackageDependencyDir,
   findPackageDir,
@@ -16,6 +17,7 @@ export {
   writePackage,
 } from "./package";
 export type {
+  DestructuredModuleRef,
   FindPackageDependencyOptions,
   PackageManifest,
   PackagePerson,

--- a/packages/tools-node/src/module.ts
+++ b/packages/tools-node/src/module.ts
@@ -1,6 +1,11 @@
 import path from "path";
 import type { PackageRef } from "./package";
-import { findPackageDir, parsePackageRef, readPackage } from "./package";
+import {
+  destructureModuleRef,
+  findPackageDir,
+  parsePackageRef,
+  readPackage,
+} from "./package";
 
 /**
  * Module reference relative to a package, such as `react-native` or
@@ -21,7 +26,13 @@ export type FileModuleRef = {
 
 /**
  * Parse a module reference into either a package module reference or a file
- * module reference.
+ * module reference. If there are any sub-modules, they are trimmed.
+ *
+ * For module references:
+ * - '@scope/package' -> { scope: '@scope', name: 'package' }
+ * - '@scope/package/index' -> { scope: '@scope', name: 'package' }, /index is stripped
+ * For file references:
+ * - './index' -> { path: './index' }
  *
  * @param moduleRef Module reference
  * @return Module components
@@ -33,18 +44,7 @@ export function parseModuleRef(r: string): PackageModuleRef | FileModuleRef {
     };
   }
 
-  const ref: PackageModuleRef = parsePackageRef(r);
-
-  const indexPath = ref.name.indexOf("/");
-  if (indexPath >= 0) {
-    const p = ref.name.substring(indexPath + 1);
-    if (p) {
-      ref.path = p;
-    }
-    ref.name = ref.name.substring(0, indexPath);
-  }
-
-  return ref;
+  return destructureModuleRef(r);
 }
 
 /**

--- a/packages/tools-node/src/module.ts
+++ b/packages/tools-node/src/module.ts
@@ -26,15 +26,9 @@ export type FileModuleRef = {
 
 /**
  * Parse a module reference into either a package module reference or a file
- * module reference. If there are any sub-modules, they are trimmed.
+ * module reference. If there are any sub-paths, they are returned in paths.
  *
- * For module references:
- * - '@scope/package' -> { scope: '@scope', name: 'package' }
- * - '@scope/package/index' -> { scope: '@scope', name: 'package' }, /index is stripped
- * For file references:
- * - './index' -> { path: './index' }
- *
- * @param moduleRef Module reference
+ * @param r Module reference
  * @return Module components
  */
 export function parseModuleRef(r: string): PackageModuleRef | FileModuleRef {

--- a/packages/tools-node/src/package.ts
+++ b/packages/tools-node/src/package.ts
@@ -55,7 +55,7 @@ export function destructureModuleRef(r: string): DestructuredModuleRef {
       const name = parts.shift();
       const path = parts.shift();
       if (name) {
-        return { name, ...(scope && { scope }), ...(path && { path }) };
+        return { name, scope, path };
       }
     }
   }
@@ -72,7 +72,7 @@ export function destructureModuleRef(r: string): DestructuredModuleRef {
 export function parsePackageRef(r: string): PackageRef {
   const { scope, name, path } = destructureModuleRef(r);
   const fullName = path ? `${name}/${path}` : name;
-  return { name: fullName, ...(scope && { scope }) };
+  return { name: fullName, scope };
 }
 
 /**

--- a/packages/tools-node/test/module.test.ts
+++ b/packages/tools-node/test/module.test.ts
@@ -28,6 +28,7 @@ describe("Node > Module", () => {
     deepEqual(parseModuleRef("react-native/Libraries/Promise"), {
       name: "react-native",
       path: "Libraries/Promise",
+      scope: undefined,
     });
   });
 
@@ -35,6 +36,7 @@ describe("Node > Module", () => {
     deepEqual(parseModuleRef("@babel/core"), {
       scope: "@babel",
       name: "core",
+      path: undefined,
     });
   });
 
@@ -50,6 +52,7 @@ describe("Node > Module", () => {
     deepEqual(parseModuleRef("@types/babel__core"), {
       scope: "@types",
       name: "babel__core",
+      path: undefined,
     });
   });
 

--- a/packages/tools-node/test/package.test.ts
+++ b/packages/tools-node/test/package.test.ts
@@ -36,7 +36,10 @@ describe("Node > Package", () => {
   });
 
   it("parsePackageRef(react-native) returns an unscoped reference", () => {
-    deepEqual(parsePackageRef("react-native"), { name: "react-native" });
+    deepEqual(parsePackageRef("react-native"), {
+      name: "react-native",
+      scope: undefined,
+    });
   });
 
   it("parsePackageRef(@babel/core) returns a scoped reference", () => {
@@ -47,7 +50,7 @@ describe("Node > Package", () => {
   });
 
   it("parsePackageRef(@alias) is allowed", () => {
-    deepEqual(parsePackageRef("@alias"), { name: "@alias" });
+    deepEqual(parsePackageRef("@alias"), { name: "@alias", scope: undefined });
   });
 
   it("parsePackageRef(@/core) is allowed", () => {


### PR DESCRIPTION
### Description

This adds a new helper `destructureModuleRef` that picks apart a module reference and separates the @scope/name/path parts in the same pass, rather than splitting it up amongst multiple functions. The other functions that use this code are then reworked to call the new function.

### Test plan

- passed all the various tests of different paths. Signature is exact including having missing keys for scope/path when not set (instead of returning scope: undefined or path: undefined.
