### PR TITLE
chore(deps): bump `knip` to v5.62.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,20 +112,83 @@
       "prettier",
       "prettier-plugin-organize-imports"
     ],
+    "metro": false,
     "workspaces": {
+      "incubator/*": {
+        "entry": [
+          "src/index.{js,ts}"
+        ],
+        "project": [
+          "src/**/*.{js,ts,tsx}"
+        ]
+      },
       "incubator/@react-native-webapis/battery-status": {
+        "entry": [
+          "src/index.ts",
+          "react-native.config.js"
+        ],
         "ignoreDependencies": [
           "@babel/core",
           "@babel/preset-env"
         ]
       },
       "incubator/@react-native-webapis/web-storage": {
+        "entry": [
+          "src/index.ts",
+          "react-native.config.js",
+          "test/**/*.test.{js,mjs,ts,tsx}"
+        ],
         "ignoreDependencies": [
           "@babel/core",
           "@babel/preset-env"
         ]
       },
+      "incubator/build": {
+        "entry": [
+          "src/{cli,index,version}.ts",
+          "test/**/*.test.ts"
+        ]
+      },
+      "incubator/commitlint-lite": {
+        "entry": [
+          "src/{cli,index}.ts",
+          "test/**/*.test.ts"
+        ]
+      },
+      "incubator/esbuild-bundle-analyzer": {
+        "entry": [
+          "src/{cli,index}.ts",
+          "test/**/*.test.ts"
+        ]
+      },
+      "incubator/ignore": {},
+      "incubator/lint-lockfile": {
+        "entry": [
+          "src/{cli,index}.ts",
+          "test/**/*.test.ts"
+        ]
+      },
+      "incubator/react-native-test-app-msal": {},
+      "incubator/yarn-plugin-dynamic-extensions": {
+        "entry": [
+          "*.js"
+        ]
+      },
+      "packages/*": {
+        "entry": [
+          "src/index.{js,ts}",
+          "test/**/*.test.{js,mjs,ts,tsx}"
+        ],
+        "project": [
+          "src/**/*.{js,ts,tsx}"
+        ]
+      },
       "packages/babel-preset-metro-react-native": {
+        "entry": [
+          "*.js",
+          "test/**/*.test.js",
+          "test/__fixtures__/**/*.ts"
+        ],
         "ignoreDependencies": [
           "@rnx-kit/babel-plugin-import-path-remapper"
         ]
@@ -133,6 +196,7 @@
       "packages/cli": {
         "entry": [
           "scripts/**/*.ts",
+          "src/bin/rnx-cli.ts",
           "src/index.ts",
           "test/**/*.test.ts"
         ],
@@ -142,13 +206,27 @@
           "tsx"
         ]
       },
+      "packages/eslint-config": {
+        "entry": [
+          "*.js"
+        ]
+      },
       "packages/jest-preset": {
+        "entry": [
+          "*.{cjs,js}",
+          "test/**/*.test.ts",
+          "test/__fixtures__/**/*.js"
+        ],
         "ignoreDependencies": [
           "react",
           "react-native"
         ]
       },
       "packages/metro-config": {
+        "entry": [
+          "src/**/*.js",
+          "test/**/*.test.ts"
+        ],
         "ignoreDependencies": [
           "@babel/core",
           "@babel/preset-env"
@@ -157,19 +235,18 @@
       "packages/metro-plugin-duplicates-checker": {
         "entry": [
           "src/index.ts",
-          "test/__mocks__/**/*.js"
+          "test/**/*.{js,ts}"
         ]
       },
       "packages/metro-serializer-esbuild": {
         "entry": [
           "metro.config.js",
-          "scripts/**/*.ts",
           "src/index.ts",
-          "test/**/*.test.ts"
+          "test/**/*.test.ts",
+          "test/__fixtures__/**/*.ts"
         ],
         "ignoreDependencies": [
-          "@babel/preset-env",
-          "@fluentui/utilities"
+          "@babel/preset-env"
         ]
       },
       "packages/react-native-auth": {
@@ -182,10 +259,16 @@
           "@react-native/metro-config"
         ]
       },
+      "packages/react-native-host": {
+        "entry": [
+          "react-native.config.js"
+        ]
+      },
       "packages/react-native-lazy-index": {
         "entry": [
-          "src/index.js",
-          "test/**/*.test.ts"
+          "*.js",
+          "test/**/*.test.ts",
+          "test/__fixtures__/**/*.js"
         ],
         "ignoreDependencies": [
           "babel-plugin-codegen"
@@ -193,9 +276,9 @@
       },
       "packages/test-app": {
         "entry": [
-          "index.js",
-          "metro.config.js",
-          "test/**/*.mjs"
+          "*.js",
+          "src/**/*.{ts,tsx}",
+          "test/**/*.{js,mjs,ts,tsx}"
         ],
         "ignoreBinaries": [
           "rnx"
@@ -206,20 +289,14 @@
           "@react-native-community/cli-platform-android",
           "@react-native-community/cli-platform-ios",
           "@react-native-webapis/web-storage",
-          "@rnx-kit/*",
-          "react-native-test-app",
-          "react-native-windows"
+          "@rnx-kit/*"
         ]
       },
-      "packages/tools-react-native": {
-        "entry": [
-          "src/index.ts",
-          "test/**/*.test.ts"
-        ]
-      },
+      "packages/tsconfig": {},
       "scripts": {
-        "ignoreDependencies": [
-          "@rnx-kit/tsconfig"
+        "entry": [
+          "*.{cjs,js}",
+          "src/**/*.js"
         ]
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2966,7 +2966,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nodelib/fs.walk@npm:1.2.8, @nodelib/fs.walk@npm:^1.2.3":
+"@nodelib/fs.walk@npm:^1.2.3":
   version: 1.2.8
   resolution: "@nodelib/fs.walk@npm:1.2.8"
   dependencies:
@@ -5011,19 +5011,6 @@ __metadata:
   dependencies:
     "@sinonjs/commons": "npm:^2.0.0"
   checksum: 10c0/24555ed94053319fa18d4efa0923b295a445a00d2515d260b9e4e2b5943bd8b5b55fee85baabb2819a13ca1f57dbc1949265a350f592eef9e2535ec9de711ebc
-  languageName: node
-  linkType: hard
-
-"@snyk/github-codeowners@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@snyk/github-codeowners@npm:1.1.0"
-  dependencies:
-    commander: "npm:^4.1.1"
-    ignore: "npm:^5.1.8"
-    p-map: "npm:^4.0.0"
-  bin:
-    github-codeowners: dist/cli.js
-  checksum: 10c0/92d860a904a1e67f8563d4ac4d540cc613f71193f7968933b4a4b1526e80a97f536f52d27762c158e3e39d48c2f3db4906ec78846309351c741abb1a28653af9
   languageName: node
   linkType: hard
 
@@ -7912,19 +7899,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"easy-table@npm:1.2.0":
-  version: 1.2.0
-  resolution: "easy-table@npm:1.2.0"
-  dependencies:
-    ansi-regex: "npm:^5.0.1"
-    wcwidth: "npm:^1.0.1"
-  dependenciesMeta:
-    wcwidth:
-      optional: true
-  checksum: 10c0/2d37937cd608586ba02e1ec479f90ccec581d366b3b0d1bb26b99ee6005f8d724e32a07a873759893461ca45b99e2d08c30326529d967ce9eedc1e9b68d4aa63
-  languageName: node
-  linkType: hard
-
 "ee-first@npm:1.1.1":
   version: 1.1.1
   resolution: "ee-first@npm:1.1.1"
@@ -8006,7 +7980,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.17.0, enhanced-resolve@npm:^5.17.1, enhanced-resolve@npm:^5.8.3":
+"enhanced-resolve@npm:^5.17.0, enhanced-resolve@npm:^5.8.3":
   version: 5.18.2
   resolution: "enhanced-resolve@npm:5.18.2"
   dependencies:
@@ -8705,7 +8679,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.2, fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.2":
+"fast-glob@npm:^3.2.2, fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.2, fast-glob@npm:^3.3.3":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:
@@ -8774,6 +8748,15 @@ __metadata:
   dependencies:
     bser: "npm:2.1.1"
   checksum: 10c0/796ce6de1f915d4230771a6ad2219e0555275f2936d66022321845f7e69c65b10baa74959322b1ab94ac65b91307f1f09a6b8e2097a337ff113101ebbc4c6958
+  languageName: node
+  linkType: hard
+
+"fd-package-json@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "fd-package-json@npm:2.0.0"
+  dependencies:
+    walk-up-path: "npm:^4.0.0"
+  checksum: 10c0/a0a48745257bc09c939486608dad9f2ced238f0c64266222cc881618ed4c8f6aa0ccfe45a1e6d4f9ce828509e8d617cec60e2a114851bebb1ff4886dc5ed5112
   languageName: node
   linkType: hard
 
@@ -8969,6 +8952,17 @@ __metadata:
     hasown: "npm:^2.0.2"
     mime-types: "npm:^2.1.12"
   checksum: 10c0/373525a9a034b9d57073e55eab79e501a714ffac02e7a9b01be1c820780652b16e4101819785e1e18f8d98f0aee866cc654d660a435c378e16a72f2e7cac9695
+  languageName: node
+  linkType: hard
+
+"formatly@npm:^0.2.4":
+  version: 0.2.4
+  resolution: "formatly@npm:0.2.4"
+  dependencies:
+    fd-package-json: "npm:^2.0.0"
+  bin:
+    formatly: bin/index.mjs
+  checksum: 10c0/43c6272a12199bc6319e7ef7043f209e7005fc35bc1b15e96ef16ad46a12fddc2b7c179fe8ade174c728e8454e3ebdc8428867cee78b082d18a91dae72866336
   languageName: node
   linkType: hard
 
@@ -9621,7 +9615,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.0.4, ignore@npm:^5.1.8, ignore@npm:^5.2.0, ignore@npm:^5.2.4":
+"ignore@npm:^5.0.4, ignore@npm:^5.2.0, ignore@npm:^5.2.4":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
@@ -10765,12 +10759,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jiti@npm:^2.4.0":
-  version: 2.4.2
-  resolution: "jiti@npm:2.4.2"
+"jiti@npm:^2.4.2":
+  version: 2.5.1
+  resolution: "jiti@npm:2.5.1"
   bin:
     jiti: lib/jiti-cli.mjs
-  checksum: 10c0/4ceac133a08c8faff7eac84aabb917e85e8257f5ad659e843004ce76e981c457c390a220881748ac67ba1b940b9b729b30fb85cbaf6e7989f04b6002c94da331
+  checksum: 10c0/f0a38d7d8842cb35ffe883038166aa2d52ffd21f1a4fc839ae4076ea7301c22a1f11373f8fc52e2667de7acde8f3e092835620dd6f72a0fbe9296b268b0874bb
   languageName: node
   linkType: hard
 
@@ -10990,23 +10984,20 @@ __metadata:
   linkType: hard
 
 "knip@npm:^5.30.2":
-  version: 5.41.1
-  resolution: "knip@npm:5.41.1"
+  version: 5.62.0
+  resolution: "knip@npm:5.62.0"
   dependencies:
-    "@nodelib/fs.walk": "npm:1.2.8"
-    "@snyk/github-codeowners": "npm:1.1.0"
-    easy-table: "npm:1.2.0"
-    enhanced-resolve: "npm:^5.17.1"
-    fast-glob: "npm:^3.3.2"
-    jiti: "npm:^2.4.0"
+    "@nodelib/fs.walk": "npm:^1.2.3"
+    fast-glob: "npm:^3.3.3"
+    formatly: "npm:^0.2.4"
+    jiti: "npm:^2.4.2"
     js-yaml: "npm:^4.1.0"
     minimist: "npm:^1.2.8"
-    picocolors: "npm:^1.1.0"
+    oxc-resolver: "npm:^11.1.0"
+    picocolors: "npm:^1.1.1"
     picomatch: "npm:^4.0.1"
-    pretty-ms: "npm:^9.0.0"
-    smol-toml: "npm:^1.3.1"
-    strip-json-comments: "npm:5.0.1"
-    summary: "npm:2.1.0"
+    smol-toml: "npm:^1.3.4"
+    strip-json-comments: "npm:5.0.2"
     zod: "npm:^3.22.4"
     zod-validation-error: "npm:^3.0.3"
   peerDependencies:
@@ -11015,7 +11006,7 @@ __metadata:
   bin:
     knip: bin/knip.js
     knip-bun: bin/knip-bun.js
-  checksum: 10c0/1a222a5cbba1999bda49d795e290f0e907fb25d91e4fd51cfa8d57b91d0a170acdee36c9a8d5a8872b3558f07e746f85c6e7a04fa196c5d4828f89dd872edd37
+  checksum: 10c0/ffc6c123d132bb423936859c3ae5cb85154cfc862985f74637bc54a4920ef34c1f19d41020f7af25100ea8e7ae61f1f5279af8066043434444bcba82b8dc1611
   languageName: node
   linkType: hard
 
@@ -12604,7 +12595,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"oxc-resolver@npm:^11.0.0":
+"oxc-resolver@npm:^11.0.0, oxc-resolver@npm:^11.1.0":
   version: 11.6.0
   resolution: "oxc-resolver@npm:11.6.0"
   dependencies:
@@ -12830,13 +12821,6 @@ __metadata:
     json-parse-even-better-errors: "npm:^2.3.0"
     lines-and-columns: "npm:^1.1.6"
   checksum: 10c0/77947f2253005be7a12d858aedbafa09c9ae39eb4863adf330f7b416ca4f4a08132e453e08de2db46459256fb66afaac5ee758b44fe6541b7cdaf9d252e59585
-  languageName: node
-  linkType: hard
-
-"parse-ms@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "parse-ms@npm:4.0.0"
-  checksum: 10c0/a7900f4f1ebac24cbf5e9708c16fb2fd482517fad353aecd7aefb8c2ba2f85ce017913ccb8925d231770404780df46244ea6fec598b3bde6490882358b4d2d16
   languageName: node
   linkType: hard
 
@@ -13083,15 +13067,6 @@ __metadata:
     ansi-styles: "npm:^5.0.0"
     react-is: "npm:^18.0.0"
   checksum: 10c0/edc5ff89f51916f036c62ed433506b55446ff739358de77207e63e88a28ca2894caac6e73dcb68166a606e51c8087d32d400473e6a9fdd2dbe743f46c9c0276f
-  languageName: node
-  linkType: hard
-
-"pretty-ms@npm:^9.0.0":
-  version: 9.1.0
-  resolution: "pretty-ms@npm:9.1.0"
-  dependencies:
-    parse-ms: "npm:^4.0.0"
-  checksum: 10c0/fd111aad8800a04dfd654e6016da69bdaa6fc6a4c280f8e727cffd8b5960558e94942f1a94d4aa6e4d179561a0fbb0366a9ebe0ccefbbb0f8ff853b129cdefb9
   languageName: node
   linkType: hard
 
@@ -14320,10 +14295,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"smol-toml@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "smol-toml@npm:1.3.1"
-  checksum: 10c0/bac5bf4f2655fd561fe41f9426d70ab68b486631beff97a7f127f5d2f811b5e247d50a06583be03d35a625dcb05b7984b94a61a81c68ea2810ac7a9bf4edc64d
+"smol-toml@npm:^1.3.4":
+  version: 1.4.1
+  resolution: "smol-toml@npm:1.4.1"
+  checksum: 10c0/0589866e6949a1d6db92e67af57b4c8a1b284e19e215cda2a0e88f43ab91677d077724fad39ff5e6a0912150c743f5f4e560da675d565348ee8c65417096b0af
   languageName: node
   linkType: hard
 
@@ -14686,10 +14661,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-json-comments@npm:5.0.1":
-  version: 5.0.1
-  resolution: "strip-json-comments@npm:5.0.1"
-  checksum: 10c0/c9d9d55a0167c57aa688df3aa20628cf6f46f0344038f189eaa9d159978e80b2bfa6da541a40d83f7bde8a3554596259bf6b70578b2172356536a0e3fa5a0982
+"strip-json-comments@npm:5.0.2":
+  version: 5.0.2
+  resolution: "strip-json-comments@npm:5.0.2"
+  checksum: 10c0/e9841b8face78a01b0eb66f81e0a3419186a96f1d26817a5e1f5260b0631c10e0a7f711dddc5988edf599e5c079e4dd6e91defd21523e556636ba5679786f5ac
   languageName: node
   linkType: hard
 
@@ -14732,13 +14707,6 @@ __metadata:
   bin:
     suggestion-bot: cli.js
   checksum: 10c0/7105f81a93342857afe656bc64246df115e074743fa7d70370c92258e759ec58e3de53ec30abd9f1a4d55966513af22dcd945d2f6dbf2f9a7db087ac53919f48
-  languageName: node
-  linkType: hard
-
-"summary@npm:2.1.0":
-  version: 2.1.0
-  resolution: "summary@npm:2.1.0"
-  checksum: 10c0/2743c1f940fb303c496ef1b085e654704a6c16872957b6b76648c34bd32c8f0b7a3c5ec4e0f8bfb71dcb8473e34d172fef31026b85562af589cf220aa901698d
   languageName: node
   linkType: hard
 
@@ -15391,6 +15359,13 @@ __metadata:
   version: 1.0.1
   resolution: "vlq@npm:1.0.1"
   checksum: 10c0/a8ec5c95d747c840198f20b4973327fa317b98397f341e7a2f352bfcf385aeb73c0eea01cc6d406c20169298375397e259efc317aec53c8ffc001ec998204aed
+  languageName: node
+  linkType: hard
+
+"walk-up-path@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "walk-up-path@npm:4.0.0"
+  checksum: 10c0/fabe344f91387d1d41df230af962ef18bf703dd4178006d55cd6412caacd187b54440002d4d53a982d4f7f0455567dcffb6d3884533c8b2268928eca3ebd8a19
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Bumps `knip` to v5.62.0 and addresses config warnings.

Supersedes #3691.

### Test plan

n/a