### PR TITLE
chore: revert "remove use of long-lived GitHub tokens"

### DIFF
--- a/.changeset/light-horses-appear.md
+++ b/.changeset/light-horses-appear.md
@@ -1,5 +1,0 @@
----
-"@rnx-kit/scripts": patch
----
-
-This version bump is for testing purposes only

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,9 @@ jobs:
           publish: npm run publish:changesets
           version: npm run version:changesets
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # We cannot use the GHA generated tokens because we've disabled
+          # creation of pull requests at the org level.
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   website:
     name: "Publish website"


### PR DESCRIPTION
### Description

Turns out we are using the PATs to allow GHA to create PRs on our behalf:

```
Error: HttpError: GitHub Actions is not permitted to create or approve pull requests.
Error: GitHub Actions is not permitted to create or approve pull requests.
```

Re-enabling it for now until we work out an alternative solution.

### Test plan

n/a