### PR TITLE
fix(metro-config): fix crash when `react-native-web` is installed

### DIFF
--- a/.changeset/lazy-laws-eat.md
+++ b/.changeset/lazy-laws-eat.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Fixed crash when `react-native-web` is installed

--- a/packages/metro-config/src/defaultConfig.js
+++ b/packages/metro-config/src/defaultConfig.js
@@ -25,18 +25,23 @@ function getPreludeModules(availablePlatforms, projectRoot) {
   const requireOptions = { paths: [projectRoot] };
   const mainModules = new Set([
     require.resolve(
-      "react-native/Libraries/Core/InitializeCore",
+      "react-native/Libraries/Core/InitializeCore.js",
       requireOptions
     ),
   ]);
   for (const moduleName of Object.values(availablePlatforms)) {
     if (moduleName) {
-      mainModules.add(
-        require.resolve(
-          `${moduleName}/Libraries/Core/InitializeCore`,
-          requireOptions
-        )
-      );
+      try {
+        mainModules.add(
+          require.resolve(
+            `${moduleName}/Libraries/Core/InitializeCore.js`,
+            requireOptions
+          )
+        );
+      } catch (_) {
+        // Not all platform implementations have `InitializeCore.js` e.g.,
+        // `react-native-web`.
+      }
     }
   }
   return Array.from(mainModules);


### PR DESCRIPTION
### Description

Fixed crash when `react-native-web` is installed

### Test plan

Add `react-native-web`:

```diff
diff --git a/packages/test-app/package.json b/packages/test-app/package.json
index 8c67682fa..c1b704db8 100644
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -39,7 +39,8 @@
   "dependencies": {
     "@react-native-webapis/web-storage": "workspace:*",
     "react": "19.1.0",
-    "react-native": "^0.81.0"
+    "react-native": "^0.81.0",
+    "react-native-web": "^0.21.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
```

Install and verify that Metro doesn't crash on startup:

```
yarn
yarn build-scope @rnx-kit/test-app
cd packages/test-app/
node --print 'require("./metro.config.js")'
```