### PR TITLE
fix(react-native-host): wire dev menu on macOS Fabric root views

### DIFF
--- a/.changeset/macos-fabric-dev-menu.md
+++ b/.changeset/macos-fabric-dev-menu.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Wire up the dev menu on macOS Fabric root views so secondary-click shows it. On react-native-macos 0.81+, this sets the new `RCTSurfaceHostingView.devMenu` property so upstream's `menuForEvent:` fires. On older versions, it installs a secondary-click gesture recognizer that pops up the dev menu directly. Without this, consumers of `host.viewWithModuleName:` lose the dev menu on the new architecture because they bypass `RCTRootViewFactory`, which is where upstream does the wiring.

--- a/packages/react-native-host/cocoa/ReactNativeHost+View.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost+View.mm
@@ -15,6 +15,11 @@ static NSString *const kReactConcurrentRoot = @"concurrentRoot";
 #import <React/RCTRootView.h>
 #endif  // USE_FABRIC
 
+#if defined(RCT_DEV_MENU) && RCT_DEV_MENU && __has_include(<React/RCTDevMenu.h>)
+#import <React/RCTDevMenu.h>
+#define RNX_WIRE_DEV_MENU 1
+#endif
+
 @implementation ReactNativeHost (View)
 
 + (instancetype)hostFromRootView:(RNXView *)rootView
@@ -52,15 +57,16 @@ static NSString *const kReactConcurrentRoot = @"concurrentRoot";
         initialProps[kReactConcurrentRoot] = @YES;
     }
 
+    RNXView *rootView;
 #if __has_include(<React/RCTFabricSurfaceHostingProxyRootView.h>)
-    return [[RCTFabricSurfaceHostingProxyRootView alloc] initWithBridge:self.bridge
-                                                             moduleName:moduleName
-                                                      initialProperties:initialProps];
+    rootView = [[RCTFabricSurfaceHostingProxyRootView alloc] initWithBridge:self.bridge
+                                                                 moduleName:moduleName
+                                                          initialProperties:initialProps];
 #elif USE_BRIDGELESS
     RCTFabricSurface *surface = [self.reactHost createSurfaceWithModuleName:moduleName
                                                           initialProperties:initialProps];
 #if __has_include(<react/renderer/graphics/LinearGradient.h>)  // >=0.77
-    return [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
+    rootView = [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
 #else
     // `-initWithSurface:` implicitly calls `start` and causes race conditions.
     // This was fixed in 0.76.7, but for backwards compatibility, we should call
@@ -68,21 +74,79 @@ static NSString *const kReactConcurrentRoot = @"concurrentRoot";
     // https://github.com/facebook/react-native/pull/47313.
     RCTSurfaceSizeMeasureMode sizeMeasureMode =
         RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact;
-    return [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface
-                                                   sizeMeasureMode:sizeMeasureMode];
+    rootView = [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface
+                                                       sizeMeasureMode:sizeMeasureMode];
 #endif  // __has_include(<react/renderer/graphics/LinearGradient.h>)
 #else   // __has_include(<React/RCTFabricSurfaceHostingProxyRootView.h>)
     RCTFabricSurface *surface =
         [[RCTFabricSurface alloc] initWithSurfacePresenter:self.surfacePresenter
                                                 moduleName:moduleName
                                          initialProperties:initialProps];
-    return [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
+    rootView = [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
 #endif  // __has_include(<React/RCTFabricSurfaceHostingProxyRootView.h>)
+
+#if defined(RNX_WIRE_DEV_MENU) && TARGET_OS_OSX
+    // react-native-macos 0.81+ exposes a `devMenu` property on
+    // `RCTSurfaceHostingView` whose `menuForEvent:` returns the dev menu on
+    // secondary click. Wire it up here so it actually fires; upstream's
+    // `RCTRootViewFactory` does the same, but consumers of this host bypass it.
+    if ([rootView respondsToSelector:@selector(setDevMenu:)]) {
+        [self usingModule:[RCTDevMenu class]
+                    block:^(id<RCTBridgeModule> _Nullable module) {
+                      if (module == nil) {
+                          return;
+                      }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+                      [rootView performSelector:@selector(setDevMenu:) withObject:module];
+#pragma clang diagnostic pop
+                    }];
+    } else {
+        // Older react-native-macos versions don't override `menuForEvent:` on
+        // the Fabric root view, so secondary-click does nothing. Install a
+        // gesture recognizer that pops up the dev menu directly.
+        NSClickGestureRecognizer *recognizer = [[NSClickGestureRecognizer alloc]
+            initWithTarget:self
+                    action:@selector(rnx_showFallbackDevMenu:)];
+        recognizer.buttonMask = 1 << 1;  // Secondary (right) button
+        recognizer.numberOfClicksRequired = 1;
+        [rootView addGestureRecognizer:recognizer];
+    }
+#endif  // RNX_WIRE_DEV_MENU && TARGET_OS_OSX
+
+    return rootView;
 #else
     return [[RCTRootView alloc] initWithBridge:self.bridge
                                     moduleName:moduleName
                              initialProperties:initialProperties];
 #endif  // USE_FABRIC
 }
+
+#if defined(RNX_WIRE_DEV_MENU) && TARGET_OS_OSX
+
+- (void)rnx_showFallbackDevMenu:(NSGestureRecognizer *)recognizer
+{
+    NSView *view = recognizer.view;
+    if (view == nil) {
+        return;
+    }
+    [self usingModule:[RCTDevMenu class]
+                block:^(id<RCTBridgeModule> _Nullable module) {
+                  if (module == nil || ![module respondsToSelector:@selector(menu)]) {
+                      return;
+                  }
+                  NSMenu *menu = [(RCTDevMenu *)module menu];
+                  if (menu == nil) {
+                      return;
+                  }
+                  NSEvent *event = NSApp.currentEvent;
+                  if (event == nil) {
+                      return;
+                  }
+                  [NSMenu popUpContextMenu:menu withEvent:event forView:view];
+                }];
+}
+
+#endif  // RNX_WIRE_DEV_MENU && TARGET_OS_OSX
 
 @end


### PR DESCRIPTION
## Summary

On macOS new architecture, right-clicking the React content of an app that uses `host.viewWithModuleName:initialProperties:` does nothing — the dev menu never appears. The reasons:

1. On **react-native-macos 0.81+**, `RCTSurfaceHostingView` does override `menuForEvent:`, but it returns `[_devMenu menu]` and `_devMenu` is wired by `RCTRootViewFactory` — a code path consumers of this host bypass.
2. On **older versions**, the Fabric root view (`RCTSurfaceHostingProxyRootView` / `RCTSurfaceHostingView`) does not override `menuForEvent:` at all.

After creating the Fabric root view, this PR:

- **0.81+ path:** runtime-checks `[rootView respondsToSelector:@selector(setDevMenu:)]`, then resolves `RCTDevMenu` via `-usingModule:block:` and assigns it via `performSelector:`. This mirrors what `RCTRootViewFactory.mm` does upstream.
- **Pre-0.81 fallback:** installs an `NSClickGestureRecognizer` with `buttonMask = 1 << 1` whose action fetches `RCTDevMenu` and calls `[NSMenu popUpContextMenu:withEvent:forView:]` with `[devMenu menu]`.

Both paths are gated by:
```objc
#if defined(RCT_DEV_MENU) && RCT_DEV_MENU && __has_include(<React/RCTDevMenu.h>)
#define RNX_WIRE_DEV_MENU 1
#endif
...
#if defined(RNX_WIRE_DEV_MENU) && TARGET_OS_OSX
```

so iOS and release builds compile the wiring out entirely. The use of `respondsToSelector:` + `performSelector:` (rather than importing `<React/RCTSurfaceHostingView.h>` and casting) keeps the file compiling against react-native-macos versions that don't have the `devMenu` property in their public headers.

## Relationship to microsoft/react-native-test-app#2757

This is the **proper, upstream-aligned fix** of a pair. microsoft/react-native-test-app#2757 is a self-contained workaround landed in the test app while this change makes its way through review and into a release; once this ships and the test app picks up the new `@rnx-kit/react-native-host`, that workaround can be removed.

The two surface different menus on secondary-click:

- **This PR** shows the standard RN dev menu (Reload, Open Debugger, …) — same UX as old-arch `RCTRootView` and as iOS.
- **microsoft/react-native-test-app#2757** shows the test app's own React menu (component picker + Load From Dev Server + …).

Any consumer of `host.viewWithModuleName:` benefits from this PR — not just the test app — which is why it belongs here in the host rather than papered over in each app.

## Test plan

- [ ] Build against react-native-macos 0.75 (no `setDevMenu:`) — fallback gesture-recognizer path is exercised; right-click the React content shows the dev menu.
- [ ] Build against react-native-macos 0.81+ (has `setDevMenu:`) — property-wiring path is exercised; right-click shows the dev menu.
- [ ] Build for iOS — `RNX_WIRE_DEV_MENU` block is gated by `TARGET_OS_OSX`, no behavior change.
- [ ] Build a release configuration — `RCT_DEV_MENU` is 0, the entire block is compiled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)