### PR TITLE
fix(cli): reduce output when building native code

### DIFF
--- a/.changeset/metal-coats-draw.md
+++ b/.changeset/metal-coats-draw.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Reduce output when building native code

--- a/packages/cli/src/build/watcher.ts
+++ b/packages/cli/src/build/watcher.ts
@@ -9,6 +9,7 @@ export function watch<T>(
   onSuccess: () => T
 ) {
   return new Promise<T | ExitCode>((resolve) => {
+    const step = "Building";
     const errors: Buffer[] = [];
 
     const isCI = Boolean(process.env.CI);
@@ -16,7 +17,8 @@ export function watch<T>(
       subproc.stdout.on("data", (chunk) => process.stdout.write(chunk));
       subproc.stderr.on("data", (chunk) => process.stderr.write(chunk));
     } else {
-      subproc.stdout.on("data", () => (logger.text += "."));
+      let i = 0;
+      subproc.stdout.on("data", () => logger.text = step + ".".repeat(++i % 6));
       subproc.stderr.on("data", (data) => errors.push(data));
     }
 
@@ -32,6 +34,6 @@ export function watch<T>(
     });
 
     logger.info(`Command: ${subproc.spawnargs.join(" ")}`);
-    logger.start("Building");
+    logger.start(step);
   });
 }

--- a/packages/cli/src/build/watcher.ts
+++ b/packages/cli/src/build/watcher.ts
@@ -18,7 +18,9 @@ export function watch<T>(
       subproc.stderr.on("data", (chunk) => process.stderr.write(chunk));
     } else {
       let i = 0;
-      subproc.stdout.on("data", () => logger.text = step + ".".repeat(++i % 6));
+      subproc.stdout.on("data", () => {
+        logger.text = step + ".".repeat(++i % 6);
+      });
       subproc.stderr.on("data", (data) => errors.push(data));
     }
 


### PR DESCRIPTION
### Description

Reduce output when building native code

### Test plan

```
cd packages/test-app
yarn build --dependencies
pod install --project-directory=ios
yarn ios
```

| Before | After |
| :-: | :-: |
| ![Screenshot 2025-04-01 at 11 10 43](https://github.com/user-attachments/assets/5d56d6c3-044e-4d41-a056-8ecdd4d2a253) | ![Screenshot 2025-04-01 at 11 30 40](https://github.com/user-attachments/assets/45ff5c0b-b3b2-40d3-b9ed-b54dea81860c) |
