### PR TITLE
fix(react-native-host): fix community JSC support

### DIFF
--- a/.changeset/cold-colts-add.md
+++ b/.changeset/cold-colts-add.md
@@ -1,0 +1,14 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Fixed community JSC support.
+
+Fix compile error in `ReactNativeHost.mm` when Hermes is not being used.
+`fatal error: 'ReactCommon/RCTHermesInstance.h' file not found`
+
+The `USE_HERMES` preprocessor definition was only being set in
+`GCC_PREPROCESSOR_DEFINITIONS` (for C and Objective-C files), but NOT in
+`CPP_PREPROCESSOR_DEFINITIONS` (for [Objective] C++) files. This caused
+`ReactNativeHost.mm` to NOT receive the `USE_HERMES=0` flag, making it
+incorrectly import Hermes symbols that aren't resolved at link time.

--- a/packages/react-native-host/ReactNativeHost.podspec
+++ b/packages/react-native-host/ReactNativeHost.podspec
@@ -10,8 +10,10 @@ repo_dir = repository['directory']
 
 new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 preprocessor_definitions = [
-  '$(inherit)',
+  '$(inherited)',
   "USE_HERMES=#{ENV['USE_HERMES'] || '0'}",
+  "USE_THIRD_PARTY_JSC=#{ENV['USE_THIRD_PARTY_JSC'] || '0'}",
+  "USE_V8=#{ENV['USE_V8'] || '0'}",
 ]
 if new_arch_enabled
   preprocessor_definitions << 'RCT_NEW_ARCH_ENABLED=1'
@@ -49,6 +51,7 @@ Pod::Spec.new do |s|
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20',
     'DEFINES_MODULE' => 'YES',
     'GCC_PREPROCESSOR_DEFINITIONS' => preprocessor_definitions,
+    'CPP_PREPROCESSOR_DEFINITIONS' => preprocessor_definitions,
     'HEADER_SEARCH_PATHS' => [
       '$(PODS_ROOT)/Headers/Private/React-Core',
       '$(PODS_CONFIGURATION_BUILD_DIR)/React-RuntimeApple/React_RuntimeApple.framework/Headers',

--- a/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
+++ b/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
@@ -8,9 +8,13 @@
 
 #if USE_HERMES
 #import <ReactCommon/RCTHermesInstance.h>
+#elif USE_V8
+#import <v8runtime/V8ExecutorFactory.h>
+#elif __has_include(<React-jsc/RCTJscInstance.h>)
+#import <React-jsc/RCTJscInstance.h>
 #else
-#import <ReactCommon/RCTJscInstance.h>
-#endif  // USE_HERMES
+#import <ReactCommon/RCTJscInstance.h>  // RN pre 0.80
+#endif                                  // USE_HERMES
 
 #ifdef USE_REACT_NATIVE_CONFIG
 #import <react/config/ReactNativeConfig.h>

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -296,9 +296,11 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 #else
       return std::make_shared<facebook::react::RCTHermesInstance>(nullptr, false);
 #endif  // USE_REACT_NATIVE_CONFIG
-#else   // USE_HERMES
+#elif USE_V8
+      return std::make_shared<facebook::react::V8ExecutorFactory>();
+#else
       return std::make_shared<facebook::react::RCTJscInstance>();
-#endif  // USE_HERMES
+#endif
     };
 
     __weak __typeof(self) weakSelf = self;


### PR DESCRIPTION

### Description

Fix compile error in `ReactNativeHost.mm` when Hermes is not being used. `fatal error: 'ReactCommon/RCTHermesInstance.h' file not found`

The `USE_HERMES` preprocessor definition was only being set in `GCC_PREPROCESSOR_DEFINITIONS` (for C and Objective-C files), but NOT in `CPP_PREPROCESSOR_DEFINITIONS` (for [Objective] C++) files. This caused `ReactNativeHost.mm` to NOT receive the `USE_HERMES=0` flag, making it incorrectly import Hermes symbols that aren't resolved at link time.

Supersedes #3845.

### Test plan

See #3845.