### PR TITLE
chore(publish): remove npm workaround

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,6 @@ jobs:
         uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@4.4.5
       - name: Install package dependencies
         run: |
-          # `npm pack` fails in pnpm mode when using npm 9+ (bundled with Node 18+)
-          # because of symlinks. See: https://github.com/npm/cli/issues/5007
-          yarn config set nodeLinker node-modules
           yarn
       - name: Build and test packages
         run: |
@@ -40,8 +37,8 @@ jobs:
       - name: Create release PR or publish to npm
         uses: changesets/action@v1
         with:
-          publish: npm run publish:changesets
-          version: npm run version:changesets
+          publish: yarn publish:changesets
+          version: yarn version:changesets
         env:
           # We cannot use the GHA generated tokens because we've disabled
           # creation of pull requests at the org level.


### PR DESCRIPTION
### Description

This should no longer be necessary with all GitHub Actions agents running npm 10.8.2 by default.

See also: https://github.com/npm/cli/commit/6f33d74f310fa27aad30fd00d58d8e4404ef8cb2

### Test plan

n/a