### PR TITLE
fix(yarn-plugin-dynamic-extensions): load user extensions relative to the source config file

### DIFF
--- a/.changeset/fresh-rice-begin.md
+++ b/.changeset/fresh-rice-begin.md
@@ -2,4 +2,4 @@
 "@rnx-kit/yarn-plugin-dynamic-extensions": patch
 ---
 
-Correct config type for package extensions module path
+Allow plugin to be disabled with an empty string or null values.

--- a/.changeset/fresh-rice-begin.md
+++ b/.changeset/fresh-rice-begin.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/yarn-plugin-dynamic-extensions": patch
+---
+
+Correct config type for package extensions module path

--- a/.changeset/fresh-rice-begin.md
+++ b/.changeset/fresh-rice-begin.md
@@ -2,4 +2,4 @@
 "@rnx-kit/yarn-plugin-dynamic-extensions": patch
 ---
 
-Allow plugin to be disabled with an empty string or null values.
+Don't load user extensions if the plugin was inherited from parent configs.

--- a/.changeset/fresh-rice-begin.md
+++ b/.changeset/fresh-rice-begin.md
@@ -2,4 +2,4 @@
 "@rnx-kit/yarn-plugin-dynamic-extensions": patch
 ---
 
-Don't load user extensions if the plugin was inherited from parent configs.
+Load user extensions relative to the source config file.

--- a/docsite/.yarnrc.yml
+++ b/docsite/.yarnrc.yml
@@ -14,6 +14,5 @@ logFilters:
     level: discard
 nodeLinker: node-modules
 npmRegistryServer: "https://registry.npmjs.org"
-dynamicPackageExtensions: false
 tsEnableAutoTypes: false
 yarnPath: ../.yarn/releases/yarn-4.6.0.cjs

--- a/incubator/yarn-plugin-dynamic-extensions/index.js
+++ b/incubator/yarn-plugin-dynamic-extensions/index.js
@@ -28,10 +28,11 @@ exports.factory = (require) => {
       return;
     }
 
+    const { npath } = require("@yarnpkg/fslib");
     const { pathToFileURL } = require("node:url");
 
     // On Windows, import paths must include the `file:` protocol.
-    const url = pathToFileURL(packageExtensions);
+    const url = pathToFileURL(npath.fromPortablePath(packageExtensions));
     const external = await import(url.toString());
     return external?.default ?? external;
   }

--- a/incubator/yarn-plugin-dynamic-extensions/index.js
+++ b/incubator/yarn-plugin-dynamic-extensions/index.js
@@ -23,7 +23,7 @@ exports.factory = (require) => {
     const packageExtensions = configuration.get(DYNAMIC_PACKAGE_EXTENSIONS_KEY);
     if (
       typeof packageExtensions !== "string" ||
-      packageExtensions === "false"
+      require("node:path").basename(packageExtensions) === "false"
     ) {
       return;
     }

--- a/incubator/yarn-plugin-dynamic-extensions/index.js
+++ b/incubator/yarn-plugin-dynamic-extensions/index.js
@@ -16,15 +16,26 @@ exports.factory = (require) => {
   const { Project, SettingsType, structUtils } = require("@yarnpkg/core");
 
   /**
+   * @param {unknown} value
+   * @returns {value is string}
+   */
+  function isEnabled(value) {
+    if (typeof value !== "string") {
+      return false;
+    }
+
+    const path = require("node:path");
+    const input = path.basename(value);
+    return !["NULL", "Null", "false", "null", "~"].includes(input);
+  }
+
+  /**
    * @param {Configuration} configuration
    * @returns {Promise<((ws: Workspace) => PackageExtensionData | undefined) | void>}
    */
   async function loadUserExtensions(configuration) {
     const packageExtensions = configuration.get(DYNAMIC_PACKAGE_EXTENSIONS_KEY);
-    if (
-      typeof packageExtensions !== "string" ||
-      require("node:path").basename(packageExtensions) === "false"
-    ) {
+    if (!isEnabled(packageExtensions)) {
       return;
     }
 

--- a/incubator/yarn-plugin-dynamic-extensions/index.js
+++ b/incubator/yarn-plugin-dynamic-extensions/index.js
@@ -14,6 +14,7 @@ exports.name = "@rnx-kit/yarn-plugin-dynamic-extensions";
 /** @type {(require: NodeJS.Require) => Plugin<Hooks>} */
 exports.factory = (require) => {
   const { Project, SettingsType, structUtils } = require("@yarnpkg/core");
+  const { npath } = require("@yarnpkg/fslib");
 
   /**
    * @param {Configuration} configuration
@@ -21,11 +22,12 @@ exports.factory = (require) => {
    * @returns {Promise<((ws: Workspace) => PackageExtensionData | undefined) | void>}
    */
   async function loadUserExtensions(configuration, projectRoot) {
-    const path = require("node:path");
-
     // Return if the plugin was inherited from a parent config
     const source = configuration.sources.get(DYNAMIC_PACKAGE_EXTENSIONS_KEY);
-    if (typeof source !== "string" || path.dirname(source) !== projectRoot) {
+    if (
+      typeof source !== "string" ||
+      npath.fromPortablePath(npath.dirname(source)) !== projectRoot
+    ) {
       return;
     }
 
@@ -34,6 +36,7 @@ exports.factory = (require) => {
       return;
     }
 
+    const path = require("node:path");
     const { pathToFileURL } = require("node:url");
 
     // On Windows, import paths must include the `file:` protocol.
@@ -60,8 +63,6 @@ exports.factory = (require) => {
         if (!projectCwd) {
           return;
         }
-
-        const { npath } = require("@yarnpkg/fslib");
 
         const root = npath.fromPortablePath(projectCwd);
         const getUserExtensions = await loadUserExtensions(configuration, root);

--- a/incubator/yarn-plugin-dynamic-extensions/index.js
+++ b/incubator/yarn-plugin-dynamic-extensions/index.js
@@ -23,12 +23,6 @@ exports.factory = (require) => {
    * @returns {Promise<((ws: Workspace) => PackageExtensionData | undefined) | void>}
    */
   async function loadUserExtensions(configuration, projectRoot) {
-    // Return if the plugin was inherited from a parent config
-    const source = configuration.sources.get(DYNAMIC_PACKAGE_EXTENSIONS_KEY);
-    if (typeof source !== "string" || npath.dirname(source) !== projectRoot) {
-      return;
-    }
-
     const packageExtensions = configuration.get(DYNAMIC_PACKAGE_EXTENSIONS_KEY);
     if (typeof packageExtensions !== "string") {
       return;
@@ -37,8 +31,12 @@ exports.factory = (require) => {
     const path = require("node:path");
     const { pathToFileURL } = require("node:url");
 
+    // Make sure we resolve user extensions relative to the source config
+    const source = configuration.sources.get(DYNAMIC_PACKAGE_EXTENSIONS_KEY);
+    const sourceDir = source ? npath.dirname(source) : projectRoot;
+
     // On Windows, import paths must include the `file:` protocol.
-    const root = npath.fromPortablePath(projectRoot);
+    const root = npath.fromPortablePath(sourceDir);
     const url = pathToFileURL(path.resolve(root, packageExtensions));
     const external = await import(url.toString());
     return external?.default ?? external;


### PR DESCRIPTION
### Description

~~Correct config type for package extensions module path. With `SettingsType.ABSOLUTE_PATH`, we no longer have to resolve the path ourselves.~~ Update: see https://github.com/microsoft/rnx-kit/pull/3543#discussion_r1980933059

~~Allow plugin to be disabled with an empty string or null values.~~ Update: see https://github.com/microsoft/rnx-kit/pull/3543#discussion_r1981572978

Load user extensions relative to the source config file.

### Test plan

n/a