### PR TITLE
fix(cli): fix Metro cache not being cleaned up

### DIFF
--- a/.changeset/slow-cases-stick.md
+++ b/.changeset/slow-cases-stick.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": major
+---
+
+Bumped minimum Node version to 22

--- a/.changeset/smart-queens-kick.md
+++ b/.changeset/smart-queens-kick.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Fixed Metro cache not being cleaned up

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -93,7 +93,7 @@
     "type-fest": "^4.0.0"
   },
   "engines": {
-    "node": ">=16.17"
+    "node": ">=22.11"
   },
   "jest": {
     "preset": "@rnx-kit/jest-preset/private"


### PR DESCRIPTION
### Description

- [major] Bumped minimum Node version to 22 (this is required for `fs.glob`)
- [patch] Fixed Metro cache not being cleaned up

### Test plan

n/a