### PR TITLE
fix(tsconfig): use Node16 module resolution in the Node config

### DIFF
--- a/.changeset/slimy-squids-switch.md
+++ b/.changeset/slimy-squids-switch.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tsconfig": patch
+---
+
+Use Node16 module resolution by default in the Node config

--- a/incubator/lint-lockfile/src/rules/noDuplicates.ts
+++ b/incubator/lint-lockfile/src/rules/noDuplicates.ts
@@ -1,4 +1,4 @@
-import type { NoDuplicatesRuleOptions as Options } from "@rnx-kit/config/src/lint.types.ts";
+import type { NoDuplicatesRuleOptions as Options } from "@rnx-kit/config/lint.types";
 import type { Rule } from "../types.ts";
 
 type PackageCount = Record<string, number | undefined>;

--- a/incubator/lint-lockfile/src/rules/noWorkspacePackageFromNpm.ts
+++ b/incubator/lint-lockfile/src/rules/noWorkspacePackageFromNpm.ts
@@ -1,4 +1,4 @@
-import type { NoWorkspacePackageFromNpmRuleOptions as Options } from "@rnx-kit/config/src/lint.types.ts";
+import type { NoWorkspacePackageFromNpmRuleOptions as Options } from "@rnx-kit/config/lint.types";
 import type { Rule } from "../types.ts";
 
 export function noWorkspacePackageFromNpmRule(

--- a/incubator/yarn-plugin-external-workspaces/tsconfig.json
+++ b/incubator/yarn-plugin-external-workspaces/tsconfig.json
@@ -1,10 +1,7 @@
 {
-  "extends": "@rnx-kit/tsconfig/tsconfig.json",
+  "extends": "@rnx-kit/tsconfig/tsconfig.node.json",
   "compilerOptions": {
-    "experimentalDecorators": true,
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "target": "ES2021"
+    "experimentalDecorators": true
   },
   "include": ["src"]
 }

--- a/incubator/yarn-plugin-install-to/tsconfig.json
+++ b/incubator/yarn-plugin-install-to/tsconfig.json
@@ -1,10 +1,7 @@
 {
-  "extends": "@rnx-kit/tsconfig/tsconfig.json",
+  "extends": "@rnx-kit/tsconfig/tsconfig.node.json",
   "compilerOptions": {
     "experimentalDecorators": true,
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "target": "ES2021",
     "noEmit": true
   },
   "include": ["src"]

--- a/packages/align-deps/tsconfig.json
+++ b/packages/align-deps/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "@rnx-kit/tsconfig/tsconfig.json",
   "compilerOptions": {
-    "alwaysStrict": false,
-    "lib": ["ES2021"]
+    "alwaysStrict": false
   },
   "include": ["src"]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,9 +1,4 @@
 {
-  "extends": "@rnx-kit/tsconfig/tsconfig.json",
-  "compilerOptions": {
-    "target": "ES2020",
-    "module": "node16",
-    "moduleResolution": "node16"
-  },
+  "extends": "@rnx-kit/tsconfig/tsconfig.node.json",
   "include": ["src"]
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -21,6 +21,9 @@
       "typescript": "./src/index.ts",
       "default": "./lib/index.js"
     },
+    "./lint.types": {
+      "default": "./src/lint.types.ts"
+    },
     "./package.json": "./package.json"
   },
   "repository": {

--- a/packages/tsconfig/tsconfig.node.json
+++ b/packages/tsconfig/tsconfig.node.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "node16",
+    "moduleResolution": "node16",
     "erasableSyntaxOnly": true,
     "rewriteRelativeImportExtensions": true
   }


### PR DESCRIPTION
### Description

Use Node16 module resolution by default in the Node config

### Test plan

n/a