### PR TITLE
feat(align-deps): notify users when a newer version of a preset is available

### DIFF
--- a/.changeset/chatty-pots-read.md
+++ b/.changeset/chatty-pots-read.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": minor
+---
+
+Notify users when a newer version of a preset is available

--- a/packages/align-deps/src/preset.ts
+++ b/packages/align-deps/src/preset.ts
@@ -1,5 +1,12 @@
+import { info } from "@rnx-kit/console";
+import { readPackage } from "@rnx-kit/tools-node/package";
 import type { Capability } from "@rnx-kit/types-kit-config";
+import { spawn } from "node:child_process";
+import * as nodefs from "node:fs";
+import { findPackageJSON } from "node:module";
+import { pathToFileURL } from "node:url";
 import semverCoerce from "semver/functions/coerce.js";
+import semverGreater from "semver/functions/gt.js";
 import semverSatisfies from "semver/functions/satisfies.js";
 import semverValidRange from "semver/ranges/valid.js";
 import { gatherRequirements } from "./dependencies.ts";
@@ -12,6 +19,36 @@ type Resolution = {
   capabilities: Capability[];
 };
 
+const notifyLatestVersion = (() => {
+  const cache = new Set<string>();
+  return (preset: string, fs = nodefs): void => {
+    if (cache.has(preset)) {
+      return;
+    }
+
+    cache.add(preset);
+
+    const manifestPath = findPackageJSON(pathToFileURL(preset));
+    if (!manifestPath) {
+      return;
+    }
+
+    const { name, version } = readPackage(manifestPath, fs);
+
+    const shell = process.platform === "win32";
+    const opts = { shell, windowsVerbatimArguments: true };
+
+    spawn("npm", ["view", name, "version"], opts).stdout.on("data", (data) => {
+      const latestVersion = data.toString().trim();
+      if (semverGreater(latestVersion, version)) {
+        info(
+          `A newer version of '${name}' was found: ${latestVersion} (current: ${version})`
+        );
+      }
+    });
+  };
+})();
+
 function loadPreset(
   preset: string,
   projectRoot: string,
@@ -20,8 +57,11 @@ function loadPreset(
   switch (preset) {
     case "microsoft/react-native":
       return reactNativePreset;
-    default:
-      return require(resolve(preset, { paths: [projectRoot] }));
+    default: {
+      const spec = resolve(preset, { paths: [projectRoot] });
+      notifyLatestVersion(spec);
+      return require(spec);
+    }
   }
 }
 


### PR DESCRIPTION
### Description

Notify users when a newer version of a preset is available.

### Test plan

Install an older version of `@fluentui-react-native/dependency-profiles`:

```diff
diff --git a/packages/test-app/package.json b/packages/test-app/package.json
index 763400430..2a6213a02 100644
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -47,6 +47,7 @@
     "@babel/plugin-transform-react-jsx-source": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
+    "@fluentui-react-native/dependency-profiles": "0.8.69",
     "@jridgewell/trace-mapping": "^0.3.18",
     "@react-native-community/cli": "^20.0.0",
     "@react-native-community/cli-platform-android": "^20.0.0",
@@ -178,7 +179,8 @@
     "alignDeps": {
       "presets": [
         "microsoft/react-native",
-        "@rnx-kit/scripts/align-deps-preset.cjs"
+        "@rnx-kit/scripts/align-deps-preset.cjs",
+        "@fluentui-react-native/dependency-profiles"
       ],
       "requirements": [
         "react-native@0.83"
```

Expected output:

```
% yarn rnx-align-deps
info A newer version of '@fluentui-react-native/dependency-profiles' was found: 0.8.70 (current: 0.8.69)
```