### PR TITLE
chore(align-deps): skip bundling when updating `README.md`

### DIFF
--- a/.changeset/cold-ants-behave.md
+++ b/.changeset/cold-ants-behave.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-shell": patch
+---
+
+Fixed import statements so that the TypeScript code can be used directly

--- a/packages/align-deps/package.json
+++ b/packages/align-deps/package.json
@@ -36,9 +36,9 @@
     "format": "rnx-kit-scripts format",
     "lint": "rnx-kit-scripts lint",
     "test": "rnx-kit-scripts test",
-    "update-preset": "node --no-warnings scripts/update-preset.ts",
-    "update-profile": "node --no-warnings scripts/update-profile.ts",
-    "update-readme": "node --no-warnings scripts/update-readme.mjs"
+    "update-preset": "node --no-warnings --conditions=typescript scripts/update-preset.ts",
+    "update-profile": "node --no-warnings --conditions=typescript scripts/update-profile.ts",
+    "update-readme": "node --no-warnings --conditions=typescript scripts/update-readme.ts"
   },
   "devDependencies": {
     "@octokit/core": "^7.0.0",

--- a/packages/align-deps/scripts/github.ts
+++ b/packages/align-deps/scripts/github.ts
@@ -2,7 +2,7 @@ import type { OctokitOptions } from "@octokit/core";
 import { Octokit } from "@octokit/core";
 import { restEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
 import { info } from "@rnx-kit/console";
-import type { Preset } from "../src/types";
+import type { Preset } from "../src/types.ts";
 
 type GitHubClient = Octokit & ReturnType<typeof restEndpointMethods>;
 

--- a/packages/align-deps/scripts/update-preset.ts
+++ b/packages/align-deps/scripts/update-preset.ts
@@ -1,10 +1,10 @@
-#!/usr/bin/env -S node --no-warnings
+#!/usr/bin/env -S node --no-warnings --conditions=typescript
 
 import { info } from "@rnx-kit/console";
 import * as fs from "node:fs";
 import * as recast from "recast";
 import typescript from "recast/parsers/typescript.js";
-import type { MetaPackage, Package } from "../src/types";
+import type { MetaPackage, Package } from "../src/types.ts";
 import { createGitHubClient, fetchPullRequestFeedback } from "./github.ts";
 import { IGNORED_CAPABILITIES } from "./update-profile.ts";
 

--- a/packages/align-deps/scripts/update-profile.ts
+++ b/packages/align-deps/scripts/update-profile.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --no-warnings
+#!/usr/bin/env -S node --no-warnings --conditions=typescript
 
 import { error, info } from "@rnx-kit/console";
 import { untar } from "@rnx-kit/tools-shell";
@@ -11,7 +11,7 @@ import * as util from "node:util";
 import packageJson from "package-json";
 import semverCoerce from "semver/functions/coerce.js";
 import semverCompare from "semver/functions/compare.js";
-import type { MetaPackage, Package, Preset } from "../src/types.js";
+import type { MetaPackage, Package, Preset } from "../src/types.ts";
 import {
   createGitHubClient,
   fetchPullRequests,
@@ -573,7 +573,7 @@ async function main({
   pullRequest,
 }: Options): Promise<void> {
   const { preset }: { preset: Readonly<Preset> } = await import(
-    `../lib/presets/${presetName}.js`
+    `../src/presets/${presetName}.ts`
   );
   const allVersions: string[] = Object.keys(preset)
     .sort((lhs, rhs) => semverCompare(coerceVersion(lhs), coerceVersion(rhs)))

--- a/packages/align-deps/src/capabilities.ts
+++ b/packages/align-deps/src/capabilities.ts
@@ -2,7 +2,7 @@ import type { Capability } from "@rnx-kit/config";
 import { warn } from "@rnx-kit/console";
 import { keysOf } from "@rnx-kit/tools-language/properties";
 import type { PackageManifest } from "@rnx-kit/tools-node/package";
-import type { MetaPackage, Package, Preset, Profile } from "./types";
+import type { MetaPackage, Package, Preset, Profile } from "./types.ts";
 
 type ResolvedDependencies = {
   dependencies: Record<string, Package[]>;

--- a/packages/align-deps/src/cli.ts
+++ b/packages/align-deps/src/cli.ts
@@ -9,14 +9,14 @@ import {
 } from "@rnx-kit/tools-workspaces";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { makeCheckCommand } from "./commands/check";
-import { makeExportCatalogsCommand } from "./commands/exportCatalogs";
-import { makeInitializeCommand } from "./commands/initialize";
-import { makeSetVersionCommand } from "./commands/setVersion";
-import { defaultConfig } from "./config";
-import { printError, printInfo } from "./errors";
-import { isString } from "./helpers";
-import type { Args, Command, DiffMode } from "./types";
+import { makeCheckCommand } from "./commands/check.ts";
+import { makeExportCatalogsCommand } from "./commands/exportCatalogs.ts";
+import { makeInitializeCommand } from "./commands/initialize.ts";
+import { makeSetVersionCommand } from "./commands/setVersion.ts";
+import { defaultConfig } from "./config.ts";
+import { printError, printInfo } from "./errors.ts";
+import { isString } from "./helpers.ts";
+import type { Args, Command, DiffMode } from "./types.ts";
 
 export const description =
   "Manage dependencies within a repository and across many repositories";

--- a/packages/align-deps/src/commands/vigilant.ts
+++ b/packages/align-deps/src/commands/vigilant.ts
@@ -22,7 +22,7 @@ import type {
   Options,
   Package,
   Preset,
-} from "../types";
+} from "../types.ts";
 
 type Report = {
   errors: Changes;

--- a/packages/align-deps/src/errors.ts
+++ b/packages/align-deps/src/errors.ts
@@ -1,5 +1,5 @@
 import { bold, error, info } from "@rnx-kit/console";
-import type { ErrorCode } from "./types";
+import type { ErrorCode } from "./types.ts";
 
 export function isError<T>(config: T | ErrorCode): config is ErrorCode {
   return typeof config === "string";

--- a/packages/align-deps/src/index.ts
+++ b/packages/align-deps/src/index.ts
@@ -1,16 +1,16 @@
-import { preset as reactNativePreset } from "./presets/microsoft/react-native";
+import { preset as reactNativePreset } from "./presets/microsoft/react-native.ts";
 
 export const presets = {
   "microsoft/react-native": reactNativePreset,
 };
 
-export { capabilitiesFor } from "./capabilities";
-export { cli, cliOptions } from "./cli";
-export { checkPackageManifest } from "./commands/check";
-export { exportCatalogs } from "./commands/exportCatalogs";
-export { checkPackageManifestUnconfigured } from "./commands/vigilant";
-export { alignDepsCommand } from "./compatibility/commander";
-export { updatePackageManifest } from "./manifest";
+export { capabilitiesFor } from "./capabilities.ts";
+export { cli, cliOptions } from "./cli.ts";
+export { checkPackageManifest } from "./commands/check.ts";
+export { exportCatalogs } from "./commands/exportCatalogs.ts";
+export { checkPackageManifestUnconfigured } from "./commands/vigilant.ts";
+export { alignDepsCommand } from "./compatibility/commander.ts";
+export { updatePackageManifest } from "./manifest.ts";
 export type {
   Args,
   Command,
@@ -22,4 +22,4 @@ export type {
   Package,
   Preset,
   Profile,
-} from "./types";
+} from "./types.ts";

--- a/packages/align-deps/test/helpers.ts
+++ b/packages/align-deps/test/helpers.ts
@@ -1,7 +1,7 @@
 import type { Capability } from "@rnx-kit/config";
 import { createRequire } from "node:module";
 import { URL } from "node:url";
-import type { Package, Profile } from "../src/types";
+import type { Package, Profile } from "../src/types.ts";
 
 export function defineRequire(path: string, base: string | URL) {
   global.require = createRequire(new URL(path, base));

--- a/packages/tools-shell/src/index.ts
+++ b/packages/tools-shell/src/index.ts
@@ -1,8 +1,8 @@
-export { idle, once, retry, withRetry } from "./async.js";
+export { idle, once, retry, withRetry } from "./async.ts";
 export {
   ensure,
   ensureInstalled,
   makeCommand,
   makeCommandSync,
-} from "./command.js";
-export { untar } from "./untar.js";
+} from "./command.ts";
+export { untar } from "./untar.ts";

--- a/packages/tools-shell/test/async.test.ts
+++ b/packages/tools-shell/test/async.test.ts
@@ -1,4 +1,4 @@
-import { idle, once, retry, withRetry } from "../src/async";
+import { idle, once, retry, withRetry } from "../src/async.ts";
 
 describe("async", () => {
   beforeEach(() => {


### PR DESCRIPTION
### Description

Skip bundling when updating `README.md`

### Test plan

We should be able to update `README.md` without having to build `align-deps` first. Its dependencies must be built still:

```
cd packages/align-deps/
yarn build --dependencies
node --run update-readme
# No changes expected
# Now change something in a profile and re-run the last command
```