### PR TITLE
fix(metro-config): disable `unstable_preserveClasses` again

### DIFF
--- a/.changeset/clear-rivers-pull.md
+++ b/.changeset/clear-rivers-pull.md
@@ -1,0 +1,7 @@
+---
+"@rnx-kit/babel-preset-metro-react-native": patch
+---
+
+Disable `unstable_preserveClasses` because Hermes' class implementation is not
+fully compliant and we cannot unconditionally enable it due to backwards
+compatibility

--- a/packages/babel-preset-metro-react-native/src/index.js
+++ b/packages/babel-preset-metro-react-native/src/index.js
@@ -160,9 +160,6 @@ function overridesFor(transformProfile, env) {
         disableImportExportTransform: true,
         unstable_transformProfile: "hermes-stable",
         useTransformReactJSXExperimental: true,
-        customTransformOptions: {
-          unstable_preserveClasses: true,
-        },
       };
 
     default:


### PR DESCRIPTION
### Description

```
✘ [ERROR] Transforming class syntax to the configured target environment ("hermes0.14" + 6 overrides) is not supported yet

    ../../node_modules/.store/react-native-virtual-ff9cec5d8c/package/Libraries/Utilities/createPerformanceLogger.js:5:0:
      5 │ class PerformanceLogger {
        ╵ ~~~~~

✘ [ERROR] Transforming class syntax to the configured target environment ("hermes0.14" + 6 overrides) is not supported yet

    ../../node_modules/.store/react-native-virtual-ff9cec5d8c/package/Libraries/Alert/Alert.js:5:0:
      5 │ class Alert {
        ╵ ~~~~~
```

Resolves #3951

### Test plan

n/a