### PR TITLE
fix(ios): 3rd party components on new arch 0.77+

### DIFF
--- a/.changeset/twenty-dancers-tap.md
+++ b/.changeset/twenty-dancers-tap.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Fix third party components on new arch 0.77+

--- a/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
+++ b/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
@@ -21,6 +21,12 @@
 #define USE_FEATURE_FLAGS
 #endif  // __has_include(<react/featureflags/ReactNativeFeatureFlags.h>)
 
+#if __has_include(<ReactCodegen/RCTThirdPartyComponentsProvider.h>)
+#define USE_CODEGEN_PROVIDER 1
+#import <ReactCodegen/RCTThirdPartyComponentsProvider.h>
+#import <React/RCTComponentViewFactory.h>
+#endif // __has_include(<ReactCodegen/RCTThirdPartyComponentsProvider.h>)
+
 #if __has_include(<react/runtime/JSEngineInstance.h>)
 using SharedJSRuntimeFactory = std::shared_ptr<facebook::react::JSEngineInstance>;
 #else

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -1,12 +1,15 @@
 #import "ReactNativeHost.h"
 
+// clang-format off
+#include "FollyConfig.h"
+// clang-format on
+
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTCxxBridgeDelegate.h>
 #import <React/RCTDevLoadingViewSetEnabled.h>
 #import <React/RCTUtils.h>
 
-#include "FollyConfig.h"
 #import "RNXBridgelessHeaders.h"
 #import "RNXFabricAdapter.h"
 #import "RNXHostConfig.h"

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -1,13 +1,12 @@
 #import "ReactNativeHost.h"
 
-#include "FollyConfig.h"
-
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTCxxBridgeDelegate.h>
 #import <React/RCTDevLoadingViewSetEnabled.h>
 #import <React/RCTUtils.h>
 
+#include "FollyConfig.h"
 #import "RNXBridgelessHeaders.h"
 #import "RNXFabricAdapter.h"
 #import "RNXHostConfig.h"
@@ -26,6 +25,11 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 @interface ReactNativeHost () <RCTCxxBridgeDelegate>
 #endif  // USE_BRIDGELESS
 @end
+
+#ifdef USE_CODEGEN_PROVIDER
+@interface ReactNativeHost () <RCTComponentViewFactoryComponentProvider>
+@end
+#endif  // USE_CODEGEN_PROVIDER
 
 @implementation ReactNativeHost {
     __weak id<RNXHostConfig> _config;
@@ -58,6 +62,11 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
             [config shouldReleaseBridgeWhenBackgrounded]) {
             _hostReleaser = [[RNXHostReleaser alloc] initWithHost:self];
         }
+
+#ifdef USE_CODEGEN_PROVIDER
+        [RCTComponentViewFactory currentComponentViewFactory].thirdPartyFabricComponentsProvider =
+            self;
+#endif  // USE_CODEGEN_PROVIDER
 
 #ifdef USE_FEATURE_FLAGS
         if (self.isBridgelessEnabled) {
@@ -224,6 +233,15 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 
 #endif  // USE_BRIDGELESS
 
+// MARK: - RCTComponentViewFactoryComponentProvider details
+
+#ifdef USE_CODEGEN_PROVIDER
+- (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents
+{
+    return [RCTThirdPartyComponentsProvider thirdPartyFabricComponents];
+}
+#endif  // USE_CODEGEN_PROVIDER
+
 // MARK: - Private
 
 - (BOOL)isBridgelessEnabled
@@ -274,7 +292,7 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 #else
       return std::make_shared<facebook::react::RCTHermesInstance>(nullptr, false);
 #endif  // USE_REACT_NATIVE_CONFIG
-#else  // USE_HERMES
+#else   // USE_HERMES
       return std::make_shared<facebook::react::RCTJscInstance>();
 #endif  // USE_HERMES
     };


### PR DESCRIPTION
### Description

On RN 0.77+ we need to setup the 3rd party component provider, or all components will end up using the interop layer, even if they have a new arch implementation.

### Test plan

Tested in the test-app by adding react-native-safe-area-context and checking that it uses the new arch implementation.

This was tested on both RN 0.76 (before the fix is needed) and 0.78 (after the fix is needed).
