### PR TITLE
fix(react-native-host): fix use of incomplete type `facebook::react::JSExecutorFactory`

### DIFF
--- a/.changeset/wild-cameras-heal.md
+++ b/.changeset/wild-cameras-heal.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Fixed invalid application of `sizeof` to an incomplete type
+`facebook::react::JSExecutorFactory`

--- a/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
+++ b/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
@@ -23,9 +23,9 @@
 
 #if __has_include(<ReactCodegen/RCTThirdPartyComponentsProvider.h>)
 #define USE_CODEGEN_PROVIDER 1
-#import <ReactCodegen/RCTThirdPartyComponentsProvider.h>
 #import <React/RCTComponentViewFactory.h>
-#endif // __has_include(<ReactCodegen/RCTThirdPartyComponentsProvider.h>)
+#import <ReactCodegen/RCTThirdPartyComponentsProvider.h>
+#endif  // __has_include(<ReactCodegen/RCTThirdPartyComponentsProvider.h>)
 
 #if __has_include(<react/runtime/JSEngineInstance.h>)
 using SharedJSRuntimeFactory = std::shared_ptr<facebook::react::JSEngineInstance>;

--- a/packages/react-native-host/cocoa/RNXTurboModuleAdapter.h
+++ b/packages/react-native-host/cocoa/RNXTurboModuleAdapter.h
@@ -1,17 +1,13 @@
 #include <memory>
 
 #import <Foundation/Foundation.h>
+#include <cxxreact/JSExecutor.h>
 
 #if USE_FABRIC
 #import <ReactCommon/RCTTurboModuleManager.h>
 #endif  // USE_FABRIC
 
 @class RCTBridge;
-
-namespace facebook::react
-{
-    class JSExecutorFactory;
-}  // namespace facebook::react
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
### Description

Fixed invalid application of `sizeof` to an incomplete type `facebook::react::JSExecutorFactory`

### Test plan

CI should pass.