### PR TITLE
fix(metro-serializer-esbuild): don't block on metafile write

### DIFF
--- a/.changeset/moody-terms-appear.md
+++ b/.changeset/moody-terms-appear.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Don't block when writing metafile

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -323,13 +323,23 @@ export function MetroSerializer(
             esbuild
               .analyzeMetafile(metafile, options)
               .then((text) => info(text));
-          }
-          if (typeof buildOptions?.metafile === "string") {
-            fs.writeFileSync(
-              path.join(path.dirname(sourcemapfile), buildOptions.metafile),
-              typeof metafile === "string" ? metafile : JSON.stringify(metafile)
-            );
+          } else {
             info("esbuild bundle size:", result.code.length);
+          }
+
+          if (typeof buildOptions?.metafile === "string") {
+            const outDir = path.dirname(sourcemapfile);
+            const out = path.join(outDir, buildOptions.metafile);
+
+            info("Writing esbuild metafile to:", out);
+
+            const metadata =
+              typeof metafile === "string"
+                ? metafile
+                : JSON.stringify(metafile);
+            fs.writeFile(out, metadata, () => {
+              info("Done writing esbuild metafile");
+            });
           }
         } else {
           info("esbuild bundle size:", result.code.length);


### PR DESCRIPTION
### Description

Don't block when writing metafile

### Test plan

Configure `metafile`:

```diff
diff --git a/packages/test-app/package.json b/packages/test-app/package.json
index 794bc85ea..a21504159 100644
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -128,7 +128,9 @@
         "id": "esbuild",
         "entryFile": "src/index.ts",
         "assetsDest": "dist",
-        "treeShake": true,
+        "treeShake": {
+          "metafile": "metafile.json"
+        },
         "plugins": [
           "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
           [
```

Bundle:

```
% yarn bundle+esbuild --dev false --platform ios
info Bundling ios...
                Welcome to Metro v0.83.2
              Fast - Scalable - Integrated


info esbuild bundle size: 821468
info Writing esbuild metafile to: metafile.json
info Writing bundle output to: dist/main+esbuild.ios.jsbundle
info Writing sourcemap output to: dist/main+esbuild.ios.jsbundle.map
info Done writing esbuild metafile
info Done writing bundle output
info Done writing sourcemap output
```