### PR TITLE
fix(react-native-host): fix `SurfaceRegistryBinding::startSurface` failing on 0.75 (and older)

### DIFF
--- a/.changeset/soft-jeans-knock.md
+++ b/.changeset/soft-jeans-knock.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Fixed `SurfaceRegistryBinding::startSurface` failing on 0.75 (and older)

--- a/packages/react-native-host/cocoa/ReactNativeHost+View.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost+View.mm
@@ -59,15 +59,19 @@ static NSString *const kReactConcurrentRoot = @"concurrentRoot";
 #elif USE_BRIDGELESS
     RCTFabricSurface *surface = [self.reactHost createSurfaceWithModuleName:moduleName
                                                           initialProperties:initialProps];
+#if __has_include(<react/renderer/components/modal/ModalHostViewUtils.h>)  // >=0.76
+    return [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
+#else
     // `-initWithSurface:` implicitly calls `start` and causes race conditions.
     // This was fixed in 0.76.7, but for backwards compatibility, we should call
-    // `-initWithSurface:sizeMeasureMode` instead. For more details, see
+    // `-initWithSurface:sizeMeasureMode` when possible. For more details, see
     // https://github.com/facebook/react-native/pull/47313.
     RCTSurfaceSizeMeasureMode sizeMeasureMode =
         RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact;
     return [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface
                                                    sizeMeasureMode:sizeMeasureMode];
-#else
+#endif  // __has_include(<react/renderer/components/modal/ModalHostViewState.h>)
+#else  // __has_include(<React/RCTFabricSurfaceHostingProxyRootView.h>)
     RCTFabricSurface *surface =
         [[RCTFabricSurface alloc] initWithSurfacePresenter:self.surfacePresenter
                                                 moduleName:moduleName

--- a/packages/react-native-host/cocoa/ReactNativeHost+View.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost+View.mm
@@ -59,7 +59,14 @@ static NSString *const kReactConcurrentRoot = @"concurrentRoot";
 #elif USE_BRIDGELESS
     RCTFabricSurface *surface = [self.reactHost createSurfaceWithModuleName:moduleName
                                                           initialProperties:initialProps];
-    return [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
+    // `-initWithSurface:` implicitly calls `start` and causes race conditions.
+    // This was fixed in 0.76.7, but for backwards compatibility, we should call
+    // `-initWithSurface:sizeMeasureMode` instead. For more details, see
+    // https://github.com/facebook/react-native/pull/47313.
+    RCTSurfaceSizeMeasureMode sizeMeasureMode =
+        RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact;
+    return [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface
+                                                   sizeMeasureMode:sizeMeasureMode];
 #else
     RCTFabricSurface *surface =
         [[RCTFabricSurface alloc] initWithSurfacePresenter:self.surfacePresenter

--- a/packages/react-native-host/cocoa/ReactNativeHost+View.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost+View.mm
@@ -59,7 +59,7 @@ static NSString *const kReactConcurrentRoot = @"concurrentRoot";
 #elif USE_BRIDGELESS
     RCTFabricSurface *surface = [self.reactHost createSurfaceWithModuleName:moduleName
                                                           initialProperties:initialProps];
-#if __has_include(<react/renderer/components/modal/ModalHostViewUtils.h>)  // >=0.76
+#if __has_include(<react/renderer/graphics/LinearGradient.h>)  // >=0.77
     return [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
 #else
     // `-initWithSurface:` implicitly calls `start` and causes race conditions.
@@ -70,8 +70,8 @@ static NSString *const kReactConcurrentRoot = @"concurrentRoot";
         RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact;
     return [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface
                                                    sizeMeasureMode:sizeMeasureMode];
-#endif  // __has_include(<react/renderer/components/modal/ModalHostViewState.h>)
-#else  // __has_include(<React/RCTFabricSurfaceHostingProxyRootView.h>)
+#endif  // __has_include(<react/renderer/graphics/LinearGradient.h>)
+#else   // __has_include(<React/RCTFabricSurfaceHostingProxyRootView.h>)
     RCTFabricSurface *surface =
         [[RCTFabricSurface alloc] initWithSurfacePresenter:self.surfacePresenter
                                                 moduleName:moduleName


### PR DESCRIPTION
### Description

Fixed `SurfaceRegistryBinding::startSurface` failing on 0.75 (and older). Regressed in 582dabc.

Resolves #3586.

### Test plan

See repro steps in #3586.