### PR TITLE
fix(react-native-host): re-define deprecated bridge methods

### DIFF
--- a/.changeset/sour-bikes-yawn.md
+++ b/.changeset/sour-bikes-yawn.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Re-define deprecated bridge methods for backwards compatibility

--- a/packages/react-native-host/cocoa/RNXHostConfig.h
+++ b/packages/react-native-host/cocoa/RNXHostConfig.h
@@ -30,6 +30,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// Handles a fatal error.
 - (void)onFatalError:(NSError *)error;
 
+// MARK: - RCTBridgeDelegate deprecated details (for backwards compatibility) [>=0.84]
+
+- (NSURL *__nullable)sourceURLForBridge:(RCTBridge *)bridge;
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
### Description

Re-define deprecated bridge methods for backwards compatibility.

See https://github.com/microsoft/react-native-test-app/actions/runs/20325720368/job/58390543783

### Test plan

In [`react-native-test-app`](https://github.com/microsoft/react-native-test-app), run:

```sh
yarn clean
cd packages/app
node --run set-react-version -- nightly
yarn
cd example
pod install --project-directory=ios
# Manually patch in the changes
yarn ios
```

### Screenshots

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/9dd5472a-dfc8-4a15-8d6e-89071527c565" />
