### PR TITLE
test: use Node's glob implementation

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -27,7 +27,6 @@
     "clipanion": "^4.0.0-rc.4",
     "esbuild": "^0.27.1",
     "eslint": "catalog:",
-    "fast-glob": "^3.2.7",
     "jest": "^29.2.1",
     "markdown-table": "^3.0.0",
     "prettier": "catalog:",

--- a/scripts/src/commands/test.js
+++ b/scripts/src/commands/test.js
@@ -55,11 +55,7 @@ export class TestCommand extends Command {
     }
 
     const tests =
-      this.args.length > 0
-        ? this.args
-        : await import("fast-glob").then(({ default: fg }) =>
-            fg.async("test/**/*.test.ts", { followSymbolicLinks: false })
-          );
+      this.args.length > 0 ? this.args : fs.globSync("test/**/*.test.ts");
     return useTsx(manifest)
       ? await execute(
           process.argv0,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5215,7 +5215,6 @@ __metadata:
     clipanion: "npm:^4.0.0-rc.4"
     esbuild: "npm:^0.27.1"
     eslint: "catalog:"
-    fast-glob: "npm:^3.2.7"
     jest: "npm:^29.2.1"
     markdown-table: "npm:^3.0.0"
     prettier: "catalog:"


### PR DESCRIPTION
### Description

Replace `fast-glob` with Node's glob implementation.

### Test plan

n/a