### PR TITLE
docs: fix npm commands

### DIFF
--- a/docsite/docs/guides/_package-run-command.mdx
+++ b/docsite/docs/guides/_package-run-command.mdx
@@ -4,12 +4,12 @@ import CodeBlock from "@theme/CodeBlock";
 
 <Tabs groupId="package-manager">
   <TabItem value="yarn" label="Yarn" default>
-    <CodeBlock language="sh">yarn {props.yarnArgs || props.args}</CodeBlock>
+    <CodeBlock language="sh">yarn {props.args}</CodeBlock>
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
-    <CodeBlock language="sh">pnpm {props.pnpmArgs || props.args}</CodeBlock>
+    <CodeBlock language="sh">pnpm {props.args}</CodeBlock>
   </TabItem>
   <TabItem value="npm" label="npm">
-    <CodeBlock language="sh">npx {props.npxArgs || props.args}</CodeBlock>
+    <CodeBlock language="sh">{props.installedScript ? "npx" : "npm run"} {props.args}</CodeBlock>
   </TabItem>
 </Tabs>

--- a/docsite/docs/guides/bundling.mdx
+++ b/docsite/docs/guides/bundling.mdx
@@ -536,7 +536,7 @@ to add automation which guards your app against bundling errors in future PRs.
 If you use Lerna, you can run one command from the root of your repo to bundle
 all packages:
 
-<PackageRunCommand args="lerna run bundle" />
+<PackageRunCommand args="lerna run bundle" installedScript />
 
 If you're using a task runner like Nx, Lage or Gulp, you can go for a more
 sophisticated integration. The advantage being that `bundle` runs as its own

--- a/docsite/docs/guides/dependency-management.mdx
+++ b/docsite/docs/guides/dependency-management.mdx
@@ -109,7 +109,7 @@ root of the repo, scanning all packages. This include packages which haven't
 onboarded yet. For those, `--requirements react-native@[version]` controls the
 target React Native release to use when checking compatibility.
 
-<PackageRunCommand args="rnx-align-deps --requirements react-native@0.66" />
+<PackageRunCommand args="rnx-align-deps --requirements react-native@0.66" installedScript />
 
 When a compatibility problem is found, the command fails with a non-zero exit
 code, which causes the PR loop to fail. This protects the repo from risky
@@ -186,7 +186,7 @@ info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this comm
 Fixing problems is automated, too! From your development terminal, run the same
 command with a `--write` parameter.
 
-<PackageRunCommand args="rnx-align-deps --requirements react-native@0.66 --write" />
+<PackageRunCommand args="rnx-align-deps --requirements react-native@0.66 --write" installedScript />
 
 **Review** and **test** the fixes before pushing them to your PR.
 
@@ -209,7 +209,7 @@ response.
 Run this command from the root of your repo. It uses the dependency manager to
 make the fixes automatically.
 
-<PackageRunCommand args="rnx-align-deps --write" />
+<PackageRunCommand args="rnx-align-deps --write" installedScript />
 
 **Review** and **test** the fixes before pushing them to the PR with the
 dependency manager update.
@@ -228,9 +228,9 @@ version and adjust all React Native dependencies to be compatible. Replace
 `[version]` with your target React Native version in `major.minor` format, such
 as "0.66" or "0.68".
 
-<PackageRunCommand args="rnx-align-deps --set-version [version]" />
+<PackageRunCommand args="rnx-align-deps --set-version [version]" installedScript />
 
-<PackageRunCommand args="rnx-align-deps --requirements react-native@[version] --write" />
+<PackageRunCommand args="rnx-align-deps --requirements react-native@[version] --write" installedScript />
 
 **Review** and **test** your packages thoroughly before merging these changes.
 
@@ -304,7 +304,7 @@ Next, configure each of your onboarded React Native packages to use the list.
 Now it's time to use the list. Run the dependency manager to update all of your
 packages.
 
-<PackageRunCommand args="rnx-align-deps --requirements react-native@0.66 --presets microsoft/react-native,path/to/dependency-profile.json --write" />
+<PackageRunCommand args="rnx-align-deps --requirements react-native@0.66 --presets microsoft/react-native,path/to/dependency-profile.json --write" installedScript />
 
 **Review** and **test** the changes before continuing.
 

--- a/docsite/docs/guides/getting-started.mdx
+++ b/docsite/docs/guides/getting-started.mdx
@@ -33,7 +33,7 @@ package produces a bundle, it's an `app`. Otherwise, it's a `library`.
 
 Fix any React Native package versions that might have compatibility issues.
 
-<PackageRunCommand args="rnx-align-deps --write" />
+<PackageRunCommand args="rnx-align-deps --write" installedScript />
 
 Review the changes. They should be limited to package.json and your Yarn / npm /
 pnpm lock file.


### PR DESCRIPTION
### Description

In our docs, we always specify `npx`, even for user scripts.

### Test plan

```
cd docsite
yarn
yarn build
yarn serve
```

Check that user scripts are executed with `npm run` and installed scripts with `npx`.