### PR TITLE
fix(align-deps): fix `--no-unmanaged` not being parsed correctly

### DIFF
--- a/.changeset/moody-suits-allow.md
+++ b/.changeset/moody-suits-allow.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": patch
+---
+
+Fixed `--no-unmanaged` not being parsed correctly

--- a/packages/align-deps/src/cli.ts
+++ b/packages/align-deps/src/cli.ts
@@ -268,5 +268,7 @@ export async function cli({ packages, ...args }: Args): Promise<void> {
 
 if (require.main === module) {
   const yargs = require("yargs");
-  yargs.usage("$0 [packages...]", description, cliOptions, cli).argv;
+  yargs
+    .parserConfiguration({ "boolean-negation": false })
+    .usage("$0 [packages...]", description, cliOptions, cli).argv;
 }


### PR DESCRIPTION
### Description

`--no-unmanaged` gets parsed as `{ unmanaged: false }` but we expect `{ "no-unmanaged": true }`. Disabling boolean negation in yargs fixes this.

### Test plan

n/a