### PR TITLE
fix(metro-resolver-symlinks): sync `Server.js` patch to latest stable

### DIFF
--- a/.changeset/chubby-webs-laugh.md
+++ b/.changeset/chubby-webs-laugh.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Synced `Server.js` patch to Metro 0.83


### PR DESCRIPTION
### Description

Synced `Server.js` patch to Metro 0.83 for better handling of `unstable_path` query parameter.

### Test plan

n/a