### PR TITLE
fix(cli): add support for 0.79

### DIFF
--- a/.changeset/lemon-forks-taste.md
+++ b/.changeset/lemon-forks-taste.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Add support for React Native 0.79


### PR DESCRIPTION
### Description

`indexPageMiddleware` is no longer needed/used in 0.79

### Test plan

In RNTA:

```
yarn set-react-version 0.79
yarn
cd example
yarn start
```

This should not crash:

```
/~/node_modules/connect/index.js:87
  if (typeof handle.handle === 'function') {
                    ^

TypeError: Cannot read properties of undefined (reading 'handle')
    at Function.use (/~/node_modules/connect/index.js:87:21)
    at exports.runServer (/~/node_modules/metro/src/index.flow.js:148:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async rnxStart (/~/node_modules/@rnx-kit/cli/lib/start.js:152:28)
```