### PR TITLE
fix(tools-packages): Resolve paths before doing cache lookups in the package cache

### DIFF
--- a/.changeset/shiny-taxis-shave.md
+++ b/.changeset/shiny-taxis-shave.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-packages": patch
+---
+
+Ensure package caching is based on normalized paths for purposes of caching

--- a/packages/tools-packages/src/package.ts
+++ b/packages/tools-packages/src/package.ts
@@ -27,14 +27,15 @@ class PackageInfoCache {
    * @returns loaded PackageInfo for the package, or throws an exception if not found
    */
   getByPath(pkgPath: string): PackageInfo {
-    const [root, manifestPath] = this.getPackagePaths(pkgPath);
+    const resolvedPath = path.resolve(pkgPath);
+    const [root, manifestPath] = this.getPackagePaths(resolvedPath);
 
     if (!this.byRoot.has(root)) {
       // it's not in the cache so load it
       const manifest = readPackage(manifestPath);
       const workspace = this.isWorkspace(root);
 
-      // it's not a valid package if the manifest can't be laoded
+      // it's not a valid package if the manifest can't be loaded
       if (manifest) {
         // create a new entry and cache it
         this.store({ name: manifest.name, root, manifest, workspace });


### PR DESCRIPTION
### Description

Packages were being cached based on the passed in paths which may be relative or absolute. Resolve the paths on entry which will make them both absolute and normalized and ensures cache consistency.
