### PR TITLE
ci(ios): enable prebuilds for dependencies

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -180,6 +180,7 @@ jobs:
         if: ${{ steps.affected-projects.outputs.ios != '' }}
         env:
           RCT_USE_PREBUILT_RNCORE: 1
+          RCT_USE_RN_DEP: 1
         with:
           project-directory: ios
           working-directory: packages/test-app
@@ -222,6 +223,7 @@ jobs:
         if: ${{ steps.affected-projects.outputs.macos != '' }}
         env:
           RCT_USE_PREBUILT_RNCORE: 1
+          RCT_USE_RN_DEP: 1
         with:
           project-directory: macos
           working-directory: packages/test-app-macos


### PR DESCRIPTION
### Description

Enable prebuilds for dependencies

### Test plan

CI should pass.