### PR TITLE
Add CI log grouping for align-deps output

### DIFF
--- a/.changeset/group-align-deps-ci.md
+++ b/.changeset/group-align-deps-ci.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": patch
+---
+
+Group align-deps package output in GitHub Actions and Azure DevOps logs.

--- a/packages/align-deps/src/ci.ts
+++ b/packages/align-deps/src/ci.ts
@@ -1,34 +1,79 @@
-type LogGroup = {
-  end: string;
-  start: string;
+type GroupMarkers = {
+  beginGroup: (title: string) => void;
+  endGroup: () => void;
 };
 
-type Env = NodeJS.ProcessEnv;
+type Output = Pick<typeof console, "error" | "log" | "warn">;
 
-function escapeGitHubCommand(value: string): string {
-  return value
-    .replace(/%/g, "%25")
-    .replace(/\r/g, "%0D")
-    .replace(/\n/g, "%0A");
+function noop() {
+  return undefined;
 }
 
-export function logGroupFor(
-  title: string,
-  env: Env = process.env
-): LogGroup | undefined {
+export function getGroupMarkers(
+  log: typeof console.log = console.log,
+  env = process.env
+): GroupMarkers {
   if (env["GITHUB_ACTIONS"] === "true") {
     return {
-      start: `::group::${escapeGitHubCommand(title)}`,
-      end: "::endgroup::",
+      beginGroup: (title) => log(`::group::${encodeURI(title)}`),
+      endGroup: () => log("::endgroup::"),
     };
   }
 
   if (env["TF_BUILD"] === "True") {
     return {
-      start: `##[group]${title}`,
-      end: "##[endgroup]",
+      beginGroup: (title) => log(`##[group]${title}`),
+      endGroup: () => log("##[endgroup]"),
     };
   }
 
-  return undefined;
+  return {
+    beginGroup: noop,
+    endGroup: noop,
+  };
+}
+
+export function withLogGroup<T>(
+  title: string,
+  fn: () => T,
+  output: Output = console,
+  env = process.env
+): T {
+  const originalLog = output.log;
+  const originalWarn = output.warn;
+  const originalError = output.error;
+  const { beginGroup, endGroup } = getGroupMarkers(originalLog, env);
+  let groupStarted = false;
+
+  const begin = () => {
+    if (!groupStarted) {
+      beginGroup(title);
+      groupStarted = true;
+    }
+  };
+
+  output.log = (...args) => {
+    begin();
+    originalLog(...args);
+  };
+  output.warn = (...args) => {
+    begin();
+    originalWarn(...args);
+  };
+  output.error = (...args) => {
+    begin();
+    originalError(...args);
+  };
+
+  try {
+    return fn();
+  } finally {
+    output.log = originalLog;
+    output.warn = originalWarn;
+    output.error = originalError;
+
+    if (groupStarted) {
+      endGroup();
+    }
+  }
 }

--- a/packages/align-deps/src/ci.ts
+++ b/packages/align-deps/src/ci.ts
@@ -1,0 +1,34 @@
+type LogGroup = {
+  end: string;
+  start: string;
+};
+
+type Env = NodeJS.ProcessEnv;
+
+function escapeGitHubCommand(value: string): string {
+  return value
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A");
+}
+
+export function logGroupFor(
+  title: string,
+  env: Env = process.env
+): LogGroup | undefined {
+  if (env["GITHUB_ACTIONS"] === "true") {
+    return {
+      start: `::group::${escapeGitHubCommand(title)}`,
+      end: "::endgroup::",
+    };
+  }
+
+  if (env["TF_BUILD"] === "True") {
+    return {
+      start: `##[group]${title}`,
+      end: "##[endgroup]",
+    };
+  }
+
+  return undefined;
+}

--- a/packages/align-deps/src/cli.ts
+++ b/packages/align-deps/src/cli.ts
@@ -9,6 +9,7 @@ import {
 } from "@rnx-kit/tools-workspaces";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { logGroupFor } from "./ci.ts";
 import { makeCheckCommand } from "./commands/check.ts";
 import { makeExportCatalogsCommand } from "./commands/exportCatalogs.ts";
 import { makeInitializeCommand } from "./commands/initialize.ts";
@@ -266,7 +267,11 @@ export async function cli({ packages, ...args }: Args): Promise<void> {
   // disk only when everything is in order for the target package. Packages with
   // invalid or missing configurations are skipped.
   const errors = manifests.reduce((errors, manifest) => {
+    const logGroup = logGroupFor(manifest);
     try {
+      if (logGroup) {
+        console.log(logGroup.start);
+      }
       const result = command(manifest);
       printError(manifest, result);
       if (result !== "success" && result !== "excluded") {
@@ -279,6 +284,10 @@ export async function cli({ packages, ...args }: Args): Promise<void> {
       }
 
       throw e;
+    } finally {
+      if (logGroup) {
+        console.log(logGroup.end);
+      }
     }
     return errors;
   }, 0);

--- a/packages/align-deps/src/cli.ts
+++ b/packages/align-deps/src/cli.ts
@@ -9,7 +9,7 @@ import {
 } from "@rnx-kit/tools-workspaces";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { logGroupFor } from "./ci.ts";
+import { withLogGroup } from "./ci.ts";
 import { makeCheckCommand } from "./commands/check.ts";
 import { makeExportCatalogsCommand } from "./commands/exportCatalogs.ts";
 import { makeInitializeCommand } from "./commands/initialize.ts";
@@ -267,29 +267,23 @@ export async function cli({ packages, ...args }: Args): Promise<void> {
   // disk only when everything is in order for the target package. Packages with
   // invalid or missing configurations are skipped.
   const errors = manifests.reduce((errors, manifest) => {
-    const logGroup = logGroupFor(manifest);
-    try {
-      if (logGroup) {
-        console.log(logGroup.start);
-      }
-      const result = command(manifest);
-      printError(manifest, result);
-      if (result !== "success" && result !== "excluded") {
-        return errors + 1;
-      }
-    } catch (e) {
-      if (hasProperty(e, "message")) {
-        error(`${manifest}: ${e.message}`);
-        return errors + 1;
-      }
+    return withLogGroup(manifest, () => {
+      try {
+        const result = command(manifest);
+        printError(manifest, result);
+        if (result !== "success" && result !== "excluded") {
+          return errors + 1;
+        }
+      } catch (e) {
+        if (hasProperty(e, "message")) {
+          error(`${manifest}: ${e.message}`);
+          return errors + 1;
+        }
 
-      throw e;
-    } finally {
-      if (logGroup) {
-        console.log(logGroup.end);
+        throw e;
       }
-    }
-    return errors;
+      return errors;
+    });
   }, 0);
 
   process.exitCode = errors;

--- a/packages/align-deps/test/ci.test.ts
+++ b/packages/align-deps/test/ci.test.ts
@@ -1,0 +1,38 @@
+import { deepEqual, equal } from "node:assert/strict";
+import { describe, it } from "node:test";
+import { logGroupFor } from "../src/ci.ts";
+
+describe("logGroupFor()", () => {
+  it("returns GitHub Actions group markers", () => {
+    deepEqual(
+      logGroupFor("packages/app/package.json", { GITHUB_ACTIONS: "true" }),
+      {
+        start: "::group::packages/app/package.json",
+        end: "::endgroup::",
+      }
+    );
+  });
+
+  it("escapes GitHub Actions command values", () => {
+    deepEqual(
+      logGroupFor("packages/%app\r\n/package.json", {
+        GITHUB_ACTIONS: "true",
+      }),
+      {
+        start: "::group::packages/%25app%0D%0A/package.json",
+        end: "::endgroup::",
+      }
+    );
+  });
+
+  it("returns Azure DevOps group markers", () => {
+    deepEqual(logGroupFor("packages/app/package.json", { TF_BUILD: "True" }), {
+      start: "##[group]packages/app/package.json",
+      end: "##[endgroup]",
+    });
+  });
+
+  it("does not group local output", () => {
+    equal(logGroupFor("packages/app/package.json", {}), undefined);
+  });
+});

--- a/packages/align-deps/test/ci.test.ts
+++ b/packages/align-deps/test/ci.test.ts
@@ -1,38 +1,113 @@
 import { deepEqual, equal } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { logGroupFor } from "../src/ci.ts";
+import { getGroupMarkers, withLogGroup } from "../src/ci.ts";
 
-describe("logGroupFor()", () => {
+describe("getGroupMarkers()", () => {
   it("returns GitHub Actions group markers", () => {
-    deepEqual(
-      logGroupFor("packages/app/package.json", { GITHUB_ACTIONS: "true" }),
-      {
-        start: "::group::packages/app/package.json",
-        end: "::endgroup::",
-      }
+    const output: string[] = [];
+    const { beginGroup, endGroup } = getGroupMarkers(
+      (message) => output.push(message),
+      { GITHUB_ACTIONS: "true" }
     );
+
+    beginGroup("packages/app/package.json");
+    endGroup();
+
+    deepEqual(output, ["::group::packages/app/package.json", "::endgroup::"]);
   });
 
-  it("escapes GitHub Actions command values", () => {
-    deepEqual(
-      logGroupFor("packages/%app\r\n/package.json", {
-        GITHUB_ACTIONS: "true",
-      }),
-      {
-        start: "::group::packages/%25app%0D%0A/package.json",
-        end: "::endgroup::",
-      }
+  it("encodes GitHub Actions group titles", () => {
+    const output: string[] = [];
+    const { beginGroup, endGroup } = getGroupMarkers(
+      (message) => output.push(message),
+      { GITHUB_ACTIONS: "true" }
     );
+
+    beginGroup("packages/%app\r\n/package.json");
+    endGroup();
+
+    deepEqual(output, [
+      "::group::packages/%25app%0D%0A/package.json",
+      "::endgroup::",
+    ]);
   });
 
   it("returns Azure DevOps group markers", () => {
-    deepEqual(logGroupFor("packages/app/package.json", { TF_BUILD: "True" }), {
-      start: "##[group]packages/app/package.json",
-      end: "##[endgroup]",
-    });
+    const output: string[] = [];
+    const { beginGroup, endGroup } = getGroupMarkers(
+      (message) => output.push(message),
+      { TF_BUILD: "True" }
+    );
+
+    beginGroup("packages/app/package.json");
+    endGroup();
+
+    deepEqual(output, ["##[group]packages/app/package.json", "##[endgroup]"]);
   });
 
   it("does not group local output", () => {
-    equal(logGroupFor("packages/app/package.json", {}), undefined);
+    const output: string[] = [];
+    const { beginGroup, endGroup } = getGroupMarkers(
+      (message) => output.push(message),
+      {}
+    );
+
+    beginGroup("packages/app/package.json");
+    endGroup();
+
+    deepEqual(output, []);
+  });
+});
+
+describe("withLogGroup()", () => {
+  function createConsole() {
+    const output: string[] = [];
+
+    return {
+      output,
+      console: {
+        log: (...args: unknown[]) => output.push(args.join(" ")),
+        warn: (...args: unknown[]) => output.push(args.join(" ")),
+        error: (...args: unknown[]) => output.push(args.join(" ")),
+      },
+    };
+  }
+
+  it("does not emit an empty group", () => {
+    const { console, output } = createConsole();
+
+    withLogGroup("packages/app/package.json", () => undefined, console, {
+      GITHUB_ACTIONS: "true",
+    });
+
+    deepEqual(output, []);
+  });
+
+  it("groups the first emitted log line", () => {
+    const { console, output } = createConsole();
+
+    withLogGroup(
+      "packages/app/package.json",
+      () => console.log("hello"),
+      console,
+      { GITHUB_ACTIONS: "true" }
+    );
+
+    deepEqual(output, [
+      "::group::packages/app/package.json",
+      "hello",
+      "::endgroup::",
+    ]);
+  });
+
+  it("restores the console methods", () => {
+    const { console } = createConsole();
+    const log = console.log;
+
+    withLogGroup("packages/app/package.json", () => undefined, console, {
+      GITHUB_ACTIONS: "true",
+    });
+
+    equal(console.log, log);
   });
 });


### PR DESCRIPTION
## Summary

Adds CI log grouping around `align-deps` output so runs over larger workspaces are easier to scan in GitHub Actions and Azure DevOps.

This keeps local output unchanged and only opens a group when a package actually writes log output, avoiding empty groups for packages with no changes.

Fixes #2906.

## Testing

- `git diff --check`
- `yarn workspace @rnx-kit/align-deps format`
- `PATH="/Users/vivek/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" yarn workspace @rnx-kit/align-deps lint`
- `PATH="/Users/vivek/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" yarn workspace @rnx-kit/align-deps build --dependencies`
- `PATH="/Users/vivek/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" yarn workspace @rnx-kit/align-deps test`
