### PR TITLE
ci: allow publish pipeline to push changes to `changeset-release/main`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   build_and_publish:
     name: "Build and publish"
+    permissions:
+      contents: write # for GH releases and Git tags (Changesets)
     if: ${{ github.repository == 'microsoft/rnx-kit' }}
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
### Description

Attempt to fix publish pipeline: https://github.com/microsoft/rnx-kit/actions/runs/14735366771/job/41359983866

### Test plan

Can't really test this since it's all on CI.