### PR TITLE
fix(react-native-host): build fixes for 0.79

### DIFF
--- a/.changeset/strange-pillows-hide.md
+++ b/.changeset/strange-pillows-hide.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+`enableFixForViewCommandRace` was removed in 0.79

--- a/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
+++ b/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
@@ -83,10 +83,12 @@ public:
     {
         return true;
     }
+#if !__has_include(<React-RCTAppDelegate/RCTReactNativeFactory.h>) && !__has_include(<React_RCTAppDelegate/RCTReactNativeFactory.h>)  // 0.77
     bool enableFixForViewCommandRace() override
     {
         return true;
     }
+#endif  // 0.77
 #else   // < 0.77
     bool useModernRuntimeScheduler() override
     {


### PR DESCRIPTION
### Description

`enableFixForViewCommandRace` was removed in 0.79

### Test plan

n/a