### PR TITLE
ci: stop testing `ram-bundle`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -112,10 +112,6 @@ jobs:
         run: |
           yarn nx affected --base origin/${{ github.base_ref }} --target bundle+esbuild
         shell: bash
-      - name: Bundle test apps with RAM bundle format
-        run: |
-          yarn nx affected --base origin/${{ github.base_ref }} --target ram-bundle
-        shell: bash
   build-android-test-app:
     name: "Build Android"
     permissions: {}

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -22,7 +22,6 @@
     "ios": "rnx run-ios --no-packager",
     "lint": "rnx-kit-scripts lint",
     "macos": "rnx run-macos --scheme ReactTestApp --no-packager",
-    "ram-bundle": "rnx ram-bundle",
     "start": "rnx start",
     "test": "rnx test --platform ios --cache false",
     "windows": "rnx run-windows --no-packager --sln windows/SampleCrossApp.sln"


### PR DESCRIPTION
### Description

`ram-bundle` has been deprecated for some time now

### Test plan

CI should pass.