### PR TITLE
fix(metro-plugin-duplicates-checker): options should be read-only

### DIFF
--- a/.changeset/icy-crabs-take.md
+++ b/.changeset/icy-crabs-take.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/metro-plugin-duplicates-checker": patch
+---
+
+`ignoredModules` and `bannedModules` options should be able to accept read-only
+arrays

--- a/packages/metro-plugin-duplicates-checker/src/checkForDuplicatePackages.ts
+++ b/packages/metro-plugin-duplicates-checker/src/checkForDuplicatePackages.ts
@@ -8,8 +8,8 @@ import {
 } from "./gatherModules";
 
 export type Options = {
-  ignoredModules?: string[];
-  bannedModules?: string[];
+  ignoredModules?: readonly string[];
+  bannedModules?: readonly string[];
   throwOnError?: boolean;
 };
 


### PR DESCRIPTION
### Description

`ignoredModules` and `bannedModules` options should be able to accept read-only arrays

### Test plan

n/a