### PR TITLE
fix(react-native-host): Various build fixes

### DIFF
--- a/.changeset/react-native-host-strict-xcconfig.md
+++ b/.changeset/react-native-host-strict-xcconfig.md
@@ -1,0 +1,12 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+fix(react-native-host): Various build fixes
+
+- Rename inner `strongSelf` in `-setBridge:` to `innerStrongSelf` so it
+  no longer shadows the outer.
+- Gate `#import <React/RCTCxxBridgeDelegate.h>` behind `#if !USE_BRIDGELESS`
+  to match the already-conditional protocol conformance.
+- Drop the stray `;` before the `-viewWithModuleName:initialProperties:`
+  body.

--- a/packages/react-native-host/cocoa/RNXHostReleaser.mm
+++ b/packages/react-native-host/cocoa/RNXHostReleaser.mm
@@ -50,12 +50,12 @@
       RCTExecuteOnUIManagerQueue(^{
         [manager addUIBlock:^(RCTUIManager *uiManager,
                               NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-          __typeof(self) strongSelf = weakSelf;
-          if (strongSelf == nil) {
+          __typeof(self) innerStrongSelf = weakSelf;
+          if (innerStrongSelf == nil) {
               return;
           }
 
-          strongSelf->_viewRegistry = viewRegistry;
+          innerStrongSelf->_viewRegistry = viewRegistry;
         }];
       });
     });

--- a/packages/react-native-host/cocoa/ReactNativeHost+View.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost+View.mm
@@ -41,7 +41,7 @@ static NSString *const kReactConcurrentRoot = @"concurrentRoot";
 }
 
 - (RNXView *)viewWithModuleName:(NSString *)moduleName
-              initialProperties:(NSDictionary *)initialProperties;
+              initialProperties:(NSDictionary *)initialProperties
 {
 #ifdef USE_FABRIC
     // Having `concurrentRoot` disabled when Fabric is enabled is not recommended:

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -6,7 +6,6 @@
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
-#import <React/RCTCxxBridgeDelegate.h>
 #import <React/RCTDevLoadingViewSetEnabled.h>
 #import <React/RCTUtils.h>
 
@@ -16,6 +15,10 @@
 #import "RNXHostConfig.h"
 #import "RNXHostReleaser.h"
 #import "RNXTurboModuleAdapter.h"
+
+#if !USE_BRIDGELESS
+#import <React/RCTCxxBridgeDelegate.h>
+#endif  // !USE_BRIDGELESS
 
 @class RCTSurfacePresenter;
 


### PR DESCRIPTION
Three small build fixes for `@rnx-kit/react-native-host` cocoa source.

### Description

- **Rename inner `strongSelf` to fix -Wshadow.** The inner block in `-setBridge:` redeclares `strongSelf`, shadowing the outer `strongSelf` captured for the `RCTExecuteOnMainQueue` scope. Rename the inner reference to `innerStrongSelf` so it no longer shadows the outer.
- **Gate `<React/RCTCxxBridgeDelegate.h>` behind `#if !USE_BRIDGELESS`.** The protocol conformance is already conditional (`<RCTContextContainerHandling>` when USE_BRIDGELESS=1, otherwise `<RCTCxxBridgeDelegate>`), but the import above it is unconditional. Consumers that don't expose `RCTCxxBridgeDelegate.h` in their USE_BRIDGELESS=1 React-Core surface fail to compile. Gate the import the same way the conformance is gated.
- **Drop stray `;` before `-viewWithModuleName:initialProperties:` body.** Flagged by `-Wsemicolon-before-method-body`; build failure under `-Werror`.

### Test plan

Tested internally where we use stricter xcconfigs.
