### PR TITLE
fix(react-native-host): `useShadowNodeStateOnClone` is removed in 0.85

### DIFF
--- a/.changeset/mean-clubs-beam.md
+++ b/.changeset/mean-clubs-beam.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Handle `useShadowNodeStateOnClone` being removed in 0.85

--- a/packages/react-native-host/cocoa/RNXFeatureMacros.h
+++ b/packages/react-native-host/cocoa/RNXFeatureMacros.h
@@ -16,6 +16,15 @@
 
 #if USE_BRIDGELESS
 
+#if __has_include(<cxxreact/ReactNativeVersion.h>)
+#include <cxxreact/ReactNativeVersion.h>
+#define REACT_NATIVE_VERSION                                                                       \
+    REACT_NATIVE_VERSION_MAJOR * 1000000 + REACT_NATIVE_VERSION_MINOR * 1000 +                     \
+        REACT_NATIVE_VERSION_PATCH
+#else
+#define REACT_NATIVE_VERSION 0
+#endif  // __has_include(<cxxreact/ReactNativeVersion.h>)
+
 #if __has_include(<react/config/ReactNativeConfig.h>)
 #define USE_REACT_NATIVE_CONFIG 1
 #endif  // __has_include(<react/config/ReactNativeConfig.h>)
@@ -38,7 +47,8 @@
 #define USE_VIEW_COMMAND_RACE_FIX 1
 #endif  // !__has_include(<React-RCTAppDelegate/RCTReactNativeFactory.h>)
 
-#if __has_include(<React-RCTAppDelegate/RCTJSRuntimeConfiguratorProtocol.h>) || __has_include(<React_RCTAppDelegate/RCTJSRuntimeConfiguratorProtocol.h>)
+// `useShadowNodeStateOnClone` should be enabled from 0.79 and is on by default in 0.85
+#if REACT_NATIVE_VERSION < 85000 && (__has_include(<React-RCTAppDelegate/RCTJSRuntimeConfiguratorProtocol.h>) || __has_include(<React_RCTAppDelegate/RCTJSRuntimeConfiguratorProtocol.h>))
 #define USE_UPDATE_RUNTIME_SHADOW_NODE_REFS_ON_COMMIT 1
 #endif  // __has_include(<React-RCTAppDelegate/RCTJSRuntimeConfiguratorProtocol.h>)
 


### PR DESCRIPTION
### Description

Handle `useShadowNodeStateOnClone` being removed in 0.85.

See https://github.com/microsoft/react-native-test-app/actions/runs/21125183934/job/60745077527

### Test plan

This must be tested in RNTA:

```sh
cd packages/app
node --run set-react-version -- nightly
yarn
# Manually patch 'node_modules/@rnx-kit/react-native-host/cocoa/RNXFeatureMacros.h'
cd example
pod install --project-directory=ios
yarn ios
```

### Screenshots

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/d41b8842-23ee-4c78-ab98-3d466b989641" />
