### PR TITLE
fix(align-deps): make error output easier to read

### DIFF
--- a/.changeset/evil-carrots-greet.md
+++ b/.changeset/evil-carrots-greet.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": patch
+---
+
+Changed the output to make errors appear more grouped and easier to read

--- a/packages/align-deps/src/commands/check.ts
+++ b/packages/align-deps/src/commands/check.ts
@@ -92,9 +92,7 @@ export function checkPackageManifest(
       inputConfig.manifest = updatedManifest;
       modifyManifest(manifestPath, updatedManifest);
     } else {
-      const violations = stringify(allChanges, [
-        `${manifestPath}: Changes are needed to satisfy all capabilities.`,
-      ]);
+      const violations = stringify(allChanges, [manifestPath]);
       logError(violations);
       return "unsatisfied";
     }

--- a/packages/align-deps/src/diff.ts
+++ b/packages/align-deps/src/diff.ts
@@ -52,33 +52,37 @@ export function stringify(
   allChanges: Partial<Changes>,
   output: string[] = []
 ): string {
-  const prefix = "\t  - ";
-
+  let totalChanges = 0;
   for (const [section, changes] of Object.entries(allChanges)) {
     if (changes.length > 0) {
-      output.push(`\tIn ${section}:`);
+      totalChanges += changes.length;
       for (const change of changes) {
         const { type, dependency } = change;
+        const prefix = `      ├── ${section}["${dependency}"]:`;
         switch (type) {
           case "added":
-            output.push(`${prefix}${dependency} "${change.target}" is missing`);
+            output.push(
+              `${prefix} dependency is missing, expected "${change.target}"`
+            );
             break;
           case "changed":
             output.push(
-              `${prefix}${dependency} "${change.current}" should be "${change.target}"`
+              `${prefix} found "${change.current}", expected "${change.target}"`
             );
             break;
           case "removed":
-            output.push(`${prefix}${dependency} should be removed`);
+            output.push(`${prefix} should be removed`);
             break;
           case "unmanaged":
-            output.push(
-              `${prefix}${dependency} can be managed by '${change.capability}'`
-            );
+            output.push(`${prefix} can be managed by '${change.capability}'`);
             break;
         }
       }
     }
+  }
+
+  if (totalChanges > 0) {
+    output.push("      └── Re-run with '--write' to fix them\n");
   }
 
   return output.join("\n");

--- a/packages/align-deps/src/errors.ts
+++ b/packages/align-deps/src/errors.ts
@@ -43,7 +43,7 @@ export function printError(manifestPath: string, code: ErrorCode): void {
       break;
 
     case "unsatisfied":
-      error(`Re-run with '--write' to fix them.`);
+      // A helpful message should have been printed with the error
       break;
   }
 }

--- a/packages/align-deps/src/findBadPackages.ts
+++ b/packages/align-deps/src/findBadPackages.ts
@@ -13,11 +13,8 @@ export function findBadPackages({
   peerDependencies,
   devDependencies,
 }: PackageManifest): ExcludedPackage[] | undefined {
-  const foundBadPackages = [
-    dependencies,
-    peerDependencies,
-    devDependencies,
-  ].reduce<Set<ExcludedPackage>>((badPackages, deps) => {
+  const badPackages = new Set<ExcludedPackage>();
+  for (const deps of [dependencies, peerDependencies, devDependencies]) {
     if (deps) {
       for (const name of Object.keys(deps)) {
         const info = isBanned(name, deps[name]);
@@ -26,7 +23,6 @@ export function findBadPackages({
         }
       }
     }
-    return badPackages;
-  }, new Set<ExcludedPackage>());
-  return foundBadPackages.size > 0 ? Array.from(foundBadPackages) : undefined;
+  }
+  return badPackages.size > 0 ? Array.from(badPackages) : undefined;
 }

--- a/packages/align-deps/test/check.test.ts
+++ b/packages/align-deps/test/check.test.ts
@@ -236,14 +236,13 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       defaultOptions,
       undefined,
       (message) => {
-        expect(message)
-          .toBe(`package.json: Changes are needed to satisfy all capabilities.
-	In peerDependencies:
-	  - react "18.1.0" is missing
-	  - react-native "^0.70.0" is missing
-	In devDependencies:
-	  - react "18.1.0" is missing
-	  - react-native "^0.70.0" is missing`);
+        expect(message).toBe(`package.json
+      ├── peerDependencies["react"]: dependency is missing, expected "18.1.0"
+      ├── peerDependencies["react-native"]: dependency is missing, expected "^0.70.0"
+      ├── devDependencies["react"]: dependency is missing, expected "18.1.0"
+      ├── devDependencies["react-native"]: dependency is missing, expected "^0.70.0"
+      └── Re-run with '--write' to fix them
+`);
       }
     );
 

--- a/scripts/rnx-align-deps.js
+++ b/scripts/rnx-align-deps.js
@@ -11,5 +11,4 @@ cli({
   ],
   requirements: ["react-native@0.79"],
   write: process.argv.includes("--write"),
-  "exclude-packages": ["@rnx-kit/metro-plugin-typescript"],
 });


### PR DESCRIPTION
### Description

Inspired by https://github.com/microsoft/react-native-macos/pull/2582, made slight changes to the output to make errors appear more grouped and hopefully easier to read:

Before:
```
warn Known bad packages are found in 'packages/babel-preset-metro-react-native/package.json':
        metro-react-native-babel-preset@*: This package was renamed to '@react-native/babel-preset' in react-native 0.73. Replace this package when you're on react-native 0.73 or higher.
info packages/metro-plugin-typescript/package.json was ignored
error packages/react-native-auth/package.json: Changes are needed to satisfy all capabilities.
        In peerDependencies:
          - react "16.11.0 || 16.13.1 || 17.0.1 || 17.0.2 || 18.0.0 || 18.1.0 || 18.2.0 || ^18.2.0 || 18.3.1 || 19.0.0 || 19.1.0" is missing
          - react-native "^0.62.3 || ^0.63.2 || ^0.64.2 || ^0.65.0 || ^0.66.0 || ^0.67.0 || ^0.68.0 || ^0.69.0 || ^0.70.0 || ^0.71.0 || ^0.72.0 || ^0.73.0 || ^0.74.0 || ^0.75.0 || ^0.76.0 || ^0.77.0 || ^0.78.0 || ^0.79.0 || ^0.80.0" is missing
error Re-run with '--write' to fix them.
error packages/test-app/package.json: Changes are needed to satisfy all capabilities.
        In dependencies:
          - react-native "^0.80.0" should be "^0.79.0"
error Re-run with '--write' to fix them.
info Visit https://aka.ms/align-deps for more information about align-deps.
```

After:
```
warn Known bad packages are found in 'packages/babel-preset-metro-react-native/package.json':
        metro-react-native-babel-preset@*: This package was renamed to '@react-native/babel-preset' in react-native 0.73. Replace this package when you're on react-native 0.73 or higher.
info packages/metro-plugin-typescript/package.json was ignored
error packages/react-native-auth/package.json
      ├── peerDependencies["react"]: dependency is missing, expected "16.11.0 || 16.13.1 || 17.0.1 || 17.0.2 || 18.0.0 || 18.1.0 || 18.2.0 || ^18.2.0 || 18.3.1 || 19.0.0 || 19.1.0"
      ├── peerDependencies["react-native"]: dependency is missing, expected "^0.62.3 || ^0.63.2 || ^0.64.2 || ^0.65.0 || ^0.66.0 || ^0.67.0 || ^0.68.0 || ^0.69.0 || ^0.70.0 || ^0.71.0 || ^0.72.0 || ^0.73.0 || ^0.74.0 || ^0.75.0 || ^0.76.0 || ^0.77.0 || ^0.78.0 || ^0.79.0 || ^0.80.0"
      └── Re-run with '--write' to fix them

error packages/test-app/package.json
      ├── dependencies["react-native"]: found "^0.80.0", expected "^0.79.0"
      └── Re-run with '--write' to fix them

info Visit https://aka.ms/align-deps for more information about align-deps.
```

### Test plan

n/a