### PR TITLE
fix(metro-service): use prepopulated `assets` if available

### DIFF
--- a/.changeset/lazy-rabbits-hear.md
+++ b/.changeset/lazy-rabbits-hear.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-service": patch
+---
+
+Use prepopulated `assets` if available

--- a/packages/metro-service/src/bundle.ts
+++ b/packages/metro-service/src/bundle.ts
@@ -77,7 +77,6 @@ export function bundle(
       platform: args.platform,
       sourceMapUrl: !sourceMap ? undefined : sourceMapUrl,
       createModuleIdFactory: config.serializer.createModuleIdFactory,
-      withAssets: Boolean(args.assetsDest),
       unstable_transformProfile: args.unstableTransformProfile,
     });
   });

--- a/packages/metro-service/src/bundle.ts
+++ b/packages/metro-service/src/bundle.ts
@@ -77,6 +77,7 @@ export function bundle(
       platform: args.platform,
       sourceMapUrl: !sourceMap ? undefined : sourceMapUrl,
       createModuleIdFactory: config.serializer.createModuleIdFactory,
+      withAssets: Boolean(args.assetsDest),
       unstable_transformProfile: args.unstableTransformProfile,
     });
   });

--- a/packages/metro-service/src/bundle/bundle-0.71.ts
+++ b/packages/metro-service/src/bundle/bundle-0.71.ts
@@ -45,8 +45,12 @@ export async function buildBundle(
   const { runMetro } = requireModuleFromMetro("metro", config.projectRoot);
   const metroServer = await runMetro(config, { watch: false });
 
+
   try {
-    const metroBundle = await output.build(metroServer, requestOptions);
+    // @ts-expect-error Build options was introduced in 0.82
+    const metroBundle = await output.build(metroServer, requestOptions, {
+      withAssets: Boolean(args.assetsDest),
+    });
 
     const bundleOutput = args.bundleOutput;
     if (bundleOutput) {

--- a/packages/metro-service/src/bundle/bundle-0.71.ts
+++ b/packages/metro-service/src/bundle/bundle-0.71.ts
@@ -12,7 +12,7 @@ type MetroBundle = typeof import("metro/src/shared/output/bundle");
 type BuildOutput = Awaited<ReturnType<MetroBundle["build"]>>;
 
 type BuildOutputWithAssets = BuildOutput & {
-  assets?: ReadonlyArray<AssetData>;
+  assets?: readonly AssetData[];
 };
 
 /**
@@ -27,7 +27,7 @@ function getAssets(
   metroServer: Server,
   projectRoot: string,
   requestOptions: RequestOptions
-): Promise<ReadonlyArray<AssetData>> {
+): Promise<readonly AssetData[]> {
   const MetroServer = requireModuleFromMetro("metro/src/Server", projectRoot);
   return metroServer.getAssets({
     ...MetroServer.DEFAULT_BUNDLE_OPTIONS,

--- a/packages/metro-service/src/bundle/bundle-0.71.ts
+++ b/packages/metro-service/src/bundle/bundle-0.71.ts
@@ -45,7 +45,6 @@ export async function buildBundle(
   const { runMetro } = requireModuleFromMetro("metro", config.projectRoot);
   const metroServer = await runMetro(config, { watch: false });
 
-
   try {
     // @ts-expect-error Build options was introduced in 0.82
     const metroBundle = await output.build(metroServer, requestOptions, {


### PR DESCRIPTION
### Description

In a future version of Metro, we will no longer need to `getAssets()`, avoiding a second graph build.

### Test plan

n/a