### PR TITLE
fix(web-storage): detect when New Arch is always enabled

### DIFF
--- a/.changeset/tidy-pets-begin.md
+++ b/.changeset/tidy-pets-begin.md
@@ -1,0 +1,5 @@
+---
+"@react-native-webapis/web-storage": patch
+---
+
+Detect when New Architecture is always enabled

--- a/incubator/@react-native-webapis/web-storage/android/build.gradle
+++ b/incubator/@react-native-webapis/web-storage/android/build.gradle
@@ -1,3 +1,4 @@
+import groovy.json.JsonSlurper
 import java.nio.file.Paths
 
 buildscript {
@@ -31,6 +32,12 @@ buildscript {
         return ((major as int) * 1000000) + ((minor as int) * 1000) + ((patch ?: 0) as int)
     }
 
+    ext.readPackageVersion = { packagePath ->
+        def packageJson = file("${packagePath}/package.json")
+        def manifest = new JsonSlurper().parseText(packageJson.text)
+        return parseVersion(manifest.version ?: "0.0.0")
+    }
+
     repositories {
         google()
         mavenCentral()
@@ -47,10 +54,10 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
-def enableNewArchitecture = (project.hasProperty("react.newArchEnabled") &&
-                             project.getProperty("react.newArchEnabled") == "true") ||
-                            (project.hasProperty("newArchEnabled") &&
-                             project.getProperty("newArchEnabled") == "true")
+def reactNativePath = findNodeModulesPath("react-native")
+def enableNewArchitecture = readPackageVersion(reactNativePath) >= 82000 ||
+                            project.findProperty("react.newArchEnabled") == "true" ||
+                            project.findProperty("newArchEnabled") == "true"
 
 if (enableNewArchitecture) {
     apply(plugin: "com.facebook.react")
@@ -58,7 +65,7 @@ if (enableNewArchitecture) {
 
 repositories {
     maven {
-        url = "${findNodeModulesPath('react-native')}/android"
+        url = "${reactNativePath}/android"
     }
 
     google()
@@ -92,6 +99,5 @@ dependencies {
         implementation(["androidx.core", "core-ktx", "1.9.0"].join(":"))
     }
 
-    //noinspection GradleDynamicVersion
-    implementation("com.facebook.react:react-native:+")
+    implementation("com.facebook.react:react-android")
 }


### PR DESCRIPTION
### Description

Detect when New Architecture is always enabled

### Test plan

In RNTA:
```sh
npm run set-react-version nightly
yarn clean && yarn

# Manually patch `node_modules/@react-native-webapis/web-storage/android/build.gradle`

cd example/android/
./gradlew --no-daemon --parallel clean build
```
