### PR TITLE
fix(align-deps): Publish a new version of align-deps as the bundled dependencies have changed

### DIFF
--- a/.changeset/tired-trains-know.md
+++ b/.changeset/tired-trains-know.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": minor
+---
+
+Bump package to bundle updates to config with minor version changes


### PR DESCRIPTION
### Description

@rnx-kit/align-deps bundles in-repo dependencies. As a result the update to the package for in-repo dependencies needs to be manually added when needed. The recent fixes in the @rnx-kit/config package need to be included in align-deps so this pushes a change file to cause it to publish a new version.
