### PR TITLE
ci(align-deps): fix repository check

### DIFF
--- a/.github/workflows/align-deps.yml
+++ b/.github/workflows/align-deps.yml
@@ -9,7 +9,7 @@ jobs:
   update:
     name: "Update `microsoft/react-native` preset"
     permissions: {}
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.repository == 'microsoft/rnx-kit' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description

Not sure if this is why manually triggering the workflow doesn't work but we'll find out.

### Test plan

n/a