### PR TITLE
fix(metro-config): add `react-native-web` support

### DIFF
--- a/.changeset/witty-ghosts-retire.md
+++ b/.changeset/witty-ghosts-retire.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/metro-config": minor
+"@rnx-kit/tools-react-native": patch
+---
+
+Add `react-native-web` support

--- a/packages/metro-config/src/defaultConfig.js
+++ b/packages/metro-config/src/defaultConfig.js
@@ -99,6 +99,11 @@ function outOfTreePlatformResolver(implementations, projectRoot) {
 
   /** @type {(context: ResolutionContext, moduleName: string, platform: string) => Resolution} */
   const platformResolver = (context, moduleName, platform) => {
+    if (platform === "web") {
+      // @ts-expect-error We intentionally modify `preferNativePlatform` to support web
+      context.preferNativePlatform = false;
+    }
+
     /** @type {CustomResolver} */
     let resolve = metroResolver;
     const resolveRequest = context.resolveRequest;
@@ -147,9 +152,10 @@ function resolveMetroConfig(fromDir) {
  * as `@react-native-community/cli` will no longer provide defaults.
  *
  * @param {string} projectRoot
+ * @param {string=} platform
  * @returns {MetroConfig[]}
  */
-function getDefaultConfig(projectRoot) {
+function getDefaultConfig(projectRoot, platform) {
   if (!needsFullConfig(projectRoot)) {
     return [];
   }
@@ -172,6 +178,13 @@ function getDefaultConfig(projectRoot) {
   defaultConfig.serializer.getModulesRunBeforeMainModule = () => {
     return preludeModules;
   };
+
+  if (platform === "web") {
+    defaultConfig.transformer.assetRegistryPath = require.resolve(
+      "react-native-web/dist/modules/AssetRegistry/index.js",
+      { paths: [projectRoot] }
+    );
+  }
 
   return [defaultConfig];
 }

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -10,8 +10,8 @@ const path = require("node:path");
 const { applyExpoWorkarounds, isExpoConfig } = require("./expoConfig");
 
 /**
- * @typedef {import("metro-config").InputConfigT} InputConfigT;
  * @typedef {import("metro-config").MetroConfig} MetroConfig;
+ * @typedef {MetroConfig & { platform?: string; }} InputConfig;
  */
 
 /** Packages that must be resolved to one specific copy. */
@@ -289,10 +289,10 @@ module.exports = {
 
   /**
    * Helper function for configuring Metro.
-   * @param {MetroConfig=} inputConfig
+   * @param {InputConfig=} inputConfig
    * @returns {MetroConfig}
    */
-  makeMetroConfig: (inputConfig = {}) => {
+  makeMetroConfig: ({ platform, ...inputConfig } = {}) => {
     const projectRoot = inputConfig.projectRoot || process.cwd();
 
     const { mergeConfig } = requireModuleFromMetro("metro-config", projectRoot);
@@ -304,9 +304,9 @@ module.exports = {
       inputConfig.resolver &&
       (inputConfig.resolver.blockList || inputConfig.resolver.blacklistRE);
 
-    /** @type {InputConfigT[]} */
+    /** @type {MetroConfig[]} */
     const [defaultConfig, ...configs] = [
-      ...getDefaultConfig(projectRoot),
+      ...getDefaultConfig(projectRoot, platform),
       {
         resolver: {
           resolverMainFields: ["react-native", "browser", "main"],

--- a/packages/tools-react-native/test/__fixtures__/available-platforms/node_modules/react-native-web/package.json
+++ b/packages/tools-react-native/test/__fixtures__/available-platforms/node_modules/react-native-web/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "react-native-web",
+  "version": "0.0.0-dev"
+}

--- a/packages/tools-react-native/test/__fixtures__/available-platforms/package.json
+++ b/packages/tools-react-native/test/__fixtures__/available-platforms/package.json
@@ -7,6 +7,7 @@
     "react-native-codegen": "0.0.0-dev",
     "react-native-macos": "0.0.0-dev",
     "react-native-tvos": "0.0.0-dev",
+    "react-native-web": "0.0.0-dev",
     "react-native-windows": "0.0.0-dev"
   },
   "engines": {

--- a/packages/tools-react-native/test/platform.test.ts
+++ b/packages/tools-react-native/test/platform.test.ts
@@ -37,6 +37,7 @@ describe("React Native > Platform", () => {
       android: "",
       ios: "",
       macos: "react-native-macos",
+      web: "react-native-web",
       win32: "@office-iss/react-native-win32",
       windows: "react-native-windows",
     });
@@ -51,6 +52,7 @@ describe("React Native > Platform", () => {
       android: "",
       ios: "",
       macos: "react-native-macos",
+      web: "react-native-web",
       win32: "@office-iss/react-native-win32",
       windows: "react-native-windows",
     });
@@ -59,6 +61,7 @@ describe("React Native > Platform", () => {
   it("parsePlatform() succeeds for all known platforms", () => {
     equal(parsePlatform("ios"), "ios");
     equal(parsePlatform("android"), "android");
+    equal(parsePlatform("web"), "web");
     equal(parsePlatform("windows"), "windows");
     equal(parsePlatform("win32"), "win32");
     equal(parsePlatform("macos"), "macos");
@@ -72,6 +75,7 @@ describe("React Native > Platform", () => {
     deepEqual(platformExtensions("android"), ["android", "native"]);
     deepEqual(platformExtensions("ios"), ["ios", "native"]);
     deepEqual(platformExtensions("macos"), ["macos", "native"]);
+    deepEqual(platformExtensions("web"), ["web"]);
     deepEqual(platformExtensions("win32"), ["win32", "win", "native"]);
     deepEqual(platformExtensions("windows"), ["windows", "win", "native"]);
   });


### PR DESCRIPTION
### Description

Add `react-native-web` support.

See https://github.com/microsoft/react-native-test-app/issues/812 for context.

### Test plan

n/a