### PR TITLE
fix(cli): ensure `host` is set when starting dev server

### DIFF
--- a/.changeset/clean-spoons-push.md
+++ b/.changeset/clean-spoons-push.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Ensure `host` is set to `localhost` by default when starting the dev server,
+otherwise it will listen to external connections.

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -58,6 +58,12 @@ export async function rnxStart(
     }
   }
 
+  // CVE-2025-11953: Ensure `host` is set to `localhost` by default, otherwise
+  // it will listen to external connections.
+  if (!args.host) {
+    args.host = "127.0.0.1";
+  }
+
   // load Metro configuration, applying overrides from the command line
   const metroConfig = await loadMetroConfig(ctx, {
     ...args,
@@ -109,7 +115,7 @@ export async function rnxStart(
 
   // create middleware -- a collection of plugins which handle incoming
   // http(s) requests, routing them to static pages or JS functions.
-  const host = args.host?.length ? args.host : "localhost";
+  const host = args.host;
   const devServerUrl = `${scheme}://${host}:${port}`;
   const devServer = createDevServerMiddleware({ host, port, watchFolders });
 


### PR DESCRIPTION
### Description

Ensure `host` is set to `localhost` by default when starting the dev server,
otherwise it will listen to external connections.

### Test plan

Start the dev server in `packages/test-app/`, then run the following command:

```
% lsof -i -P | grep -i "8081"
node      14144 tido   18u  IPv4 0xf937265a3b363f23      0t0  TCP localhost:8081 (LISTEN)
```

- Verify that the address is `localhost:8081` and **not** `*:8081`.
- Verify that the bundle is served: `curl -v 'http://localhost:8081/index.bundle?platform=ios' &> /dev/null`