### PR TITLE
chore: retire `tsx` usage in tests where possible

### DIFF
--- a/.changeset/some-cats-judge.md
+++ b/.changeset/some-cats-judge.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer": patch
+---
+
+Replaced `semver` dependency

--- a/incubator/build/src/build.ts
+++ b/incubator/build/src/build.ts
@@ -1,12 +1,12 @@
 import { once } from "@rnx-kit/tools-shell/async";
 import ora from "ora";
-import { deleteBranch, pushCurrentChanges } from "./git.js";
+import { deleteBranch, pushCurrentChanges } from "./git.ts";
 import type {
   BuildParams,
   DistributionPlugin,
   Remote,
   RepositoryInfo,
-} from "./types.js";
+} from "./types.ts";
 
 export async function startBuild(
   remote: Remote,

--- a/incubator/build/src/cli.ts
+++ b/incubator/build/src/cli.ts
@@ -2,18 +2,18 @@ import { findPackageDir } from "@rnx-kit/tools-node/package";
 import * as path from "node:path";
 import type { Options } from "yargs";
 import yargs from "yargs";
-import { startBuild } from "./build.js";
+import { startBuild } from "./build.ts";
 import {
   DEPLOYMENT,
   DEVICE_TYPES,
   PLATFORMS,
   USER_CONFIG_FILE,
-} from "./constants.js";
-import { getDistribution } from "./distribution.js";
-import { getRepositoryRoot } from "./git.js";
-import { detectPackageManager } from "./packageManager.js";
-import { getRemoteInfo } from "./remotes.js";
-import type { DeviceType, Platform } from "./types.js";
+} from "./constants.ts";
+import { getDistribution } from "./distribution.ts";
+import { getRepositoryRoot } from "./git.ts";
+import { detectPackageManager } from "./packageManager.ts";
+import { getRemoteInfo } from "./remotes.ts";
+import type { DeviceType, Platform } from "./types.ts";
 
 type RequiredOptionInferenceHelper<T> = Options & {
   choices: readonly T[];

--- a/incubator/build/src/distribution.ts
+++ b/incubator/build/src/distribution.ts
@@ -5,7 +5,7 @@ import type {
   DistributionPlugin,
   JSObject,
   PluginInterface,
-} from "./types.js";
+} from "./types.ts";
 
 type Plugin = [string, JSObject];
 
@@ -32,7 +32,7 @@ function loadPlugin(
     });
   }
 
-  return import("./distribution/local.js");
+  return import("./distribution/local.ts");
 }
 
 export function getDistribution(

--- a/incubator/build/src/distribution/local.ts
+++ b/incubator/build/src/distribution/local.ts
@@ -1,7 +1,7 @@
 import type { Ora } from "ora";
-import { extract } from "../archive.js";
-import * as platforms from "../platforms.js";
-import type { BuildParams, Context, Platform } from "../types.js";
+import { extract } from "../archive.ts";
+import * as platforms from "../platforms.ts";
+import type { BuildParams, Context, Platform } from "../types.ts";
 
 export async function deploy(
   context: Context & BuildParams,

--- a/incubator/build/src/git.ts
+++ b/incubator/build/src/git.ts
@@ -1,5 +1,5 @@
 import { makeCommand, makeCommandSync } from "@rnx-kit/tools-shell/command";
-import { BUILD_ID } from "./constants.js";
+import { BUILD_ID } from "./constants.ts";
 
 const git = makeCommand("git");
 const gitSync = makeCommandSync("git");

--- a/incubator/build/src/index.ts
+++ b/incubator/build/src/index.ts
@@ -1,15 +1,15 @@
-export { startBuild } from "./build.js";
+export { startBuild } from "./build.ts";
 export {
   DEPLOYMENT,
   DEVICE_TYPES,
   PLATFORMS,
   USER_CONFIG_FILE,
-} from "./constants.js";
-export { getDistribution } from "./distribution.js";
-export { getRemoteUrl, getRepositoryRoot, stage } from "./git.js";
-export { detectPackageManager } from "./packageManager.js";
-export { renderQRCode } from "./qrcode.js";
-export { getRemoteInfo } from "./remotes.js";
+} from "./constants.ts";
+export { getDistribution } from "./distribution.ts";
+export { getRemoteUrl, getRepositoryRoot, stage } from "./git.ts";
+export { detectPackageManager } from "./packageManager.ts";
+export { renderQRCode } from "./qrcode.ts";
+export { getRemoteInfo } from "./remotes.ts";
 export type {
   BuildParams,
   Context,
@@ -20,4 +20,4 @@ export type {
   PluginInterface,
   Remote,
   RepositoryInfo,
-} from "./types.js";
+} from "./types.ts";

--- a/incubator/build/src/platforms.ts
+++ b/incubator/build/src/platforms.ts
@@ -1,5 +1,5 @@
 import type { Ora } from "ora";
-import type { BuildParams, Platform } from "./types.js";
+import type { BuildParams, Platform } from "./types.ts";
 
 type PlatformImpl = {
   deploy: (artifact: string, param: BuildParams, spinner: Ora) => Promise<void>;
@@ -8,12 +8,12 @@ type PlatformImpl = {
 export function get(platform: Platform): Promise<PlatformImpl> {
   switch (platform) {
     case "android":
-      return import("./platforms/android.js");
+      return import("./platforms/android.ts");
     case "ios":
-      return import("./platforms/ios.js");
+      return import("./platforms/ios.ts");
     case "macos":
-      return import("./platforms/macos.js");
+      return import("./platforms/macos.ts");
     case "windows":
-      return import("./platforms/windows.js");
+      return import("./platforms/windows.ts");
   }
 }

--- a/incubator/build/src/platforms/android.ts
+++ b/incubator/build/src/platforms/android.ts
@@ -5,7 +5,7 @@ import {
   start,
 } from "@rnx-kit/tools-android";
 import type { Ora } from "ora";
-import type { BuildParams } from "../types.js";
+import type { BuildParams } from "../types.ts";
 
 const ANDROID_HOME = process.env.ANDROID_HOME || "";
 

--- a/incubator/build/src/platforms/ios.ts
+++ b/incubator/build/src/platforms/ios.ts
@@ -10,8 +10,8 @@ import { ensureInstalled } from "@rnx-kit/tools-shell/command";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Ora } from "ora";
-import { untar } from "../archive.js";
-import type { BuildParams } from "../types.js";
+import { untar } from "../archive.ts";
+import type { BuildParams } from "../types.ts";
 
 export async function deploy(
   archive: string,

--- a/incubator/build/src/platforms/macos.ts
+++ b/incubator/build/src/platforms/macos.ts
@@ -1,8 +1,8 @@
 import { open } from "@rnx-kit/tools-apple/macos";
 import * as os from "node:os";
 import type { Ora } from "ora";
-import { untar } from "../archive.js";
-import type { BuildParams } from "../types.js";
+import { untar } from "../archive.ts";
+import type { BuildParams } from "../types.ts";
 
 export async function deploy(
   archive: string,

--- a/incubator/build/src/platforms/windows.ts
+++ b/incubator/build/src/platforms/windows.ts
@@ -1,7 +1,7 @@
 import { install, start } from "@rnx-kit/tools-windows";
 import * as os from "node:os";
 import type { Ora } from "ora";
-import type { BuildParams } from "../types.js";
+import type { BuildParams } from "../types.ts";
 
 export async function deploy(
   app: string,

--- a/incubator/build/src/remotes.ts
+++ b/incubator/build/src/remotes.ts
@@ -1,5 +1,5 @@
-import * as github from "./remotes/github.js";
-import type { Remote, RepositoryInfo } from "./types.js";
+import * as github from "./remotes/github.ts";
+import type { Remote, RepositoryInfo } from "./types.ts";
 
 export function getRemoteInfo(): [Remote, RepositoryInfo] {
   const githubRepo = github.getRepositoryInfo();

--- a/incubator/build/src/remotes/github.ts
+++ b/incubator/build/src/remotes/github.ts
@@ -16,16 +16,16 @@ import {
   MAX_DOWNLOAD_ATTEMPTS,
   USER_CONFIG_FILE,
   WORKFLOW_ID,
-} from "../constants.js";
-import { ensureDir } from "../filesystem.js";
-import { getRemoteUrl, getRepositoryRoot, stage } from "../git.js";
-import { elapsedTime } from "../time.js";
+} from "../constants.ts";
+import { ensureDir } from "../filesystem.ts";
+import { getRemoteUrl, getRepositoryRoot, stage } from "../git.ts";
+import { elapsedTime } from "../time.ts";
 import type {
   BuildParams,
   Context,
   RepositoryInfo,
   UserConfig,
-} from "../types.js";
+} from "../types.ts";
 
 type WorkflowRunId =
   RestEndpointMethodTypes["actions"]["listJobsForWorkflowRun"]["parameters"];

--- a/incubator/build/src/types.ts
+++ b/incubator/build/src/types.ts
@@ -1,10 +1,10 @@
 import type { Ora } from "ora";
-import type { DEPLOYMENT, DEVICE_TYPES, PLATFORMS } from "./constants.js";
+import type { DEPLOYMENT, DEVICE_TYPES, PLATFORMS } from "./constants.ts";
 
 // This type is only used in a comment. JSDoc currently does not support
 // importing types, but we can work around this limitation by importing and
 // re-exporting it: https://github.com/microsoft/TypeScript/issues/43950
-import type { renderQRCode } from "./qrcode.js";
+import type { renderQRCode } from "./qrcode.ts";
 export type { renderQRCode };
 
 export type Deployment = (typeof DEPLOYMENT)[number];

--- a/incubator/build/test/archive.test.ts
+++ b/incubator/build/test/archive.test.ts
@@ -2,7 +2,7 @@ import { deepEqual, equal } from "node:assert/strict";
 import * as fs from "node:fs";
 import { afterEach, describe, it } from "node:test";
 import { URL, fileURLToPath } from "node:url";
-import { extract, untar, unzip } from "../src/archive";
+import { extract, untar, unzip } from "../src/archive.ts";
 
 function fixturePath(artifact: string): string {
   const url = new URL(`__fixtures__/${artifact}`, import.meta.url);

--- a/incubator/build/test/packageManager.test.ts
+++ b/incubator/build/test/packageManager.test.ts
@@ -2,7 +2,7 @@ import { equal, ok } from "node:assert/strict";
 import * as os from "node:os";
 import { afterEach, describe, it } from "node:test";
 import { URL, fileURLToPath } from "node:url";
-import { detectPackageManager } from "../src/packageManager";
+import { detectPackageManager } from "../src/packageManager.ts";
 
 function changeToFixtureDir(fixture: string) {
   const url = new URL(`__fixtures__/${fixture}-project`, import.meta.url);

--- a/incubator/build/test/remotes/github.test.ts
+++ b/incubator/build/test/remotes/github.test.ts
@@ -1,6 +1,6 @@
 import { deepEqual, equal } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { getRepositoryInfo } from "../../src/remotes/github";
+import { getRepositoryInfo } from "../../src/remotes/github.ts";
 
 describe("getRepositoryInfo()", () => {
   const currentInfo = {

--- a/incubator/build/test/time.test.ts
+++ b/incubator/build/test/time.test.ts
@@ -1,6 +1,6 @@
 import { equal } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { elapsedTime } from "../src/time";
+import { elapsedTime } from "../src/time.ts";
 
 describe("elapsedTime()", () => {
   const now = "1970-01-01T00:00:00Z";

--- a/incubator/build/test/version.test.ts
+++ b/incubator/build/test/version.test.ts
@@ -1,6 +1,6 @@
 import { equal } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { latestVersion } from "../src/version";
+import { latestVersion } from "../src/version.ts";
 
 describe("latestVersion()", () => {
   it("returns 0.0.0 if no versions are passed", () => {

--- a/incubator/polyfills/package.json
+++ b/incubator/polyfills/package.json
@@ -14,6 +14,7 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "type": "commonjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/incubator/polyfills/src/dependency.ts
+++ b/incubator/polyfills/src/dependency.ts
@@ -1,8 +1,8 @@
 import { error } from "@rnx-kit/console";
 import { readPackage } from "@rnx-kit/tools-node";
-import * as fs from "fs";
-import * as path from "path";
-import type { Context } from "./types";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { Context } from "./types.ts";
 
 function getDependencies({ projectRoot }: Context): string[] {
   const manifest = readPackage(projectRoot);

--- a/incubator/polyfills/src/index.ts
+++ b/incubator/polyfills/src/index.ts
@@ -2,7 +2,7 @@ import type { ConfigAPI } from "@babel/core";
 import { types as t } from "@babel/core";
 import { declare } from "@babel/helper-plugin-utils";
 import babelTemplate from "@babel/template";
-import { getDependencyPolyfills } from "./dependency";
+import { getDependencyPolyfills } from "./dependency.ts";
 
 module.exports = declare((api: ConfigAPI) => {
   api.assertVersion(7);

--- a/incubator/polyfills/test/index.test.ts
+++ b/incubator/polyfills/test/index.test.ts
@@ -2,6 +2,7 @@ import * as babel from "@babel/core";
 import { deepEqual, equal, fail, match } from "node:assert/strict";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
+import { URL, fileURLToPath } from "node:url";
 
 describe("polyfills", () => {
   const currentWorkingDir = process.cwd();
@@ -10,7 +11,7 @@ describe("polyfills", () => {
   };
 
   function setFixture(): void {
-    process.chdir(path.join(__dirname, "__fixtures__"));
+    process.chdir(fileURLToPath(new URL("__fixtures__", import.meta.url)));
   }
 
   function transform(code: string): string | null | undefined {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "publish:changesets": "changeset publish",
     "rnx-align-deps": "yarn workspace @rnx-kit/align-deps bundle && scripts/rnx-align-deps.js",
     "show-affected": "nx show projects --affected",
-    "test": "nx run-many --targets build,test --output-style stream",
+    "test": "nx run-many --targets build,test",
     "update-readme": "nx run-many --target update-readme",
     "version:changesets": "changeset version && yarn install --mode update-lockfile"
   },

--- a/packages/align-deps/src/cli.ts
+++ b/packages/align-deps/src/cli.ts
@@ -7,8 +7,8 @@ import {
   findWorkspacePackages,
   findWorkspaceRoot,
 } from "@rnx-kit/tools-workspaces";
-import * as fs from "fs";
-import * as path from "path";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { makeCheckCommand } from "./commands/check";
 import { makeExportCatalogsCommand } from "./commands/exportCatalogs";
 import { makeInitializeCommand } from "./commands/initialize";

--- a/packages/align-deps/src/commands/check.ts
+++ b/packages/align-deps/src/commands/check.ts
@@ -1,6 +1,7 @@
 import { error, info } from "@rnx-kit/console";
 import { readPackage } from "@rnx-kit/tools-node/package";
-import * as path from "path";
+import * as nodefs from "node:fs";
+import * as path from "node:path";
 import { migrateConfig } from "../compatibility/config";
 import { loadConfig } from "../config";
 import { diff, stringify } from "../diff";
@@ -40,7 +41,8 @@ export function checkPackageManifest(
   manifestPath: string,
   options: Options,
   inputConfig = loadConfig(manifestPath, options),
-  logError = error
+  logError = error,
+  /** @internal */ fs = nodefs
 ): ErrorCode {
   if (isError(inputConfig)) {
     return inputConfig;
@@ -90,7 +92,7 @@ export function checkPackageManifest(
       // The config object may be passed to other commands, so we need to
       // update it in-place to ensure consistency.
       inputConfig.manifest = updatedManifest;
-      modifyManifest(manifestPath, updatedManifest);
+      modifyManifest(manifestPath, updatedManifest, fs);
     } else {
       const violations = stringify(allChanges, [manifestPath]);
       logError(violations);

--- a/packages/align-deps/src/commands/initialize.ts
+++ b/packages/align-deps/src/commands/initialize.ts
@@ -2,7 +2,7 @@ import type { KitType } from "@rnx-kit/config";
 import { error } from "@rnx-kit/console";
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
 import { readPackage } from "@rnx-kit/tools-node/package";
-import * as path from "path";
+import * as path from "node:path";
 import semverMinVersion from "semver/ranges/min-version";
 import { capabilitiesFor } from "../capabilities";
 import { defaultConfig } from "../config";

--- a/packages/align-deps/src/commands/vigilant.ts
+++ b/packages/align-deps/src/commands/vigilant.ts
@@ -2,7 +2,8 @@ import type { Capability, KitConfig } from "@rnx-kit/config";
 import { error, warn } from "@rnx-kit/console";
 import { keysOf } from "@rnx-kit/tools-language/properties";
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
-import * as path from "path";
+import * as nodefs from "node:fs";
+import * as path from "node:path";
 import semverSubset from "semver/ranges/subset";
 import {
   capabilityProvidedBy,
@@ -291,7 +292,8 @@ export function checkPackageManifestUnconfigured(
   manifestPath: string,
   options: Options,
   config: AlignDepsConfig,
-  logError = error
+  logError = error,
+  /** @internal */ fs = nodefs
 ): ErrorCode {
   const { excludePackages, write } = options;
   if (excludePackages?.includes(config.manifest.name)) {
@@ -315,7 +317,7 @@ export function checkPackageManifestUnconfigured(
 
   if (errorCount > 0) {
     if (write) {
-      modifyManifest(manifestPath, manifest);
+      modifyManifest(manifestPath, manifest, fs);
     } else {
       const violations = stringify(errors, [
         `${manifestPath}: Found ${errorCount} violation(s) outside of capabilities.`,

--- a/packages/align-deps/src/config.ts
+++ b/packages/align-deps/src/config.ts
@@ -3,7 +3,8 @@ import { getKitCapabilities, getKitConfig } from "@rnx-kit/config";
 import { error, warn } from "@rnx-kit/console";
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
 import { readPackage } from "@rnx-kit/tools-node/package";
-import * as path from "path";
+import * as nodefs from "node:fs";
+import * as path from "node:path";
 import { findBadPackages } from "./findBadPackages";
 import type {
   AlignDepsConfig,
@@ -12,7 +13,7 @@ import type {
   Options,
 } from "./types";
 
-type ConfigResult = AlignDepsConfig | LegacyCheckConfig | ErrorCode;
+export type ConfigResult = AlignDepsConfig | LegacyCheckConfig | ErrorCode;
 
 const ILLEGAL_CAPABILITIES = ["__proto__", "constructor", "prototype"];
 
@@ -79,9 +80,10 @@ export function sanitizeCapabilities(
  */
 export function loadConfig(
   manifestPath: string,
-  { excludePackages }: Pick<Options, "excludePackages">
+  { excludePackages }: Pick<Options, "excludePackages">,
+  /** @internal */ fs = nodefs
 ): ConfigResult {
-  const manifest = readPackage(manifestPath);
+  const manifest = readPackage(manifestPath, fs);
   if (!isPackageManifest(manifest)) {
     return "invalid-manifest";
   }

--- a/packages/align-deps/src/helpers.ts
+++ b/packages/align-deps/src/helpers.ts
@@ -1,7 +1,7 @@
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
 import { writePackage } from "@rnx-kit/tools-node/package";
 import detectIndent from "detect-indent";
-import fs from "fs";
+import * as nodefs from "node:fs";
 import semverValidRange from "semver/ranges/valid";
 
 export const dependencySections = [
@@ -57,11 +57,12 @@ export function isString(str: unknown): str is string {
 
 export function modifyManifest(
   pkgPath: string,
-  manifest: PackageManifest
+  manifest: PackageManifest,
+  /** @internal */ fs = nodefs
 ): void {
   const content = fs.readFileSync(pkgPath, { encoding: "utf-8" });
   const indent = detectIndent(content).indent || "  ";
-  writePackage(pkgPath, manifest, indent);
+  writePackage(pkgPath, manifest, indent, fs);
 }
 
 export function omitEmptySections(manifest: PackageManifest): PackageManifest {

--- a/packages/align-deps/test/check.app.test.ts
+++ b/packages/align-deps/test/check.app.test.ts
@@ -1,8 +1,7 @@
-import path from "path";
-import { checkPackageManifest } from "../src/commands/check";
+import * as path from "node:path";
+import { checkPackageManifest as checkPackageManifestActual } from "../src/commands/check";
 import { defaultConfig } from "../src/config";
 
-jest.mock("fs");
 jest.unmock("@rnx-kit/config");
 
 const defaultOptions = {
@@ -14,31 +13,42 @@ const defaultOptions = {
   write: true,
 };
 
+function checkPackageManifest(manifestPath: string) {
+  const fs = require("./__mocks__/fs.js");
+  return checkPackageManifestActual(
+    manifestPath,
+    defaultOptions,
+    undefined,
+    undefined,
+    fs
+  );
+}
+
 function fixturePath(name: string) {
-  return path.join(process.cwd(), "test", "__fixtures__", name);
+  return path.join(__dirname, "__fixtures__", name);
 }
 
 describe("checkPackageManifest({ kitType: 'app' })", () => {
-  test("fails if multiple profiles are returned", () => {
+  it("fails if multiple profiles are returned", () => {
     const manifestPath = path.join(
       fixturePath("misconfigured-app"),
       "package.json"
     );
 
-    const result = checkPackageManifest(manifestPath, defaultOptions);
+    const result = checkPackageManifest(manifestPath);
 
     expect(result).toBe("invalid-app-requirements");
   });
 });
 
 describe("checkPackageManifest({ kitType: 'app' }) (backwards compatibility)", () => {
-  const fs = require("fs");
+  const fs = require("./__mocks__/fs.js");
 
   afterAll(() => {
     jest.clearAllMocks();
   });
 
-  test("adds required dependencies", () => {
+  it("adds required dependencies", () => {
     const manifestPath = path.join(fixturePath("awesome-repo"), "package.json");
 
     let destination = "";
@@ -48,7 +58,7 @@ describe("checkPackageManifest({ kitType: 'app' }) (backwards compatibility)", (
       updatedManifest = content;
     });
 
-    expect(checkPackageManifest(manifestPath, defaultOptions)).toBe("success");
+    expect(checkPackageManifest(manifestPath)).toBe("success");
     expect(destination).toBe(manifestPath);
     expect(updatedManifest).toMatchSnapshot();
   });

--- a/packages/align-deps/test/check.test.ts
+++ b/packages/align-deps/test/check.test.ts
@@ -1,11 +1,11 @@
-import { checkPackageManifest } from "../src/commands/check";
-import { defaultConfig } from "../src/config";
+import { checkPackageManifest as checkPackageManifestActual } from "../src/commands/check";
+import type { ConfigResult } from "../src/config";
+import { defaultConfig, loadConfig } from "../src/config";
 import { profile as profile_0_68 } from "../src/presets/microsoft/react-native/profile-0.68";
 import { profile as profile_0_69 } from "../src/presets/microsoft/react-native/profile-0.69";
 import { profile as profile_0_70 } from "../src/presets/microsoft/react-native/profile-0.70";
+import type { Options } from "../src/types";
 import { packageVersion } from "./helpers";
-
-jest.mock("fs");
 
 const defaultOptions = {
   presets: defaultConfig.presets,
@@ -21,9 +21,25 @@ const writeOptions = {
   write: true,
 };
 
+function checkPackageManifest(
+  manifestPath: string,
+  options: Options = defaultOptions,
+  _inputConfig?: ConfigResult,
+  logError?: (message: string) => void
+) {
+  const fs = require("./__mocks__/fs.js");
+  return checkPackageManifestActual(
+    manifestPath,
+    options,
+    loadConfig(manifestPath, options, fs),
+    logError,
+    fs
+  );
+}
+
 describe("checkPackageManifest({ kitType: 'library' })", () => {
   const rnxKitConfig = require("@rnx-kit/config");
-  const fs = require("fs");
+  const fs = require("./__mocks__/fs.js");
 
   const consoleLogSpy = jest.spyOn(global.console, "log");
   const consoleWarnSpy = jest.spyOn(global.console, "warn");
@@ -59,7 +75,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
   });
 
   test("returns error code when reading invalid manifests", () => {
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
     expect(result).toBe("invalid-manifest");
     expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
@@ -72,7 +88,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       dependencies: { "react-native-linear-gradient": "0.0.0" },
     });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("not-configured");
     expect(consoleLogSpy).not.toHaveBeenCalled();
@@ -95,7 +111,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       alignDeps: { requirements: ["react-native@0.70"] },
     });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("success");
     expect(consoleLogSpy).not.toHaveBeenCalled();
@@ -112,7 +128,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       alignDeps: { requirements: ["react-native@^0.69.0 || ^0.70.0"] },
     });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("success");
     expect(consoleLogSpy).not.toHaveBeenCalled();
@@ -126,7 +142,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       alignDeps: { requirements: ["react-native@0.70"] },
     });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("success");
     expect(consoleLogSpy).not.toHaveBeenCalled();
@@ -153,7 +169,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       },
     });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("success");
     expect(consoleLogSpy).not.toHaveBeenCalled();
@@ -333,7 +349,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       },
     });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("success");
     expect(consoleLogSpy).not.toHaveBeenCalled();
@@ -363,7 +379,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       },
     });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("success");
     expect(consoleLogSpy).not.toHaveBeenCalled();
@@ -393,7 +409,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       },
     });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("success");
     expect(consoleLogSpy).not.toHaveBeenCalled();
@@ -475,7 +491,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
 
 describe("checkPackageManifest({ kitType: 'library' }) (backwards compatibility)", () => {
   const rnxKitConfig = require("@rnx-kit/config");
-  const fs = require("fs");
+  const fs = require("./__mocks__/fs.js");
 
   const mockManifest = {
     name: "@rnx-kit/align-deps",
@@ -504,7 +520,7 @@ describe("checkPackageManifest({ kitType: 'library' }) (backwards compatibility)
   });
 
   test("returns error code when reading invalid manifests", () => {
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
     expect(result).not.toBe("success");
   });
 
@@ -514,7 +530,7 @@ describe("checkPackageManifest({ kitType: 'library' }) (backwards compatibility)
       dependencies: { "react-native-linear-gradient": "0.0.0" },
     });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("not-configured");
   });
@@ -532,7 +548,7 @@ describe("checkPackageManifest({ kitType: 'library' }) (backwards compatibility)
     });
     rnxKitConfig.__setMockConfig({ reactNativeVersion: "0.70.0" });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("success");
   });
@@ -544,7 +560,7 @@ describe("checkPackageManifest({ kitType: 'library' }) (backwards compatibility)
     });
     rnxKitConfig.__setMockConfig({ reactNativeVersion: "^0.69.0 || ^0.70.0" });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("success");
   });
@@ -553,7 +569,7 @@ describe("checkPackageManifest({ kitType: 'library' }) (backwards compatibility)
     fs.__setMockContent(mockManifest);
     rnxKitConfig.__setMockConfig({ reactNativeVersion: "0.70.0" });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("success");
   });
@@ -575,7 +591,7 @@ describe("checkPackageManifest({ kitType: 'library' }) (backwards compatibility)
       capabilities: ["core-ios"],
     });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("success");
   });
@@ -613,7 +629,7 @@ describe("checkPackageManifest({ kitType: 'library' }) (backwards compatibility)
       capabilities: ["core-ios"],
     });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("unsatisfied");
   });
@@ -667,7 +683,7 @@ describe("checkPackageManifest({ kitType: 'library' }) (backwards compatibility)
       capabilities: ["core-ios"],
     });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("success");
   });
@@ -690,7 +706,7 @@ describe("checkPackageManifest({ kitType: 'library' }) (backwards compatibility)
       capabilities: ["core-ios"],
     });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("success");
   });
@@ -713,7 +729,7 @@ describe("checkPackageManifest({ kitType: 'library' }) (backwards compatibility)
       capabilities: ["core-ios"],
     });
 
-    const result = checkPackageManifest("package.json", defaultOptions);
+    const result = checkPackageManifest("package.json");
 
     expect(result).toBe("success");
   });

--- a/packages/align-deps/test/config.test.ts
+++ b/packages/align-deps/test/config.test.ts
@@ -7,8 +7,6 @@ import {
   sanitizeCapabilities,
 } from "../src/config";
 
-jest.mock("@rnx-kit/config");
-
 describe("containsValidPresets()", () => {
   test("is valid when 'presets' is unset", () => {
     expect(containsValidPresets({})).toBe(true);

--- a/packages/align-deps/test/dependencies.test.ts
+++ b/packages/align-deps/test/dependencies.test.ts
@@ -1,6 +1,6 @@
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
 import { readPackage } from "@rnx-kit/tools-node/package";
-import path from "path";
+import * as path from "node:path";
 import { gatherRequirements, visitDependencies } from "../src/dependencies";
 import { profile as profile_0_69 } from "../src/presets/microsoft/react-native/profile-0.69";
 import { profile as profile_0_70 } from "../src/presets/microsoft/react-native/profile-0.70";

--- a/packages/align-deps/test/setVersion.test.ts
+++ b/packages/align-deps/test/setVersion.test.ts
@@ -1,18 +1,22 @@
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
 import prompts from "prompts";
-import { makeSetVersionCommand } from "../src/commands/setVersion";
+import { makeSetVersionCommand as makeSetVersionCommandActual } from "../src/commands/setVersion";
 import { defaultConfig } from "../src/config";
-
-jest.mock("fs");
+import type { Options } from "../src/types";
 
 type Result = {
   didWrite: boolean;
   manifest: Record<string, unknown>;
 };
 
+function makeSetVersionCommand(versions: string | number, options: Options) {
+  const fs = require("./__mocks__/fs.js");
+  return makeSetVersionCommandActual(versions, options, fs);
+}
+
 describe("makeSetVersionCommand()", () => {
   const rnxKitConfig = require("@rnx-kit/config");
-  const fs = require("fs");
+  const fs = require("./__mocks__/fs.js");
 
   function setupMocks(manifest: PackageManifest): Result {
     fs.__setMockContent(manifest);

--- a/packages/align-deps/test/vigilant.test.ts
+++ b/packages/align-deps/test/vigilant.test.ts
@@ -1,12 +1,10 @@
 import {
   buildManifestProfile,
-  checkPackageManifestUnconfigured,
+  checkPackageManifestUnconfigured as checkPackageManifestUnconfiguredActual,
   inspect,
 } from "../src/commands/vigilant";
 import { defaultConfig } from "../src/config";
-import type { AlignDepsConfig } from "../src/types";
-
-jest.mock("fs");
+import type { AlignDepsConfig, Options } from "../src/types";
 
 function makeConfig(
   requirements: AlignDepsConfig["alignDeps"]["requirements"],
@@ -439,7 +437,7 @@ describe("inspect()", () => {
 
 describe("checkPackageManifestUnconfigured()", () => {
   const rnxKitConfig = require("@rnx-kit/config");
-  const fs = require("fs");
+  const fs = require("./__mocks__/fs.js");
 
   const consoleErrorSpy = jest.spyOn(global.console, "error");
 
@@ -451,6 +449,20 @@ describe("checkPackageManifestUnconfigured()", () => {
     verbose: false,
     write: false,
   };
+
+  function checkPackageManifestUnconfigured(
+    manifestPath: string,
+    options: Options = defaultOptions,
+    inputConfig: AlignDepsConfig
+  ) {
+    return checkPackageManifestUnconfiguredActual(
+      manifestPath,
+      options,
+      inputConfig,
+      undefined,
+      fs
+    );
+  }
 
   beforeEach(() => {
     consoleErrorSpy.mockReset();

--- a/packages/bundle-diff/src/cli.ts
+++ b/packages/bundle-diff/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import * as nodefs from "fs";
-import { diff } from "./diff";
+import * as nodefs from "node:fs";
+import { diff } from "./diff.ts";
 
 export function withSign(n: number): string {
   if (Number.isNaN(n)) {

--- a/packages/bundle-diff/src/diff.ts
+++ b/packages/bundle-diff/src/diff.ts
@@ -1,4 +1,4 @@
-import type { BasicSourceMap, SourceDiff } from "./types";
+import type { BasicSourceMap, SourceDiff } from "./types.ts";
 
 export function isValidSourceMap(
   obj: Partial<BasicSourceMap>

--- a/packages/bundle-diff/src/index.ts
+++ b/packages/bundle-diff/src/index.ts
@@ -1,2 +1,2 @@
-export { cli } from "./cli";
-export { diff } from "./diff";
+export { cli } from "./cli.ts";
+export { diff } from "./diff.ts";

--- a/packages/bundle-diff/test/cli.test.ts
+++ b/packages/bundle-diff/test/cli.test.ts
@@ -1,10 +1,19 @@
 import { equal } from "node:assert/strict";
 import type * as nodefs from "node:fs";
+import { createRequire } from "node:module";
 import { describe, it } from "node:test";
-import { cli, numDigits, numDigitsStringLength, withSign } from "../src/cli";
-import { aSourceMap, bSourceMap } from "./mockSourceMaps";
+import { URL } from "node:url";
+import { aSourceMap, bSourceMap } from "./mockSourceMaps.ts";
 
-describe("numDigits()", () => {
+// These needs to be set before we import `../src/cli.ts` because they get read
+// at module initialization time.
+// @ts-expect-error Tests are run in ESM mode where `module` is not defined
+global.module = null;
+global.require = createRequire(new URL("../src/cli.ts", import.meta.url));
+
+describe("numDigits()", async () => {
+  const { numDigits, withSign } = await import("../src/cli.ts");
+
   it("returns number of digits in a number", () => {
     equal(numDigits(1000), 4);
     equal(numDigits(100), 3);
@@ -17,7 +26,9 @@ describe("numDigits()", () => {
   });
 });
 
-describe("withSign()", () => {
+describe("withSign()", async () => {
+  const { withSign } = await import("../src/cli.ts");
+
   it("returns number string with a sign", () => {
     equal(withSign(0), "±0");
     equal(withSign(1), "+1");
@@ -26,7 +37,9 @@ describe("withSign()", () => {
   });
 });
 
-describe("numDigitsStringLength()", () => {
+describe("numDigitsStringLength()", async () => {
+  const { numDigitsStringLength, withSign } = await import("../src/cli.ts");
+
   it("returns number of digits needed to represent a string's length", () => {
     equal(numDigitsStringLength("@rnx/bundle-diff"), 2);
     equal(numDigitsStringLength(""), 1);
@@ -34,7 +47,9 @@ describe("numDigitsStringLength()", () => {
   });
 });
 
-describe("cli()", () => {
+describe("cli()", async () => {
+  const { cli } = await import("../src/cli.ts");
+
   const fsMock = {
     readFileSync: (path: string) => {
       switch (path) {

--- a/packages/bundle-diff/test/diff.test.ts
+++ b/packages/bundle-diff/test/diff.test.ts
@@ -1,7 +1,7 @@
 import { deepEqual, ok } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { diff, isValidSourceMap, makeMap } from "../src/diff";
-import { aSourceMap, bSourceMap } from "./mockSourceMaps";
+import { diff, isValidSourceMap, makeMap } from "../src/diff.ts";
+import { aSourceMap, bSourceMap } from "./mockSourceMaps.ts";
 
 describe("isValidSourceMap()", () => {
   it("returns true when an object resembles a source map", () => {

--- a/packages/commitlint-lite/src/cli.ts
+++ b/packages/commitlint-lite/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { COMMIT_TYPES, MAX_LINE_LENGTH } from "./constants.js";
-import { lint } from "./index.js";
+import { COMMIT_TYPES, MAX_LINE_LENGTH } from "./constants.ts";
+import { lint } from "./index.ts";
 
 const data: Buffer[] = [];
 process.stdin.on("data", (chunk) => data.push(chunk));

--- a/packages/commitlint-lite/src/index.ts
+++ b/packages/commitlint-lite/src/index.ts
@@ -1,5 +1,5 @@
-import { COMMIT_TYPES, MAX_LINE_LENGTH } from "./constants.js";
-import type { Issue } from "./types.js";
+import { COMMIT_TYPES, MAX_LINE_LENGTH } from "./constants.ts";
+import type { Issue } from "./types.ts";
 
 export function lint(message: string): Issue[] {
   if (!message) {

--- a/packages/commitlint-lite/test/index.test.ts
+++ b/packages/commitlint-lite/test/index.test.ts
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { MAX_LINE_LENGTH } from "../src/constants";
-import { lint } from "../src/index";
+import { MAX_LINE_LENGTH } from "../src/constants.ts";
+import { lint } from "../src/index.ts";
 
 describe("Lint commit message", () => {
   it("should fail non-conforming messages", () => {

--- a/packages/config/src/getBundleConfig.ts
+++ b/packages/config/src/getBundleConfig.ts
@@ -1,6 +1,6 @@
 import type { AllPlatforms } from "@rnx-kit/tools-react-native/platform";
-import type { BundleConfig, BundleParameters } from "./bundleConfig";
-import type { KitConfig } from "./kitConfig";
+import type { BundleConfig, BundleParameters } from "./bundleConfig.ts";
+import type { KitConfig } from "./kitConfig.ts";
 
 function failOnUnsupportedProp(
   parameters: BundleParameters,

--- a/packages/config/src/getKitCapabilities.ts
+++ b/packages/config/src/getKitCapabilities.ts
@@ -1,6 +1,6 @@
 import { warn } from "@rnx-kit/console";
 import semver from "semver";
-import type { KitConfig } from "./kitConfig";
+import type { KitConfig } from "./kitConfig.ts";
 
 type RequiredConfig = Required<
   Pick<

--- a/packages/config/src/getKitConfig.ts
+++ b/packages/config/src/getKitConfig.ts
@@ -11,7 +11,7 @@ import {
 import merge from "lodash.merge";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { KitConfig } from "./kitConfig";
+import type { KitConfig } from "./kitConfig.ts";
 
 /**
  * Options for retrieving a kit config. The default is equivalent to passing

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -4,19 +4,19 @@ export type {
   BundlerPlugins,
   HermesOptions,
   TypeScriptValidationOptions,
-} from "./bundleConfig";
+} from "./bundleConfig.ts";
 
-export { getBundleConfig, getPlatformBundleConfig } from "./getBundleConfig";
+export { getBundleConfig, getPlatformBundleConfig } from "./getBundleConfig.ts";
 
-export { getKitCapabilities } from "./getKitCapabilities";
-export type { KitCapabilities } from "./getKitCapabilities";
+export { getKitCapabilities } from "./getKitCapabilities.ts";
+export type { KitCapabilities } from "./getKitCapabilities.ts";
 
 export {
   getKitConfig,
   getKitConfigFromPackageInfo,
   getKitConfigFromPackageManifest,
-} from "./getKitConfig";
-export type { GetKitConfigOptions } from "./getKitConfig";
+} from "./getKitConfig.ts";
+export type { GetKitConfigOptions } from "./getKitConfig.ts";
 
 export type {
   Capability,
@@ -25,6 +25,6 @@ export type {
   KitConfig,
   KitType,
   MetaCapability,
-} from "./kitConfig";
+} from "./kitConfig.ts";
 
-export type { ServerConfig } from "./serverConfig";
+export type { ServerConfig } from "./serverConfig.ts";

--- a/packages/config/src/kitConfig.ts
+++ b/packages/config/src/kitConfig.ts
@@ -1,9 +1,9 @@
-import type { BundleConfig } from "./bundleConfig";
+import type { BundleConfig } from "./bundleConfig.ts";
 import type {
   NoDuplicatesRuleOptions,
   NoWorkspacePackageFromNpmRuleOptions,
-} from "./lint.types";
-import type { ServerConfig } from "./serverConfig";
+} from "./lint.types.ts";
+import type { ServerConfig } from "./serverConfig.ts";
 
 export type MetaCapability = "core/testing";
 

--- a/packages/config/src/serverConfig.ts
+++ b/packages/config/src/serverConfig.ts
@@ -1,4 +1,4 @@
-import type { BundlerPlugins, Plugin } from "./bundleConfig";
+import type { BundlerPlugins, Plugin } from "./bundleConfig.ts";
 
 export type ServerConfig = BundlerPlugins & {
   /**

--- a/packages/config/test/getBundleConfig.test.ts
+++ b/packages/config/test/getBundleConfig.test.ts
@@ -1,11 +1,11 @@
 import { deepEqual, equal, ok, throws } from "node:assert/strict";
 import { describe, it } from "node:test";
-import type { BundleConfig } from "../src/bundleConfig";
+import type { BundleConfig } from "../src/bundleConfig.ts";
 import {
   getBundleConfig,
   getPlatformBundleConfig,
-} from "../src/getBundleConfig";
-import type { KitConfig } from "../src/kitConfig";
+} from "../src/getBundleConfig.ts";
+import type { KitConfig } from "../src/kitConfig.ts";
 
 const kitConfig: KitConfig = {
   bundle: [

--- a/packages/config/test/getKitCapabilities.test.ts
+++ b/packages/config/test/getKitCapabilities.test.ts
@@ -1,6 +1,6 @@
 import { deepEqual, doesNotThrow, equal, throws } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { getKitCapabilities } from "../src/getKitCapabilities";
+import { getKitCapabilities } from "../src/getKitCapabilities.ts";
 
 describe("getKitCapabilities()", () => {
   it("throws when supported React Native versions is invalid", (t) => {

--- a/packages/config/test/getKitConfig.test.ts
+++ b/packages/config/test/getKitConfig.test.ts
@@ -1,8 +1,10 @@
 import { deepEqual, ok } from "node:assert/strict";
-import { afterEach, describe, it } from "node:test";
+import { createRequire } from "node:module";
+import * as path from "node:path";
+import { after, afterEach, before, describe, it } from "node:test";
 import { URL, fileURLToPath } from "node:url";
-import type { GetKitConfigOptions } from "../src/getKitConfig";
-import { getKitConfig } from "../src/getKitConfig";
+import type { GetKitConfigOptions } from "../src/getKitConfig.ts";
+import { getKitConfig } from "../src/getKitConfig.ts";
 
 describe("getKitConfig()", () => {
   const baseConfig = {
@@ -30,7 +32,16 @@ describe("getKitConfig()", () => {
     return { module: fixture, cwd: packagePath(".") };
   }
 
+  before(() => {
+    global.require = createRequire(path.dirname(path.dirname(import.meta.url)));
+  });
+
   afterEach(() => process.chdir(currentWorkingDir));
+
+  after(() => {
+    // @ts-expect-error Tests are run in ESM mode where `require` is not defined
+    global.require = undefined;
+  });
 
   it("returns undefined for an unconfigured package when using the current working directory", () => {
     process.chdir(packagePath("kit-test-unconfigured"));

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -1,4 +1,4 @@
-import { WriteStream } from "tty";
+import { WriteStream } from "node:tty";
 
 type Color = (s: string) => string;
 type Log = typeof console.log;

--- a/packages/console/test/index.test.ts
+++ b/packages/console/test/index.test.ts
@@ -1,6 +1,6 @@
 import { deepEqual, equal } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { error, info, warn } from "../src/index";
+import { error, info, warn } from "../src/index.ts";
 
 describe("console", () => {
   const args = ["string", 0, true];

--- a/packages/esbuild-plugin-import-path-remapper/package.json
+++ b/packages/esbuild-plugin-import-path-remapper/package.json
@@ -14,6 +14,7 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "type": "commonjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rnx-kit",

--- a/packages/esbuild-plugin-import-path-remapper/test/esbuild-plugin-import-path-remapper.test.ts
+++ b/packages/esbuild-plugin-import-path-remapper/test/esbuild-plugin-import-path-remapper.test.ts
@@ -1,7 +1,7 @@
 import esbuild from "esbuild";
 import { doesNotMatch, match } from "node:assert/strict";
 import { describe, it } from "node:test";
-import ImportPathRemapperPlugin from "../src/index";
+import ImportPathRemapperPlugin from "../src/index.ts";
 
 describe("@rnx-kit/esbuild-plugin-import-path-remapper", () => {
   it("remaps main imports from lib to src.", async () => {

--- a/packages/metro-config/test/assetPluginForMonorepos.test.ts
+++ b/packages/metro-config/test/assetPluginForMonorepos.test.ts
@@ -4,9 +4,9 @@ import type Server from "metro/private/Server";
 import { equal } from "node:assert/strict";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, it } from "node:test";
+import assetPlugin from "../src/assetPluginForMonorepos.js";
 
 describe("@rnx-kit/metro-config/assetPluginForMonorepos", () => {
-  const assetPlugin = require("../src/assetPluginForMonorepos");
   const { enhanceMiddleware } = assetPlugin;
 
   const cases = [

--- a/packages/metro-config/test/expoConfig.test.ts
+++ b/packages/metro-config/test/expoConfig.test.ts
@@ -1,7 +1,7 @@
 import type { MetroConfig } from "metro-config";
 import { deepEqual, ok } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { applyExpoWorkarounds, isExpoConfig } from "../src/expoConfig";
+import { applyExpoWorkarounds, isExpoConfig } from "../src/expoConfig.js";
 
 describe("isExpoConfig()", () => {
   it("returns true when it's likely a config comes from Expo", () => {

--- a/packages/metro-config/test/index.test.ts
+++ b/packages/metro-config/test/index.test.ts
@@ -2,14 +2,8 @@ import { deepEqual, equal, fail, match, ok, throws } from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
-import { enhanceMiddleware } from "../src/assetPluginForMonorepos";
-import {
-  defaultWatchFolders,
-  exclusionList,
-  extractUniquePartsFromYarnStoreDir,
-  makeMetroConfig,
-  resolveUniqueModule,
-} from "../src/index";
+import { enhanceMiddleware } from "../src/assetPluginForMonorepos.js";
+import metroConfigModule from "../src/index.js";
 
 const currentWorkingDir = process.cwd();
 
@@ -28,6 +22,8 @@ function setFixture(name: string): void {
 }
 
 describe("defaultWatchFolders()", () => {
+  const { defaultWatchFolders } = metroConfigModule;
+
   afterEach(() => process.chdir(currentWorkingDir));
 
   it("returns an empty list outside a monorepo", () => {
@@ -57,6 +53,8 @@ describe("defaultWatchFolders()", () => {
 });
 
 describe("extractUniquePartsFromYarnStoreDir()", () => {
+  const { extractUniquePartsFromYarnStoreDir } = metroConfigModule;
+
   it("returns version+hash from a versioned path", () => {
     const [pre, unique] = extractUniquePartsFromYarnStoreDir(
       "node_modules/.store/@babel-core-npm-7.27.1-0f1bf48e52"
@@ -86,6 +84,8 @@ describe("extractUniquePartsFromYarnStoreDir()", () => {
 });
 
 describe("resolveUniqueModule()", () => {
+  const { resolveUniqueModule } = metroConfigModule;
+
   afterEach(() => process.chdir(currentWorkingDir));
 
   it("ignores symlinks", () => {
@@ -206,6 +206,8 @@ describe("resolveUniqueModule()", () => {
 });
 
 describe("exclusionList()", () => {
+  const { exclusionList } = metroConfigModule;
+
   afterEach(() => process.chdir(currentWorkingDir));
 
   it("ignores extra copies of react and react-native", () => {
@@ -351,6 +353,8 @@ describe("exclusionList()", () => {
 });
 
 describe("makeMetroConfig()", () => {
+  const { exclusionList, makeMetroConfig } = metroConfigModule;
+
   const projectRoot = path.resolve("../test-app");
 
   it("returns a default Metro config", async () => {

--- a/packages/metro-plugin-cyclic-dependencies-detector/src/detectCycles.ts
+++ b/packages/metro-plugin-cyclic-dependencies-detector/src/detectCycles.ts
@@ -1,7 +1,7 @@
 import { error, warn } from "@rnx-kit/console";
 import { getPackageModuleRefFromModulePath } from "@rnx-kit/tools-node/module";
 import type { ReadOnlyDependencies, ReadOnlyGraph } from "metro";
-import * as path from "path";
+import * as path from "node:path";
 
 export type CyclicDependencies = Record<string, string[]>;
 

--- a/packages/metro-plugin-cyclic-dependencies-detector/src/index.ts
+++ b/packages/metro-plugin-cyclic-dependencies-detector/src/index.ts
@@ -1,9 +1,9 @@
 import type { MetroPlugin } from "@rnx-kit/metro-serializer";
-import type { PluginOptions } from "./detectCycles";
-import { detectCycles } from "./detectCycles";
+import type { PluginOptions } from "./detectCycles.ts";
+import { detectCycles } from "./detectCycles.ts";
 
-export { packageRelativePath } from "./detectCycles";
-export type { PluginOptions } from "./detectCycles";
+export { packageRelativePath } from "./detectCycles.ts";
+export type { PluginOptions } from "./detectCycles.ts";
 
 export function CyclicDependencies(
   pluginOptions: PluginOptions = {}

--- a/packages/metro-plugin-cyclic-dependencies-detector/test/detectCycles.test.ts
+++ b/packages/metro-plugin-cyclic-dependencies-detector/test/detectCycles.test.ts
@@ -1,13 +1,13 @@
 import { deepEqual, equal, throws } from "node:assert/strict";
 import { describe, it } from "node:test";
-import type { CyclicDependencies } from "../src/detectCycles";
-import { detectCycles, traverseDependencies } from "../src/detectCycles";
+import type { CyclicDependencies } from "../src/detectCycles.ts";
+import { detectCycles, traverseDependencies } from "../src/detectCycles.ts";
 import {
   entryPoint,
   graphWithCycles,
   graphWithNoCycles,
   repoRoot,
-} from "./testData";
+} from "./testData.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 function noop() {}

--- a/packages/metro-plugin-duplicates-checker/src/checkForDuplicatePackages.ts
+++ b/packages/metro-plugin-duplicates-checker/src/checkForDuplicatePackages.ts
@@ -2,11 +2,11 @@ import { error, warn } from "@rnx-kit/console";
 import type { ReadOnlyGraph } from "metro";
 import type { MixedSourceMap } from "metro-source-map";
 import * as nodefs from "node:fs";
-import type { ModuleMap } from "./gatherModules";
+import type { ModuleMap } from "./gatherModules.ts";
 import {
   gatherModulesFromGraph,
   gatherModulesFromSourceMap,
-} from "./gatherModules";
+} from "./gatherModules.ts";
 
 export type Options = {
   ignoredModules?: readonly string[];

--- a/packages/metro-plugin-duplicates-checker/src/index.ts
+++ b/packages/metro-plugin-duplicates-checker/src/index.ts
@@ -1,16 +1,16 @@
 import { error } from "@rnx-kit/console";
 import type { MetroPlugin } from "@rnx-kit/metro-serializer";
-import { readFile } from "fs";
 import type { MixedSourceMap } from "metro-source-map";
-import type { Options, Result } from "./checkForDuplicatePackages";
+import { readFile } from "node:fs";
+import type { Options, Result } from "./checkForDuplicatePackages.ts";
 import {
   checkForDuplicateDependencies,
   checkForDuplicatePackages,
   defaultOptions,
-} from "./checkForDuplicatePackages";
+} from "./checkForDuplicatePackages.ts";
 
-export { detectDuplicatePackages } from "./checkForDuplicatePackages";
-export { normalizePath, resolveModule } from "./gatherModules";
+export { detectDuplicatePackages } from "./checkForDuplicatePackages.ts";
+export { normalizePath, resolveModule } from "./gatherModules.ts";
 export { checkForDuplicatePackages };
 export type { Options, Result };
 

--- a/packages/metro-plugin-duplicates-checker/test/checkForDuplicatePackages.test.ts
+++ b/packages/metro-plugin-duplicates-checker/test/checkForDuplicatePackages.test.ts
@@ -1,14 +1,14 @@
 import { deepEqual, equal } from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
-import type { Options } from "../src/checkForDuplicatePackages";
+import type { Options } from "../src/checkForDuplicatePackages.ts";
 import {
   checkForDuplicateDependencies as checkForDuplicateDependenciesActual,
   checkForDuplicatePackages as checkForDuplicatePackagesActual,
   countCopies,
   detectDuplicatePackages,
   printModule,
-} from "../src/checkForDuplicatePackages";
-import * as mockfs from "./__mocks__/fs";
+} from "../src/checkForDuplicatePackages.ts";
+import mockfs from "./__mocks__/fs.js";
 import {
   bundleGraph,
   bundleGraphFS,
@@ -18,7 +18,7 @@ import {
   bundleSourceMapFS,
   bundleSourceMapWithDuplicates,
   bundleSourceMapWithDuplicatesFS,
-} from "./testData";
+} from "./testData.ts";
 
 const defaultOptions: Options = {
   ignoredModules: [],

--- a/packages/metro-plugin-duplicates-checker/test/gatherModules.test.ts
+++ b/packages/metro-plugin-duplicates-checker/test/gatherModules.test.ts
@@ -6,14 +6,14 @@ import {
   gatherModulesFromSources as gatherModulesFromSourcesActual,
   normalizePath,
   resolveModule as resolveModuleActual,
-} from "../src/gatherModules";
-import * as mockfs from "./__mocks__/fs";
+} from "../src/gatherModules.ts";
+import mockfs from "./__mocks__/fs.js";
 import {
   bundleGraph,
   bundleGraphFS,
   bundleSourceMap,
   bundleSourceMapFS,
-} from "./testData";
+} from "./testData.ts";
 
 describe("normalizePath()", () => {
   it("trims Webpack URLs", () => {

--- a/packages/metro-plugin-duplicates-checker/test/testData.ts
+++ b/packages/metro-plugin-duplicates-checker/test/testData.ts
@@ -2,11 +2,11 @@
 
 import type { Graph, Module } from "@rnx-kit/metro-serializer";
 import type { BasicSourceMap } from "metro-source-map";
-import * as path from "node:path";
+import { URL, fileURLToPath } from "node:url";
 
 const mockModule = {} as Module;
 
-export const repoRoot = path.resolve(__dirname, "..", "..", "..");
+export const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
 
 function makeManifest(name, version = "0.0.0") {
   return JSON.stringify({ name, version });

--- a/packages/metro-plugin-typescript/src/projectCache.ts
+++ b/packages/metro-plugin-typescript/src/projectCache.ts
@@ -5,8 +5,8 @@ import {
   Project,
   readConfigFile,
 } from "@rnx-kit/typescript-service";
-import * as fs from "fs";
-import * as path from "path";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import ts from "typescript";
 import { createEnhanceLanguageServiceHost } from "./host";
 import type { ProjectCache, ProjectInfo } from "./types";

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -7,11 +7,16 @@ import type { SerializerConfigT } from "metro-config";
 import type { SerializerOptions } from "metro/private/DeltaBundler/types";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getModulePath, getSideEffects, isImporting, outputOf } from "./module";
-import { absolutizeSourceMap } from "./sourceMap";
-import { assertVersion } from "./version";
+import {
+  getModulePath,
+  getSideEffects,
+  isImporting,
+  outputOf,
+} from "./module.ts";
+import { absolutizeSourceMap } from "./sourceMap.ts";
+import { assertVersion } from "./version.ts";
 
-export { esbuildTransformerConfig } from "./esbuildTransformerConfig";
+export { esbuildTransformerConfig } from "./esbuildTransformerConfig.ts";
 
 export type Options = Pick<
   BuildOptions,

--- a/packages/metro-serializer-esbuild/src/module.ts
+++ b/packages/metro-serializer-esbuild/src/module.ts
@@ -3,7 +3,7 @@ import { findPackage, readPackage } from "@rnx-kit/tools-node/package";
 import type { BuildOptions } from "esbuild";
 import type { Module, ReadOnlyDependencies } from "metro";
 import * as path from "node:path";
-import { generateSourceMappingURL } from "./sourceMap";
+import { generateSourceMappingURL } from "./sourceMap.ts";
 
 export function getModulePath(
   moduleName: string,

--- a/packages/metro-serializer-esbuild/test/index.test.ts
+++ b/packages/metro-serializer-esbuild/test/index.test.ts
@@ -3,8 +3,10 @@ import type { BundleArgs } from "@rnx-kit/metro-service";
 import { bundle, loadMetroConfig } from "@rnx-kit/metro-service";
 import type Bundle from "metro/private/shared/output/bundle";
 import { deepEqual, ok } from "node:assert/strict";
+import { createRequire } from "node:module";
 import * as path from "node:path";
-import { describe, it } from "node:test";
+import { after, before, describe, it } from "node:test";
+import { URL, fileURLToPath } from "node:url";
 
 async function buildBundle(
   args: BundleArgs,
@@ -21,7 +23,16 @@ async function buildBundle(
 }
 
 describe("metro-serializer-esbuild", () => {
-  const root = path.dirname(__dirname);
+  const root = fileURLToPath(new URL("..", import.meta.url));
+
+  before(() => {
+    global.require = createRequire(root);
+  });
+
+  after(() => {
+    // @ts-expect-error Tests are run in ESM mode where `require` is not defined
+    global.require = undefined;
+  });
 
   async function bundle(
     entryFile: string,

--- a/packages/metro-serializer/package.json
+++ b/packages/metro-serializer/package.json
@@ -34,15 +34,13 @@
     "test": "rnx-kit-scripts test"
   },
   "dependencies": {
-    "@rnx-kit/tools-react-native": "^2.3.0",
-    "semver": "^7.0.0"
+    "@rnx-kit/tools-react-native": "^2.3.0"
   },
   "devDependencies": {
     "@rnx-kit/eslint-config": "*",
     "@rnx-kit/scripts": "*",
     "@rnx-kit/tsconfig": "*",
     "@types/node": "^22.0.0",
-    "@types/semver": "^7.0.0",
     "metro": "^0.83.1"
   },
   "engines": {

--- a/packages/metro-serializer/test/index.test.ts
+++ b/packages/metro-serializer/test/index.test.ts
@@ -1,8 +1,8 @@
 import type { Graph, SerializerOptions } from "metro";
 import { deepEqual, equal } from "node:assert/strict";
 import { describe, it } from "node:test";
-import type { CustomSerializerResult, MetroPlugin } from "../src/index";
-import { MetroSerializer as MetroSerializerActual } from "../src/index";
+import type { CustomSerializerResult, MetroPlugin } from "../src/index.ts";
+import { MetroSerializer as MetroSerializerActual } from "../src/index.ts";
 
 function isPromise<T>(obj: T | Promise<T>): obj is Promise<T> {
   return obj && typeof obj === "object" && typeof obj["then"] === "function";

--- a/packages/metro-service/src/asset/android.ts
+++ b/packages/metro-service/src/asset/android.ts
@@ -1,11 +1,11 @@
 // https://github.com/react-native-community/cli/blob/716555851b442a83a1bf5e0db27b6226318c9a69/packages/cli-plugin-metro/src/commands/bundle/getAssetDestPathAndroid.ts
 
-import * as path from "path";
+import * as path from "node:path";
 import {
   getAndroidResourceFolderName,
   getAndroidResourceIdentifier,
-} from "../assets-registry/path-support";
-import type { PackagerAsset, SaveAssetsPlugin } from "./types";
+} from "../assets-registry/path-support.js";
+import type { PackagerAsset, SaveAssetsPlugin } from "./types.ts";
 
 export function getAssetDestPathAndroid(
   asset: PackagerAsset,

--- a/packages/metro-service/src/asset/default.ts
+++ b/packages/metro-service/src/asset/default.ts
@@ -1,5 +1,5 @@
-import path from "path";
-import type { PackagerAsset, SaveAssetsPlugin } from "./types";
+import * as path from "node:path";
+import type { PackagerAsset, SaveAssetsPlugin } from "./types.ts";
 
 export function getAssetDestPath(asset: PackagerAsset, scale: number): string {
   const suffix = scale === 1 ? "" : `@${scale}x`;

--- a/packages/metro-service/src/asset/ios.ts
+++ b/packages/metro-service/src/asset/ios.ts
@@ -2,12 +2,12 @@
 // https://github.com/react-native-community/cli/blob/716555851b442a83a1bf5e0db27b6226318c9a69/packages/cli-plugin-metro/src/commands/bundle/getAssetDestPathIOS.ts
 
 import { error, info } from "@rnx-kit/console";
-import fs from "fs";
-import path from "path";
-import { getAndroidResourceIdentifier } from "../assets-registry/path-support";
-import { getAssetDestPath } from "./default";
-import { filterPlatformAssetScales } from "./filter";
-import type { AssetData, SaveAssetsPlugin } from "./types";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getAndroidResourceIdentifier } from "../assets-registry/path-support.js";
+import { getAssetDestPath } from "./default.ts";
+import { filterPlatformAssetScales } from "./filter.ts";
+import type { AssetData, SaveAssetsPlugin } from "./types.ts";
 
 type ImageSet = {
   basePath: string;

--- a/packages/metro-service/src/asset/saveAssets.ts
+++ b/packages/metro-service/src/asset/saveAssets.ts
@@ -1,9 +1,9 @@
 import { findCommunityCliPluginPath } from "@rnx-kit/tools-react-native/cli";
 import * as path from "node:path";
-import { saveAssetsAndroid } from "./android";
-import { saveAssetsDefault } from "./default";
-import { saveAssetsIOS } from "./ios";
-import type { SaveAssetsPlugin } from "./types";
+import { saveAssetsAndroid } from "./android.ts";
+import { saveAssetsDefault } from "./default.ts";
+import { saveAssetsIOS } from "./ios.ts";
+import type { SaveAssetsPlugin } from "./types.ts";
 
 // Eventually this will be part of the rn config, but we require it on older rn
 // versions for win32 and the cli doesn't allow extra config properties.

--- a/packages/metro-service/src/asset/types.ts
+++ b/packages/metro-service/src/asset/types.ts
@@ -1,5 +1,5 @@
 import type { AssetData } from "metro";
-import type { PackagerAsset } from "../assets-registry/registry";
+import type { PackagerAsset } from "../assets-registry/registry.ts";
 
 export type SaveAssetsPlugin = (
   assets: readonly AssetData[],

--- a/packages/metro-service/src/asset/write.ts
+++ b/packages/metro-service/src/asset/write.ts
@@ -3,8 +3,8 @@
 import { info, warn } from "@rnx-kit/console";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { filterPlatformAssetScales } from "./filter";
-import type { AssetData, SaveAssetsPlugin } from "./types";
+import { filterPlatformAssetScales } from "./filter.ts";
+import type { AssetData, SaveAssetsPlugin } from "./types.ts";
 
 type CopyCallback = (error?: NodeJS.ErrnoException) => void;
 

--- a/packages/metro-service/src/babel.ts
+++ b/packages/metro-service/src/babel.ts
@@ -1,7 +1,7 @@
 import { warn } from "@rnx-kit/console";
-import * as fs from "fs";
 import type { ConfigT } from "metro-config";
-import * as path from "path";
+import * as fs from "node:fs";
+import * as path from "node:path";
 
 export function ensureBabelConfig({ projectRoot }: ConfigT): void {
   // Even though Babel supports more file extensions

--- a/packages/metro-service/src/bundle.ts
+++ b/packages/metro-service/src/bundle.ts
@@ -5,8 +5,8 @@ import { requireModuleFromMetro } from "@rnx-kit/tools-react-native/metro";
 import type { ConfigT } from "metro-config";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { ensureBabelConfig } from "./babel";
-import type { BundleArgs } from "./types";
+import { ensureBabelConfig } from "./babel.ts";
+import type { BundleArgs } from "./types.ts";
 
 export function bundle(
   args: BundleArgs,

--- a/packages/metro-service/src/config.ts
+++ b/packages/metro-service/src/config.ts
@@ -7,8 +7,8 @@ import type {
   Resolution,
   ResolutionContext,
 } from "metro-resolver";
-import * as path from "path";
-import { requireMetroPath } from "./metro";
+import * as path from "node:path";
+import { requireMetroPath } from "./metro.ts";
 
 export type MetroConfigOverrides = {
   config?: string;

--- a/packages/metro-service/src/index.ts
+++ b/packages/metro-service/src/index.ts
@@ -1,8 +1,8 @@
-export { bundle } from "./bundle";
-export { loadMetroConfig } from "./config";
-export type { MetroConfigOverrides } from "./config";
-export { ramBundle } from "./ramBundle";
-export { isDevServerRunning, startServer } from "./server";
-export { makeReporter, makeTerminal } from "./terminal";
-export type { MetroTerminal } from "./terminal";
-export type { BundleArgs } from "./types";
+export { bundle } from "./bundle.ts";
+export { loadMetroConfig } from "./config.ts";
+export type { MetroConfigOverrides } from "./config.ts";
+export { ramBundle } from "./ramBundle.ts";
+export { isDevServerRunning, startServer } from "./server.ts";
+export { makeReporter, makeTerminal } from "./terminal.ts";
+export type { MetroTerminal } from "./terminal.ts";
+export type { BundleArgs } from "./types.ts";

--- a/packages/metro-service/src/ramBundle.ts
+++ b/packages/metro-service/src/ramBundle.ts
@@ -1,9 +1,9 @@
 import { warn } from "@rnx-kit/console";
 import type { ConfigT } from "metro-config";
-import * as path from "path";
-import { bundle } from "./bundle";
-import { requireMetroPath } from "./metro";
-import type { BundleArgs } from "./types";
+import * as path from "node:path";
+import { bundle } from "./bundle.ts";
+import { requireMetroPath } from "./metro.ts";
+import type { BundleArgs } from "./types.ts";
 
 export function ramBundle(args: BundleArgs, config: ConfigT): Promise<void> {
   warn(

--- a/packages/metro-service/src/server.ts
+++ b/packages/metro-service/src/server.ts
@@ -1,7 +1,7 @@
 import { requireModuleFromMetro } from "@rnx-kit/tools-react-native/metro";
 import type { runServer } from "metro";
-import net from "node:net";
-import { ensureBabelConfig } from "./babel";
+import * as net from "node:net";
+import { ensureBabelConfig } from "./babel.ts";
 
 type ServerStatus = "not_running" | "already_running" | "in_use" | "unknown";
 

--- a/packages/metro-service/test/asset/android.test.ts
+++ b/packages/metro-service/test/asset/android.test.ts
@@ -1,8 +1,8 @@
 import { equal, fail, ok } from "node:assert/strict";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { getAssetDestPathAndroid } from "../../src/asset/android";
-import { makeAsset } from "./helper";
+import { getAssetDestPathAndroid } from "../../src/asset/android.ts";
+import { makeAsset } from "./helper.ts";
 
 describe("getAssetDestPathAndroid", () => {
   it("should use the right destination folder", () => {

--- a/packages/metro-service/test/asset/default.test.ts
+++ b/packages/metro-service/test/asset/default.test.ts
@@ -1,8 +1,8 @@
 import { equal } from "node:assert/strict";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { getAssetDestPath } from "../../src/asset/default";
-import { makeAsset } from "./helper";
+import { getAssetDestPath } from "../../src/asset/default.ts";
+import { makeAsset } from "./helper.ts";
 
 describe("getAssetDestPath", () => {
   it("should build correct path", () => {

--- a/packages/metro-service/test/asset/filter.test.ts
+++ b/packages/metro-service/test/asset/filter.test.ts
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { filterPlatformAssetScales } from "../../src/asset/filter";
+import { filterPlatformAssetScales } from "../../src/asset/filter.ts";
 
 describe("filterPlatformAssetScales", () => {
   it("removes everything but 2x and 3x for iOS", () => {

--- a/packages/metro-service/test/asset/helper.ts
+++ b/packages/metro-service/test/asset/helper.ts
@@ -1,4 +1,4 @@
-import type { PackagerAsset } from "../../src/assets-registry/registry";
+import type { PackagerAsset } from "../../src/assets-registry/registry.ts";
 
 type Asset = Pick<PackagerAsset, "name" | "type" | "httpServerLocation">;
 

--- a/packages/react-native-lazy-index/test/experiences.test.ts
+++ b/packages/react-native-lazy-index/test/experiences.test.ts
@@ -1,6 +1,6 @@
 import { deepEqual, ok, throws } from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
-import { getFlightedModule, parseExperiences } from "../src/experiences";
+import { getFlightedModule, parseExperiences } from "../src/experiences.js";
 
 describe("parseExperiences()", () => {
   afterEach(() => {

--- a/packages/react-native-lazy-index/test/index.test.ts
+++ b/packages/react-native-lazy-index/test/index.test.ts
@@ -1,11 +1,14 @@
 import type { BabelFileResult } from "@babel/core";
+import * as babel from "@babel/core";
 import { equal, ok } from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+function fixturePath(fixture: string): string {
+  return fileURLToPath(new URL(`__fixtures__/${fixture}`, import.meta.url));
+}
 
 describe("react-native-lazy-index", () => {
-  const babel = require("@babel/core");
-  const path = require("node:path");
-
   const currentWorkingDir = process.cwd();
 
   const snapshotMyAwesomeApp = `
@@ -42,7 +45,7 @@ AppRegistry.registerComponent("FinalFeature", () => {
     fixture: string | Record<string, string>
   ): BabelFileResult | null {
     if (typeof fixture === "string") {
-      const workingDir = path.join(__dirname, "__fixtures__", fixture);
+      const workingDir = fixturePath(fixture);
       process.chdir(workingDir);
       return babel.transformSync(
         `// @codegen\nmodule.exports = require("../../../src/index")();`,

--- a/packages/template/test/index.test.ts
+++ b/packages/template/test/index.test.ts
@@ -1,7 +1,7 @@
 // this file has a method that tests the FakeMethod from ../src/index.ts
 import { equal } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { fakeMethod } from "../src/index";
+import { fakeMethod } from "../src/index.ts";
 
 describe("FakeMethod", () => {
   it("should return a string", () => {

--- a/packages/third-party-notices/src/cli.ts
+++ b/packages/third-party-notices/src/cli.ts
@@ -1,5 +1,5 @@
 import { error } from "@rnx-kit/console";
-import * as path from "path";
+import * as path from "node:path";
 import * as yargs from "yargs";
 import type { WriteThirdPartyNoticesOptions } from "./types";
 import { writeThirdPartyNotices } from "./write-third-party-notices";

--- a/packages/third-party-notices/src/write-third-party-notices.ts
+++ b/packages/third-party-notices/src/write-third-party-notices.ts
@@ -6,7 +6,7 @@ import {
 } from "@rnx-kit/tools-node/package";
 import * as fs from "fs";
 import type { BasicSourceMap } from "metro-source-map";
-import * as path from "path";
+import * as path from "node:path";
 import { createLicenseJSON } from "./output/json";
 import { createLicenseFileContents } from "./output/text";
 import type {

--- a/packages/third-party-notices/test/licence.test.ts
+++ b/packages/third-party-notices/test/licence.test.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import * as path from "node:path";
 import { createLicenseJSON } from "../src/output/json";
 import { createLicenseFileContents } from "../src/output/text";
 import type { License } from "../src/types";

--- a/packages/third-party-notices/test/normalizePaths.test.ts
+++ b/packages/third-party-notices/test/normalizePaths.test.ts
@@ -1,7 +1,7 @@
 import { normalizePath } from "../src/write-third-party-notices";
 
 // this is different from the one in pathHelper due to this having to test cross platform path normalization.
-import os from "os";
+import * as os from "node:os";
 const absolutePathRoot = os.platform() === "win32" ? "o:/" : "/";
 
 describe("normalizePath", () => {

--- a/packages/third-party-notices/test/parseModule.test.ts
+++ b/packages/third-party-notices/test/parseModule.test.ts
@@ -6,11 +6,13 @@ jest.mock("fs");
 
 const options: WriteThirdPartyNoticesOptions = {
   rootPath: `${absolutePathRoot}src`,
+  sourceMapFile: "",
   json: false,
 };
 
 const optionsWithIgnores: WriteThirdPartyNoticesOptions = {
   rootPath: `${absolutePathRoot}src`,
+  sourceMapFile: "",
   json: false,
   ignoreModules: ["ignoredModule"],
   ignoreScopes: ["@ignoredScope"],

--- a/packages/third-party-notices/test/pathHelper.ts
+++ b/packages/third-party-notices/test/pathHelper.ts
@@ -1,3 +1,3 @@
-import os from "node:os";
+import * as os from "node:os";
 
 export const absolutePathRoot = os.platform() === "win32" ? "o:/" : "/";

--- a/packages/third-party-notices/test/sourceMap.test.ts
+++ b/packages/third-party-notices/test/sourceMap.test.ts
@@ -9,6 +9,7 @@ jest.mock("fs");
 
 const options: WriteThirdPartyNoticesOptions = {
   rootPath: `${absolutePathRoot}src`,
+  sourceMapFile: "",
   json: false,
 };
 

--- a/packages/tools-filesystem/test/ensureDir.test.ts
+++ b/packages/tools-filesystem/test/ensureDir.test.ts
@@ -1,7 +1,7 @@
 import { equal, ok } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { ensureDir, ensureDirForFile } from "../src/index";
-import { mockFS } from "../src/mocks";
+import { ensureDir, ensureDirForFile } from "../src/index.ts";
+import { mockFS } from "../src/mocks.ts";
 
 describe("ensureDir()", () => {
   const DIR_CONTENT = JSON.stringify({ recursive: true, mode: 0o755 });

--- a/packages/tools-filesystem/test/writeTextFile.test.ts
+++ b/packages/tools-filesystem/test/writeTextFile.test.ts
@@ -1,7 +1,7 @@
 import { equal, ok } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { writeJSONFile, writeTextFile } from "../src/index";
-import { mockFS } from "../src/mocks";
+import { writeJSONFile, writeTextFile } from "../src/index.ts";
+import { mockFS } from "../src/mocks.ts";
 
 describe("writeTextFile()", () => {
   const CONTENT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";

--- a/packages/tools-language/src/index.ts
+++ b/packages/tools-language/src/index.ts
@@ -1,1 +1,1 @@
-export { hasProperty, keysOf, pickValues } from "./properties";
+export { hasProperty, keysOf, pickValues } from "./properties.ts";

--- a/packages/tools-language/test/properties.test.ts
+++ b/packages/tools-language/test/properties.test.ts
@@ -1,6 +1,6 @@
 import { deepEqual, equal, ok } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { hasProperty, pickValues } from "../src/properties";
+import { hasProperty, pickValues } from "../src/properties.ts";
 
 describe("Language > Props > pickValues", () => {
   it("returns undefined when no keys are found", () => {

--- a/packages/tools-node/src/index.ts
+++ b/packages/tools-node/src/index.ts
@@ -3,8 +3,8 @@ export {
   isFileModuleRef,
   isPackageModuleRef,
   parseModuleRef,
-} from "./module";
-export type { FileModuleRef, PackageModuleRef } from "./module";
+} from "./module.ts";
+export type { FileModuleRef, PackageModuleRef } from "./module.ts";
 
 export {
   destructureModuleRef,
@@ -15,13 +15,13 @@ export {
   readPackage,
   resolveDependencyChain,
   writePackage,
-} from "./package";
+} from "./package.ts";
 export type {
   DestructuredModuleRef,
   FindPackageDependencyOptions,
   PackageManifest,
   PackagePerson,
   PackageRef,
-} from "./package";
+} from "./package.ts";
 
-export { findUp, normalizePath } from "./path";
+export { findUp, normalizePath } from "./path.ts";

--- a/packages/tools-node/src/module.ts
+++ b/packages/tools-node/src/module.ts
@@ -1,11 +1,11 @@
-import path from "path";
-import type { PackageRef } from "./package";
+import * as path from "node:path";
+import type { PackageRef } from "./package.ts";
 import {
   destructureModuleRef,
   findPackageDir,
   parsePackageRef,
   readPackage,
-} from "./package";
+} from "./package.ts";
 
 /**
  * Module reference relative to a package, such as `react-native` or

--- a/packages/tools-node/src/package.ts
+++ b/packages/tools-node/src/package.ts
@@ -1,6 +1,6 @@
-import * as nodefs from "fs";
-import * as path from "path";
-import { findUp } from "./path";
+import * as nodefs from "node:fs";
+import * as path from "node:path";
+import { findUp } from "./path.ts";
 
 /**
  * Components of a package reference.

--- a/packages/tools-node/src/path.ts
+++ b/packages/tools-node/src/path.ts
@@ -1,5 +1,5 @@
-import * as nodefs from "fs";
-import * as path from "path";
+import * as nodefs from "node:fs";
+import * as path from "node:path";
 
 type FileType = "file" | "directory";
 

--- a/packages/tools-node/test/module.test.ts
+++ b/packages/tools-node/test/module.test.ts
@@ -9,7 +9,7 @@ import {
   isFileModuleRef,
   isPackageModuleRef,
   parseModuleRef,
-} from "../src/module";
+} from "../src/module.ts";
 
 describe("Node > Module", () => {
   const fixtureDir = fileURLToPath(new URL("__fixtures__", import.meta.url));

--- a/packages/tools-node/test/package.test.ts
+++ b/packages/tools-node/test/package.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, before, beforeEach, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
-import type { PackageManifest } from "../src/package";
+import type { PackageManifest } from "../src/package.ts";
 import {
   findPackage,
   findPackageDependencyDir,
@@ -12,7 +12,7 @@ import {
   parsePackageRef,
   readPackage,
   writePackage,
-} from "../src/package";
+} from "../src/package.ts";
 
 describe("Node > Package", () => {
   const fixtureDir = fileURLToPath(new URL("__fixtures__", import.meta.url));

--- a/packages/tools-node/test/path.test.ts
+++ b/packages/tools-node/test/path.test.ts
@@ -1,6 +1,6 @@
 import { equal } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { normalizePath } from "../src/path";
+import { normalizePath } from "../src/path.ts";
 
 describe("Node > Path", () => {
   it("normalizePath() changes all backslashes to forward slashes", () => {

--- a/packages/tools-packages/src/accessors.ts
+++ b/packages/tools-packages/src/accessors.ts
@@ -1,4 +1,4 @@
-import type { GetPackageValue, PackageInfo } from "./types";
+import type { GetPackageValue, PackageInfo } from "./types.ts";
 
 /**
  * Helper function to create a typed accessor function for getting and storing information

--- a/packages/tools-packages/src/index.ts
+++ b/packages/tools-packages/src/index.ts
@@ -1,14 +1,14 @@
 export {
   createPackageValueAccessors,
   createPackageValueLoader,
-} from "./accessors";
+} from "./accessors.ts";
 export {
   findPackageInfo,
   getPackageInfoFromPath,
   getPackageInfoFromWorkspaces,
-} from "./package";
+} from "./package.ts";
 export type {
   GetPackageValue,
   PackageInfo,
   PackageValueAccessors,
-} from "./types";
+} from "./types.ts";

--- a/packages/tools-packages/src/package.ts
+++ b/packages/tools-packages/src/package.ts
@@ -1,7 +1,7 @@
 import { findPackage, readPackage } from "@rnx-kit/tools-node";
 import { getWorkspacesInfoSync } from "@rnx-kit/tools-workspaces";
-import path from "node:path";
-import type { PackageInfo } from "./types";
+import * as path from "node:path";
+import type { PackageInfo } from "./types.ts";
 
 class PackageInfoCache {
   private workspaceInfo;

--- a/packages/tools-packages/test/accessors.test.ts
+++ b/packages/tools-packages/test/accessors.test.ts
@@ -1,10 +1,11 @@
 import { deepEqual } from "node:assert/strict";
-import fs from "node:fs";
-import path from "node:path";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { describe, it } from "node:test";
-import { createPackageValueLoader } from "../src/accessors";
-import { getPackageInfoFromPath, getRootPackageInfo } from "../src/package";
-import type { PackageInfo } from "../src/types";
+import { fileURLToPath } from "node:url";
+import { createPackageValueLoader } from "../src/accessors.ts";
+import { getPackageInfoFromPath, getRootPackageInfo } from "../src/package.ts";
+import type { PackageInfo } from "../src/types.ts";
 
 function loadTsConfig(pkgInfo: PackageInfo) {
   const tsconfigPath = path.join(pkgInfo.root, "tsconfig.json");
@@ -21,7 +22,7 @@ describe("package value loader", () => {
   });
 
   it("returns the value when found", () => {
-    const pkgPath = path.resolve(__dirname, "../package.json");
+    const pkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
     const pkgInfo = getPackageInfoFromPath(pkgPath);
     const value = getTsConfigPath(pkgInfo);
     deepEqual(value, path.join(pkgInfo.root, "tsconfig.json"));

--- a/packages/tools-react-native/src/cache.ts
+++ b/packages/tools-react-native/src/cache.ts
@@ -3,7 +3,7 @@ import { findUp } from "@rnx-kit/tools-node/path";
 import * as crypto from "node:crypto";
 import * as nodefs from "node:fs";
 import * as path from "node:path";
-import { REACT_NATIVE_CONFIG_FILES } from "./context";
+import { REACT_NATIVE_CONFIG_FILES } from "./context.ts";
 
 const HASH_ALGO = "sha256";
 const UTF8 = { encoding: "utf-8" as const };

--- a/packages/tools-react-native/src/cli.ts
+++ b/packages/tools-react-native/src/cli.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs";
-import { resolveFrom } from "./resolve";
+import { resolveFrom } from "./resolve.ts";
 
 export function findCommunityCliPluginPath(
   projectRoot = process.cwd(),

--- a/packages/tools-react-native/src/context.ts
+++ b/packages/tools-react-native/src/context.ts
@@ -12,7 +12,7 @@ import {
   getSavedState,
   loadConfigFromCache,
   saveConfigToCache,
-} from "./cache";
+} from "./cache.ts";
 
 // As of 0.76, `@react-native-community/cli` is no longer a dependency of
 // `react-native`. Consumers have to take a direct dependency on CLI instead.

--- a/packages/tools-react-native/src/index.ts
+++ b/packages/tools-react-native/src/index.ts
@@ -3,12 +3,12 @@ export {
   loadContextAsync,
   readReactNativeConfig,
   resolveCommunityCLI,
-} from "./context";
+} from "./context.ts";
 export {
   findMetroPath,
   getMetroVersion,
   requireModuleFromMetro,
-} from "./metro";
+} from "./metro.ts";
 export {
   expandPlatformExtensions,
   getAvailablePlatforms,
@@ -18,5 +18,5 @@ export {
   platformExtensions,
   platformValues,
   tryParsePlatform,
-} from "./platform";
-export type { AllPlatforms } from "./platform";
+} from "./platform.ts";
+export type { AllPlatforms } from "./platform.ts";

--- a/packages/tools-react-native/src/metro.ts
+++ b/packages/tools-react-native/src/metro.ts
@@ -1,7 +1,7 @@
 import { readPackage } from "@rnx-kit/tools-node/package";
 import type { Module, ReadOnlyGraph, SerializerOptions } from "metro";
-import { findCommunityCliPluginPath } from "./cli";
-import { resolveFrom } from "./resolve";
+import { findCommunityCliPluginPath } from "./cli.ts";
+import { resolveFrom } from "./resolve.ts";
 
 // https://github.com/facebook/metro/blob/v0.83.2/packages/metro-runtime/src/modules/types.js
 type Bundle = {

--- a/packages/tools-react-native/src/platform.ts
+++ b/packages/tools-react-native/src/platform.ts
@@ -1,7 +1,7 @@
 import { findPackageDependencyDir } from "@rnx-kit/tools-node/package";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { readReactNativeConfig } from "./context";
+import { readReactNativeConfig } from "./context.ts";
 
 /**
  * List of supported react-native platforms.

--- a/packages/tools-react-native/test/cache.test.ts
+++ b/packages/tools-react-native/test/cache.test.ts
@@ -7,7 +7,7 @@ import {
   getSavedState,
   loadConfigFromCache,
   saveConfigToCache,
-} from "../src/cache";
+} from "../src/cache.ts";
 
 const config = {
   root: ".",

--- a/packages/tools-react-native/test/fixtures.ts
+++ b/packages/tools-react-native/test/fixtures.ts
@@ -1,0 +1,5 @@
+import { URL, fileURLToPath } from "node:url";
+
+export function fixturePath(name: string): string {
+  return fileURLToPath(new URL(`__fixtures__/${name}`, import.meta.url));
+}

--- a/packages/tools-react-native/test/metro.test.ts
+++ b/packages/tools-react-native/test/metro.test.ts
@@ -1,7 +1,10 @@
 import { ok, throws } from "node:assert/strict";
+import { createRequire } from "node:module";
 import * as path from "node:path";
-import { describe, it } from "node:test";
-import { requireModuleFromMetro } from "../src/metro";
+import { after, before, describe, it } from "node:test";
+import { URL } from "node:url";
+import { requireModuleFromMetro } from "../src/metro.ts";
+import { fixturePath } from "./fixtures.ts";
 
 describe("requireModuleFromMetro", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -11,8 +14,17 @@ describe("requireModuleFromMetro", () => {
     return requireModuleFromMetro("metro-resolver", fromDir).resolve;
   }
 
+  before(() => {
+    global.require = createRequire(new URL("../src/metro.ts", import.meta.url));
+  });
+
+  after(() => {
+    // @ts-expect-error Tests are run in ESM mode where `require` is not defined
+    global.require = undefined;
+  });
+
   it("returns `metro-resolver` installed by `react-native`", () => {
-    const p = path.join(__dirname, "__fixtures__", "metro-resolver-duplicates");
+    const p = fixturePath("metro-resolver-duplicates");
 
     ok(
       getMetroResolver(p)(context, "", null).includes(
@@ -33,7 +45,7 @@ describe("requireModuleFromMetro", () => {
     "returns `metro-resolver` from a central storage",
     { skip: process.platform === "win32" },
     () => {
-      const p = path.join(__dirname, "__fixtures__", "pnpm");
+      const p = fixturePath("pnpm");
 
       ok(
         getMetroResolver(p)(context, "", null).includes(

--- a/packages/tools-react-native/test/platform.test.ts
+++ b/packages/tools-react-native/test/platform.test.ts
@@ -6,7 +6,8 @@ import {
   getAvailablePlatformsUncached,
   parsePlatform,
   platformExtensions,
-} from "../src/platform";
+} from "../src/platform.ts";
+import { fixturePath } from "./fixtures.ts";
 
 describe("React Native > Platform", () => {
   it("expandPlatformExtensions() expands returns all platform extensions", () => {
@@ -31,7 +32,7 @@ describe("React Native > Platform", () => {
   });
 
   it("getAvailablePlatformsUncached() returns available platforms", () => {
-    const fixture = path.join(__dirname, "__fixtures__", "available-platforms");
+    const fixture = fixturePath("available-platforms");
     deepEqual(getAvailablePlatformsUncached(fixture), {
       android: "",
       ios: "",
@@ -43,9 +44,7 @@ describe("React Native > Platform", () => {
 
   it("getAvailablePlatformsUncached() finds package root", () => {
     const fixture = path.join(
-      __dirname,
-      "__fixtures__",
-      "available-platforms",
+      fixturePath("available-platforms"),
       "node_modules"
     );
     deepEqual(getAvailablePlatformsUncached(fixture), {

--- a/packages/tools-workspaces/src/common.ts
+++ b/packages/tools-workspaces/src/common.ts
@@ -85,16 +85,16 @@ export function getImplementation(sentinel: string): Promise<PackageManager> {
     case BUN_LOCKB: // fallthrough — logic defining workspaces config is the same as for npm and yarn
     case PACKAGE_LOCK_JSON: // fallthrough — logic defining workspaces config is the same for npm and yarn
     case YARN_LOCK:
-      return import("./yarn.js");
+      return import("./yarn.ts");
 
     case LERNA_JSON:
-      return import("./lerna.js");
+      return import("./lerna.ts");
 
     case PNPM_WORKSPACE_YAML:
-      return import("./pnpm.js");
+      return import("./pnpm.ts");
 
     case RUSH_JSON:
-      return import("./rush.js");
+      return import("./rush.ts");
   }
 
   throw new Error(

--- a/packages/tools-workspaces/src/index.ts
+++ b/packages/tools-workspaces/src/index.ts
@@ -4,10 +4,10 @@ import {
   findSentinelSync,
   getImplementation,
   getImplementationSync,
-} from "./common";
-import { WorkspacesInfoImpl } from "./info";
-import type { WorkspacesInfo } from "./types";
-export type { WorkspacesInfo } from "./types";
+} from "./common.ts";
+import { WorkspacesInfoImpl } from "./info.ts";
+import type { WorkspacesInfo } from "./types.ts";
+export type { WorkspacesInfo } from "./types.ts";
 
 /**
  * Returns a list of all packages declared under workspaces.

--- a/packages/tools-workspaces/src/info.ts
+++ b/packages/tools-workspaces/src/info.ts
@@ -4,8 +4,8 @@ import {
   findPackages,
   findPackagesSync,
   getImplementationSync,
-} from "./common";
-import type { WorkspacesInfo } from "./types";
+} from "./common.ts";
+import type { WorkspacesInfo } from "./types.ts";
 
 export class WorkspacesInfoImpl implements WorkspacesInfo {
   private root: string;

--- a/packages/tools-workspaces/src/lerna.ts
+++ b/packages/tools-workspaces/src/lerna.ts
@@ -9,7 +9,7 @@ import {
   readJSON,
   readJSONSync,
   WORKSPACE_ROOT_SENTINELS,
-} from "./common";
+} from "./common.ts";
 
 function filterSentinels(): string[] {
   return WORKSPACE_ROOT_SENTINELS.filter((sentinel) => sentinel !== LERNA_JSON);

--- a/packages/tools-workspaces/src/pnpm.ts
+++ b/packages/tools-workspaces/src/pnpm.ts
@@ -3,7 +3,7 @@ import {
   default as readYamlFile,
   sync as readYamlFileSync,
 } from "read-yaml-file";
-import { findPackages, findPackagesSync } from "./common";
+import { findPackages, findPackagesSync } from "./common.ts";
 
 type Workspace = {
   packages?: string[];

--- a/packages/tools-workspaces/src/rush.ts
+++ b/packages/tools-workspaces/src/rush.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { readJSON, readJSONSync } from "./common";
+import { readJSON, readJSONSync } from "./common.ts";
 
 type RushProject = {
   packageName: string;

--- a/packages/tools-workspaces/src/yarn.ts
+++ b/packages/tools-workspaces/src/yarn.ts
@@ -4,7 +4,7 @@ import {
   findPackagesSync,
   readJSON,
   readJSONSync,
-} from "./common";
+} from "./common.ts";
 
 type Manifest = {
   workspaces?: string[] | { packages: string[] };

--- a/packages/tools-workspaces/test/bun.test.ts
+++ b/packages/tools-workspaces/test/bun.test.ts
@@ -1,13 +1,18 @@
 import { equal, match } from "node:assert/strict";
-import { afterEach, describe, it } from "node:test";
-import { findSentinel, findSentinelSync } from "../src/common";
+import { after, afterEach, before, describe, it } from "node:test";
+import { findSentinel, findSentinelSync } from "../src/common.ts";
 import {
   findWorkspacePackages,
   findWorkspacePackagesSync,
   findWorkspaceRoot,
   findWorkspaceRootSync,
-} from "../src/index";
-import { setFixture, unsetFixture } from "./helper";
+} from "../src/index.ts";
+import {
+  defineRequire,
+  setFixture,
+  undefineRequire,
+  unsetFixture,
+} from "./helper.ts";
 
 describe("findSentinel", () => {
   afterEach(() => {
@@ -44,9 +49,13 @@ describe("findWorkspacePackages", () => {
     /__fixtures__[/\\]bun.lock[/\\]packages[/\\]t-800$/,
   ];
 
+  before(defineRequire);
+
   afterEach(() => {
     unsetFixture();
   });
+
+  after(undefineRequire);
 
   it("returns packages for Bun workspaces", async () => {
     setFixture("bun.lock");

--- a/packages/tools-workspaces/test/common.test.ts
+++ b/packages/tools-workspaces/test/common.test.ts
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { findPackages, findPackagesSync } from "../src/common";
+import { findPackages, findPackagesSync } from "../src/common.ts";
 
 describe("findPackages", () => {
   it("returns an empty array when passed no patterns", async () => {

--- a/packages/tools-workspaces/test/helper.ts
+++ b/packages/tools-workspaces/test/helper.ts
@@ -1,13 +1,38 @@
-import * as path from "node:path";
+import { URL, fileURLToPath } from "node:url";
+import * as lerna from "../src/lerna.ts";
+import * as pnpm from "../src/pnpm.ts";
+import * as rush from "../src/rush.ts";
+import * as yarn from "../src/yarn.ts";
 
 const cwd = process.cwd();
 
 export function setFixture(name: string): string {
-  const p = path.join(__dirname, "__fixtures__", name);
+  const p = fileURLToPath(new URL(`__fixtures__/${name}`, import.meta.url));
   process.chdir(p);
   return p;
 }
 
 export function unsetFixture(): void {
   process.chdir(cwd);
+}
+
+export function defineRequire() {
+  // @ts-expect-error Tests are run in ESM mode where `require` is not defined
+  global.require = (spec) => {
+    switch (spec) {
+      case "./lerna":
+        return lerna;
+      case "./pnpm":
+        return pnpm;
+      case "./rush":
+        return rush;
+      case "./yarn":
+        return yarn;
+    }
+  };
+}
+
+export function undefineRequire() {
+  // @ts-expect-error Tests are run in ESM mode where `require` is not defined
+  global.require = undefined;
 }

--- a/packages/tools-workspaces/test/lerna.test.ts
+++ b/packages/tools-workspaces/test/lerna.test.ts
@@ -1,13 +1,18 @@
 import { equal, match } from "node:assert/strict";
-import { afterEach, describe, it } from "node:test";
-import { findSentinel, findSentinelSync } from "../src/common";
+import { after, afterEach, before, describe, it } from "node:test";
+import { findSentinel, findSentinelSync } from "../src/common.ts";
 import {
   findWorkspacePackages,
   findWorkspacePackagesSync,
   findWorkspaceRoot,
   findWorkspaceRootSync,
-} from "../src/index";
-import { setFixture, unsetFixture } from "./helper";
+} from "../src/index.ts";
+import {
+  defineRequire,
+  setFixture,
+  undefineRequire,
+  unsetFixture,
+} from "./helper.ts";
 
 describe("findSentinel", () => {
   afterEach(() => {
@@ -48,9 +53,13 @@ describe("findWorkspacePackages", () => {
     /__fixtures__[/\\]lerna-workspaces[/\\]packages[/\\]t-800$/,
   ];
 
+  before(defineRequire);
+
   afterEach(() => {
     unsetFixture();
   });
+
+  after(undefineRequire);
 
   it("returns packages for Lerna workspaces", async () => {
     setFixture("lerna-packages");

--- a/packages/tools-workspaces/test/npm.test.ts
+++ b/packages/tools-workspaces/test/npm.test.ts
@@ -1,13 +1,18 @@
 import { equal, match } from "node:assert/strict";
-import { afterEach, describe, it } from "node:test";
-import { findSentinel, findSentinelSync } from "../src/common";
+import { after, afterEach, before, describe, it } from "node:test";
+import { findSentinel, findSentinelSync } from "../src/common.ts";
 import {
   findWorkspacePackages,
   findWorkspacePackagesSync,
   findWorkspaceRoot,
   findWorkspaceRootSync,
-} from "../src/index";
-import { setFixture, unsetFixture } from "./helper";
+} from "../src/index.ts";
+import {
+  defineRequire,
+  setFixture,
+  undefineRequire,
+  unsetFixture,
+} from "./helper.ts";
 
 describe("findSentinel", () => {
   afterEach(() => {
@@ -34,9 +39,13 @@ describe("findWorkspacePackages", () => {
     /__fixtures__[/\\]npm[/\\]packages[/\\]t-800$/,
   ];
 
+  before(defineRequire);
+
   afterEach(() => {
     unsetFixture();
   });
+
+  after(undefineRequire);
 
   it("returns packages for npm workspaces", async () => {
     setFixture("npm");

--- a/packages/tools-workspaces/test/pnpm.test.ts
+++ b/packages/tools-workspaces/test/pnpm.test.ts
@@ -1,13 +1,18 @@
 import { equal, match } from "node:assert/strict";
-import { afterEach, describe, it } from "node:test";
-import { findSentinel, findSentinelSync } from "../src/common";
+import { after, afterEach, before, describe, it } from "node:test";
+import { findSentinel, findSentinelSync } from "../src/common.ts";
 import {
   findWorkspacePackages,
   findWorkspacePackagesSync,
   findWorkspaceRoot,
   findWorkspaceRootSync,
-} from "../src/index";
-import { setFixture, unsetFixture } from "./helper";
+} from "../src/index.ts";
+import {
+  defineRequire,
+  setFixture,
+  undefineRequire,
+  unsetFixture,
+} from "./helper.ts";
 
 describe("findSentinel", () => {
   afterEach(() => {
@@ -34,9 +39,13 @@ describe("findWorkspacePackages", () => {
     /__fixtures__[/\\]pnpm[/\\]packages[/\\]t-800$/,
   ];
 
+  before(defineRequire);
+
   afterEach(() => {
     unsetFixture();
   });
+
+  after(undefineRequire);
 
   it("returns packages for pnpm workspaces", async () => {
     setFixture("pnpm");

--- a/packages/tools-workspaces/test/rush.test.ts
+++ b/packages/tools-workspaces/test/rush.test.ts
@@ -1,13 +1,18 @@
 import { equal, match } from "node:assert/strict";
-import { afterEach, describe, it } from "node:test";
-import { findSentinel, findSentinelSync } from "../src/common";
+import { after, afterEach, before, describe, it } from "node:test";
+import { findSentinel, findSentinelSync } from "../src/common.ts";
 import {
   findWorkspacePackages,
   findWorkspacePackagesSync,
   findWorkspaceRoot,
   findWorkspaceRootSync,
-} from "../src/index";
-import { setFixture, unsetFixture } from "./helper";
+} from "../src/index.ts";
+import {
+  defineRequire,
+  setFixture,
+  undefineRequire,
+  unsetFixture,
+} from "./helper.ts";
 
 describe("findSentinel", () => {
   afterEach(() => {
@@ -34,9 +39,13 @@ describe("findWorkspacePackages", () => {
     /__fixtures__[/\\]rush[/\\]packages[/\\]t-800$/,
   ];
 
+  before(defineRequire);
+
   afterEach(() => {
     unsetFixture();
   });
+
+  after(undefineRequire);
 
   it("returns packages for Rush workspaces", async () => {
     setFixture("rush");

--- a/packages/tools-workspaces/test/yarn.test.ts
+++ b/packages/tools-workspaces/test/yarn.test.ts
@@ -1,13 +1,18 @@
 import { equal, match } from "node:assert/strict";
-import { afterEach, describe, it } from "node:test";
-import { findSentinel, findSentinelSync } from "../src/common";
+import { after, afterEach, before, describe, it } from "node:test";
+import { findSentinel, findSentinelSync } from "../src/common.ts";
 import {
   findWorkspacePackages,
   findWorkspacePackagesSync,
   findWorkspaceRoot,
   findWorkspaceRootSync,
-} from "../src/index";
-import { setFixture, unsetFixture } from "./helper";
+} from "../src/index.ts";
+import {
+  defineRequire,
+  setFixture,
+  undefineRequire,
+  unsetFixture,
+} from "./helper.ts";
 
 describe("findSentinel", () => {
   afterEach(() => {
@@ -34,9 +39,13 @@ describe("findWorkspacePackages", () => {
     /__fixtures__[/\\]yarn[/\\]packages[/\\]t-800$/,
   ];
 
+  before(defineRequire);
+
   afterEach(() => {
     unsetFixture();
   });
+
+  after(undefineRequire);
 
   it("returns packages for Yarn workspaces", async () => {
     setFixture("yarn");

--- a/packages/typescript-service/src/cache.ts
+++ b/packages/typescript-service/src/cache.ts
@@ -1,7 +1,7 @@
 import { normalizePath } from "@rnx-kit/tools-node";
-import * as nodefs from "fs";
+import * as nodefs from "node:fs";
 import type ts from "typescript";
-import { VersionedSnapshot } from "./snapshot";
+import { VersionedSnapshot } from "./snapshot.ts";
 
 export class ProjectFileCache {
   private files = new Map<string, VersionedSnapshot>();

--- a/packages/typescript-service/src/config.ts
+++ b/packages/typescript-service/src/config.ts
@@ -1,5 +1,5 @@
 import ts from "typescript";
-import { createDiagnosticWriter } from "./diagnostics";
+import { createDiagnosticWriter } from "./diagnostics.ts";
 
 export function findConfigFile(
   searchPath: string,

--- a/packages/typescript-service/src/diagnostics.ts
+++ b/packages/typescript-service/src/diagnostics.ts
@@ -1,5 +1,5 @@
 import ts from "typescript";
-import { getCanonicalFileName, getNewLine } from "./util";
+import { getCanonicalFileName, getNewLine } from "./util.ts";
 
 export type DiagnosticWriter = {
   format: (diagnostic: ts.Diagnostic) => string;

--- a/packages/typescript-service/src/index.ts
+++ b/packages/typescript-service/src/index.ts
@@ -1,10 +1,10 @@
 // Diagnostics
-export { createDiagnosticWriter } from "./diagnostics";
-export type { DiagnosticWriter } from "./diagnostics";
+export { createDiagnosticWriter } from "./diagnostics.ts";
+export type { DiagnosticWriter } from "./diagnostics.ts";
 
 // Configuration
-export { findConfigFile, readConfigFile } from "./config";
+export { findConfigFile, readConfigFile } from "./config.ts";
 
 // Language services
-export { Project } from "./project";
-export { Service } from "./service";
+export { Project } from "./project.ts";
+export { Service } from "./service.ts";

--- a/packages/typescript-service/src/project.ts
+++ b/packages/typescript-service/src/project.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
-import { ExternalFileCache, ProjectFileCache } from "./cache";
-import type { DiagnosticWriter } from "./diagnostics";
+import { ExternalFileCache, ProjectFileCache } from "./cache.ts";
+import type { DiagnosticWriter } from "./diagnostics.ts";
 
 export class Project {
   private diagnosticWriter: DiagnosticWriter;

--- a/packages/typescript-service/src/service.ts
+++ b/packages/typescript-service/src/service.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
-import { createDiagnosticWriter } from "./diagnostics";
-import { Project } from "./project";
+import { createDiagnosticWriter } from "./diagnostics.ts";
+import { Project } from "./project.ts";
 
 export class Service {
   private documentRegistry;

--- a/packages/typescript-service/src/snapshot.ts
+++ b/packages/typescript-service/src/snapshot.ts
@@ -1,4 +1,4 @@
-import * as nodefs from "fs";
+import * as nodefs from "node:fs";
 import ts from "typescript";
 
 export class VersionedSnapshot {

--- a/packages/typescript-service/test/cache.test.ts
+++ b/packages/typescript-service/test/cache.test.ts
@@ -2,7 +2,7 @@ import { deepEqual, equal, ok } from "node:assert/strict";
 import type * as nodefs from "node:fs";
 import { describe, it } from "node:test";
 import ts from "typescript";
-import { ExternalFileCache, ProjectFileCache } from "../src/cache";
+import { ExternalFileCache, ProjectFileCache } from "../src/cache.ts";
 
 function mockFS(obj: unknown) {
   return obj as typeof nodefs;

--- a/packages/typescript-service/test/config.test.ts
+++ b/packages/typescript-service/test/config.test.ts
@@ -2,7 +2,7 @@ import { deepEqual, equal, ok } from "node:assert/strict";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import ts from "typescript";
-import { findConfigFile, readConfigFile } from "../src/config";
+import { findConfigFile, readConfigFile } from "../src/config.ts";
 
 const fixturePath = path.join(process.cwd(), "test", "__fixtures__");
 

--- a/packages/typescript-service/test/project.test.ts
+++ b/packages/typescript-service/test/project.test.ts
@@ -5,9 +5,9 @@ import * as path from "node:path";
 import type { TestContext } from "node:test";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import ts from "typescript";
-import { findConfigFile, readConfigFile } from "../src/config";
-import type { DiagnosticWriter } from "../src/diagnostics";
-import { Project } from "../src/project";
+import { findConfigFile, readConfigFile } from "../src/config.ts";
+import type { DiagnosticWriter } from "../src/diagnostics.ts";
+import { Project } from "../src/project.ts";
 
 describe("Project", () => {
   const fixturePath = path.join(process.cwd(), "test", "__fixtures__");

--- a/packages/typescript-service/test/service.test.ts
+++ b/packages/typescript-service/test/service.test.ts
@@ -1,8 +1,8 @@
 import { ok } from "node:assert/strict";
 import { describe, it } from "node:test";
 import type ts from "typescript";
-import { Project } from "../src/project";
-import { Service } from "../src/service";
+import { Project } from "../src/project.ts";
+import { Service } from "../src/service.ts";
 
 describe("Service.openProject()", () => {
   it("returns a valid object", () => {

--- a/packages/typescript-service/test/snapshot.test.ts
+++ b/packages/typescript-service/test/snapshot.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import ts from "typescript";
-import { VersionedSnapshot } from "../src/snapshot";
+import { VersionedSnapshot } from "../src/snapshot.ts";
 
 describe("VersionedSnapshot", () => {
   const fixturePath = path.join(process.cwd(), "test", "__fixtures__");

--- a/packages/typescript-service/test/util.test.ts
+++ b/packages/typescript-service/test/util.test.ts
@@ -1,6 +1,6 @@
 import { equal, ok } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { getCanonicalFileName, getNewLine } from "../src/util";
+import { getCanonicalFileName, getNewLine } from "../src/util.ts";
 
 describe("Utility", () => {
   it("getCanonicalFileName() only changes upper/lower-case", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5035,9 +5035,7 @@ __metadata:
     "@rnx-kit/tools-react-native": "npm:^2.3.0"
     "@rnx-kit/tsconfig": "npm:*"
     "@types/node": "npm:^22.0.0"
-    "@types/semver": "npm:^7.0.0"
     metro: "npm:^0.83.1"
-    semver: "npm:^7.0.0"
   languageName: unknown
   linkType: soft
 
@@ -11334,14 +11332,14 @@ __metadata:
   linkType: hard
 
 "jest-pnp-resolver@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "jest-pnp-resolver@npm:1.2.2"
+  version: 1.2.3
+  resolution: "jest-pnp-resolver@npm:1.2.3"
   peerDependencies:
     jest-resolve: "*"
   peerDependenciesMeta:
     jest-resolve:
       optional: true
-  checksum: 10c0/f6ef6193f7f015830aea3a13a4fd9f53a60746bbaa2d56d18af4afd26ed1b527039c466c8d2447f68b149db8a912b9493a727f29b809ff883b8b5daec16e98ce
+  checksum: 10c0/86eec0c78449a2de733a6d3e316d49461af6a858070e113c97f75fb742a48c2396ea94150cbca44159ffd4a959f743a47a8b37a792ef6fdad2cf0a5cba973fac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Retire `tsx` usage in tests where possible.

There are two packages that still require it because of mixed CJS/ESM usage. These packages have a `"type": "commonjs"` field added to their `package.json`.

I also had to partially rewire `align-deps` tests because Jest randomly decided that it will no longer mock `fs`/`node:fs`. 

### Test plan

CI should pass.