### PR TITLE
fix(tsconfig): The new tsconfig.nodenext.json wasn't being included in files

### DIFF
--- a/.changeset/brown-ideas-kick.md
+++ b/.changeset/brown-ideas-kick.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tsconfig": patch
+---
+
+tsconfig.nodenext.json was missing from the files section

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -22,6 +22,7 @@
     "tsconfig.esm.json",
     "tsconfig.esm.node.json",
     "tsconfig.node.json",
+    "tsconfig.nodenext.json",
     "tsconfig.json"
   ],
   "main": "tsconfig.json",


### PR DESCRIPTION
### Description

As a result the export pointed to nothing for external consumers.
