### PR TITLE
chore: allow `rnx-cli` to be run without explicitly building it first

### DIFF
--- a/.changeset/nice-planets-lay.md
+++ b/.changeset/nice-planets-lay.md
@@ -1,0 +1,13 @@
+---
+"@rnx-kit/metro-plugin-cyclic-dependencies-detector": patch
+"@rnx-kit/metro-plugin-duplicates-checker": patch
+"@rnx-kit/metro-serializer-esbuild": patch
+"@rnx-kit/metro-plugin-typescript": patch
+"@rnx-kit/third-party-notices": patch
+"@rnx-kit/typescript-service": patch
+"@rnx-kit/metro-serializer": patch
+"@rnx-kit/metro-service": patch
+"@rnx-kit/align-deps": patch
+---
+
+Declare package exports

--- a/packages/align-deps/package.json
+++ b/packages/align-deps/package.json
@@ -17,6 +17,14 @@
   "bin": {
     "rnx-align-deps": "lib/index.js"
   },
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "typescript": "./src/index.ts",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/cli/scripts/rnx.bin
+++ b/packages/cli/scripts/rnx.bin
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# The name of this file must end with `.bin` to be recognized by Yarn as an
+# executable script. See implementation:
+# https://github.com/yarnpkg/berry/blob/%40yarnpkg/core/4.4.3/packages/yarnpkg-core/sources/scriptUtils.ts#L607
+
+if [[ ! -f "../cli/lib/bin/rnx-cli.js" ]]; then
+  echo "@rnx-kit/cli needs to be built..."
+  yarn workspace rnx-kit build-scope @rnx-kit/test-app
+fi
+node ../cli/bin/rnx-cli.cjs $@

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -49,5 +49,7 @@ export const rnxAlignDeps = alignDepsCommand.func;
 export const rnxAlignDepsCommand = alignDepsCommand;
 
 // @rnx-kit/third-party-notices
-export const rnxWriteThirdPartyNotices = writeThirdPartyNoticesCommand.func;
-export const rnxWriteThirdPartyNoticesCommand = writeThirdPartyNoticesCommand;
+export const rnxWriteThirdPartyNotices: typeof writeThirdPartyNoticesCommand.func =
+  writeThirdPartyNoticesCommand.func;
+export const rnxWriteThirdPartyNoticesCommand: typeof writeThirdPartyNoticesCommand =
+  writeThirdPartyNoticesCommand;

--- a/packages/metro-plugin-cyclic-dependencies-detector/package.json
+++ b/packages/metro-plugin-cyclic-dependencies-detector/package.json
@@ -14,6 +14,14 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "typescript": "./src/index.ts",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/metro-plugin-duplicates-checker/package.json
+++ b/packages/metro-plugin-duplicates-checker/package.json
@@ -17,6 +17,14 @@
   "bin": {
     "check-duplicates": "lib/index.js"
   },
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "typescript": "./src/index.ts",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/metro-plugin-typescript/package.json
+++ b/packages/metro-plugin-typescript/package.json
@@ -14,6 +14,14 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "typescript": "./src/index.ts",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -14,6 +14,14 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "typescript": "./src/index.ts",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/metro-serializer/package.json
+++ b/packages/metro-serializer/package.json
@@ -14,6 +14,14 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "typescript": "./src/index.ts",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/metro-service/package.json
+++ b/packages/metro-service/package.json
@@ -14,6 +14,14 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "typescript": "./src/index.ts",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/test-app-macos/package.json
+++ b/packages/test-app-macos/package.json
@@ -4,8 +4,8 @@
   "version": "0.1.0",
   "private": true,
   "bin": {
-    "rnx": "../cli/bin/rnx-cli.cjs",
-    "rnx.reason": "Workaround for Node not being able to find `rnx-cli` because of Yarn virtual packages"
+    "rnx": "../cli/scripts/rnx.bin",
+    "rnx.reason": "Run `rnx-cli` without explicitly building it first"
   },
   "scripts": {
     "build": "rnx align-deps",

--- a/packages/test-app-windows/package.json
+++ b/packages/test-app-windows/package.json
@@ -4,8 +4,8 @@
   "version": "0.1.0",
   "private": true,
   "bin": {
-    "rnx": "../cli/bin/rnx-cli.cjs",
-    "rnx.reason": "Workaround for Node not being able to find `rnx-cli` because of Yarn virtual packages"
+    "rnx": "../cli/scripts/rnx.bin",
+    "rnx.reason": "Run `rnx-cli` without explicitly building it first"
   },
   "scripts": {
     "build": "rnx align-deps",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -4,8 +4,8 @@
   "version": "0.1.0",
   "private": true,
   "bin": {
-    "rnx": "../cli/bin/rnx-cli.cjs",
-    "rnx.reason": "Workaround for Node not being able to find `rnx-cli` because of Yarn virtual packages"
+    "rnx": "../cli/scripts/rnx.bin",
+    "rnx.reason": "Run `rnx-cli` without explicitly building it first"
   },
   "scripts": {
     "android": "rnx run-android --no-packager --appId com.msft.identity.client.sample.local",

--- a/packages/test-app/test/validateSourceMap.mjs
+++ b/packages/test-app/test/validateSourceMap.mjs
@@ -2,8 +2,8 @@
 // @ts-check
 
 import { originalPositionFor, TraceMap } from "@jridgewell/trace-mapping";
-import * as assert from "assert";
-import * as fs from "fs";
+import * as assert from "node:assert";
+import * as fs from "node:fs";
 
 const findInSourceFile = (() => {
   /** @type {Record<string, string[]>} */
@@ -37,17 +37,18 @@ if (!bundlePath || !fs.existsSync(bundlePath)) {
 
   // TODO: This is probably not the best way to validate source maps, but I
   // couldn't find one that was up-to-date and didn't throw false positives.
-  [
+  const cases = [
     { source: "src/App.native.tsx", needle: "function App(" },
     { source: "src/App.native.tsx", needle: "function Button(" },
     { source: "src/App.native.tsx", needle: "function DevMenu(" },
     { source: "src/App.native.tsx", needle: "function Feature(" },
     { source: "src/App.native.tsx", needle: "function Separator(" },
     { source: "src/App.native.tsx", needle: "function useStyles(" },
-  ].forEach(({ source, needle }) => {
+  ];
+  for (const { source, needle } of cases) {
     assert.deepEqual(
       originalPositionFor(tracer, findInSourceFile(bundlePath, needle)),
       { source, name: null, ...findInSourceFile(source, needle) }
     );
-  });
+  }
 }

--- a/packages/third-party-notices/package.json
+++ b/packages/third-party-notices/package.json
@@ -18,6 +18,14 @@
   "bin": {
     "build-tpn": "./lib/build-tpn.js"
   },
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "typescript": "./src/index.ts",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/typescript-service/package.json
+++ b/packages/typescript-service/package.json
@@ -14,6 +14,14 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "typescript": "./src/index.ts",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/scripts/src/commands/format.js
+++ b/scripts/src/commands/format.js
@@ -20,7 +20,7 @@ export class FormatCommand extends Command {
       "--write",
       "--log-level",
       "error",
-      "**/*.{js,json,jsx,md,mjs,ts,tsx,yml}",
+      "**/*.{js,json,jsx,md,mjs,mts,ts,tsx,yml}",
       "!{CODE_OF_CONDUCT,SECURITY}.md",
       "!**/{__fixtures__,lib}/**",
       "!**/CHANGELOG.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5283,8 +5283,8 @@ __metadata:
     react-native-macos: "npm:^0.78.0"
     react-native-test-app: "npm:^4.1.4"
   bin:
-    rnx: ../cli/bin/rnx-cli.cjs
-    rnx.reason: Workaround for Node not being able to find `rnx-cli` because of Yarn virtual packages
+    rnx: ../cli/scripts/rnx.bin
+    rnx.reason: Run `rnx-cli` without explicitly building it first
   languageName: unknown
   linkType: soft
 
@@ -5325,8 +5325,8 @@ __metadata:
     react-native-test-app: "npm:^4.3.1"
     react-native-windows: "npm:^0.79.0"
   bin:
-    rnx: ../cli/bin/rnx-cli.cjs
-    rnx.reason: Workaround for Node not being able to find `rnx-cli` because of Yarn virtual packages
+    rnx: ../cli/scripts/rnx.bin
+    rnx.reason: Run `rnx-cli` without explicitly building it first
   languageName: unknown
   linkType: soft
 
@@ -5372,8 +5372,8 @@ __metadata:
     react-native-test-app: "npm:^4.4.6"
     react-test-renderer: "npm:19.1.0"
   bin:
-    rnx: ../cli/bin/rnx-cli.cjs
-    rnx.reason: Workaround for Node not being able to find `rnx-cli` because of Yarn virtual packages
+    rnx: ../cli/scripts/rnx.bin
+    rnx.reason: Run `rnx-cli` without explicitly building it first
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

Allow `rnx-cli` to be run without explicitly building it first. Note that we don't use `tsx` here because we have external dependencies that depend on built bits.

### Test plan

n/a