### PR TITLE
fix(eslint-plugin): Fix (dev)dependency cycle in the repo between eslint-config and eslint-plugin

### DIFF
--- a/.changeset/forty-doors-itch.md
+++ b/.changeset/forty-doors-itch.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/eslint-plugin": patch
+---
+
+Tooling only change to use locally defined eslint.config.js to break dependency
+cycle

--- a/packages/eslint-plugin/eslint.config.js
+++ b/packages/eslint-plugin/eslint.config.js
@@ -1,1 +1,23 @@
-module.exports = require("@rnx-kit/eslint-config");
+const sdl = require("@microsoft/eslint-plugin-sdl");
+const rnx = require("./src");
+
+/**
+ * Note that we don't directly use `sdl.configs.required` because:
+ *
+ *   1. It includes rules for Angular and Electron
+ *   2. Its `react` preset conflicts with our direct use of `eslint-plugin-react`
+ *
+ * https://github.com/microsoft/eslint-plugin-sdl/blob/957996315c80fdadcd1a9f7bb76fc4663d33ef1e/lib/index.js#L47-L54
+ */
+module.exports = [
+  ...sdl.configs.common,
+  ...sdl.configs.node,
+  ...rnx.configs.strict,
+  ...rnx.configs.stylistic,
+  {
+    rules: {
+      "@typescript-eslint/consistent-type-definitions": ["error", "type"],
+      ...sdl.configs.react[0].rules,
+    },
+  },
+];

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -53,7 +53,7 @@
     "eslint": ">=8.57.0"
   },
   "devDependencies": {
-    "@rnx-kit/eslint-config": "*",
+    "@microsoft/eslint-plugin-sdl": "^1.0.0",
     "@rnx-kit/scripts": "*",
     "@rnx-kit/tsconfig": "*",
     "@types/eslint": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3905,8 +3905,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rnx-kit/eslint-plugin@workspace:packages/eslint-plugin"
   dependencies:
+    "@microsoft/eslint-plugin-sdl": "npm:^1.0.0"
     "@react-native/eslint-plugin": "npm:^0.76.0"
-    "@rnx-kit/eslint-config": "npm:*"
     "@rnx-kit/scripts": "npm:*"
     "@rnx-kit/tsconfig": "npm:*"
     "@types/eslint": "npm:^9.0.0"


### PR DESCRIPTION
### Description

Quick fix to what is technically a cycle in the repo.
- `@rnx-kit/eslint-config` - leverages `@rnx-kit/eslint-plugin` to lint files in our repo, this is private and internal.
- `@rnx-kit/eslint-plugin` - has a devDependency on `@rnx-kit/eslint-config` which to use for linting files in the plugin package.

This breaks the cycle by using the same config that eslint-config uses but directly referencing the configuration code in the plugin itself.

### Test plan

Only affects repo builds and linting of files. Linting run passes.