### PR TITLE
feat(react-native-host): extend RNXHostConfig with optional host hooks (1/3)

### DIFF
--- a/packages/react-native-host/cocoa/RNXHostConfig.h
+++ b/packages/react-native-host/cocoa/RNXHostConfig.h
@@ -3,6 +3,12 @@
 #import <React/RCTBridgeDelegate.h>
 #import <React/RCTLog.h>
 
+#ifdef __cplusplus
+#include <jsi/jsi.h>
+#endif
+
+@class ReactNativeHost;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /// Configuration object for ``ReactNativeHost``.
@@ -29,6 +35,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Handles a fatal error.
 - (void)onFatalError:(NSError *)error;
+
+/// Called after the JS instance has finished loading. ``error`` is ``nil``
+/// on success.
+- (void)host:(ReactNativeHost *)host didLoadInstanceWithError:(nullable NSError *)error
+    __attribute__((__swift_name__("host(_:didLoadInstanceWithError:)")));
+
+/// Called when the instance is about to be unloaded.
+- (void)hostWillUnloadInstance:(ReactNativeHost *)host;
+
+#ifdef __cplusplus
+/// Called after host bindings install but before the user JS bundle loads.
+/// Use to evaluate pre-user JS on the runtime. Bridgeless mode only.
+- (void)host:(ReactNativeHost *)host didInitializeRuntime:(facebook::jsi::Runtime &)runtime;
+#endif  // __cplusplus
 
 // MARK: - RCTBridgeDelegate deprecated details (for backwards compatibility) [>=0.84]
 

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -35,6 +35,41 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 @end
 #endif  // USE_CODEGEN_PROVIDER
 
+#if USE_BRIDGELESS
+
+// Forwards host:didInitializeRuntime: from RCTHost to the consumer's RNXHostConfig.
+@interface _RNXForwardingRCTHostDelegate : NSObject <RCTHostDelegate>
+- (instancetype)initWithHost:(ReactNativeHost *)host config:(id<RNXHostConfig>)config;
+@end
+
+@implementation _RNXForwardingRCTHostDelegate {
+    __weak ReactNativeHost *_host;
+    __weak id<RNXHostConfig> _config;
+}
+
+- (instancetype)initWithHost:(ReactNativeHost *)host config:(id<RNXHostConfig>)config
+{
+    if (self = [super init]) {
+        _host = host;
+        _config = config;
+    }
+    return self;
+}
+
+- (void)host:(RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtime &)runtime
+{
+    id<RNXHostConfig> config = _config;
+    ReactNativeHost *forwardedHost = _host;
+    if (forwardedHost != nil &&
+        [config respondsToSelector:@selector(host:didInitializeRuntime:)]) {
+        [config host:forwardedHost didInitializeRuntime:runtime];
+    }
+}
+
+@end
+
+#endif  // USE_BRIDGELESS
+
 @implementation ReactNativeHost {
     __weak id<RNXHostConfig> _config;
     NSDictionary *_launchOptions;
@@ -44,6 +79,9 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
     RCTHost *_reactHost;
     NSLock *_isShuttingDown;
     RNXHostReleaser *_hostReleaser;
+#if USE_BRIDGELESS
+    _RNXForwardingRCTHostDelegate *_hostDelegateProxy;
+#endif  // USE_BRIDGELESS
 #ifdef USE_REACT_NATIVE_CONFIG
     std::shared_ptr<ReactNativeConfig> _reactNativeConfig;
 #endif  // USE_REACT_NATIVE_CONFIG
@@ -99,9 +137,61 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
             });
         }
 
+        if ([config respondsToSelector:@selector(host:didLoadInstanceWithError:)]) {
+            [[NSNotificationCenter defaultCenter]
+                addObserver:self
+                   selector:@selector(_rnxInstanceDidLoad:)
+                       name:RCTJavaScriptDidLoadNotification
+                     object:nil];
+            [[NSNotificationCenter defaultCenter]
+                addObserver:self
+                   selector:@selector(_rnxInstanceDidFailToLoad:)
+                       name:RCTJavaScriptDidFailToLoadNotification
+                     object:nil];
+        }
+        if ([config respondsToSelector:@selector(hostWillUnloadInstance:)]) {
+            [[NSNotificationCenter defaultCenter]
+                addObserver:self
+                   selector:@selector(_rnxInstanceWillUnload:)
+                       name:RCTBridgeWillBeInvalidatedNotification
+                     object:nil];
+        }
+
         [self initializeReactHost];
     }
     return self;
+}
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)_rnxInstanceDidLoad:(NSNotification *)__unused notification
+{
+    id<RNXHostConfig> config = _config;
+    if ([config respondsToSelector:@selector(host:didLoadInstanceWithError:)]) {
+        [config host:self didLoadInstanceWithError:nil];
+    }
+}
+
+- (void)_rnxInstanceDidFailToLoad:(NSNotification *)notification
+{
+    id<RNXHostConfig> config = _config;
+    if ([config respondsToSelector:@selector(host:didLoadInstanceWithError:)]) {
+        NSError *error = notification.userInfo[@"error"];
+        [config host:self didLoadInstanceWithError:error ?: [NSError errorWithDomain:@"ReactNativeHost"
+                                                                                code:0
+                                                                            userInfo:nil]];
+    }
+}
+
+- (void)_rnxInstanceWillUnload:(NSNotification *)__unused notification
+{
+    id<RNXHostConfig> config = _config;
+    if ([config respondsToSelector:@selector(hostWillUnloadInstance:)]) {
+        [config hostWillUnloadInstance:self];
+    }
 }
 
 - (RCTBridge *)bridge
@@ -303,6 +393,10 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 #endif
     };
 
+    // Retained as an ivar because RCTHost stores host delegates weakly.
+    _hostDelegateProxy = [[_RNXForwardingRCTHostDelegate alloc] initWithHost:self
+                                                                      config:_config];
+
     __weak __typeof(self) weakSelf = self;
     if ([RCTHost instancesRespondToSelector:@selector
                  (initWithBundleURLProvider:
@@ -312,13 +406,13 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
              initWithBundleURLProvider:^{
                return [weakSelf sourceURLForBridge:nil];
              }
-                          hostDelegate:nil
+                          hostDelegate:_hostDelegateProxy
             turboModuleManagerDelegate:_turboModuleAdapter
                       jsEngineProvider:jsEngineProvider
                          launchOptions:_launchOptions];
     } else {
         _reactHost = [[RCTHost alloc] initWithBundleURL:[self sourceURLForBridge:nil]
-                                           hostDelegate:nil
+                                           hostDelegate:_hostDelegateProxy
                              turboModuleManagerDelegate:_turboModuleAdapter
                                        jsEngineProvider:jsEngineProvider];
     }


### PR DESCRIPTION
### Description

Adds three optional lifecycle hooks to `RNXHostConfig`. All three are opt-in via `respondsToSelector:` — consumers that don't implement them see no behavior change.

#### `host:didLoadInstanceWithError:` and `hostWillUnloadInstance:`

`ReactNativeHost` subscribes to `RCTJavaScriptDidLoadNotification`, `RCTJavaScriptDidFailToLoadNotification`, and `RCTBridgeWillBeInvalidatedNotification` when the config implements the
 corresponding selectors, and forwards. `-dealloc` removes the observers.

Works in both bridge and bridgeless modes — the same notifications fire in both.

#### `host:didInitializeRuntime:` (Objective-C++ only)

Fires inside the bridgeless `RCTHost` runtime-initialization lambda, after host bindings install (TurboModules, native logger, native component registry) but **before** the user JS
bundle loads. Useful for evaluating pre-user JS on the runtime — e.g., bundles that must be available before app code runs via `runtime.evaluateJavaScript`.

Bridgeless mode only. Wired via an internal `_RNXForwardingRCTHostDelegate` passed as `RCTHost`'s `hostDelegate` (was `nil`). Retained as an ivar because `RCTHost` stores host delegates
 weakly. C++-typed (`jsi::Runtime &`), so only visible to Objective-C++ consumers.

### Test plan

Tested internally