### PR TITLE
fix(config): Fix bugs with extends in kit configuration

### DIFF
--- a/.changeset/eight-stars-wait.md
+++ b/.changeset/eight-stars-wait.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/config": minor
+---
+
+Fix issues where loading multiple kit configs in the same process would pollute the cached objects

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -21,6 +21,7 @@ Configuration information for an rnx-kit package. This is retrieved from
 
 | Name                  | Type                                          | Description                                                                                                                                                                                                                                         |
 | --------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| extends               | `string \| undefined`                         | Load a base configuration from a file or module. See [Extending a base configuration](#extending-a-base-configuration).                                                                                                                             |
 | kitType               | `"app" \| "library" \| undefined`             | Library or App package. Used by the dependency manager when projecting capabilities into `dependencies`, `devDependencies`, and `peerDependencies`. Library package dependencies are private, in dev and peer. App package dependencies are public. |
 | reactNativeVersion    | `string \| undefined`                         | React Native version (or range) which this package supports.                                                                                                                                                                                        |
 | reactNativeDevVersion | `string \| undefined`                         | React Native version to use during development of this package. If not specified, the minimum `reactNativeVersion` is used.                                                                                                                         |
@@ -28,6 +29,46 @@ Configuration information for an rnx-kit package. This is retrieved from
 | server                | `ServerConfig \| undefined`                   | Specifies how the package's bundle server is configured.                                                                                                                                                                                            |
 | capabilities          | `Capability[] \| undefined`                   | List of [capabilities](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check#capabilities) that this package needs. A capability is a well-known name (string).                                                                         |
 | customProfiles        | `string \| undefined`                         | Path to a file containing [custom profiles](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check#custom-profiles).                                                                                                                     |
+
+#### Extending a base configuration
+
+A package can inherit from a shared configuration by setting `extends` on its
+`rnx-kit` field. The value is one of:
+
+- A relative or absolute path to a `.js` / `.cjs` / `.json` file that exports
+  a `KitConfig` (`module.exports = { ... }`).
+- A bare module specifier (e.g. `"@my-org/rnx-kit-base"`) — resolved via
+  Node's module resolution from the consuming package's directory.
+- A path to a `package.json` — its `rnx-kit` field is used as the base.
+
+The resolved configuration is the deep merge of the base into the consumer's
+own config, with consumer values winning on conflict (lodash-style merge:
+arrays are merged by index, plain objects are merged recursively). The
+`extends` field is stripped from the merged result.
+
+```jsonc
+// my-org/rnx-kit-base/index.js
+module.exports = {
+  kitType: "library",
+  reactNativeVersion: "^0.74.0",
+};
+```
+
+```jsonc
+// consumer/package.json
+{
+  "rnx-kit": {
+    "extends": "@my-org/rnx-kit-base",
+    "bundle": { "id": "core" },
+  },
+}
+```
+
+A base configuration can itself declare `extends`; the chain is resolved
+recursively, with each layer's `extends` resolved relative to the file that
+declared it. Multiple packages may safely share the same base — resolution
+does not mutate the base, so a sibling package's overrides never leak across
+into another consumer's resolved config.
 
 ### `BundleConfig` inherits `BundleParameters`
 
@@ -103,6 +144,18 @@ Query for a package's rnx-kit configuration.
 | module    | `string \| undefined` | Read package configuration from the named module. When given, this takes precedence over `cwd`. |
 | cwd       | `string \| undefined` | Read package configuration from the given directory. Ignored when `module` is given.            |
 | [Return]  | `KitConfig \| null`   | Package configuration, or `null` if nothing was found.                                          |
+
+### `getKitConfigFromPackageManifest(packageJson, packageDir)`
+
+Resolve a `KitConfig` from an already-loaded package manifest. Useful when
+the caller has already parsed `package.json` and wants to avoid re-reading
+it from disk. Any `extends` chain is resolved relative to `packageDir`.
+
+| Parameter   | Type                     | Description                                                                    |
+| ----------- | ------------------------ | ------------------------------------------------------------------------------ |
+| packageJson | `PackageManifest`        | Parsed `package.json` for the package being inspected.                         |
+| packageDir  | `string`                 | Directory containing `packageJson`. Used to resolve `extends` references.      |
+| [Return]    | `KitConfig \| undefined` | Resolved configuration, or `undefined` if the manifest has no `rnx-kit` field. |
 
 ### `getBundleConfig(config, id)`
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -21,7 +21,6 @@ Configuration information for an rnx-kit package. This is retrieved from
 
 | Name                  | Type                                          | Description                                                                                                                                                                                                                                         |
 | --------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| extends               | `string \| undefined`                         | Load a base configuration from a file or module. See [Extending a base configuration](#extending-a-base-configuration).                                                                                                                             |
 | kitType               | `"app" \| "library" \| undefined`             | Library or App package. Used by the dependency manager when projecting capabilities into `dependencies`, `devDependencies`, and `peerDependencies`. Library package dependencies are private, in dev and peer. App package dependencies are public. |
 | reactNativeVersion    | `string \| undefined`                         | React Native version (or range) which this package supports.                                                                                                                                                                                        |
 | reactNativeDevVersion | `string \| undefined`                         | React Native version to use during development of this package. If not specified, the minimum `reactNativeVersion` is used.                                                                                                                         |
@@ -29,46 +28,6 @@ Configuration information for an rnx-kit package. This is retrieved from
 | server                | `ServerConfig \| undefined`                   | Specifies how the package's bundle server is configured.                                                                                                                                                                                            |
 | capabilities          | `Capability[] \| undefined`                   | List of [capabilities](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check#capabilities) that this package needs. A capability is a well-known name (string).                                                                         |
 | customProfiles        | `string \| undefined`                         | Path to a file containing [custom profiles](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check#custom-profiles).                                                                                                                     |
-
-#### Extending a base configuration
-
-A package can inherit from a shared configuration by setting `extends` on its
-`rnx-kit` field. The value is one of:
-
-- A relative or absolute path to a `.js` / `.cjs` / `.json` file that exports
-  a `KitConfig` (`module.exports = { ... }`).
-- A bare module specifier (e.g. `"@my-org/rnx-kit-base"`) — resolved via
-  Node's module resolution from the consuming package's directory.
-- A path to a `package.json` — its `rnx-kit` field is used as the base.
-
-The resolved configuration is the deep merge of the base into the consumer's
-own config, with consumer values winning on conflict (lodash-style merge:
-arrays are merged by index, plain objects are merged recursively). The
-`extends` field is stripped from the merged result.
-
-```jsonc
-// my-org/rnx-kit-base/index.js
-module.exports = {
-  kitType: "library",
-  reactNativeVersion: "^0.74.0",
-};
-```
-
-```jsonc
-// consumer/package.json
-{
-  "rnx-kit": {
-    "extends": "@my-org/rnx-kit-base",
-    "bundle": { "id": "core" },
-  },
-}
-```
-
-A base configuration can itself declare `extends`; the chain is resolved
-recursively, with each layer's `extends` resolved relative to the file that
-declared it. Multiple packages may safely share the same base — resolution
-does not mutate the base, so a sibling package's overrides never leak across
-into another consumer's resolved config.
 
 ### `BundleConfig` inherits `BundleParameters`
 

--- a/packages/config/src/getKitConfig.ts
+++ b/packages/config/src/getKitConfig.ts
@@ -71,11 +71,17 @@ function loadBaseConfig(
     const pkgInfo = getPackageInfoFromPath(spec);
     baseConfig = getKitConfigFromPackageInfo(pkgInfo);
   } else {
-    // otherwise require the file directly
-    baseConfig = require(spec);
+    // require the file, then recurse so that any `extends` declared in the
+    // loaded module is resolved relative to its own directory
+    const loaded = require(spec) as KitConfig;
+    baseConfig = loadBaseConfig(loaded, path.dirname(spec)) ?? {};
   }
 
-  const mergedConfig = merge(baseConfig, config);
+  // Clone the base before merging: `baseConfig` may be a cached object
+  // (require cache for JS files, package-info cache for package.json refs),
+  // and `lodash.merge` mutates its target — without the clone, every
+  // subsequent extender would see the previous extender's overrides.
+  const mergedConfig = merge(structuredClone(baseConfig), config);
   delete mergedConfig["extends"];
   return mergedConfig;
 }

--- a/packages/config/test/__fixtures__/node_modules/kit-test-extends-chain/mid.config.js
+++ b/packages/config/test/__fixtures__/node_modules/kit-test-extends-chain/mid.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: "./root.config.js",
+  bundle: {
+    id: "mid-bundle",
+  },
+};

--- a/packages/config/test/__fixtures__/node_modules/kit-test-extends-chain/package.json
+++ b/packages/config/test/__fixtures__/node_modules/kit-test-extends-chain/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "kit-test-extends-chain",
+  "version": "0.0.1",
+  "description": "Package whose extends chains through two JS files (regression fixture)",
+  "rnx-kit": {
+    "extends": "./mid.config.js"
+  }
+}

--- a/packages/config/test/__fixtures__/node_modules/kit-test-extends-chain/root.config.js
+++ b/packages/config/test/__fixtures__/node_modules/kit-test-extends-chain/root.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  kitType: "library",
+  reactNativeVersion: "0.74.0",
+};

--- a/packages/config/test/__fixtures__/node_modules/kit-test-extends-shared-a/package.json
+++ b/packages/config/test/__fixtures__/node_modules/kit-test-extends-shared-a/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "name": "kit-test-extends-shared-a",
+  "version": "0.0.1",
+  "description": "Consumer A — extends shared base and adds its own bundle override",
+  "rnx-kit": {
+    "extends": "rnx-kit-shared-base",
+    "bundle": {
+      "id": "bundle-a"
+    }
+  }
+}

--- a/packages/config/test/__fixtures__/node_modules/kit-test-extends-shared-b/package.json
+++ b/packages/config/test/__fixtures__/node_modules/kit-test-extends-shared-b/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "kit-test-extends-shared-b",
+  "version": "0.0.1",
+  "description": "Consumer B — extends the same base as A but adds nothing of its own",
+  "rnx-kit": {
+    "extends": "rnx-kit-shared-base"
+  }
+}

--- a/packages/config/test/__fixtures__/node_modules/rnx-kit-shared-base/index.js
+++ b/packages/config/test/__fixtures__/node_modules/rnx-kit-shared-base/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  kitType: "library",
+  reactNativeVersion: "0.74.0",
+};

--- a/packages/config/test/__fixtures__/node_modules/rnx-kit-shared-base/package.json
+++ b/packages/config/test/__fixtures__/node_modules/rnx-kit-shared-base/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "name": "rnx-kit-shared-base",
+  "version": "0.0.1",
+  "description": "Shared base config used by multiple consumers (regression fixture)",
+  "main": "index.js"
+}

--- a/packages/config/test/getKitConfig.test.ts
+++ b/packages/config/test/getKitConfig.test.ts
@@ -81,4 +81,43 @@ describe("getKitConfig()", () => {
   it("merges with base config from module", () => {
     deepEqual(getKitConfig(optionsFor("kit-test-extends-module")), baseConfig);
   });
+
+  it("does not leak overrides between packages sharing the same base", () => {
+    // Regression: `lodash.merge` mutates its target, and both branches of
+    // `loadBaseConfig` (`require.cache` for JS files, package-info cache for
+    // package.json refs) hand back a cached reference. Without a clone, the
+    // first consumer's overrides poison the cached base for every consumer
+    // that follows.
+    const a = getKitConfig(optionsFor("kit-test-extends-shared-a"));
+    const b = getKitConfig(optionsFor("kit-test-extends-shared-b"));
+
+    ok(a, "consumer a should resolve a config");
+    ok(b, "consumer b should resolve a config");
+
+    // Sanity: both consumers see the shared base values.
+    deepEqual(a.kitType, "library");
+    deepEqual(b.kitType, "library");
+
+    // a declares its own bundle; b does not.
+    deepEqual(a.bundle, { id: "bundle-a" });
+    ok(
+      !("bundle" in b),
+      "consumer b must not see consumer a's bundle override"
+    );
+  });
+
+  it("recursively resolves extends through chained JS files", () => {
+    // Regression: the JS-file branch of `loadBaseConfig` used to call
+    // `require(spec)` and stop, so a JS preset that itself declared `extends`
+    // had its own base silently dropped.
+    const config = getKitConfig(optionsFor("kit-test-extends-chain"));
+    ok(config, "chained config should resolve");
+
+    // Values from the root layer.
+    deepEqual(config.kitType, "library");
+    // Values from the mid layer.
+    deepEqual(config.bundle, { id: "mid-bundle" });
+    // The merged config should not carry an `extends` field forward.
+    ok(!("extends" in config), "extends should be stripped from merged config");
+  });
 });


### PR DESCRIPTION
### Description

**NOTE: This is marked as a minor change as if people were using `extends` in the kit configuration in tools like `@rnx-kit/align-deps` their behavior may change on update.**

This fixes two issues in loading kit configurations with extends.

- `lodash.merge` mutates the base object, meaning that when a package kit config extended a base config, it would pollute that cached base config, then the next package would see the pollution and add to it, and so on.
- extends was broken for js config files.

Also added the extends documentation to the config/README.md

### Test plan

Added new test fixtures to test the scenarios.