### PR TITLE
fix(reporter): fix hook lint warning blocking publish

### DIFF
--- a/.changeset/nine-bottles-lie.md
+++ b/.changeset/nine-bottles-lie.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/reporter": patch
+---
+
+Fix a hook error in CI jobs

--- a/incubator/reporter/src/levels.ts
+++ b/incubator/reporter/src/levels.ts
@@ -45,6 +45,6 @@ export function supportsLevel(
  * @returns should this level be sent to the error stream
  * @internal
  */
-export function useErrorStream(level: LogLevel): boolean {
+export function shouldUseErrorStream(level: LogLevel): boolean {
   return level === "error" || level === "warn";
 }

--- a/incubator/reporter/src/output.ts
+++ b/incubator/reporter/src/output.ts
@@ -5,8 +5,8 @@ import { noChange } from "./formatting.ts";
 import {
   defaultLevel,
   nonErrorLevels,
+  shouldUseErrorStream,
   supportsLevel,
-  useErrorStream,
 } from "./levels.ts";
 import type { LogLevel, OutputOptions, OutputSettings } from "./types.ts";
 import { allLogLevels } from "./types.ts";
@@ -103,7 +103,7 @@ function getConsoleWrites(setting: LogLevel) {
   };
   for (const level of nonErrorLevels) {
     if (supportsLevel(level, setting)) {
-      results[level] = useErrorStream(level) ? writeStderr : writeStdout;
+      results[level] = shouldUseErrorStream(level) ? writeStderr : writeStdout;
     }
   }
   return results;

--- a/incubator/reporter/test/levels.test.ts
+++ b/incubator/reporter/test/levels.test.ts
@@ -2,8 +2,8 @@ import {
   asLogLevel,
   defaultLevel,
   nonErrorLevels,
+  shouldUseErrorStream,
   supportsLevel,
-  useErrorStream,
 } from "../src/levels";
 import { allLogLevels } from "../src/types";
 
@@ -25,9 +25,9 @@ describe("levels", () => {
     expect(supportsLevel("verbose", "warn")).toBe(false);
   });
 
-  it("useErrorStream returns true for error/warn, false otherwise", () => {
-    expect(useErrorStream("error")).toBe(true);
-    expect(useErrorStream("warn")).toBe(true);
-    expect(useErrorStream("log")).toBe(false);
+  it("shouldUseErrorStream returns true for error/warn, false otherwise", () => {
+    expect(shouldUseErrorStream("error")).toBe(true);
+    expect(shouldUseErrorStream("warn")).toBe(true);
+    expect(shouldUseErrorStream("log")).toBe(false);
   });
 });


### PR DESCRIPTION
### Description

Had a function named useErrorStream that was being treated as a hook and caused a lint warning in the publish CI jobs.

Renamed to shouldUseErrorStream to clarify its purpose and avoid the lint warning