### PR TITLE
fix(metro-config): fix asset URLs not being restored when targeting Windows

### DIFF
--- a/.changeset/angry-llamas-sip.md
+++ b/.changeset/angry-llamas-sip.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Fixed asset URLs not being restored when targeting Windows

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -320,7 +320,19 @@ function additionalConfig(projectRoot, inputConfig) {
     ];
   } else {
     const { restoreAssetURL } = require("./assetPlugins/escapeAssetURLs.js");
-    config.server = { rewriteRequestUrl: restoreAssetURL };
+    config.server = {
+      // Some platforms (notably Windows) still prefer `enhanceMiddleware` over
+      // `rewriteRequestUrl`. We need to set both to ensure asset URLs are
+      // properly restored.
+      enhanceMiddleware: (middleware) => {
+        /** @type {import("connect").NextHandleFunction} */
+        return (req, res, next) => {
+          req.url = restoreAssetURL(req.url ?? "");
+          return middleware(req, res, next);
+        };
+      },
+      rewriteRequestUrl: restoreAssetURL,
+    };
 
     transformer.assetPlugins = [
       require.resolve("./assetPlugins/escapeAssetURLs.js"),


### PR DESCRIPTION
### Description

Fixed asset URLs not being restored when targeting Windows

### Test plan

Manually tested in https://github.com/microsoft/react-native-test-app/pull/2651, both in existing and new projects.