### PR TITLE
feat(react-native-host): expose auxiliary RCTTurboModuleManagerDelegate via RNXHostConfig (2/3)

### DIFF
--- a/packages/react-native-host/cocoa/RNXHostConfig.h
+++ b/packages/react-native-host/cocoa/RNXHostConfig.h
@@ -7,6 +7,10 @@
 #include <jsi/jsi.h>
 #endif
 
+#if __has_include(<ReactCommon/RCTTurboModuleManager.h>)
+#import <ReactCommon/RCTTurboModuleManager.h>
+#endif
+
 @class ReactNativeHost;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -24,6 +28,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Returns whether the bridge should be released when the app is backgrounded.
 @property (nonatomic, readonly) BOOL shouldReleaseBridgeWhenBackgrounded;
+
+#if __has_include(<ReactCommon/RCTTurboModuleManager.h>)
+/// Auxiliary ``RCTTurboModuleManagerDelegate`` consulted before
+/// ``RNXTurboModuleAdapter``'s defaults. For each delegate method the
+/// adapter implements, the auxiliary is called via ``respondsToSelector:``
+/// first; returning ``nil`` / ``Nil`` falls through to default behavior.
+@property (nonatomic, readonly, weak, nullable) id<RCTTurboModuleManagerDelegate> turboModuleManagerDelegate;
+#endif
 
 /// Logs a message.
 - (void)logWithLevel:(RCTLogLevel)level

--- a/packages/react-native-host/cocoa/RNXHostConfig.h
+++ b/packages/react-native-host/cocoa/RNXHostConfig.h
@@ -3,6 +3,12 @@
 #import <React/RCTBridgeDelegate.h>
 #import <React/RCTLog.h>
 
+#ifdef __cplusplus
+#include <jsi/jsi.h>
+#endif
+
+@class ReactNativeHost;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /// Configuration object for ``ReactNativeHost``.
@@ -29,6 +35,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Handles a fatal error.
 - (void)onFatalError:(NSError *)error;
+
+/// Called after the JS instance has finished loading. ``error`` is ``nil``
+/// on success.
+- (void)host:(ReactNativeHost *)host didLoadInstanceWithError:(nullable NSError *)error
+    __attribute__((__swift_name__("host(_:didLoadInstanceWithError:)")));
+
+/// Called when the instance is about to be unloaded.
+- (void)hostWillUnloadInstance:(ReactNativeHost *)host;
+
+#ifdef __cplusplus
+/// Called after host bindings install but before the user JS bundle loads.
+/// Use to evaluate pre-user JS on the runtime. Bridgeless mode only.
+- (void)host:(ReactNativeHost *)host didInitializeRuntime:(facebook::jsi::Runtime &)runtime;
+#endif  // __cplusplus
 
 // MARK: - RCTBridgeDelegate deprecated details (for backwards compatibility) [>=0.84]
 

--- a/packages/react-native-host/cocoa/RNXTurboModuleAdapter.h
+++ b/packages/react-native-host/cocoa/RNXTurboModuleAdapter.h
@@ -8,6 +8,7 @@
 #endif  // USE_FABRIC
 
 @class RCTBridge;
+@protocol RNXHostConfig;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -16,6 +17,10 @@ NS_ASSUME_NONNULL_BEGIN
 #else
 @interface RNXTurboModuleAdapter : NSObject
 #endif  // USE_FABRIC
+
+/// Weak reference to the host's config; powers consultation of
+/// ``RNXHostConfig.turboModuleManagerDelegate``.
+@property (nonatomic, weak, nullable) id<RNXHostConfig> hostConfig;
 
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:
     (RCTBridge *)bridge;

--- a/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
+++ b/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
@@ -1,5 +1,7 @@
 #import "RNXTurboModuleAdapter.h"
 
+#import "RNXHostConfig.h"
+
 #include "FollyConfig.h"
 
 #if USE_FABRIC
@@ -103,6 +105,16 @@
 
 - (Class)getModuleClassFromName:(char const *)name
 {
+    id<RNXHostConfig> config = _hostConfig;
+    if ([config respondsToSelector:@selector(turboModuleManagerDelegate)]) {
+        id<RCTTurboModuleManagerDelegate> aux = [config turboModuleManagerDelegate];
+        if ([aux respondsToSelector:_cmd]) {
+            Class cls = [aux getModuleClassFromName:name];
+            if (cls != Nil) {
+                return cls;
+            }
+        }
+    }
     return RCTCoreModulesClassProvider(name);
 }
 
@@ -120,6 +132,16 @@
 
 - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
 {
+    id<RNXHostConfig> config = _hostConfig;
+    if ([config respondsToSelector:@selector(turboModuleManagerDelegate)]) {
+        id<RCTTurboModuleManagerDelegate> aux = [config turboModuleManagerDelegate];
+        if ([aux respondsToSelector:_cmd]) {
+            id<RCTTurboModule> instance = [aux getModuleInstanceFromClass:moduleClass];
+            if (instance != nil) {
+                return instance;
+            }
+        }
+    }
 #if USE_OSS_CODEGEN
     return RCTAppSetupDefaultModuleFromClass(moduleClass, [RCTAppDependencyProvider new]);
 #elif __has_include(<React-RCTAppDelegate/RCTDependencyProvider.h>) || __has_include(<React_RCTAppDelegate/RCTDependencyProvider.h>)

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -354,6 +354,7 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 {
 #if USE_FABRIC
     _turboModuleAdapter = [[RNXTurboModuleAdapter alloc] init];
+    _turboModuleAdapter.hostConfig = _config;
     RCTEnableTurboModule(true);
 #endif
 }

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -35,6 +35,41 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 @end
 #endif  // USE_CODEGEN_PROVIDER
 
+#if USE_BRIDGELESS
+
+// Forwards host:didInitializeRuntime: from RCTHost to the consumer's RNXHostConfig.
+@interface _RNXForwardingRCTHostDelegate : NSObject <RCTHostDelegate>
+- (instancetype)initWithHost:(ReactNativeHost *)host config:(id<RNXHostConfig>)config;
+@end
+
+@implementation _RNXForwardingRCTHostDelegate {
+    __weak ReactNativeHost *_host;
+    __weak id<RNXHostConfig> _config;
+}
+
+- (instancetype)initWithHost:(ReactNativeHost *)host config:(id<RNXHostConfig>)config
+{
+    if (self = [super init]) {
+        _host = host;
+        _config = config;
+    }
+    return self;
+}
+
+- (void)host:(RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtime &)runtime
+{
+    id<RNXHostConfig> config = _config;
+    ReactNativeHost *forwardedHost = _host;
+    if (forwardedHost != nil &&
+        [config respondsToSelector:@selector(host:didInitializeRuntime:)]) {
+        [config host:forwardedHost didInitializeRuntime:runtime];
+    }
+}
+
+@end
+
+#endif  // USE_BRIDGELESS
+
 @implementation ReactNativeHost {
     __weak id<RNXHostConfig> _config;
     NSDictionary *_launchOptions;
@@ -44,6 +79,9 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
     RCTHost *_reactHost;
     NSLock *_isShuttingDown;
     RNXHostReleaser *_hostReleaser;
+#if USE_BRIDGELESS
+    _RNXForwardingRCTHostDelegate *_hostDelegateProxy;
+#endif  // USE_BRIDGELESS
 #ifdef USE_REACT_NATIVE_CONFIG
     std::shared_ptr<ReactNativeConfig> _reactNativeConfig;
 #endif  // USE_REACT_NATIVE_CONFIG
@@ -99,9 +137,61 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
             });
         }
 
+        if ([config respondsToSelector:@selector(host:didLoadInstanceWithError:)]) {
+            [[NSNotificationCenter defaultCenter]
+                addObserver:self
+                   selector:@selector(_rnxInstanceDidLoad:)
+                       name:RCTJavaScriptDidLoadNotification
+                     object:nil];
+            [[NSNotificationCenter defaultCenter]
+                addObserver:self
+                   selector:@selector(_rnxInstanceDidFailToLoad:)
+                       name:RCTJavaScriptDidFailToLoadNotification
+                     object:nil];
+        }
+        if ([config respondsToSelector:@selector(hostWillUnloadInstance:)]) {
+            [[NSNotificationCenter defaultCenter]
+                addObserver:self
+                   selector:@selector(_rnxInstanceWillUnload:)
+                       name:RCTBridgeWillBeInvalidatedNotification
+                     object:nil];
+        }
+
         [self initializeReactHost];
     }
     return self;
+}
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)_rnxInstanceDidLoad:(NSNotification *)__unused notification
+{
+    id<RNXHostConfig> config = _config;
+    if ([config respondsToSelector:@selector(host:didLoadInstanceWithError:)]) {
+        [config host:self didLoadInstanceWithError:nil];
+    }
+}
+
+- (void)_rnxInstanceDidFailToLoad:(NSNotification *)notification
+{
+    id<RNXHostConfig> config = _config;
+    if ([config respondsToSelector:@selector(host:didLoadInstanceWithError:)]) {
+        NSError *error = notification.userInfo[@"error"];
+        [config host:self didLoadInstanceWithError:error ?: [NSError errorWithDomain:@"ReactNativeHost"
+                                                                                code:0
+                                                                            userInfo:nil]];
+    }
+}
+
+- (void)_rnxInstanceWillUnload:(NSNotification *)__unused notification
+{
+    id<RNXHostConfig> config = _config;
+    if ([config respondsToSelector:@selector(hostWillUnloadInstance:)]) {
+        [config hostWillUnloadInstance:self];
+    }
 }
 
 - (RCTBridge *)bridge
@@ -303,6 +393,10 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 #endif
     };
 
+    // Retained as an ivar because RCTHost stores host delegates weakly.
+    _hostDelegateProxy = [[_RNXForwardingRCTHostDelegate alloc] initWithHost:self
+                                                                      config:_config];
+
     __weak __typeof(self) weakSelf = self;
     if ([RCTHost instancesRespondToSelector:@selector
                  (initWithBundleURLProvider:
@@ -312,13 +406,13 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
              initWithBundleURLProvider:^{
                return [weakSelf sourceURLForBridge:nil];
              }
-                          hostDelegate:nil
+                          hostDelegate:_hostDelegateProxy
             turboModuleManagerDelegate:_turboModuleAdapter
                       jsEngineProvider:jsEngineProvider
                          launchOptions:_launchOptions];
     } else {
         _reactHost = [[RCTHost alloc] initWithBundleURL:[self sourceURLForBridge:nil]
-                                           hostDelegate:nil
+                                           hostDelegate:_hostDelegateProxy
                              turboModuleManagerDelegate:_turboModuleAdapter
                                        jsEngineProvider:jsEngineProvider];
     }


### PR DESCRIPTION
### Description

Depends on #4144 

Adds an optional `turboModuleManagerDelegate` property to `RNXHostConfig` that lets consumers participate in TurboModule construction without replacing `RNXTurboModuleAdapter`.

#### Motivation

`RNXTurboModuleAdapter` is rnx-kit's `RCTTurboModuleManagerDelegate`. Today it owns the full TurboModule construction path:

- `getModuleClassFromName:` falls back to `RCTCoreModulesClassProvider`
- `getModuleInstanceFromClass:` falls back to `RCTAppSetupDefaultModuleFromClass`

For modules that need *per-host state* — e.g., an `RCTExceptionsManager` initialized with a per-host delegate, or an `RCTDevSettings` with a custom data source — there's no extension
point. In bridge mode this case is handled via `RCTBridgeDelegate.extraModulesForBridge:` (the bridge prefers pre-constructed instances vended there). In bridgeless mode, that hook
isn't called — modules go through `RCTTurboModuleManager.delegate` instead.

#### Design

`RNXHostConfig` adds:

```objc
@property (nonatomic, readonly, weak, nullable) id<RCTTurboModuleManagerDelegate> turboModuleManagerDelegate;
```

`RNXTurboModuleAdapter` adds a `hostConfig` weak reference and, for each `RCTTurboModuleManagerDelegate` method it implements, consults the auxiliary via `respondsToSelector:` first;
returning `nil` / `Nil` falls through to the existing default behavior.

```objc
- (Class)getModuleClassFromName:(char const *)name {
    id<RCTTurboModuleManagerDelegate> aux = _hostConfig.turboModuleManagerDelegate;
    if ([aux respondsToSelector:_cmd]) {
        Class cls = [aux getModuleClassFromName:name];
        if (cls != Nil) return cls;
    }
    return RCTCoreModulesClassProvider(name);
}
```

Same shape for `getModuleInstanceFromClass:`.

#### Properties

- **Symmetric with bridge-mode `extraModulesForBridge:`**: the per-host injection point that bridge consumers use.
- **Backward-compatible**: consumers that don't implement `turboModuleManagerDelegate` see no behavior change.
- **Generic, not per-method**: any current or future `RCTTurboModuleManagerDelegate` method (`getModuleProvider:`, `getTurboModule:jsInvoker:`, etc.) the consumer implements is routed
automatically — no per-hook plumbing required in rnx-kit.
- **Zero overhead** when the auxiliary delegate doesn't respond — single `respondsToSelector:` check.

#### Example

```objc
@interface MyHostConfig : NSObject <RNXHostConfig, RCTTurboModuleManagerDelegate>
@end

@implementation MyHostConfig {
    MyExceptionsManagerDelegate *_exceptionsDelegate;
}

- (id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate {
    return self;
}

// Required RCTTurboModuleManagerDelegate methods — return nil to defer to rnx-kit's defaults.
- (Class)getModuleClassFromName:(const char *)name { return Nil; }

- (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)cls {
    if (cls == [RCTExceptionsManager class]) {
        return [[RCTExceptionsManager alloc] initWithDelegate:_exceptionsDelegate];
    }
    return nil;
}
@end
```

### Test plan

Tested internally
