### PR TITLE
fix(metro-resolver-symlinks): use Metro's symlink resolver

### DIFF
--- a/.changeset/bright-cobras-tell.md
+++ b/.changeset/bright-cobras-tell.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": minor
+---
+
+Added support for Yarn's pnpm layout

--- a/.changeset/thick-months-help.md
+++ b/.changeset/thick-months-help.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Use Metro's symlink resolver when available

--- a/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/node_modules/.store/@babel-core-npm-7.27.1-0f1bf48e52/package/package.json
+++ b/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/node_modules/.store/@babel-core-npm-7.27.1-0f1bf48e52/package/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@babel/core",
+  "version": "7.27.1",
+  "description": "Babel compiler core.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/babel/babel.git",
+    "directory": "packages/babel-core"
+  }
+}

--- a/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/node_modules/.store/react-native-virtual-3e97acc5aa/package/package.json
+++ b/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/node_modules/.store/react-native-virtual-3e97acc5aa/package/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "react-native",
+  "version": "1000.0.0",
+  "description": "A framework for building native apps using React",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:facebook/react-native.git"
+  }
+}

--- a/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/node_modules/@babel/core
+++ b/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/node_modules/@babel/core
@@ -1,0 +1,1 @@
+../.store/@babel-core-npm-7.27.1-0f1bf48e52/package

--- a/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/node_modules/react-native
+++ b/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/node_modules/react-native
@@ -1,0 +1,1 @@
+.store/react-native-virtual-3e97acc5aa/package

--- a/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/package.json
+++ b/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/package.json
@@ -1,0 +1,7 @@
+{
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ]
+  }
+}

--- a/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/yarn.lock
+++ b/packages/metro-config/test/__fixtures__/yarn-pnpm-repo/yarn.lock
@@ -1,0 +1,1 @@
+# `@rnx-kit/tools-workspaces` determines repo root by looking for a lock file

--- a/packages/metro-resolver-symlinks/src/resolvers.ts
+++ b/packages/metro-resolver-symlinks/src/resolvers.ts
@@ -3,10 +3,7 @@ import { applyEnhancedResolver } from "./resolvers/enhanced-resolve";
 import { applyMetroResolver } from "./resolvers/metro-resolver";
 import { applyOxcResolver } from "./resolvers/oxc-resolver";
 import type { CallResolver, Options } from "./types";
-import {
-  patchMetro,
-  shouldEnableRetryResolvingFromDisk,
-} from "./utils/patchMetro";
+import { patchMetro, shouldEnableRetryResolvingFromDisk } from "./utils/metro";
 
 export function getResolver(options: Options): CallResolver {
   if (shouldEnableRetryResolvingFromDisk(options)) {

--- a/packages/metro-resolver-symlinks/src/types.ts
+++ b/packages/metro-resolver-symlinks/src/types.ts
@@ -1,7 +1,7 @@
 import type {
+  CustomResolutionContext,
   CustomResolver,
   Resolution,
-  ResolutionContext,
 } from "metro-resolver";
 
 type ExperimentalOptions = {
@@ -17,7 +17,7 @@ export type CallResolver = (
 
 export type MetroResolver = typeof import("metro-resolver").resolve;
 
-export type ResolutionContextCompat = ResolutionContext & {
+export type ResolutionContextCompat = CustomResolutionContext & {
   /**
    * Introduced in 0.76
    * @see {@link https://github.com/facebook/metro/commit/c6548f7ccc5b8ad59ea98f4bd7f1f5822deec0cd}


### PR DESCRIPTION
### Description

Use Metro's symlink resolver when available.

Requires #3622.
Resolves #2254.

### Test plan

1. Disable our Metro symlinks resolver
    ```diff
    diff --git a/packages/test-app/metro.config.js b/packages/test-app/metro.config.js
    index a44c75da..6722133c 100644
    --- a/packages/test-app/metro.config.js
    +++ b/packages/test-app/metro.config.js
    @@ -30,7 +30,7 @@ module.exports = makeMetroConfig({
               }
             : {}),
         },
    -    resolveRequest: MetroSymlinksResolver(),
    +    //resolveRequest: MetroSymlinksResolver(),
         blacklistRE: blockList,
         blockList,
       },
    ```
2. Build and bundle:
    ```
    yarn build-scope @rnx-kit/test-app
    cd packages/test-app
    yarn bundle:ios --reset-cache
    ```