### PR TITLE
docs(command example): fix missing space

### DIFF
--- a/docsite/docs/guides/_package-run-command.mdx
+++ b/docsite/docs/guides/_package-run-command.mdx
@@ -11,7 +11,7 @@ import CodeBlock from "@theme/CodeBlock";
   </TabItem>
   <TabItem value="npm" label="npm">
     <CodeBlock language="sh">
-      {props.installedScript ? "npx" : "npm run"} {props.args}
+      {props.installedScript ? "npx " : "npm run "} {props.args}
     </CodeBlock>
   </TabItem>
 </Tabs>


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

Hi, I saw there is a missing space on the run command component as you can see below. When copy pasting the space is not included and we can't just copy paste.

So I added the missing space!

Before:
<img width="520" height="348" alt="image" src="https://github.com/user-attachments/assets/d61b9bf4-dbd4-46d2-8165-bff3ec834565" />

After:
<img width="529" height="355" alt="image" src="https://github.com/user-attachments/assets/012ef19b-21ee-4842-8603-a9015078beab" />


<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

It did not resolve any issue

### Test plan

It's just a space so i tried to run the project in local and it worked fine :)
<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
