### PR TITLE
fix(metro-resolver-symlinks): allow `oxc-resolver` to be used with `experimental_retryResolvingFromDisk`

### DIFF
--- a/.changeset/tasty-badgers-reply.md
+++ b/.changeset/tasty-badgers-reply.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Allow `oxc-resolver` to be used with `experimental_retryResolvingFromDisk`

--- a/packages/metro-resolver-symlinks/src/resolvers.ts
+++ b/packages/metro-resolver-symlinks/src/resolvers.ts
@@ -6,9 +6,9 @@ import type { CallResolver, Options } from "./types";
 import { patchMetro, shouldEnableRetryResolvingFromDisk } from "./utils/metro";
 
 export function getResolver(options: Options): CallResolver {
-  if (shouldEnableRetryResolvingFromDisk(options)) {
+  const retryFromDisk = shouldEnableRetryResolvingFromDisk(options);
+  if (retryFromDisk) {
     patchMetro(options);
-    return applyEnhancedResolver;
   }
 
   switch (options.resolver) {
@@ -18,6 +18,6 @@ export function getResolver(options: Options): CallResolver {
       info("Note: Oxc Resolver support is still experimental");
       return applyOxcResolver;
     default:
-      return applyMetroResolver;
+      return retryFromDisk ? applyEnhancedResolver : applyMetroResolver;
   }
 }


### PR DESCRIPTION
### Description

Allow `oxc-resolver` to be used with `experimental_retryResolvingFromDisk`

### Test plan

n/a