### PR TITLE
fix(cli): fix crash when exiting Metro server in 0.83

### DIFF
--- a/.changeset/moody-shrimps-roll.md
+++ b/.changeset/moody-shrimps-roll.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Fix crash when exiting Metro server in 0.83


### PR DESCRIPTION
### Description

Exiting the Metro server crashes starting with 0.83:

```
% yarn start

                        ▒▒▓▓▓▓▒▒
                     ▒▓▓▓▒▒░░▒▒▓▓▓▒
                  ▒▓▓▓▓░░░▒▒▒▒░░░▓▓▓▓▒
                 ▓▓▒▒▒▓▓▓▓▓▓▓▓▓▓▓▓▒▒▒▓▓
                 ▓▓░░░░░▒▓▓▓▓▓▓▒░░░░░▓▓
                 ▓▓░░▓▓▒░░░▒▒░░░▒▓▒░░▓▓
                 ▓▓░░▓▓▓▓▓▒▒▒▒▓▓▓▓▒░░▓▓
                 ▓▓░░▓▓▓▓▓▓▓▓▓▓▓▓▓▒░░▓▓
                 ▓▓▒░░▒▒▓▓▓▓▓▓▓▓▒░░░▒▓▓
                  ▒▓▓▓▒░░░▒▓▓▒░░░▒▓▓▓▒
                     ▒▓▓▓▒░░░░▒▓▓▓▒
                        ▒▒▓▓▓▓▒▒


                Welcome to Metro v0.83.0
              Fast - Scalable - Integrated


┃ Open developer menu                  D
┃ Open debugger                        J
┃ Show bundler address QR code         Q
┃ Reload the app                       R
┠───────────────────────────────────────
┃ Show this help message               H
┃ Quit                            Ctrl-C

info Exiting...
node:internal/readline/emitKeypressEvents:74
            throw err;
            ^

TypeError: server.close is not a function
    at process.<anonymous> (/~/node_modules/@rnx-kit/cli/lib/serve/keyboard.js:75:16)
    at process.emit (node:events:518:28)
    at ReadStream.<anonymous> (/~/node_modules/@rnx-kit/cli/lib/serve/keyboard.js:90:29)
    at ReadStream.emit (node:events:518:28)
    at emitKeys (node:internal/readline/utils:370:14)
    at emitKeys.next (<anonymous>)
    at ReadStream.onData (node:internal/readline/emitKeypressEvents:64:36)
    at ReadStream.emit (node:events:518:28)
    at addChunk (node:internal/streams/readable:561:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)

Node.js v22.15.0
```

### Test plan

n/a