### PR TITLE
fix(metro-plugin-esbuild): bump minimum Node version

### DIFF
--- a/.changeset/loud-parks-watch.md
+++ b/.changeset/loud-parks-watch.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": minor
+---
+
+Bumped minimum Node version to 22

--- a/packages/metro-serializer-esbuild/package.json
+++ b/packages/metro-serializer-esbuild/package.json
@@ -38,8 +38,7 @@
     "@rnx-kit/tools-node": "^3.0.3",
     "@rnx-kit/tools-react-native": "^2.3.2",
     "esbuild": "^0.27.1",
-    "esbuild-plugin-lodash": "^1.2.0",
-    "fast-glob": "^3.2.7"
+    "esbuild-plugin-lodash": "^1.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
@@ -65,6 +64,6 @@
     "react-native": "^0.81.0"
   },
   "engines": {
-    "node": ">=16.17"
+    "node": ">=22.11"
   }
 }

--- a/packages/metro-serializer-esbuild/src/module.ts
+++ b/packages/metro-serializer-esbuild/src/module.ts
@@ -2,6 +2,7 @@ import { warn } from "@rnx-kit/console";
 import { findPackage, readPackage } from "@rnx-kit/tools-node/package";
 import type { BuildOptions } from "esbuild";
 import type { Module, ReadOnlyDependencies } from "metro";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { generateSourceMappingURL } from "./sourceMap.ts";
 
@@ -41,13 +42,10 @@ export const getSideEffects = (() => {
     if (!(pkgJson in pkgCache)) {
       const { sideEffects } = readPackage(pkgJson);
       if (Array.isArray(sideEffects)) {
-        const fg = require("fast-glob");
-        pkgCache[pkgJson] = fg
-          .sync(sideEffects, {
-            cwd: path.dirname(pkgJson),
-            absolute: true,
-          })
-          .map((p: string) => p.replace(/[/\\]/g, path.sep));
+        const cwd = path.dirname(pkgJson);
+        pkgCache[pkgJson] = fs
+          .globSync(sideEffects, { cwd })
+          .map((p: string) => path.join(cwd, p.replace(/[/\\]/g, path.sep)));
       } else if (typeof sideEffects === "boolean") {
         pkgCache[pkgJson] = sideEffects;
       } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5034,7 +5034,6 @@ __metadata:
     "@types/node": "npm:^24.0.0"
     esbuild: "npm:^0.27.1"
     esbuild-plugin-lodash: "npm:^1.2.0"
-    fast-glob: "npm:^3.2.7"
     lodash-es: "npm:^4.17.21"
     metro: "npm:^0.83.1"
     metro-config: "npm:^0.83.1"


### PR DESCRIPTION
### Description

Bumped minimum Node version to 22

### Test plan

n/a