### PR TITLE
feat(react-native-host): allow opting out of React-RCTAppDelegate dependency (3/3)

### DIFF
--- a/packages/react-native-host/cocoa/RNXHostConfig.h
+++ b/packages/react-native-host/cocoa/RNXHostConfig.h
@@ -7,6 +7,10 @@
 #include <jsi/jsi.h>
 #endif
 
+#if __has_include(<ReactCommon/RCTTurboModuleManager.h>)
+#import <ReactCommon/RCTTurboModuleManager.h>
+#endif
+
 @class ReactNativeHost;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -24,6 +28,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Returns whether the bridge should be released when the app is backgrounded.
 @property (nonatomic, readonly) BOOL shouldReleaseBridgeWhenBackgrounded;
+
+#if __has_include(<ReactCommon/RCTTurboModuleManager.h>)
+/// Auxiliary ``RCTTurboModuleManagerDelegate`` consulted before
+/// ``RNXTurboModuleAdapter``'s defaults. For each delegate method the
+/// adapter implements, the auxiliary is called via ``respondsToSelector:``
+/// first; returning ``nil`` / ``Nil`` falls through to default behavior.
+@property (nonatomic, readonly, weak, nullable) id<RCTTurboModuleManagerDelegate> turboModuleManagerDelegate;
+#endif
 
 /// Logs a message.
 - (void)logWithLevel:(RCTLogLevel)level

--- a/packages/react-native-host/cocoa/RNXHostConfig.h
+++ b/packages/react-native-host/cocoa/RNXHostConfig.h
@@ -3,6 +3,12 @@
 #import <React/RCTBridgeDelegate.h>
 #import <React/RCTLog.h>
 
+#ifdef __cplusplus
+#include <jsi/jsi.h>
+#endif
+
+@class ReactNativeHost;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /// Configuration object for ``ReactNativeHost``.
@@ -29,6 +35,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Handles a fatal error.
 - (void)onFatalError:(NSError *)error;
+
+/// Called after the JS instance has finished loading. ``error`` is ``nil``
+/// on success.
+- (void)host:(ReactNativeHost *)host didLoadInstanceWithError:(nullable NSError *)error
+    __attribute__((__swift_name__("host(_:didLoadInstanceWithError:)")));
+
+/// Called when the instance is about to be unloaded.
+- (void)hostWillUnloadInstance:(ReactNativeHost *)host;
+
+#ifdef __cplusplus
+/// Called after host bindings install but before the user JS bundle loads.
+/// Use to evaluate pre-user JS on the runtime. Bridgeless mode only.
+- (void)host:(ReactNativeHost *)host didInitializeRuntime:(facebook::jsi::Runtime &)runtime;
+#endif  // __cplusplus
 
 // MARK: - RCTBridgeDelegate deprecated details (for backwards compatibility) [>=0.84]
 

--- a/packages/react-native-host/cocoa/RNXTurboModuleAdapter.h
+++ b/packages/react-native-host/cocoa/RNXTurboModuleAdapter.h
@@ -8,6 +8,7 @@
 #endif  // USE_FABRIC
 
 @class RCTBridge;
+@protocol RNXHostConfig;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -16,6 +17,10 @@ NS_ASSUME_NONNULL_BEGIN
 #else
 @interface RNXTurboModuleAdapter : NSObject
 #endif  // USE_FABRIC
+
+/// Weak reference to the host's config; powers consultation of
+/// ``RNXHostConfig.turboModuleManagerDelegate``.
+@property (nonatomic, weak, nullable) id<RNXHostConfig> hostConfig;
 
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:
     (RCTBridge *)bridge;

--- a/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
+++ b/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
@@ -8,6 +8,24 @@
 #import <React/CoreModulesPlugins.h>
 #import <ReactCommon/RCTTurboModuleManager.h>
 
+// `RNX_USE_RCT_APP_DELEGATE_HELPERS` lets a consumer opt out of pulling in
+// the React-RCTAppDelegate / ReactAppDependencyProvider helpers. They're
+// useful for the standard "single host per app" wrapper flow but are
+// deliberately incompatible with multi-host integrations (each host has
+// its own modules / executor factory). When unset, default to 1 if the
+// headers are reachable, preserving the existing behavior.
+#ifndef RNX_USE_RCT_APP_DELEGATE_HELPERS
+#  if __has_include(<React/RCTAppSetupUtils.h>) || \
+      __has_include(<React-RCTAppDelegate/RCTAppSetupUtils.h>) || \
+      __has_include(<React_RCTAppDelegate/RCTAppSetupUtils.h>)
+#    define RNX_USE_RCT_APP_DELEGATE_HELPERS 1
+#  else
+#    define RNX_USE_RCT_APP_DELEGATE_HELPERS 0
+#  endif
+#endif
+
+#if RNX_USE_RCT_APP_DELEGATE_HELPERS
+
 #if __has_include(<React/RCTAppSetupUtils.h>)  // <0.72
 #import <React/RCTAppSetupUtils.h>
 #else
@@ -46,16 +64,18 @@
 
 #endif  // __has_include(<React/RCTAppSetupUtils.h>)
 
-#if __has_include(<react/nativemodule/defaults/DefaultTurboModules.h>)  // >= 0.75
-#import <react/nativemodule/defaults/DefaultTurboModules.h>
-#endif
-
 #if __has_include(<ReactAppDependencyProvider/RCTAppDependencyProvider.h>)
 #import <ReactAppDependencyProvider/RCTAppDependencyProvider.h>
 #define USE_OSS_CODEGEN 1
 #else
 #define USE_OSS_CODEGEN 0
 #endif  // __has_include(<ReactAppDependencyProvider/RCTAppDependencyProvider.h>)
+
+#endif  // RNX_USE_RCT_APP_DELEGATE_HELPERS
+
+#if __has_include(<react/nativemodule/defaults/DefaultTurboModules.h>)  // >= 0.75
+#import <react/nativemodule/defaults/DefaultTurboModules.h>
+#endif
 
 #endif  // USE_FABRIC
 
@@ -142,6 +162,7 @@
             }
         }
     }
+#if RNX_USE_RCT_APP_DELEGATE_HELPERS
 #if USE_OSS_CODEGEN
     return RCTAppSetupDefaultModuleFromClass(moduleClass, [RCTAppDependencyProvider new]);
 #elif __has_include(<React-RCTAppDelegate/RCTDependencyProvider.h>) || __has_include(<React_RCTAppDelegate/RCTDependencyProvider.h>)
@@ -149,6 +170,12 @@
 #else
     return RCTAppSetupDefaultModuleFromClass(moduleClass);
 #endif  // USE_OSS_CODEGEN
+#else
+    // Returning nil falls back to RCTTurboModuleManager's default `[cls new]`.
+    // Custom initializers belong in `turboModuleManagerDelegate`.
+    (void)moduleClass;
+    return nil;
+#endif  // RNX_USE_RCT_APP_DELEGATE_HELPERS
 }
 
 // MARK: - Private
@@ -156,6 +183,7 @@
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)initJsExecutorFactoryWithBridge:
     (RCTBridge *)bridge
 {
+#if RNX_USE_RCT_APP_DELEGATE_HELPERS
 #if USE_RUNTIME_SCHEDULER
     _runtimeScheduler =
         std::make_shared<facebook::react::RuntimeScheduler>(RCTRuntimeExecutorFromBridge(bridge));
@@ -171,6 +199,18 @@
                                                               jsInvoker:bridge.jsCallInvoker];
     return RCTAppSetupDefaultJsExecutorFactory(bridge, _turboModuleManager);
 #endif  // USE_RUNTIME_SCHEDULER
+#else
+    // Without React-RCTAppDelegate, the bridge-mode JS executor factory
+    // can't be constructed from these helpers. Bridgeless integrations
+    // never reach this code path (RCTHost owns runtime construction via
+    // RCTHostJSEngineProvider). Bridge-mode consumers wanting to use this
+    // adapter must either build with RNX_USE_RCT_APP_DELEGATE_HELPERS=1
+    // (the default when React-RCTAppDelegate is available) or supply
+    // their own RCTBridgeDelegate implementation that overrides
+    // jsExecutorFactoryForBridge:.
+    (void)bridge;
+    return nullptr;
+#endif  // RNX_USE_RCT_APP_DELEGATE_HELPERS
 }
 
 - (void)onRuntimeReady:(NSNotification *)note

--- a/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
+++ b/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
@@ -1,5 +1,7 @@
 #import "RNXTurboModuleAdapter.h"
 
+#import "RNXHostConfig.h"
+
 #include "FollyConfig.h"
 
 #if USE_FABRIC
@@ -103,6 +105,16 @@
 
 - (Class)getModuleClassFromName:(char const *)name
 {
+    id<RNXHostConfig> config = _hostConfig;
+    if ([config respondsToSelector:@selector(turboModuleManagerDelegate)]) {
+        id<RCTTurboModuleManagerDelegate> aux = [config turboModuleManagerDelegate];
+        if ([aux respondsToSelector:_cmd]) {
+            Class cls = [aux getModuleClassFromName:name];
+            if (cls != Nil) {
+                return cls;
+            }
+        }
+    }
     return RCTCoreModulesClassProvider(name);
 }
 
@@ -120,6 +132,16 @@
 
 - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
 {
+    id<RNXHostConfig> config = _hostConfig;
+    if ([config respondsToSelector:@selector(turboModuleManagerDelegate)]) {
+        id<RCTTurboModuleManagerDelegate> aux = [config turboModuleManagerDelegate];
+        if ([aux respondsToSelector:_cmd]) {
+            id<RCTTurboModule> instance = [aux getModuleInstanceFromClass:moduleClass];
+            if (instance != nil) {
+                return instance;
+            }
+        }
+    }
 #if USE_OSS_CODEGEN
     return RCTAppSetupDefaultModuleFromClass(moduleClass, [RCTAppDependencyProvider new]);
 #elif __has_include(<React-RCTAppDelegate/RCTDependencyProvider.h>) || __has_include(<React_RCTAppDelegate/RCTDependencyProvider.h>)

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -354,6 +354,7 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 {
 #if USE_FABRIC
     _turboModuleAdapter = [[RNXTurboModuleAdapter alloc] init];
+    _turboModuleAdapter.hostConfig = _config;
     RCTEnableTurboModule(true);
 #endif
 }

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -35,6 +35,41 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 @end
 #endif  // USE_CODEGEN_PROVIDER
 
+#if USE_BRIDGELESS
+
+// Forwards host:didInitializeRuntime: from RCTHost to the consumer's RNXHostConfig.
+@interface _RNXForwardingRCTHostDelegate : NSObject <RCTHostDelegate>
+- (instancetype)initWithHost:(ReactNativeHost *)host config:(id<RNXHostConfig>)config;
+@end
+
+@implementation _RNXForwardingRCTHostDelegate {
+    __weak ReactNativeHost *_host;
+    __weak id<RNXHostConfig> _config;
+}
+
+- (instancetype)initWithHost:(ReactNativeHost *)host config:(id<RNXHostConfig>)config
+{
+    if (self = [super init]) {
+        _host = host;
+        _config = config;
+    }
+    return self;
+}
+
+- (void)host:(RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtime &)runtime
+{
+    id<RNXHostConfig> config = _config;
+    ReactNativeHost *forwardedHost = _host;
+    if (forwardedHost != nil &&
+        [config respondsToSelector:@selector(host:didInitializeRuntime:)]) {
+        [config host:forwardedHost didInitializeRuntime:runtime];
+    }
+}
+
+@end
+
+#endif  // USE_BRIDGELESS
+
 @implementation ReactNativeHost {
     __weak id<RNXHostConfig> _config;
     NSDictionary *_launchOptions;
@@ -44,6 +79,9 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
     RCTHost *_reactHost;
     NSLock *_isShuttingDown;
     RNXHostReleaser *_hostReleaser;
+#if USE_BRIDGELESS
+    _RNXForwardingRCTHostDelegate *_hostDelegateProxy;
+#endif  // USE_BRIDGELESS
 #ifdef USE_REACT_NATIVE_CONFIG
     std::shared_ptr<ReactNativeConfig> _reactNativeConfig;
 #endif  // USE_REACT_NATIVE_CONFIG
@@ -99,9 +137,61 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
             });
         }
 
+        if ([config respondsToSelector:@selector(host:didLoadInstanceWithError:)]) {
+            [[NSNotificationCenter defaultCenter]
+                addObserver:self
+                   selector:@selector(_rnxInstanceDidLoad:)
+                       name:RCTJavaScriptDidLoadNotification
+                     object:nil];
+            [[NSNotificationCenter defaultCenter]
+                addObserver:self
+                   selector:@selector(_rnxInstanceDidFailToLoad:)
+                       name:RCTJavaScriptDidFailToLoadNotification
+                     object:nil];
+        }
+        if ([config respondsToSelector:@selector(hostWillUnloadInstance:)]) {
+            [[NSNotificationCenter defaultCenter]
+                addObserver:self
+                   selector:@selector(_rnxInstanceWillUnload:)
+                       name:RCTBridgeWillBeInvalidatedNotification
+                     object:nil];
+        }
+
         [self initializeReactHost];
     }
     return self;
+}
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)_rnxInstanceDidLoad:(NSNotification *)__unused notification
+{
+    id<RNXHostConfig> config = _config;
+    if ([config respondsToSelector:@selector(host:didLoadInstanceWithError:)]) {
+        [config host:self didLoadInstanceWithError:nil];
+    }
+}
+
+- (void)_rnxInstanceDidFailToLoad:(NSNotification *)notification
+{
+    id<RNXHostConfig> config = _config;
+    if ([config respondsToSelector:@selector(host:didLoadInstanceWithError:)]) {
+        NSError *error = notification.userInfo[@"error"];
+        [config host:self didLoadInstanceWithError:error ?: [NSError errorWithDomain:@"ReactNativeHost"
+                                                                                code:0
+                                                                            userInfo:nil]];
+    }
+}
+
+- (void)_rnxInstanceWillUnload:(NSNotification *)__unused notification
+{
+    id<RNXHostConfig> config = _config;
+    if ([config respondsToSelector:@selector(hostWillUnloadInstance:)]) {
+        [config hostWillUnloadInstance:self];
+    }
 }
 
 - (RCTBridge *)bridge
@@ -303,6 +393,10 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 #endif
     };
 
+    // Retained as an ivar because RCTHost stores host delegates weakly.
+    _hostDelegateProxy = [[_RNXForwardingRCTHostDelegate alloc] initWithHost:self
+                                                                      config:_config];
+
     __weak __typeof(self) weakSelf = self;
     if ([RCTHost instancesRespondToSelector:@selector
                  (initWithBundleURLProvider:
@@ -312,13 +406,13 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
              initWithBundleURLProvider:^{
                return [weakSelf sourceURLForBridge:nil];
              }
-                          hostDelegate:nil
+                          hostDelegate:_hostDelegateProxy
             turboModuleManagerDelegate:_turboModuleAdapter
                       jsEngineProvider:jsEngineProvider
                          launchOptions:_launchOptions];
     } else {
         _reactHost = [[RCTHost alloc] initWithBundleURL:[self sourceURLForBridge:nil]
-                                           hostDelegate:nil
+                                           hostDelegate:_hostDelegateProxy
                              turboModuleManagerDelegate:_turboModuleAdapter
                                        jsEngineProvider:jsEngineProvider];
     }


### PR DESCRIPTION
### Description

Depends on #4144
Depends on #4145

Adds `RNX_USE_RCT_APP_DELEGATE_HELPERS` (default `1`, preserving current behavior). Set to `0` to drop the React-RCTAppDelegate / ReactAppDependencyProvider framework dependency from
`RNXTurboModuleAdapter`.

#### Motivation

`React-RCTAppDelegate`'s `RCTAppSetupDefaultModuleFromClass` and `RCTAppSetupDefaultJsExecutorFactory` helpers assume a single-host-per-app shape — process-wide module providers and
executor factories. Multi-host integrations (where each host has its own modules and lifecycle) want neither. Today the only way to use `RNXTurboModuleAdapter` is to link against
React-RCTAppDelegate even if it's actively the wrong design for the consumer.

#### Design

When `RNX_USE_RCT_APP_DELEGATE_HELPERS=0`:

- `getModuleInstanceFromClass:` skips `RCTAppSetupDefaultModuleFromClass` and returns `nil`. Consumers vending custom-initialized modules do so via
`RNXHostConfig.turboModuleManagerDelegate.getModuleInstanceFromClass:` (added in the previous PR). Falling through to `nil` makes `RCTTurboModuleManager` use its default `[cls new]` for
 modules the consumer doesn't override — same behavior the manager has for unknown classes.

- `jsExecutorFactoryForBridge:` returns `nullptr`. Bridgeless integrations (`RCTHost`-driven) construct the JS runtime via `RCTHostJSEngineProvider` and never reach this path.
Bridge-mode consumers wanting this adapter must either keep `HELPERS=1` or supply their own `RCTBridgeDelegate.jsExecutorFactoryForBridge:`.

The macro auto-defaults to `1` when the React-RCTAppDelegate headers are reachable (via `__has_include`), so behavior is unchanged for existing consumers. Multi-host consumers `#define
RNX_USE_RCT_APP_DELEGATE_HELPERS 0` in their build settings to opt out.

#### Why this is useful

Without the previous PR in this stack (the auxiliary `turboModuleManagerDelegate` hook), opting out of the helpers leaves the consumer with nil-returning defaults and no escape hatch —
pointless. With the auxiliary delegate in place, consumers have a real alternative: implement `getModuleInstanceFromClass:` themselves to vend whatever modules they need, and
`RNX_USE_RCT_APP_DELEGATE_HELPERS=0` drops the framework dependency cleanly.

### Test plan

Tested internally
