### PR TITLE
fix(align-deps): fix root workspace being checked twice

### DIFF
--- a/.changeset/easy-pillows-tease.md
+++ b/.changeset/easy-pillows-tease.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": patch
+---
+
+Fixed root workspace being checked twice depending on configuration

--- a/packages/align-deps/src/cli.ts
+++ b/packages/align-deps/src/cli.ts
@@ -145,7 +145,10 @@ async function getManifests(
     const allPackages = (await findWorkspacePackages()).map((p) =>
       path.join(path.relative(cwd, p), "package.json")
     );
-    allPackages.push(manifestPath);
+    // Add the root workspace if it isn't there
+    if (!allPackages.includes(manifestPath)) {
+      allPackages.push(manifestPath);
+    }
     return allPackages;
   } catch (e) {
     if (hasProperty(e, "message")) {


### PR DESCRIPTION
### Description

Fixed root workspace being checked twice depending on configuration

### Test plan

Add root workspace to the `workspaces` field and make `align-deps` list all packages:

```diff
diff --git a/package.json b/package.json
index 019d24f96..48aa82dcd 100644
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "workspaces": {
     "packages": [
+      ".",
       "incubator/*",
       "incubator/@react-native-webapis/*",
       "packages/*",
diff --git a/packages/align-deps/src/commands/check.ts b/packages/align-deps/src/commands/check.ts
index 0ee58d8b9..a19b583d4 100644
--- a/packages/align-deps/src/commands/check.ts
+++ b/packages/align-deps/src/commands/check.ts
@@ -128,6 +128,7 @@ export function makeCheckCommand(options: Options): Command {
   }

   return (manifest: string) => {
+    console.info(manifest);
     const inputConfig = loadConfig(manifest, options);
     const config = isError(inputConfig)
       ? inputConfig
```

Run `yarn rnx-align-deps` and verify that `package.json` only appears once.