### PR TITLE
ci: reduce build timeout limit

### DIFF
--- a/.github/workflows/align-deps.yml
+++ b/.github/workflows/align-deps.yml
@@ -83,3 +83,4 @@ jobs:
           sign-commits: true
           title: "fix(align-deps): ${{ steps.changeset.outputs.message }}"
           body-path: packages/align-deps/update-profile.output.txt
+    timeout-minutes: 15

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -81,6 +81,7 @@ jobs:
             git diff | yarn suggestion-bot
           fi
           git diff --exit-code
+    timeout-minutes: 60
   build:
     name: "Build"
     permissions: {}
@@ -112,6 +113,7 @@ jobs:
         run: |
           yarn nx affected --base origin/${{ github.base_ref }} --target bundle+esbuild
         shell: bash
+    timeout-minutes: 60
   build-android-test-app:
     name: "Build Android"
     permissions: {}
@@ -144,6 +146,7 @@ jobs:
         run: |
           yarn build:android
         working-directory: packages/test-app
+    timeout-minutes: 60
   build-ios-test-app:
     name: "Build iOS"
     permissions: {}
@@ -185,6 +188,7 @@ jobs:
         run: |
           yarn build:ios | xcbeautify
         working-directory: packages/test-app
+    timeout-minutes: 60
   build-website:
     name: "Build the website"
     permissions: {}
@@ -204,6 +208,7 @@ jobs:
         run: |
           yarn build
         working-directory: docsite
+    timeout-minutes: 60
   label:
     name: "Label"
     permissions:


### PR DESCRIPTION
### Description

Seeing some builds take hours before they time out when our builds usually don't exceed 15 minutes.

### Test plan

n/a