### PR TITLE
fix(tools-node): limit package dependency search scope

### DIFF
--- a/.changeset/curly-needles-rest.md
+++ b/.changeset/curly-needles-rest.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-node": patch
+---
+
+Add a `stopAt` option to limit `findPackageDependencyDir` searches.

--- a/packages/tools-node/src/package.ts
+++ b/packages/tools-node/src/package.ts
@@ -171,6 +171,11 @@ export type FindPackageDependencyOptions = {
   startDir?: string;
 
   /**
+   * Optional directory where the search should stop.
+   */
+  stopAt?: string;
+
+  /**
    * Optional flag controlling whether symlinks can be found. Defaults to `true`.
    * When `false`, and the package dependency directory is a symlink, it will not
    * be found.
@@ -201,10 +206,12 @@ export function findPackageDependencyDir(
 ): string | undefined {
   const pkgName =
     typeof ref === "string" ? ref : path.join(ref.scope ?? "", ref.name);
+  const startDir = options?.startDir ?? process.cwd();
   const packageDir = findUp(
     path.join("node_modules", pkgName),
     {
-      startDir: options?.startDir,
+      startDir,
+      stopAt: options?.stopAt,
       type: "directory",
       allowSymlinks: options?.allowSymlinks,
     },

--- a/packages/tools-node/src/package.ts
+++ b/packages/tools-node/src/package.ts
@@ -206,11 +206,10 @@ export function findPackageDependencyDir(
 ): string | undefined {
   const pkgName =
     typeof ref === "string" ? ref : path.join(ref.scope ?? "", ref.name);
-  const startDir = options?.startDir ?? process.cwd();
   const packageDir = findUp(
     path.join("node_modules", pkgName),
     {
-      startDir,
+      startDir: options?.startDir,
       stopAt: options?.stopAt,
       type: "directory",
       allowSymlinks: options?.allowSymlinks,

--- a/packages/tools-node/test/package.test.ts
+++ b/packages/tools-node/test/package.test.ts
@@ -212,4 +212,40 @@ describe("Node > Package", () => {
     );
     equal(pkgDir, undefined);
   });
+
+  it("findPackageDependencyDir() does not search beyond stopAt", () => {
+    const rootDir = path.join(testTempDir, "repo");
+    const workspaceDir = path.join(rootDir, "packages", "app");
+    const externalDir = path.join(testTempDir, "node_modules", "external");
+    const localDir = path.join(
+      rootDir,
+      "packages",
+      "node_modules",
+      "local"
+    );
+    const blockedLocalDir = path.join(rootDir, "node_modules", "blocked");
+
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.mkdirSync(externalDir, { recursive: true });
+    fs.mkdirSync(localDir, { recursive: true });
+    fs.mkdirSync(blockedLocalDir, { recursive: true });
+
+    const blockedPkgDir = findPackageDependencyDir("external", {
+      startDir: workspaceDir,
+      stopAt: rootDir,
+    });
+    equal(blockedPkgDir, undefined);
+
+    const localPkgDir = findPackageDependencyDir("local", {
+      startDir: workspaceDir,
+      stopAt: rootDir,
+    });
+    equal(localPkgDir, localDir);
+
+    const blockedLocalPkgDir = findPackageDependencyDir("blocked", {
+      startDir: workspaceDir,
+      stopAt: rootDir,
+    });
+    equal(blockedLocalPkgDir, undefined);
+  });
 });

--- a/packages/tools-node/test/package.test.ts
+++ b/packages/tools-node/test/package.test.ts
@@ -217,12 +217,7 @@ describe("Node > Package", () => {
     const rootDir = path.join(testTempDir, "repo");
     const workspaceDir = path.join(rootDir, "packages", "app");
     const externalDir = path.join(testTempDir, "node_modules", "external");
-    const localDir = path.join(
-      rootDir,
-      "packages",
-      "node_modules",
-      "local"
-    );
+    const localDir = path.join(rootDir, "packages", "node_modules", "local");
     const blockedLocalDir = path.join(rootDir, "node_modules", "blocked");
 
     fs.mkdirSync(workspaceDir, { recursive: true });


### PR DESCRIPTION
### Description

Resolves #801.

This adds a `stopDir` option to `findPackageDependencyDir` so callers can keep dependency lookup bounded to a repository root instead of walking all the way up the filesystem. The stop directory itself remains part of the search, so root-level `node_modules` is still found.

A regression test covers both cases: a dependency above `stopDir` is ignored, while a dependency at `stopDir/node_modules` is still resolved.

### Test plan

- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" yarn workspace @rnx-kit/tools-node test`
- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" yarn workspace @rnx-kit/tools-node build`
- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" yarn workspace @rnx-kit/tools-node lint`
- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" yarn change:check`

Note: the default local Node v20.15.0 cannot run the repo test command because it lacks `fs.globSync`; the commands above were run with local Node v22.22.0.