### PR TITLE
fix(tools-node): allow module references with a trailing slash

### DIFF
--- a/.changeset/tiny-waves-look.md
+++ b/.changeset/tiny-waves-look.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-node": patch
+---
+
+Allow module references with a trailing slash

--- a/packages/tools-node/src/package.ts
+++ b/packages/tools-node/src/package.ts
@@ -43,13 +43,14 @@ function getModuleRefParts(
  * @returns either a destructured module reference or undefined if it is a file reference
  */
 export function destructureModuleRef(r: string): DestructuredModuleRef {
-  if (r && !r.endsWith("/")) {
+  if (r) {
     const parts = getModuleRefParts(r);
     if (parts.length > 0) {
       // if we only have one term the first term will be treated as the name, even if it is a scope
       if (parts.length === 1) {
         return { name: parts[0] };
       }
+
       // otherwise split the parts and return them
       const scope = parts[0].startsWith("@") ? parts.shift() : undefined;
       const name = parts.shift();
@@ -59,6 +60,7 @@ export function destructureModuleRef(r: string): DestructuredModuleRef {
       }
     }
   }
+
   throw new Error(`Invalid package reference: "${r}"`);
 }
 

--- a/packages/tools-node/test/package.test.ts
+++ b/packages/tools-node/test/package.test.ts
@@ -49,6 +49,10 @@ describe("Node > Package", () => {
     });
   });
 
+  it("parsePackageRef() allows trailing /", () => {
+    deepEqual(parsePackageRef("process/"), { name: "process", scope: undefined });
+  });
+
   it("parsePackageRef(@alias) is allowed", () => {
     deepEqual(parsePackageRef("@alias"), { name: "@alias", scope: undefined });
   });
@@ -57,13 +61,13 @@ describe("Node > Package", () => {
     deepEqual(parsePackageRef("@/core"), { scope: "@", name: "core" });
   });
 
+  it("parsePackageRef(@babel/) is allowed", () => {
+    deepEqual(parsePackageRef("@babel/"), { name: "@babel", scope: undefined });
+  });
+
   it("parsePackageRef(undefined) throws an Error", () => {
     // @ts-expect-error Argument of type 'undefined' is not assignable to parameter of type 'string'
     throws(() => parsePackageRef(undefined));
-  });
-
-  it("parsePackageRef(@babel/) throws an Error", () => {
-    throws(() => parsePackageRef("@babel/"));
   });
 
   it("readPackage() loads package.json when given its containing directory", () => {

--- a/packages/tools-node/test/package.test.ts
+++ b/packages/tools-node/test/package.test.ts
@@ -50,7 +50,10 @@ describe("Node > Package", () => {
   });
 
   it("parsePackageRef() allows trailing /", () => {
-    deepEqual(parsePackageRef("process/"), { name: "process", scope: undefined });
+    deepEqual(parsePackageRef("process/"), {
+      name: "process",
+      scope: undefined,
+    });
   });
 
   it("parsePackageRef(@alias) is allowed", () => {


### PR DESCRIPTION
### Description

Allow module references with a trailing slash.

Resolves #3515.

### Test plan

Tests were added.