### PR TITLE
fix(metro-resolver-symlinks): fix types not being exported

### DIFF
--- a/.changeset/floppy-moons-roll.md
+++ b/.changeset/floppy-moons-roll.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Fixed no types being exported

--- a/packages/metro-resolver-symlinks/src/index.ts
+++ b/packages/metro-resolver-symlinks/src/index.ts
@@ -1,3 +1,6 @@
 import { makeResolver } from "./symlinkResolver.ts";
 
 module.exports = makeResolver;
+
+// eslint-disable-next-line no-restricted-exports
+export default makeResolver;


### PR DESCRIPTION
### Description

Fixed no types being exported

### Test plan

```
cd packages/metro-resolver-symlinks
yarn build --dependencies
```

Verify that `lib/index.d.ts` exports types and that `lib/index.js` exports `makeResolver` as default for both CJS and ESM.