### PR TITLE
fix(metro-service): ingest changes up to 0.82

### DIFF
--- a/.changeset/five-planets-hunt.md
+++ b/.changeset/five-planets-hunt.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-react-native": minor
+---
+
+Added helper function for locating `@react-native/community-cli-plugin`

--- a/.changeset/two-olives-grin.md
+++ b/.changeset/two-olives-grin.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-service": minor
+---
+
+Added support for Metro 0.82

--- a/packages/metro-service/src/asset/index.ts
+++ b/packages/metro-service/src/asset/index.ts
@@ -1,1 +1,0 @@
-export { saveAssets } from "./write";

--- a/packages/metro-service/src/asset/saveAssets.ts
+++ b/packages/metro-service/src/asset/saveAssets.ts
@@ -1,0 +1,44 @@
+import { findCommunityCliPluginPath } from "@rnx-kit/tools-react-native/cli";
+import * as path from "node:path";
+import { saveAssetsAndroid } from "./android";
+import { saveAssetsDefault } from "./default";
+import { saveAssetsIOS } from "./ios";
+import type { SaveAssetsPlugin } from "./types";
+
+// Eventually this will be part of the rn config, but we require it on older rn
+// versions for win32 and the cli doesn't allow extra config properties.
+// See https://github.com/react-native-community/cli/pull/2002
+export function getSaveAssetsPlugin(
+  platform: string,
+  projectRoot: string
+): SaveAssetsPlugin {
+  if (platform === "win32") {
+    try {
+      const saveAssetsPlugin = require.resolve(
+        "@office-iss/react-native-win32/saveAssetPlugin",
+        { paths: [projectRoot] }
+      );
+      return require(saveAssetsPlugin);
+    } catch (_) {
+      /* empty */
+    }
+  }
+
+  // Use `@react-native/community-cli-plugin` when possible
+  const pluginPath = findCommunityCliPluginPath(projectRoot);
+  if (pluginPath) {
+    const { default: saveAssets } = require(
+      path.join(pluginPath, "dist", "commands", "bundle", "saveAssets.js")
+    );
+    return saveAssets;
+  }
+
+  switch (platform) {
+    case "ios":
+      return saveAssetsIOS;
+    case "android":
+      return saveAssetsAndroid;
+    default:
+      return saveAssetsDefault;
+  }
+}

--- a/packages/metro-service/src/assets-registry/path-support.js
+++ b/packages/metro-service/src/assets-registry/path-support.js
@@ -7,12 +7,13 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  *  strict
+ * @format
  */
 
 'use strict';
 
+/*:: import type {PackagerAsset} from './registry.js'; */
 
 const androidScaleSuffix = {
   '0.75': 'ldpi',
@@ -29,7 +30,7 @@ const ANDROID_BASE_DENSITY = 160;
  * FIXME: using number to represent discrete scale numbers is fragile in essence because of
  * floating point numbers imprecision.
  */
-function getAndroidAssetSuffix(scale) {
+function getAndroidAssetSuffix(scale /*: number */) /*: string */ {
   if (scale.toString() in androidScaleSuffix) {
     // $FlowFixMe[invalid-computed-prop]
     return androidScaleSuffix[scale.toString()];
@@ -55,9 +56,9 @@ const drawableFileTypes = new Set([
 ]);
 
 function getAndroidResourceFolderName(
-  asset,
-  scale,
-) {
+  asset /*: PackagerAsset */,
+  scale /*: number */,
+) /*: string */ {
   if (!drawableFileTypes.has(asset.type)) {
     return 'raw';
   }
@@ -75,15 +76,17 @@ function getAndroidResourceFolderName(
   return 'drawable-' + suffix;
 }
 
-function getAndroidResourceIdentifier(asset) {
+function getAndroidResourceIdentifier(
+  asset /*: PackagerAsset */,
+) /*: string */ {
   return (getBasePath(asset) + '/' + asset.name)
     .toLowerCase()
     .replace(/\//g, '_') // Encode folder structure in file name
     .replace(/([^a-z0-9_])/g, '') // Remove illegal chars
-    .replace(/^assets_/, ''); // Remove "assets_" prefix
+    .replace(/^(?:assets|assetsunstable_path)_/, ''); // Remove "assets_" or "assetsunstable_path_" prefix
 }
 
-function getBasePath(asset) {
+function getBasePath(asset /*: PackagerAsset */) /*: string */ {
   const basePath = asset.httpServerLocation;
   return basePath.startsWith('/') ? basePath.slice(1) : basePath;
 }

--- a/packages/metro-service/src/assets-registry/registry.js
+++ b/packages/metro-service/src/assets-registry/registry.js
@@ -13,17 +13,33 @@
 
 'use strict';
 
+/*::
+export type AssetDestPathResolver = 'android' | 'generic';
 
+export type PackagerAsset = {
+  +__packager_asset: boolean,
+  +fileSystemLocation: string,
+  +httpServerLocation: string,
+  +width: ?number,
+  +height: ?number,
+  +scales: Array<number>,
+  +hash: string,
+  +name: string,
+  +type: string,
+  +resolver?: AssetDestPathResolver,
+  ...
+};
+*/
 
-const assets = [];
+const assets /*: Array<PackagerAsset> */ = [];
 
-function registerAsset(asset) {
+function registerAsset(asset /*: PackagerAsset */) /*: number */ {
   // `push` returns new array length, so the first asset will
   // get id 1 (not 0) to make the value truthy
   return assets.push(asset);
 }
 
-function getAssetByID(assetId) {
+function getAssetByID(assetId /*: number */) /*: PackagerAsset */ {
   return assets[assetId - 1];
 }
 

--- a/packages/metro-service/src/bundle/bundle-0.66.ts
+++ b/packages/metro-service/src/bundle/bundle-0.66.ts
@@ -1,0 +1,41 @@
+import { info } from "@rnx-kit/console";
+import { requireModuleFromMetro } from "@rnx-kit/tools-react-native/metro";
+import type { ConfigT } from "metro-config";
+import { getSaveAssetsPlugin } from "../asset/saveAssets";
+import { saveAssets } from "../asset/write";
+import type { BundleArgs, RequestOptions } from "../types";
+
+// Source: https://github.com/facebook/react-native/blob/0.80-stable/packages/community-cli-plugin/src/commands/bundle/buildBundle.js#L113
+export async function buildBundle(
+  args: BundleArgs,
+  config: ConfigT,
+  output: typeof import("metro/src/shared/output/bundle"),
+  requestOpts: RequestOptions
+): Promise<void> {
+  const Server = requireModuleFromMetro("metro/src/Server", config.projectRoot);
+  const server = new Server(config);
+
+  try {
+    const bundle = await output.build(server, requestOpts);
+
+    await output.save(bundle, args, info);
+
+    // Save the assets of the bundle
+    const outputAssets = await server.getAssets({
+      ...Server.DEFAULT_BUNDLE_OPTIONS,
+      ...requestOpts,
+      bundleType: "todo",
+    });
+
+    // When we're done saving bundle output and the assets, we're done.
+    return await saveAssets(
+      outputAssets,
+      args.platform,
+      args.assetsDest,
+      args.assetCatalogDest,
+      getSaveAssetsPlugin(args.platform, config.projectRoot)
+    );
+  } finally {
+    server.end();
+  }
+}

--- a/packages/metro-service/src/bundle/bundle-0.71.ts
+++ b/packages/metro-service/src/bundle/bundle-0.71.ts
@@ -1,0 +1,60 @@
+import { warn } from "@rnx-kit/console";
+import { requireModuleFromMetro } from "@rnx-kit/tools-react-native/metro";
+import type { ConfigT } from "metro-config";
+import { getSaveAssetsPlugin } from "../asset/saveAssets";
+import { saveAssets } from "../asset/write";
+import type { BundleArgs, RequestOptions } from "../types";
+
+// Source: https://github.com/facebook/metro/blob/v0.82.4/packages/metro/src/index.flow.js#L386
+export async function buildBundle(
+  args: BundleArgs,
+  config: ConfigT,
+  output: typeof import("metro/src/shared/output/bundle"),
+  requestOptions: RequestOptions
+): Promise<void> {
+  const { runMetro } = requireModuleFromMetro("metro", config.projectRoot);
+  const metroServer = await runMetro(config, { watch: false });
+
+  try {
+    const metroBundle = await output.build(metroServer, requestOptions);
+
+    const bundleOutput = args.bundleOutput;
+    if (bundleOutput) {
+      const { dev, platform, sourcemapOutput } = args;
+      const outputOptions = { bundleOutput, sourcemapOutput, dev, platform };
+      await output.save(metroBundle, outputOptions, (message) =>
+        config.reporter.update({
+          // @ts-expect-error `bundle_save_log` was introduced in 0.82
+          type: "bundle_save_log",
+          message,
+        })
+      );
+    }
+
+    if (!args.assetsDest) {
+      warn("Assets destination folder is not set, skipping...");
+      return;
+    }
+
+    const MetroServer = requireModuleFromMetro(
+      "metro/src/Server",
+      config.projectRoot
+    );
+
+    const assets = await metroServer.getAssets({
+      ...MetroServer.DEFAULT_BUNDLE_OPTIONS,
+      ...requestOptions,
+    });
+
+    // When we're done saving bundle output and the assets, we're done.
+    await saveAssets(
+      assets,
+      args.platform,
+      args.assetsDest,
+      args.assetCatalogDest,
+      getSaveAssetsPlugin(args.platform, config.projectRoot)
+    );
+  } finally {
+    metroServer.end();
+  }
+}

--- a/packages/metro-service/src/index.ts
+++ b/packages/metro-service/src/index.ts
@@ -1,8 +1,8 @@
 export { bundle } from "./bundle";
-export type { BundleArgs } from "./bundle";
 export { loadMetroConfig } from "./config";
 export type { MetroConfigOverrides } from "./config";
 export { ramBundle } from "./ramBundle";
 export { isDevServerRunning, startServer } from "./server";
 export { makeReporter, makeTerminal } from "./terminal";
 export type { MetroTerminal } from "./terminal";
+export type { BundleArgs } from "./types";

--- a/packages/metro-service/src/ramBundle.ts
+++ b/packages/metro-service/src/ramBundle.ts
@@ -1,9 +1,9 @@
 import { warn } from "@rnx-kit/console";
 import type { ConfigT } from "metro-config";
 import * as path from "path";
-import type { BundleArgs } from "./bundle";
 import { bundle } from "./bundle";
 import { requireMetroPath } from "./metro";
+import type { BundleArgs } from "./types";
 
 export function ramBundle(args: BundleArgs, config: ConfigT): Promise<void> {
   warn(

--- a/packages/metro-service/src/types.ts
+++ b/packages/metro-service/src/types.ts
@@ -1,0 +1,31 @@
+import type { BundleOptions, OutputOptions } from "metro/src/shared/types";
+
+export type BundleArgs = {
+  assetsDest?: string;
+  assetCatalogDest?: string;
+  entryFile: string;
+  resetCache?: boolean;
+  resetGlobalCache?: boolean;
+  transformer?: string;
+  minify?: boolean;
+  config?: string;
+  platform: string;
+  dev: boolean;
+  bundleOutput: string;
+  bundleEncoding?: OutputOptions["bundleEncoding"];
+  maxWorkers?: number;
+  sourcemapOutput?: string;
+  sourcemapSourcesRoot?: string;
+  sourcemapUseAbsolutePath: boolean;
+  verbose?: boolean;
+  unstableTransformProfile?: BundleOptions["unstable_transformProfile"];
+};
+
+export type RequestOptions = {
+  entryFile: string;
+  sourceMapUrl?: string;
+  dev: boolean;
+  minify: boolean;
+  platform: string;
+  unstable_transformProfile?: BundleOptions["unstable_transformProfile"];
+};

--- a/packages/test-app/ios/Podfile.lock
+++ b/packages/test-app/ios/Podfile.lock
@@ -1508,7 +1508,7 @@ PODS:
   - ReactTestApp-DevSupport (4.3.10):
     - React-Core
     - React-jsi
-  - ReactTestApp-MSAL (5.0.1):
+  - ReactTestApp-MSAL (5.0.2):
     - MSAL
   - ReactTestApp-Resources (1.0.0-dev)
   - RNWWebStorage (0.4.2):
@@ -1532,7 +1532,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNXAuth (0.3.0):
+  - RNXAuth (0.3.1):
     - React-Core
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
@@ -1827,10 +1827,10 @@ SPEC CHECKSUMS:
   ReactCommon: 5008bd981a06fe63176ef815f092685ffee8f7eb
   ReactNativeHost: a541dc920fe917cb40eeb46d371b48568aa3a8a8
   ReactTestApp-DevSupport: 45d6eeb4188c286d2ebf8f77ff17ee5d66b9f9a4
-  ReactTestApp-MSAL: 90d3923624b7a11b06c113bcaa3ffc964e1c9422
+  ReactTestApp-MSAL: 473fb7d89bbfdb27c95d5238618c88728133356b
   ReactTestApp-Resources: 70da1d78d943a1fdff6362ce3f778e5b4560c95a
   RNWWebStorage: 0a5121f22dff32796a16cbd91a008659dd4ae6c4
-  RNXAuth: 2657f06d72c76bb1b4f85ba363db5e278f428165
+  RNXAuth: dcb6df2855f79d783692fa1fa58c246d36e5af89
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: e14bad835e12b6c7e2260fc320bd00e0f4b45add
 

--- a/packages/tools-react-native/cli.d.ts
+++ b/packages/tools-react-native/cli.d.ts
@@ -1,0 +1,1 @@
+export { findCommunityCliPluginPath } from "./lib/cli";

--- a/packages/tools-react-native/cli.js
+++ b/packages/tools-react-native/cli.js
@@ -1,0 +1,1 @@
+module.exports = require("./lib/cli.js");

--- a/packages/tools-react-native/package.json
+++ b/packages/tools-react-native/package.json
@@ -13,6 +13,8 @@
     "lib/**/*.js",
     "cache.d.ts",
     "cache.js",
+    "cli.d.ts",
+    "cli.js",
     "context.d.ts",
     "context.js",
     "metro.d.ts",
@@ -33,6 +35,11 @@
       "types": "./lib/cache.d.ts",
       "typescript": "./src/cache.ts",
       "default": "./lib/cache.js"
+    },
+    "./cli": {
+      "types": "./lib/cli.d.ts",
+      "typescript": "./src/cli.ts",
+      "default": "./lib/cli.js"
     },
     "./context": {
       "types": "./lib/context.d.ts",

--- a/packages/tools-react-native/src/cli.ts
+++ b/packages/tools-react-native/src/cli.ts
@@ -1,0 +1,18 @@
+import * as fs from "node:fs";
+import { resolveFrom } from "./resolve";
+
+export function findCommunityCliPluginPath(
+  projectRoot = process.cwd(),
+  rnDir = resolveFrom("react-native", projectRoot)
+): string | undefined {
+  if (!rnDir) {
+    return undefined;
+  }
+
+  const pkg = fs.readFileSync(`${rnDir}/package.json`, { encoding: "utf-8" });
+  if (!pkg.includes("@react-native/community-cli-plugin")) {
+    return undefined;
+  }
+
+  return resolveFrom("@react-native/community-cli-plugin", rnDir);
+}

--- a/packages/tools-react-native/src/metro.ts
+++ b/packages/tools-react-native/src/metro.ts
@@ -1,8 +1,6 @@
-import {
-  findPackageDependencyDir,
-  readPackage,
-} from "@rnx-kit/tools-node/package";
-import * as fs from "fs";
+import { readPackage } from "@rnx-kit/tools-node/package";
+import { findCommunityCliPluginPath } from "./cli";
+import { resolveFrom } from "./resolve";
 
 type MetroImport =
   | typeof import("metro")
@@ -24,13 +22,6 @@ type MetroModule =
   | "metro-resolver"
   | "metro-source-map";
 
-function resolveFrom(name: string, startDir: string): string | undefined {
-  return findPackageDependencyDir(name, {
-    startDir,
-    resolveSymlinks: true,
-  });
-}
-
 /**
  * Finds the installation path of Metro.
  * @param projectRoot The root of the project; defaults to the current working directory
@@ -42,17 +33,11 @@ export function findMetroPath(projectRoot = process.cwd()): string | undefined {
     return undefined;
   }
 
-  const pkg = fs.readFileSync(`${rnDir}/package.json`, { encoding: "utf-8" });
-  if (pkg.includes("@react-native/community-cli-plugin")) {
-    // `metro` dependency was moved to `@react-native/community-cli-plugin` in 0.73
-    // https://github.com/facebook/react-native/commit/fdcb94ad1310af6613cfb2a2c3f22f200bfa1c86
-    const cliPluginDir = resolveFrom(
-      "@react-native/community-cli-plugin",
-      rnDir
-    );
-    if (cliPluginDir) {
-      return resolveFrom("metro", cliPluginDir);
-    }
+  // `metro` dependency was moved to `@react-native/community-cli-plugin` in 0.73
+  // https://github.com/facebook/react-native/commit/fdcb94ad1310af6613cfb2a2c3f22f200bfa1c86
+  const cliPluginDir = findCommunityCliPluginPath(projectRoot, rnDir);
+  if (cliPluginDir) {
+    return resolveFrom("metro", cliPluginDir);
   }
 
   const cliDir = resolveFrom("@react-native-community/cli", rnDir);

--- a/packages/tools-react-native/src/resolve.ts
+++ b/packages/tools-react-native/src/resolve.ts
@@ -1,0 +1,11 @@
+import { findPackageDependencyDir } from "@rnx-kit/tools-node/package";
+
+export function resolveFrom(
+  name: string,
+  startDir: string
+): string | undefined {
+  return findPackageDependencyDir(name, {
+    startDir,
+    resolveSymlinks: true,
+  });
+}


### PR DESCRIPTION
### Description

- `@rnx-kit/metro-service`: Added support for Metro 0.82
- `@rnx-kit/tools-react-native`: Added helper function for locating `@react-native/community-cli-plugin`

### Test plan

```
yarn build-scope @rnx-kit/test-app
cd packages/test-app
yarn bundle:ios
pod install --project-directory=ios
yarn ios
```

Verify the app starts without Metro server.

### Screenshots

![image](https://github.com/user-attachments/assets/8e369ffd-e837-4d89-82a8-454e9d43007c)
