### PR TITLE
fix(cli): allow `react-native.config.js` to be imported without the extension

### DIFF
--- a/.changeset/nice-heads-trade.md
+++ b/.changeset/nice-heads-trade.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Allow `react-native.config.js` to be imported without the `.js` extension

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
     },
+    "./react-native.config": "./react-native.config.js",
     "./react-native.config.js": "./react-native.config.js",
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
### Description

Allow `react-native.config.js` to be imported without the `.js` extension

### Test plan

n/a