### PR TITLE
fix(cli): log address:port when starting dev server

### DIFF
--- a/.changeset/green-tools-heal.md
+++ b/.changeset/green-tools-heal.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Log the address/port when starting dev server

--- a/packages/cli/src/serve/keyboard.ts
+++ b/packages/cli/src/serve/keyboard.ts
@@ -67,7 +67,7 @@ export function attachKeyHandlers(server: HttpServer, params: Params) {
     openDebuggerKeyboardHandler.dismiss();
     process.stdin.pause();
     process.stdin.setRawMode(false);
-    info("Exiting...");
+    info("Closing all connections...");
 
     const httpServer = server.httpServer ?? server;
     httpServer.close();

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -184,8 +184,17 @@ export async function rnxStart(
     update(event: ReportableEvent) {
       terminalReporter.update(event);
       reportEventDelegate?.(event);
-      if (interactive && event.type === "dep_graph_loading") {
-        help();
+      switch (event.type) {
+        case "dep_graph_loading":
+          if (interactive) {
+            help();
+          }
+          break;
+        case "server_listening":
+          logger.info(
+            `Dev server is listening on ${scheme}://${event.address}:${event.port}`
+          );
+          break;
       }
     },
   };


### PR DESCRIPTION
### Description

Log the address/port when starting dev server.

### Test plan

```
% yarn start

                        ▒▒▓▓▓▓▒▒
                     ▒▓▓▓▒▒░░▒▒▓▓▓▒
                  ▒▓▓▓▓░░░▒▒▒▒░░░▓▓▓▓▒
                 ▓▓▒▒▒▓▓▓▓▓▓▓▓▓▓▓▓▒▒▒▓▓
                 ▓▓░░░░░▒▓▓▓▓▓▓▒░░░░░▓▓
                 ▓▓░░▓▓▒░░░▒▒░░░▒▓▒░░▓▓
                 ▓▓░░▓▓▓▓▓▒▒▒▒▓▓▓▓▒░░▓▓
                 ▓▓░░▓▓▓▓▓▓▓▓▓▓▓▓▓▒░░▓▓
                 ▓▓▒░░▒▒▓▓▓▓▓▓▓▓▒░░░▒▓▓
                  ▒▓▓▓▒░░░▒▓▓▒░░░▒▓▓▓▒
                     ▒▓▓▓▒░░░░▒▓▓▓▒
                        ▒▒▓▓▓▓▒▒


info Dev server is listening on http://127.0.0.1:8081
                Welcome to Metro v0.83.3
              Fast - Scalable - Integrated


┃ Open developer menu                  D
┃ Open debugger                        J
┃ Show bundler address QR code         Q
┃ Reload the app                       R
┠───────────────────────────────────────
┃ Show this help message               H
┃ Quit                            Ctrl-C
```