### PR TITLE
ci: use `NODE_AUTH_TOKEN` instead of `NPM_TOKEN`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           # We cannot use the GHA generated tokens because we've disabled
           # creation of pull requests at the org level.
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   website:
     name: "Publish website"
     permissions:


### PR DESCRIPTION
### Description

Use `NODE_AUTH_TOKEN` instead of `NPM_TOKEN` to make sure it gets picked up by `.npmrc`

### Test plan

n/a