### PR TITLE
feat(metro-config): support Yarn in pnpm mode

### DIFF
--- a/.changeset/bright-cobras-tell.md
+++ b/.changeset/bright-cobras-tell.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": minor
+---
+
+Added support for Yarn's pnpm layout

--- a/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/node_modules/.store/@babel-core-npm-7.27.1-0f1bf48e52/package/package.json
+++ b/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/node_modules/.store/@babel-core-npm-7.27.1-0f1bf48e52/package/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@babel/core",
+  "version": "7.27.1",
+  "description": "Babel compiler core.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/babel/babel.git",
+    "directory": "packages/babel-core"
+  }
+}

--- a/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/node_modules/.store/react-native-virtual-3e97acc5aa/package/package.json
+++ b/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/node_modules/.store/react-native-virtual-3e97acc5aa/package/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "react-native",
+  "version": "1000.0.0",
+  "description": "A framework for building native apps using React",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:facebook/react-native.git"
+  }
+}

--- a/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/node_modules/@babel/core
+++ b/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/node_modules/@babel/core
@@ -1,0 +1,1 @@
+../.store/@babel-core-npm-7.27.1-0f1bf48e52/package

--- a/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/node_modules/react-native
+++ b/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/node_modules/react-native
@@ -1,0 +1,1 @@
+.store/react-native-virtual-3e97acc5aa/package

--- a/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/package.json
+++ b/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/package.json
@@ -1,0 +1,7 @@
+{
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ]
+  }
+}

--- a/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/yarn.lock
+++ b/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/yarn.lock
@@ -1,0 +1,1 @@
+# `@rnx-kit/tools-workspaces` determines repo root by looking for a lock file


### PR DESCRIPTION
### Description

Added support for Yarn's pnpm layout

### Test plan

1. Disable our Metro symlinks resolver
    ```diff
    diff --git a/packages/test-app/metro.config.js b/packages/test-app/metro.config.js
    index a44c75da..6722133c 100644
    --- a/packages/test-app/metro.config.js
    +++ b/packages/test-app/metro.config.js
    @@ -30,7 +30,7 @@ module.exports = makeMetroConfig({
               }
             : {}),
         },
    -    resolveRequest: MetroSymlinksResolver(),
    +    //resolveRequest: MetroSymlinksResolver(),
         blacklistRE: blockList,
         blockList,
       },
    ```
2. Build and bundle:
    ```
    yarn build-scope @rnx-kit/test-app
    cd packages/test-app
    yarn bundle:ios --reset-cache
    ```

Bundle should succeed and not report any duplicates.