### PR TITLE
chore: cache the location of the `tsgo` binary

### DIFF
--- a/.changeset/plenty-turtles-joke.md
+++ b/.changeset/plenty-turtles-joke.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/types-bundle-config": patch
+---
+
+Fixed output folder structure

--- a/packages/types-bundle-config/tsconfig.json
+++ b/packages/types-bundle-config/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@rnx-kit/tsconfig/tsconfig.node.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "include": ["src"]
 }

--- a/scripts/src/commands/build.js
+++ b/scripts/src/commands/build.js
@@ -2,7 +2,9 @@
 
 import { Command, Option } from "clipanion";
 import * as fs from "node:fs";
-import { runScript } from "../process.js";
+import * as path from "node:path";
+import { URL, fileURLToPath } from "node:url";
+import { execute, runScript, workspaceRoot } from "../process.js";
 
 export class BuildCommand extends Command {
   /** @override */
@@ -33,7 +35,53 @@ export class BuildCommand extends Command {
       return await runScript("nx", "build", name);
     }
 
-    const tsc = this.withTsc ? "tsc" : "tsgo";
-    return await runScript(tsc, "--outDir", "lib", ...this.args);
+    if (this.withTsc) {
+      return await runScript("tsc", "--outDir", "lib", ...this.args);
+    }
+
+    const tsc = await this.getNativeBinaryPath();
+    return await execute(tsc, "--outDir", "lib", ...this.args);
+  }
+
+  async getNativeBinaryPath() {
+    const cachePath = path.join(
+      workspaceRoot(),
+      "node_modules",
+      ".cache",
+      "tsgo"
+    );
+
+    if (fs.existsSync(cachePath)) {
+      const tsgo = fs.readFileSync(cachePath, { encoding: "utf-8" });
+      if (fs.existsSync(tsgo)) {
+        return tsgo;
+      }
+    }
+
+    // If we haven't cached the location of `tsgo` yet, we can find it by
+    // calling `getExePath` from `@typescript/native-preview`. This is what
+    // `tsgo.js` does internally, but it does not cache the location and does
+    // this lookup every time it is executed.
+
+    const manifestPath = import.meta
+      .resolve("@typescript/native-preview/package.json");
+    const manifest = JSON.parse(
+      fs.readFileSync(fileURLToPath(manifestPath), { encoding: "utf-8" })
+    );
+
+    // On Windows, absolute paths must be valid file:// URLs
+    const getExePathPath = new URL(
+      manifest.imports["#getExePath"],
+      manifestPath
+    );
+    const getExePath = await import(getExePathPath.href);
+    const tsgo = getExePath.default();
+
+    // Save the location of the native binary so that we don't have to do the
+    // lookup again next time.
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    fs.writeFile(cachePath, tsgo, { encoding: "utf-8" }, () => undefined);
+
+    return tsgo;
   }
 }

--- a/scripts/src/process.js
+++ b/scripts/src/process.js
@@ -18,7 +18,7 @@ function isRunningNx(command, args) {
   return command.startsWith("yarn") && args[0] === "nx";
 }
 
-function workspaceRoot() {
+export function workspaceRoot() {
   return fileURLToPath(new URL("../../", import.meta.url));
 }
 


### PR DESCRIPTION
### Description

Every time we invoke `tsgo`, it looks up the location of the binary based on the current platform and architecture. Our build script should now cache this location and invoke it directly.

### Test plan

CI should pass.