### PR TITLE
fix: update USE_HERMES in ReactNativeHost.podspec

### DIFF
--- a/packages/react-native-host/ReactNativeHost.podspec
+++ b/packages/react-native-host/ReactNativeHost.podspec
@@ -11,7 +11,7 @@ repo_dir = repository['directory']
 new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 preprocessor_definitions = [
   '$(inherit)',
-  "USE_HERMES=#{ENV['USE_HERMES'] || '0'}",
+  "USE_HERMES=#{ENV['USE_HERMES'] || '1'}",
 ]
 if new_arch_enabled
   preprocessor_definitions << 'RCT_NEW_ARCH_ENABLED=1'


### PR DESCRIPTION
### Description

this might be quite wrong but when playing around with RN 0.81-rc0 I got an issue in https://github.com/microsoft/rnx-kit/blob/a007c24ce897f68ee870569654792e2b0a985981/packages/react-native-host/cocoa/RNXBridgelessHeaders.h#L11 with USE_HERMES being uset.


### Test plan

unfortunately I didn't test this and just wen back to 0.80, so it's just a heads up