### PR TITLE
fix(metro-resolver-symlinks): add support for 0.82+

### DIFF
--- a/.changeset/eight-wasps-wonder.md
+++ b/.changeset/eight-wasps-wonder.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+`experimental_retryResolvingFromDisk` should no longer be necessary as of 0.82+

--- a/packages/metro-resolver-symlinks/src/utils/enhancedResolveHelpers.ts
+++ b/packages/metro-resolver-symlinks/src/utils/enhancedResolveHelpers.ts
@@ -1,6 +1,7 @@
 import { expandPlatformExtensions } from "@rnx-kit/tools-react-native/platform";
 import * as path from "node:path";
 import type { ResolutionContextCompat } from "../types";
+import { isPackageExportsEnabled } from "./metro";
 
 export function getFromDir({
   originModulePath,
@@ -9,16 +10,15 @@ export function getFromDir({
 }
 
 export function makeEnhancedResolveOptions(
-  {
-    extraNodeModules,
-    mainFields,
-    sourceExts,
-    unstable_conditionNames,
-    unstable_enablePackageExports,
-  }: ResolutionContextCompat,
+  context: ResolutionContextCompat,
   platform = "common"
 ) {
+  const { extraNodeModules, mainFields, sourceExts, unstable_conditionNames } =
+    context;
+
   const extensions = sourceExts.map((ext) => `.${ext}`);
+  const enablePackageExports = isPackageExportsEnabled(context);
+
   return {
     // Map Metro's `context.extraNodeModules` to Webpack's `resolve.alias`.
     // Metro's implementation is a subset of Webpack's. See:
@@ -30,13 +30,13 @@ export function makeEnhancedResolveOptions(
     // Add `require` to handle packages that are missing `default`
     // conditional. See
     // https://github.com/webpack/enhanced-resolve/issues/313
-    conditionNames: unstable_enablePackageExports
+    conditionNames: enablePackageExports
       ? unstable_conditionNames.slice()
       : ["require", "node"],
 
     // Unless `unstable_enablePackageExports` is enabled, disable exports
     // map as it currently takes precedence over the `react-native` field.
-    ...(unstable_enablePackageExports ? undefined : { exportsFields: [] }),
+    ...(enablePackageExports ? undefined : { exportsFields: [] }),
 
     extensions:
       platform === "common"


### PR DESCRIPTION
### Description

`experimental_retryResolvingFromDisk` should no longer be necessary as of 0.82: https://reactnative.dev/blog/2025/04/08/react-native-0.79#metro-faster-startup-and-package-exports-support

Resolves #3585, closes #1289.

### Test plan

1. Force upgrade to 0.82:
    ```diff
    diff --git a/package.json b/package.json
    index 9dc267ce..499299b6 100644
    --- a/package.json
    +++ b/package.json
    @@ -61,6 +61,16 @@
         "@react-native-community/cli-types": "^15.0.1",
         "@rnx-kit/react-native-host": "workspace:*",
         "@vue/compiler-sfc": "link:./incubator/ignore",
    +    "metro": "^0.82",
    +    "metro-babel-transformer": "^0.82",
    +    "metro-config": "^0.82",
    +    "metro-core": "^0.82",
    +    "metro-react-native-babel-transformer": "^0.82",
    +    "metro-resolver": "^0.82",
    +    "metro-runtime": "^0.82",
    +    "metro-source-map": "^0.82",
    +    "metro-symbolicate": "^0.82",
    +    "metro-transform-worker": "^0.82",
         "react-native-macos/@react-native/assets-registry": "^0.78.0",
         "react-native-macos/@react-native/codegen": "^0.78.0",
         "react-native-macos/@react-native/community-cli-plugin": "^0.78.0",
    diff --git a/packages/metro-service/src/bundle.ts b/packages/metro-service/src/bundle.ts
    index e79b2e5b..05470c52 100644
    --- a/packages/metro-service/src/bundle.ts
    +++ b/packages/metro-service/src/bundle.ts
    @@ -139,7 +139,6 @@ export async function bundle(
         const outputAssets = await server.getAssets({
           ...Server.DEFAULT_BUNDLE_OPTIONS,
           ...requestOpts,
    -      bundleType: "todo",
         });
    
         // When we're done saving bundle output and the assets, we're done.
    ```
2. Build: `yarn build-scope @rnx-kit/test-app`
3. Bundle: `yarn bundle:android --reset-cache`
4. Enable:
    ```diff
    diff --git a/packages/test-app/metro.config.js b/packages/test-app/metro.config.js
    index a44c75da..25d0392c 100644
    --- a/packages/test-app/metro.config.js
    +++ b/packages/test-app/metro.config.js
    @@ -30,7 +30,7 @@ module.exports = makeMetroConfig({
               }
             : {}),
         },
    -    resolveRequest: MetroSymlinksResolver(),
    +    resolveRequest: MetroSymlinksResolver({ experimental_retryResolvingFromDisk: "true" }),
         blacklistRE: blockList,
         blockList,
       },
    ```
    Then bundle again: `yarn bundle:android --reset-cache`
5. Force enable:
    ```diff
    diff --git a/packages/test-app/metro.config.js b/packages/test-app/metro.config.js
    index a44c75da..25d0392c 100644
    --- a/packages/test-app/metro.config.js
    +++ b/packages/test-app/metro.config.js
    @@ -30,7 +30,7 @@ module.exports = makeMetroConfig({
               }
             : {}),
         },
    -    resolveRequest: MetroSymlinksResolver(),
    +    resolveRequest: MetroSymlinksResolver({ experimental_retryResolvingFromDisk: "force" }),
         blacklistRE: blockList,
         blockList,
       },
    ```
    Then bundle again: `yarn bundle:android --reset-cache`
