### PR TITLE
ci(align-deps): set `--disable-proto=delete` instead of `throw`

### DIFF
--- a/.github/workflows/align-deps.yml
+++ b/.github/workflows/align-deps.yml
@@ -6,7 +6,7 @@ on:
     - cron: 0 4 * * 1-5
   workflow_dispatch:
 env:
-  NODE_OPTIONS: "--disable-proto=throw"
+  NODE_OPTIONS: "--disable-proto=delete"
 jobs:
   update:
     name: "Update `microsoft/react-native` preset"


### PR DESCRIPTION
### Description

Most GitHub Actions use `Object.assign` (probably because the template does) and will always throw unexpectedly.

### Test plan

n/a