### PR TITLE
chore(renovate): ignore archived packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,9 @@
 {
   "extends": ["config:recommended", "schedule:earlyMondays"],
   "addLabels": ["dependencies"],
+  "ignorePaths": [
+    "**/#archived/**",
+  ],
   "packageRules": [
     {
       "groupName": "@react-native-community/cli",
@@ -48,6 +51,7 @@
     {
       "matchPackageNames": [
         "@fluentui/utilities",
+        "@rnx-kit/{/,}**",
         "react",
         "react-dom",
         "react-test-renderer"


### PR DESCRIPTION
### Description

Ignore archived packages when updating dependencies.

Addresses issues like

<img width="509" height="182" alt="image" src="https://github.com/user-attachments/assets/b2b39928-23ed-4315-93e6-1c1df5fe6639" />

and

<img width="814" height="175" alt="image" src="https://github.com/user-attachments/assets/0fd3aaf8-3d6a-4af6-b383-e845500b256e" />

### Test plan

n/a