### PR TITLE
fix(metro-config): ensure empty module can be resolved

### DIFF
--- a/.changeset/ready-paws-hang.md
+++ b/.changeset/ready-paws-hang.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/metro-config": patch
+---
+
+Ensure the empty module can be resolved even when watch folders is an empty
+array

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -67,6 +67,24 @@ function defaultWatchFolders() {
 }
 
 /**
+ * Ensures that the empty module is resolvable if there are no watch folders.
+ * @param {MetroConfig} config
+ * @returns {MetroConfig}
+ */
+function ensureEmptyModule(config) {
+  const { resolver, watchFolders } = config;
+  if (!Array.isArray(watchFolders) || watchFolders.length === 0) {
+    const emptyModulePath = resolver?.emptyModulePath;
+    if (emptyModulePath) {
+      // @ts-expect-error If there are no watch folders, Metro won't be able to
+      // resolve the empty module.
+      config.watchFolders = [path.dirname(emptyModulePath)];
+    }
+  }
+  return config;
+}
+
+/**
  * Extracts unique parts from a Yarn store directory.
  * @param {string} p
  * @returns {[string, string]}
@@ -399,6 +417,7 @@ module.exports = {
       applyExpoWorkarounds(userConfig, defaultConfig);
     }
 
-    return mergeConfig(defaultConfig, ...configs);
+    const finalConfig = mergeConfig(defaultConfig, ...configs);
+    return ensureEmptyModule(finalConfig);
   },
 };


### PR DESCRIPTION
### Description

Ensure the empty module can be resolved even when watch folders is an empty array

### Test plan

n/a