### PR TITLE
fix(eslint-plugin): bump `eslint-plugin-react-hooks` to 5.2.0

### DIFF
--- a/.changeset/wild-trains-wink.md
+++ b/.changeset/wild-trains-wink.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/eslint-plugin": patch
+---
+
+Bumped `eslint-plugin-react-hooks` to 5.2.0

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -46,7 +46,7 @@
     "@react-native/eslint-plugin": "^0.76.0",
     "enhanced-resolve": "^5.8.3",
     "eslint-plugin-react": "^7.35.2",
-    "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "typescript-eslint": "^8.0.0"
   },
   "peerDependencies": {

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -2,7 +2,6 @@
 "use strict";
 
 const react = require("eslint-plugin-react");
-// @ts-expect-error Could not find a declaration file for module
 const reactHooks = require("eslint-plugin-react-hooks");
 
 module.exports = [
@@ -11,14 +10,11 @@ module.exports = [
     rules: react.configs.recommended.rules,
     languageOptions: { parserOptions: react.configs.recommended.parserOptions },
   },
+  reactHooks.configs["recommended-latest"],
   {
     name: "rnx-kit/react",
-    plugins: {
-      "react-hooks": reactHooks,
-    },
     rules: {
       "react/prop-types": "off",
-      ...reactHooks.configs.recommended.rules,
     },
     settings: {
       react: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4851,7 +4851,7 @@ __metadata:
     "@typescript-eslint/types": "npm:^8.0.0"
     enhanced-resolve: "npm:^5.8.3"
     eslint-plugin-react: "npm:^7.35.2"
-    eslint-plugin-react-hooks: "npm:^5.0.0"
+    eslint-plugin-react-hooks: "npm:^5.2.0"
     typescript-eslint: "npm:^8.0.0"
   peerDependencies:
     eslint: ">=8.57.0"
@@ -9199,12 +9199,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks@npm:^5.0.0":
-  version: 5.1.0
-  resolution: "eslint-plugin-react-hooks@npm:5.1.0"
+"eslint-plugin-react-hooks@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "eslint-plugin-react-hooks@npm:5.2.0"
   peerDependencies:
     eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
-  checksum: 10c0/37ef76e1d916d46ab8e93a596078efcf2162e2c653614437e0c54e31d02a5dadabec22802fab717effe257aeb4bdc20c2a710666a89ab1cf07e01e614dde75d8
+  checksum: 10c0/1c8d50fa5984c6dea32470651807d2922cc3934cf3425e78f84a24c2dfd972e7f019bee84aefb27e0cf2c13fea0ac1d4473267727408feeb1c56333ca1489385
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Bumped `eslint-plugin-react-hooks` to 5.2.0. 5.2.0 introduces flat config which means that we can simplify somewhat.

### Test plan

n/a