### PR TITLE
fix(cli): fix run command crashing without build

### DIFF
--- a/.changeset/three-baboons-speak.md
+++ b/.changeset/three-baboons-speak.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Fix `run` command crashing if the `build` command was not invoked first

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -1,4 +1,5 @@
 import type { Config } from "@react-native-community/cli-types";
+import { RNX_FAST_PATH } from "./bin/constants";
 import { rnxBuildCommand } from "./build";
 import type { InputParams } from "./build/types";
 import { runAndroid } from "./run/android";
@@ -24,6 +25,9 @@ export function rnxRun(
 }
 
 export const rnxRunCommand = {
+  // The run command may invoke the build command which currently requires
+  // loading the full config.
+  [RNX_FAST_PATH]: false,
   name: "rnx-run",
   description:
     "Build and run your native app for testing in emulator/simulator or on device",


### PR DESCRIPTION
### Description

Fix `run` command crashing if the `build` command was not invoked first

### Test plan

1. Clone https://github.com/microsoft/react-native-test-app/pull/2266
2. Run `yarn android` from the `examples` folder