### PR TITLE
feat(tools-formatting): Add a tree formatter to tools-formatting

### DIFF
--- a/.changeset/deep-clubs-melt.md
+++ b/.changeset/deep-clubs-melt.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-formatting": patch
+---
+
+Add tree formatter to formatting package

--- a/incubator/tools-formatting/README.md
+++ b/incubator/tools-formatting/README.md
@@ -53,6 +53,75 @@ const table = formatAsTable(
 console.log(table);
 ```
 
+### Tree formatting
+
+`formatAsTree` assembles a header and a list of pre-formatted rows into a
+tree-shaped string. It is a pure formatter — no buffering, no console output,
+no styling — so callers stay in control of how rows are produced and styled.
+
+```typescript
+import { formatAsTree } from "@rnx-kit/tools-formatting";
+
+const report = formatAsTree("Found problems in package.json", [
+  'missing field "license"',
+  "version is invalid",
+  "homepage is empty",
+]);
+console.log(report);
+// Found problems in package.json
+// ├── missing field "license"
+// ├── version is invalid
+// └── homepage is empty
+```
+
+Rows that contain `\n` are expanded into multiple output lines, with the trunk
+character preserved on continuation lines so the structure stays readable:
+
+```typescript
+formatAsTree("Type errors", [
+  'src/foo.ts:12\n  Type "string" is not assignable to type "number"',
+  'src/bar.ts:7\n  Cannot find name "baz"',
+]);
+// Type errors
+// ├── src/foo.ts:12
+// │     Type "string" is not assignable to type "number"
+// └── src/bar.ts:7
+//       Cannot find name "baz"
+```
+
+For terminals without unicode support, set `asciiOnly`:
+
+```typescript
+formatAsTree("Header", ["a", "b"], { asciiOnly: true });
+// Header
+// +-- a
+// `-- b
+```
+
+Or supply a fully custom set of branch characters via `treeParts`:
+
+```typescript
+formatAsTree("Header", ["a", "b"], {
+  treeParts: {
+    row: ["* ", "  "], // [first-line prefix, multi-line continuation]
+    last: ["> ", "  "],
+  },
+});
+```
+
+`indent` (number of spaces or a literal string) is prepended to every row line,
+including continuations, while leaving the header column flush:
+
+```typescript
+formatAsTree("Header", ["a", "b"], { indent: 2 });
+// Header
+//   ├── a
+//   └── b
+```
+
+The result never has a trailing newline, so it composes cleanly with whatever
+emits it.
+
 ### Path shortening
 
 `shortenPath` truncates file paths for display, keeping the most significant
@@ -89,27 +158,50 @@ shortenPath("/a/b/c/d/e.ts", 2);
 
 ### Functions
 
-| Function                     | Description                                                                     |
-| ---------------------------- | ------------------------------------------------------------------------------- |
-| `formatAsTable(data, opts?)` | Format a 2D data array into a bordered ASCII table.                             |
-| `shortenPath(path, segs?)`   | Shorten a file path to the last _segs_ segments (default 3), with `...` prefix. |
+| Function                            | Description                                                                     |
+| ----------------------------------- | ------------------------------------------------------------------------------- |
+| `formatAsTable(data, opts?)`        | Format a 2D data array into a bordered ASCII table.                             |
+| `formatAsTree(header, rows, opts?)` | Format a header and a list of rows into a tree-shaped string.                   |
+| `shortenPath(path, segs?)`          | Shorten a file path to the last _segs_ segments (default 3), with `...` prefix. |
 
 ### TableOptions
 
-| Field       | Type                          | Default | Description                                     |
-| ----------- | ----------------------------- | ------- | ----------------------------------------------- |
-| `columns`   | `(string \| ColumnOptions)[]` | auto    | Column labels or configuration objects.         |
-| `sort`      | `number[]`                    | none    | Column indices to sort by, in precedence order. |
-| `showIndex` | `boolean`                     | `false` | Show a row index column.                        |
-| `noColors`  | `boolean`                     | `false` | Strip ANSI styling from output.                 |
+| Field        | Type                          | Default | Description                                                              |
+| ------------ | ----------------------------- | ------- | ------------------------------------------------------------------------ |
+| `columns`    | `(string \| ColumnOptions)[]` | auto    | Column labels or configuration objects.                                  |
+| `sort`       | `number[]`                    | none    | Column indices to sort by, in precedence order.                          |
+| `showIndex`  | `boolean`                     | `false` | Show a row index column.                                                 |
+| `asciiOnly`  | `boolean`                     | `false` | Use ASCII-only border characters instead of unicode box drawing.         |
+| `tableParts` | `TableViewParts`              | --      | Fully override the border characters. Takes precedence over `asciiOnly`. |
+| `noColors`   | `boolean`                     | `false` | Strip ANSI styling from output.                                          |
 
 ### ColumnOptions
 
-| Field       | Type                        | Default  | Description                                  |
-| ----------- | --------------------------- | -------- | -------------------------------------------- |
-| `label`     | `string`                    | auto     | Column header label.                         |
-| `digits`    | `number`                    | --       | Fixed decimal places for numeric values.     |
-| `localeFmt` | `boolean`                   | `false`  | Use locale number formatting.                |
-| `align`     | `"left"\|"right"\|"center"` | `"left"` | Cell text alignment.                         |
-| `maxWidth`  | `number`                    | --       | Maximum column width (truncates with `...`). |
-| `style`     | `StyleValue \| function`    | --       | ANSI style or custom formatter.              |
+| Field       | Type                        | Default  | Description                                             |
+| ----------- | --------------------------- | -------- | ------------------------------------------------------- |
+| `label`     | `string`                    | auto     | Column header label.                                    |
+| `format`    | `(value) => string`         | --       | Convert a cell value to a string. Defaults to `String`. |
+| `digits`    | `number`                    | --       | Fixed decimal places for numeric values.                |
+| `localeFmt` | `boolean`                   | `false`  | Use locale number formatting.                           |
+| `align`     | `"left"\|"right"\|"center"` | `"left"` | Cell text alignment.                                    |
+| `maxWidth`  | `number`                    | --       | Maximum column width (truncates with `...`).            |
+| `style`     | `StyleValue \| function`    | --       | ANSI style or custom formatter.                         |
+
+### TreeFormattingOptions
+
+| Field       | Type               | Default | Description                                                                |
+| ----------- | ------------------ | ------- | -------------------------------------------------------------------------- |
+| `asciiOnly` | `boolean`          | `false` | Use ASCII-only branch characters (`+-- ` / `` `--  ``) instead of unicode. |
+| `treeParts` | `TreeViewParts`    | --      | Fully override the branch characters. Takes precedence over `asciiOnly`.   |
+| `indent`    | `number \| string` | none    | Prepend this many spaces (number) or this exact string to every row line.  |
+
+### TreeViewParts
+
+Describes the branch glyphs used for each row as
+`[first-line prefix, continuation prefix]`. The continuation prefix is used
+when a row's text contains `\n`. All four prefixes should have the same width.
+
+| Field  | Type               | Description                                              |
+| ------ | ------------------ | -------------------------------------------------------- |
+| `row`  | `[string, string]` | Prefixes for any non-last row (e.g. `["├── ", "│   "]`). |
+| `last` | `[string, string]` | Prefixes for the final row (e.g. `["└── ", "    "]`).    |

--- a/incubator/tools-formatting/src/const.ts
+++ b/incubator/tools-formatting/src/const.ts
@@ -1,3 +1,35 @@
+import type { TableViewParts, TreeViewParts } from "./types.ts";
+
 export const ELLIPSIS = "...";
 export const SRC_DIRS = ["src", "lib", "dist", "bin"];
 export const SEPARATORS = ["/", "\\"];
+
+type StyleKeys = "default" | "ascii";
+
+export const TREE_STYLES: Record<StyleKeys, TreeViewParts> = {
+  default: {
+    row: ["├── ", "│   "],
+    last: ["└── ", "    "],
+  },
+  ascii: {
+    row: ["+-- ", "|   "],
+    last: ["`-- ", "    "],
+  },
+};
+
+export const TABLE_STYLES: Record<StyleKeys, TableViewParts> = {
+  default: {
+    top: ["┌", "┬", "┐"],
+    mid: ["├", "┼", "┤"],
+    bottom: ["└", "┴", "┘"],
+    row: ["│", "│", "│"],
+    fill: "─",
+  },
+  ascii: {
+    top: ["+", "+", "+"],
+    mid: ["+", "+", "+"],
+    bottom: ["+", "+", "+"],
+    row: ["|", "|", "|"],
+    fill: "-",
+  },
+};

--- a/incubator/tools-formatting/src/index.ts
+++ b/incubator/tools-formatting/src/index.ts
@@ -2,3 +2,13 @@ export { shortenPath } from "./paths.ts";
 
 export type { TableOptions, ColumnOptions } from "./table.ts";
 export { formatAsTable } from "./table.ts";
+
+export type {
+  ColorOptions,
+  StyleValue,
+  TableViewParts,
+  TextOptions,
+  TreeFormattingOptions,
+  TreeViewParts,
+} from "./types.ts";
+export { formatAsTree } from "./trees.ts";

--- a/incubator/tools-formatting/src/paths.ts
+++ b/incubator/tools-formatting/src/paths.ts
@@ -17,7 +17,7 @@ import { ELLIPSIS, SEPARATORS, SRC_DIRS } from "./const.ts";
  * @returns The shortened file path
  */
 export function shortenPath(path: string, segments = 3): string {
-  let last = 0;
+  let last = -1;
   for (let i = path.length - 1; i > ELLIPSIS.length; i--) {
     if (SEPARATORS.includes(path[i])) {
       segments--;
@@ -25,7 +25,7 @@ export function shortenPath(path: string, segments = 3): string {
         // check the last slice to see if it starts with a known source dir, if so keep iterating.
         if (last > i && SRC_DIRS.includes(path.slice(i + 1, last))) {
           segments++;
-          last = 0;
+          last = -1;
         } else {
           return ELLIPSIS + path.slice(i);
         }

--- a/incubator/tools-formatting/src/table.ts
+++ b/incubator/tools-formatting/src/table.ts
@@ -1,30 +1,37 @@
 import { stripVTControlCharacters, styleText } from "node:util";
+import { TABLE_STYLES } from "./const.ts";
+import type {
+  StyleValue,
+  TextOptions,
+  ColorOptions,
+  TableViewParts,
+} from "./types.ts";
 
-export type StyleValue = Parameters<typeof styleText>[0];
 export type ValueFormatter<T = unknown> = (value: T) => string;
 
-export type TableOptions = {
-  /**
-   * Configuration for each column, can be a string for the column label or an object with additional formatting
-   * options. If not provided, columns will be labeled Column1, Column2, etc.
-   */
-  columns?: (string | ColumnOptions)[];
+export type TableOptions = TextOptions &
+  ColorOptions & {
+    /**
+     * Configuration for each column, can be a string for the column label or an object with additional formatting
+     * options. If not provided, columns will be labeled Column1, Column2, etc.
+     */
+    columns?: (string | ColumnOptions)[];
 
-  /**
-   * Optional array of column indices to sort by, in order of precedence. If not provided, no sorting will be applied.
-   */
-  sort?: number[];
+    /**
+     * Optional array of column indices to sort by, in order of precedence. If not provided, no sorting will be applied.
+     */
+    sort?: number[];
 
-  /**
-   * Show an index column at the start of the table with the row number. Defaults to false.
-   */
-  showIndex?: boolean;
+    /**
+     * Show an index column at the start of the table with the row number. Defaults to false.
+     */
+    showIndex?: boolean;
 
-  /**
-   * No color styling will be applied to the table output if this is set to true. Defaults to false.
-   */
-  noColors?: boolean;
-};
+    /**
+     * Optional custom parts to use when drawing the table, such as row separators, header separators, etc.
+     */
+    tableParts?: TableViewParts;
+  };
 
 /**
  * Options for configuring column output
@@ -48,8 +55,9 @@ export type ColumnOptions = {
 
 export function formatAsTable(
   values: unknown[][],
-  { columns, sort, showIndex, noColors }: TableOptions = {}
+  options: TableOptions = {}
 ): string {
+  const { columns, sort, noColors } = options;
   if (values.length === 0) {
     return "";
   }
@@ -80,7 +88,7 @@ export function formatAsTable(
   }
 
   // now render the table based on the prepared row and column data
-  return drawTable(rows, colData, showIndex, noColors);
+  return drawTable(rows, colData, options);
 }
 
 type ResolvedColumnOptions = Omit<ColumnOptions, "label"> & {
@@ -165,17 +173,21 @@ function toRowData(
  * Draw the set of table rows with the given column data
  * @param rows processed rows to render
  * @param columns processed column data with widths and styling information
- * @param addIndex whether to add an index column at the start of the table
+ * @param options table rendering options
  * @returns a string representing the drawn table to be printed to the console
  */
 function drawTable(
   rows: CellEntry[][],
   columns: ResolvedColumnOptions[],
-  addIndex = false,
-  noColors = false
+  { showIndex, noColors, tableParts, asciiOnly }: TableOptions = {}
 ): string {
-  const indexWidth = addIndex ? Math.max(String(rows.length + 1).length, 5) : 0;
-  let output = drawLine(columns, "top", indexWidth);
+  const style =
+    tableParts ?? (asciiOnly ? TABLE_STYLES.ascii : TABLE_STYLES.default);
+  const fill = style.fill;
+  const indexWidth = showIndex
+    ? Math.max(String(rows.length + 1).length, 5)
+    : 0;
+  let output = drawLine(columns, style.top, fill, indexWidth) + "\n";
   const headerRow = columns.map((col) => {
     const rawText = stripVTControlCharacters(col.label);
     return {
@@ -183,44 +195,35 @@ function drawTable(
       width: rawText.length,
     } as CellEntry;
   });
-  output += drawRow(headerRow, columns, "index", indexWidth);
-  output += drawLine(columns, "mid", indexWidth);
+  output += drawRow(headerRow, columns, style.row, "index", indexWidth);
+  output += drawLine(columns, style.mid, fill, indexWidth) + "\n";
   for (let index = 0; index < rows.length; index++) {
-    output += drawRow(rows[index], columns, index + 1, indexWidth);
+    output += drawRow(rows[index], columns, style.row, index + 1, indexWidth);
   }
-  output += drawLine(columns, "bottom", indexWidth);
+  output += drawLine(columns, style.bottom, fill, indexWidth);
   return output;
 }
-
-const segments = {
-  top: ["┌", "┬", "┐"],
-  mid: ["├", "┼", "┤"],
-  bottom: ["└", "┴", "┘"],
-};
 
 /**
  * Draw table lines based on column widths and the type of line (top, mid, bottom)
  * @param colData set of column data with widths to determine how long to draw each segment
- * @param type one of "top", "mid", or "bottom" to determine which line segments to use
+ * @param seg the set of line segments to use for this line, in the order [left, middle, right]
  * @param indexWidth width of the index column, if present. Column will be skipped if width is 0.
  * @returns the drawn line as a string
  */
 function drawLine(
   colData: ResolvedColumnOptions[],
-  type: keyof typeof segments,
+  seg: [string, string, string],
+  fill: string,
   indexWidth = 0
 ) {
-  const seg = segments[type];
   let line = seg[0];
   if (indexWidth > 0) {
-    line += "─".repeat(indexWidth + 2) + seg[1];
+    line += fill.repeat(indexWidth + 2) + seg[1];
   }
   for (let i = 0; i < colData.length; i++) {
-    line += "─".repeat(colData[i].width + 2);
+    line += fill.repeat(colData[i].width + 2);
     line += i === colData.length - 1 ? seg[2] : seg[1];
-  }
-  if (type !== "bottom") {
-    line += "\n";
   }
   return line;
 }
@@ -266,19 +269,23 @@ function alignedText(
 function drawRow(
   cells: CellEntry[],
   columns: ResolvedColumnOptions[],
+  segments: [string, string, string],
   index: number | string,
   indexWidth = 0
 ) {
-  let row = "│";
+  let row = segments[0];
   if (indexWidth > 0) {
     const indexText = String(index);
-    row += alignedText(indexText, indexText.length, indexWidth, "right") + "│";
+    row +=
+      alignedText(indexText, indexText.length, indexWidth, "right") +
+      segments[1];
   }
 
   for (let i = 0; i < cells.length; i++) {
     const col = columns[i];
+    const segment = i === cells.length - 1 ? segments[2] : segments[1];
     const { text, width } = cells[i];
-    row += alignedText(text, width, col.width, col.align ?? "left") + "│";
+    row += alignedText(text, width, col.width, col.align ?? "left") + segment;
   }
   return row + "\n";
 }

--- a/incubator/tools-formatting/src/trees.ts
+++ b/incubator/tools-formatting/src/trees.ts
@@ -1,0 +1,50 @@
+import { TREE_STYLES } from "./const.ts";
+import type { TreeFormattingOptions } from "./types.ts";
+
+/**
+ * Format a header and a list of rows into a tree-like string representation using the
+ * specified tree formatting options.
+ * @param header header text to display at the top of the tree
+ * @param rows array of strings representing each row to display under the header
+ * @param options tree formatting options to control the appearance of the tree
+ * @returns a string representing the formatted tree. There will be no trailing newline.
+ */
+export function formatAsTree(
+  header: string,
+  rows: string[],
+  options: TreeFormattingOptions = {}
+): string {
+  const { asciiOnly, treeParts } = options;
+  const indent = resolveIndent(options.indent);
+
+  const treeStyle =
+    treeParts ?? (asciiOnly ? TREE_STYLES.ascii : TREE_STYLES.default);
+
+  let result = header;
+
+  for (let i = 0; i < rows.length; i++) {
+    const isLast = i === rows.length - 1;
+    const [branch, cont] = isLast ? treeStyle.last : treeStyle.row;
+    const lines = rows[i].split("\n");
+    for (let j = 0; j < lines.length; j++) {
+      result += "\n" + indent + (j === 0 ? branch : cont) + lines[j];
+    }
+  }
+  return result;
+}
+
+/**
+ * Resolve the indent value into a string. If a number is provided, it will be converted
+ * into that many spaces. If a string is provided, it will be returned as-is. Falsy
+ * values resolve to an empty string.
+ */
+function resolveIndent(indent: TreeFormattingOptions["indent"]): string {
+  // undefined or falsy indent resolves to empty string
+  if (!indent) {
+    return "";
+  }
+  if (typeof indent === "number") {
+    return " ".repeat(Math.max(0, indent));
+  }
+  return indent;
+}

--- a/incubator/tools-formatting/src/types.ts
+++ b/incubator/tools-formatting/src/types.ts
@@ -1,0 +1,88 @@
+import type { styleText } from "node:util";
+
+/**
+ * The type of value that can be passed to `styleText` to apply styling to text output.
+ */
+export type StyleValue = Parameters<typeof styleText>[0];
+
+/**
+ * Baseline color formatting options
+ */
+export type ColorOptions = {
+  /**
+   * Disable color formatting in the output
+   */
+  noColors?: boolean;
+};
+
+/**
+ * Baseline text formatting options
+ */
+export type TextOptions = {
+  /**
+   * Use ASCII output only, disable unicode character output
+   */
+  asciiOnly?: boolean;
+};
+
+/**
+ * Tree formatting options
+ */
+export type TreeFormattingOptions = TextOptions & {
+  /**
+   * Customizable parts of the tree view to use when rendering each row and the last row
+   * of the tree. If not specified, a default set of unicode tree characters will be used.
+   */
+  treeParts?: TreeViewParts;
+
+  /**
+   * Indent the tree output by a number of spaces or prefix each line with a string.
+   */
+  indent?: number | string;
+};
+
+/**
+ * Parts of a tree view.
+ *
+ * Each row of the tree has a first-line prefix and a continuation prefix used for any extra lines
+ * produced when the row text contains a `\n`. The last row is treated separately so the trunk
+ * character can be dropped once the branch closes. All four prefixes should have the same width
+ * so columns line up.
+ *
+ *   {
+ *     row: ["├── ", "│   "],  // [first-line prefix, continuation prefix]
+ *     last: ["└── ", "    "], // same shape, used for the final row
+ *   }
+ *
+ * With rows that include `\n`, the above produces:
+ *
+ *   Header
+ *   ├── single-line row
+ *   ├── row with a newline
+ *   │   continuation of the previous row
+ *   └── last row, which also
+ *       wraps onto a second line
+ */
+export type TreeViewParts = {
+  row: [string, string];
+  last: [string, string];
+};
+
+/**
+ * Parts of a table view, each consisting of three strings representing the left, middle, and right
+ * segments of the table border or row. For example, the top border of a table would be composed of
+ * the left corner, the column separator, and the right corner, which are represented by the three
+ * strings in the `top` tuple.
+ */
+export type TableViewParts = {
+  /** top line of the table */
+  top: [string, string, string];
+  /** middle line of the table, typically used as a separator between header and body rows */
+  mid: [string, string, string];
+  /** a standard row of the table */
+  row: [string, string, string];
+  /** bottom line of the table */
+  bottom: [string, string, string];
+  /** line fill character */
+  fill: string;
+};

--- a/incubator/tools-formatting/test/table.test.ts
+++ b/incubator/tools-formatting/test/table.test.ts
@@ -63,8 +63,16 @@ describe("formatAsTable", () => {
       noColors: true,
     });
     const lines = result.split("\n").filter(Boolean);
-    // first data row should have "op" left-aligned
-    ok(lines[3]!.includes("│ op"));
+    // "op" left-aligned: "│ op" with trailing padding before the next separator
+    ok(
+      lines[3]!.includes("│ op  "),
+      "left-aligned cell should have trailing padding"
+    );
+    // "1" right-aligned in a 5-char column: "│     1 │" (5 leading spaces, value, 1 trailing)
+    ok(
+      lines[3]!.includes("│     1 │"),
+      "right-aligned cell should have leading padding"
+    );
   });
 
   it("left-aligns columns by default", () => {

--- a/incubator/tools-formatting/test/trees.test.ts
+++ b/incubator/tools-formatting/test/trees.test.ts
@@ -1,0 +1,91 @@
+import { equal, ok } from "node:assert/strict";
+import { describe, it } from "node:test";
+import { formatAsTree } from "../src/trees.ts";
+
+describe("formatAsTree", () => {
+  it("returns just the header when there are no rows", () => {
+    equal(formatAsTree("Header", []), "Header");
+  });
+
+  it("does not append a trailing newline", () => {
+    const result = formatAsTree("Header", ["a"]);
+    ok(!result.endsWith("\n"));
+  });
+
+  it("uses ├── for non-last rows and └── for the last", () => {
+    const result = formatAsTree("Header", ["first", "second", "third"]);
+    const lines = result.split("\n");
+    equal(lines[0], "Header");
+    equal(lines[1], "├── first");
+    equal(lines[2], "├── second");
+    equal(lines[3], "└── third");
+  });
+
+  it("uses └── for a single row", () => {
+    const result = formatAsTree("Header", ["only"]);
+    const lines = result.split("\n");
+    equal(lines[0], "Header");
+    equal(lines[1], "└── only");
+  });
+
+  it("uses ASCII characters when asciiOnly is set", () => {
+    const result = formatAsTree("Header", ["a", "b"], { asciiOnly: true });
+    const lines = result.split("\n");
+    equal(lines[1], "+-- a");
+    equal(lines[2], "`-- b");
+  });
+
+  it("treeParts overrides asciiOnly when both are provided", () => {
+    const result = formatAsTree("Header", ["a", "b"], {
+      asciiOnly: true,
+      treeParts: {
+        row: ["* ", "  "],
+        last: ["> ", "  "],
+      },
+    });
+    const lines = result.split("\n");
+    equal(lines[1], "* a");
+    equal(lines[2], "> b");
+  });
+
+  it("expands a multi-line row into one output line per source line with continuation prefix", () => {
+    const result = formatAsTree("Header", ["first-line\nsecond-line", "only"]);
+    const lines = result.split("\n");
+    equal(lines[0], "Header");
+    equal(lines[1], "├── first-line");
+    equal(lines[2], "│   second-line");
+    equal(lines[3], "└── only");
+  });
+
+  it("uses the empty-trunk continuation for a multi-line last row", () => {
+    const result = formatAsTree("Header", ["a\nb"]);
+    const lines = result.split("\n");
+    equal(lines[0], "Header");
+    equal(lines[1], "└── a");
+    equal(lines[2], "    b");
+  });
+
+  it("indent as a number prepends that many spaces to each row line", () => {
+    const result = formatAsTree("Header", ["a", "b"], { indent: 2 });
+    const lines = result.split("\n");
+    // header is intentionally not indented
+    equal(lines[0], "Header");
+    equal(lines[1], "  ├── a");
+    equal(lines[2], "  └── b");
+  });
+
+  it("indent as a string prepends that string to each row line", () => {
+    const result = formatAsTree("Header", ["a", "b"], { indent: ">> " });
+    const lines = result.split("\n");
+    equal(lines[1], ">> ├── a");
+    equal(lines[2], ">> └── b");
+  });
+
+  it("indent applies to multi-line continuation lines as well", () => {
+    const result = formatAsTree("Header", ["a\nb"], { indent: 2 });
+    const lines = result.split("\n");
+    equal(lines[1], "  └── a");
+    // 2 spaces of indent + "    " (last-row continuation) = 6 spaces before "b"
+    equal(lines[2], "      b");
+  });
+});


### PR DESCRIPTION
### Description

This adds a simple console tree formatter to the package which outputs a header and a set of sub-messages associated with that header.

It also generalizes some of the ascii art patterns to have unicode/ascii defaults (for both tables and trees) as well as allowing direct customization.

### Test plan

Tests updated as part of this change.