### PR TITLE
fix(third-party-notices): ignore submodule manifests

### DIFF
--- a/.changeset/lovely-cloths-teach.md
+++ b/.changeset/lovely-cloths-teach.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/third-party-notices": patch
+---
+
+Fixed submodule manifests being picked up as the package manifest

--- a/packages/third-party-notices/src/write-third-party-notices.ts
+++ b/packages/third-party-notices/src/write-third-party-notices.ts
@@ -108,6 +108,18 @@ export async function getCurrentPackageId(
   return undefined;
 }
 
+function isPackageManifest(manifest: ReturnType<typeof readPackage>): boolean {
+  return Boolean(
+    manifest.license ||
+    manifest.licenses ||
+    manifest.files ||
+    manifest.exports ||
+    manifest.dependencies ||
+    manifest.peerDependencies ||
+    manifest.devDependencies
+  );
+}
+
 // helper functions
 export function normalizePath(p: string, currentPackageId?: string): string {
   let result = p.replaceAll("webpack:///", "");
@@ -159,10 +171,20 @@ export function splitSourcePath(rootPath: string, p: string): string[] {
 
   // This is most likely an absolute file path e.g.,
   // `/~/node_modules/.store/react-native-virtual-3e97acc5aa/package/index.js`
-  const pkgRoot = findPackageDir(p);
-  if (pkgRoot) {
+  let pkgRoot = findPackageDir(p);
+  while (pkgRoot) {
     const manifest = readPackage(pkgRoot);
-    return [manifest.name, pkgRoot];
+    // Retry if this package manifest seems to be a submodule manifest
+    if (isPackageManifest(manifest)) {
+      return [manifest.name, pkgRoot];
+    }
+
+    const parentDir = path.dirname(pkgRoot);
+    if (parentDir === pkgRoot) {
+      break;
+    }
+
+    pkgRoot = findPackageDir(parentDir);
   }
 
   throw new Error(`Could not parse module: ${p}`);


### PR DESCRIPTION
### Description

Fixed submodule manifests being picked up as the package manifest.

Resolves #4118.

### Test plan

See #4118 for repro.