### PR TITLE
fix(eslint-plugin): enable `no-unneeded-ternary`

### DIFF
--- a/.changeset/fast-flowers-arrive.md
+++ b/.changeset/fast-flowers-arrive.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/eslint-plugin": patch
+---
+
+Enabled `no-unneeded-ternary` as a warning in the recommended preset, and as an
+error in the strict preset.

--- a/packages/eslint-plugin/src/configs/recommended.js
+++ b/packages/eslint-plugin/src/configs/recommended.js
@@ -54,6 +54,7 @@ module.exports = [
       ],
       "@typescript-eslint/no-var-requires": "off",
       "no-undef": "off",
+      "no-unneeded-ternary": "warn",
     },
   },
 ];

--- a/packages/eslint-plugin/src/configs/strict.js
+++ b/packages/eslint-plugin/src/configs/strict.js
@@ -19,6 +19,7 @@ module.exports = [
           },
         },
       ],
+      "no-unneeded-ternary": "error",
     },
   },
 ];


### PR DESCRIPTION
### Description

Enabled [`no-unneeded-ternary`](https://eslint.org/docs/latest/rules/no-unneeded-ternary) as a warning in the recommended preset, and as an error in the strict preset.

### Test plan

n/a