### PR TITLE
fix(metro-config): delay calling `getModulesRunBeforeMainModule`

### DIFF
--- a/.changeset/warm-sites-fix.md
+++ b/.changeset/warm-sites-fix.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Delay calling `getModulesRunBeforeMainModule` until necessary

--- a/packages/metro-config/src/expoConfig.js
+++ b/packages/metro-config/src/expoConfig.js
@@ -48,11 +48,11 @@ function applyExpoWorkarounds(config, defaultConfig) {
     config.serializer?.getModulesRunBeforeMainModule;
   if (getModulesRunBeforeMainModule) {
     const core = /Libraries[/\\]Core[/\\]InitializeCore/;
-    const prelude =
-      defaultConfig.serializer?.getModulesRunBeforeMainModule?.("") ?? [];
+    const getDefaultModulesRunBeforeMainModule =
+      defaultConfig.serializer?.getModulesRunBeforeMainModule ?? (() => []);
     // @ts-expect-error Cannot assign to 'getModulesRunBeforeMainModule' because it is a read-only property
     config.serializer.getModulesRunBeforeMainModule = (entryFilePath) => {
-      const modules = prelude.slice();
+      const modules = getDefaultModulesRunBeforeMainModule(entryFilePath);
       for (const m of getModulesRunBeforeMainModule(entryFilePath)) {
         if (!core.test(m)) {
           modules.push(m);

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -5,8 +5,8 @@ const {
   findMetroPath,
   requireModuleFromMetro,
 } = require("@rnx-kit/tools-react-native/metro");
-const fs = require("fs");
-const path = require("path");
+const fs = require("node:fs");
+const path = require("node:path");
 const { applyExpoWorkarounds, isExpoConfig } = require("./expoConfig");
 
 /**
@@ -274,7 +274,7 @@ function exclusionList(additionalExclusions = [], projectRoot = process.cwd()) {
     /[/\\](.*?\.bundle|.*?\.noindex|\.vs|\.vscode|Pods|__tests__)[/\\]/,
 
     // Ignore unrelated file changes
-    /\.(a|apk|appx|bak|bat|binlog|c|cache|cc|class|cpp|cs|dex|dll|env|exe|flat|gz|h|hpp|jar|lock|m|mm|modulemap|o|obj|pch|pdb|plist|pbxproj|sh|so|tflite|tgz|tlog|xcconfig|xcscheme|xcworkspacedata|zip)$/,
+    /\.(a|apk|appx|bak|bat|binlog|c|cache|cc|class|cpp|cs|dex|dll|env|exe|flat|gz|h|hpp|jar|lock|m|mm|modulemap|o|obj|pch|pdb|plist|pbxproj|sh|so|tflite|tgz|tlog|wrn|xcconfig|xcscheme|xcworkspacedata|zip)$/,
 
     ...additionalExclusions,
   ];

--- a/packages/metro-config/test/index.test.ts
+++ b/packages/metro-config/test/index.test.ts
@@ -306,6 +306,7 @@ describe("exclusionList()", () => {
       "project/file.tflite",
       "project/file.tgz",
       "project/file.tlog",
+      "project/file.wrn",
       "project/file.xcconfig",
       "project/file.xcscheme",
       "project/file.xcworkspacedata",


### PR DESCRIPTION
### Description

Delay calling `getModulesRunBeforeMainModule` until necessary.

On Windows, we also want to ignore `.wrn` files generated by MSBuild.

### Test plan

n/a