### PR TITLE
fix(align-deps): automatically group log lines on CI

### DIFF
--- a/.changeset/tricky-comics-push.md
+++ b/.changeset/tricky-comics-push.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": patch
+---
+
+Automatically group log lines on GitHub Actions and Azure Pipelines

--- a/packages/align-deps/src/commands/check.ts
+++ b/packages/align-deps/src/commands/check.ts
@@ -1,4 +1,3 @@
-import { error, info } from "@rnx-kit/console";
 import { readPackage } from "@rnx-kit/tools-node/package";
 import * as nodefs from "node:fs";
 import * as path from "node:path";
@@ -9,6 +8,7 @@ import { isError } from "../errors.ts";
 import { modifyManifest } from "../helpers.ts";
 import { updatePackageManifest } from "../manifest.ts";
 import { resolve } from "../preset.ts";
+import { makeDefaultReporter, withGroupReporter } from "../reporter.ts";
 import type { Command, ErrorCode, Options } from "../types.ts";
 import { checkPackageManifestUnconfigured } from "./vigilant.ts";
 
@@ -41,7 +41,7 @@ export function checkPackageManifest(
   manifestPath: string,
   options: Options,
   inputConfig = loadConfig(manifestPath, options),
-  logError = error,
+  reporter = makeDefaultReporter(manifestPath),
   /** @internal */ fs = nodefs
 ): ErrorCode {
   if (isError(inputConfig)) {
@@ -64,15 +64,14 @@ export function checkPackageManifest(
 
   if (options.verbose) {
     if (kitType === "app") {
-      info(
-        `${manifestPath}: Aligning your app's dependencies according to the following profiles:`,
-        Object.keys(prodPreset).join(", ")
+      reporter.info(
+        `${manifestPath}: profiles resolved for the app: ${Object.keys(prodPreset).join(", ")}`
       );
     } else {
-      info(
-        `${manifestPath}: Aligning your library's dependencies according to the following profiles:\n` +
-          `\t- Development: ${Object.keys(devPreset).join(", ")}\n` +
-          `\t- Production: ${Object.keys(prodPreset).join(", ")}`
+      reporter.info(
+        `${manifestPath}: profiles resolved for the library:\n` +
+          `     ├── Development: ${Object.keys(devPreset).join(", ")}\n` +
+          `     └── Production: ${Object.keys(prodPreset).join(", ")}`
       );
     }
   }
@@ -95,7 +94,7 @@ export function checkPackageManifest(
       modifyManifest(manifestPath, updatedManifest, fs);
     } else {
       const violations = stringify(allChanges, [manifestPath]);
-      logError(violations);
+      reporter.error(violations);
       return "unsatisfied";
     }
   }
@@ -135,35 +134,37 @@ export function makeCheckCommand(options: Options): Command {
 
     // If the package is configured, run the normal check first.
     if (!isError(config)) {
-      const output: string[] = [];
-      const logError = (message: string) => {
-        output.push(message);
-      };
-      const res1 = checkPackageManifest(manifest, options, config, logError);
-      const res2 = checkPackageManifestUnconfigured(
-        manifest,
-        options,
-        config,
-        logError
-      );
-      for (const message of output) {
-        error(message);
-      }
-      return res1 !== "success" ? res1 : res2;
+      return withGroupReporter(manifest, (reporter) => {
+        const res1 = checkPackageManifest(manifest, options, config, reporter);
+        const res2 = checkPackageManifestUnconfigured(
+          manifest,
+          options,
+          config,
+          reporter
+        );
+        return res1 !== "success" ? res1 : res2;
+      });
     }
 
     // Otherwise, run the unconfigured check only.
     if (config === "invalid-configuration" || config === "not-configured") {
       // In "vigilant" mode, we allow packages to declare which presets should
       // be used in config, overriding the `--presets` flag.
-      return checkPackageManifestUnconfigured(manifest, options, {
-        kitType: "library",
-        alignDeps: {
-          presets,
-          requirements,
-          capabilities: [],
-        },
-        manifest: readPackage(manifest),
+      return withGroupReporter(manifest, (reporter) => {
+        return checkPackageManifestUnconfigured(
+          manifest,
+          options,
+          {
+            kitType: "library",
+            alignDeps: {
+              presets,
+              requirements,
+              capabilities: [],
+            },
+            manifest: readPackage(manifest),
+          },
+          reporter
+        );
       });
     }
 

--- a/packages/align-deps/src/commands/vigilant.ts
+++ b/packages/align-deps/src/commands/vigilant.ts
@@ -1,4 +1,3 @@
-import { error, warn } from "@rnx-kit/console";
 import { keysOf } from "@rnx-kit/tools-language/properties";
 import type { Capability, KitConfig } from "@rnx-kit/types-kit-config";
 import type { PackageManifest } from "@rnx-kit/types-node";
@@ -13,6 +12,7 @@ import { isSubset, stringify } from "../diff.ts";
 import { dependencySections, modifyManifest } from "../helpers.ts";
 import { updateDependencies } from "../manifest.ts";
 import { ensurePreset, filterPreset, mergePresets } from "../preset.ts";
+import { makeDefaultReporter } from "../reporter.ts";
 import type {
   AlignDepsOptions,
   Changes,
@@ -291,7 +291,7 @@ export function checkPackageManifestUnconfigured(
   manifestPath: string,
   options: Options,
   config: AlignDepsOptions,
-  logError = error,
+  reporter = makeDefaultReporter(manifestPath),
   /** @internal */ fs = nodefs
 ): ErrorCode {
   const { excludePackages, write } = options;
@@ -311,7 +311,7 @@ export function checkPackageManifestUnconfigured(
     const violations = stringify({ capabilities: warnings }, [
       `${manifestPath}: Found dependencies that are currently missing from capabilities:`,
     ]);
-    warn(violations);
+    reporter.warn(violations);
   }
 
   if (errorCount > 0) {
@@ -321,7 +321,7 @@ export function checkPackageManifestUnconfigured(
       const violations = stringify(errors, [
         `${manifestPath}: Found ${errorCount} violation(s) outside of capabilities.`,
       ]);
-      logError(violations);
+      reporter.error(violations);
       return "unsatisfied";
     }
   }

--- a/packages/align-deps/src/reporter.ts
+++ b/packages/align-deps/src/reporter.ts
@@ -1,0 +1,79 @@
+import { error, info, warn } from "@rnx-kit/console";
+
+type GroupMarkers = {
+  beginGroup(title: string): void;
+  endGroup(title: string): void;
+};
+
+export type Reporter = {
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+  close(): void;
+};
+
+const getGroupMarkers = (() => {
+  // Accessing `process.env` is expensive. Cache the result and use it for the
+  // remaining time of the process.
+  let groupMarkers: GroupMarkers | undefined = undefined;
+  return (log = console.log): GroupMarkers => {
+    if (!groupMarkers) {
+      if (process.env["GITHUB_ACTIONS"] === "true") {
+        groupMarkers = {
+          beginGroup: (title) => log(`::group::${encodeURI(title)}`),
+          endGroup: () => log("::endgroup::"),
+        };
+      } else if (process.env["TF_BUILD"] === "True") {
+        groupMarkers = {
+          beginGroup: (title) => log(`##[group]${title}`),
+          endGroup: () => log("##[endgroup]"),
+        };
+      } else {
+        const noop = () => undefined;
+        groupMarkers = {
+          beginGroup: noop,
+          endGroup: noop,
+        };
+      }
+    }
+    return groupMarkers;
+  };
+})();
+
+export function makeDefaultReporter(_title: string): Reporter {
+  return { info, warn, error, close: () => undefined };
+}
+
+export function makeGroupedReporter(title: string): Reporter {
+  const { beginGroup, endGroup } = getGroupMarkers();
+  let groupBegun = false;
+  return {
+    info: (message) => {
+      groupBegun = groupBegun || (beginGroup(title), true);
+      info(message);
+    },
+    warn: (message) => {
+      groupBegun = groupBegun || (beginGroup(title), true);
+      warn(message);
+    },
+    error: (message) => {
+      groupBegun = groupBegun || (beginGroup(title), true);
+      error(message);
+    },
+    close: () => {
+      if (groupBegun) {
+        endGroup(title);
+      }
+    },
+  };
+}
+
+export function withGroupReporter<T>(
+  title: string,
+  fn: (reporter: Reporter) => T
+): T {
+  const reporter = makeGroupedReporter(title);
+  const result = fn(reporter);
+  reporter.close();
+  return result;
+}

--- a/packages/align-deps/test/commands/check.test.ts
+++ b/packages/align-deps/test/commands/check.test.ts
@@ -1,4 +1,4 @@
-import { equal, notEqual } from "node:assert/strict";
+import { equal, fail, notEqual } from "node:assert/strict";
 import type { PathOrFileDescriptor } from "node:fs";
 import { after, before, beforeEach, describe, it } from "node:test";
 import { checkPackageManifest as checkPackageManifestActual } from "../../src/commands/check.ts";
@@ -7,6 +7,7 @@ import { defaultConfig, loadConfig } from "../../src/config.ts";
 import { profile as profile_0_68 } from "../../src/presets/microsoft/react-native/profile-0.68.ts";
 import { profile as profile_0_69 } from "../../src/presets/microsoft/react-native/profile-0.69.ts";
 import { profile as profile_0_70 } from "../../src/presets/microsoft/react-native/profile-0.70.ts";
+import type { Reporter } from "../../src/reporter.ts";
 import type { Options } from "../../src/types.ts";
 import * as mockfs from "../__mocks__/fs.ts";
 import { defineRequire, packageVersion, undefineRequire } from "../helpers.ts";
@@ -29,14 +30,14 @@ function checkPackageManifest(
   manifestPath: string,
   options: Options = defaultOptions,
   _inputConfig?: ConfigResult,
-  logError?: (message: string) => void
+  reporter?: Reporter
 ) {
   const fs = mockfs as unknown as typeof import("node:fs");
   return checkPackageManifestActual(
     manifestPath,
     options,
     loadConfig(manifestPath, options, fs),
-    logError,
+    reporter,
     fs
   );
 }
@@ -287,17 +288,22 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       "package.json",
       defaultOptions,
       undefined,
-      (message) => {
-        equal(
-          message,
-          `package.json
+      {
+        info: fail,
+        warn: fail,
+        error: (message) => {
+          equal(
+            message,
+            `package.json
       ├── peerDependencies["react"]: dependency is missing, expected "18.1.0"
       ├── peerDependencies["react-native"]: dependency is missing, expected "^0.70.0"
       ├── devDependencies["react"]: dependency is missing, expected "18.1.0"
       ├── devDependencies["react-native"]: dependency is missing, expected "^0.70.0"
       └── Re-run with '--write' to fix them
 `
-        );
+          );
+        },
+        close: fail,
       }
     );
 
@@ -350,7 +356,7 @@ describe("checkPackageManifest({ kitType: 'library' })", () => {
       "\t"
     );
     mockfs.__setMockFileWriter((_, content) => {
-      output = content;
+      output = content.toString();
     });
 
     equal(checkPackageManifest("package.json", writeOptions), "success");
@@ -688,7 +694,7 @@ describe("checkPackageManifest({ kitType: 'library' }) (backwards compatibility)
       },
     });
     mockfs.__setMockFileWriter((p, _content) => {
-      didWriteToPath = p;
+      didWriteToPath = Boolean(p);
     });
 
     equal(checkPackageManifest("package.json", writeOptions), "success");
@@ -708,7 +714,7 @@ describe("checkPackageManifest({ kitType: 'library' }) (backwards compatibility)
   });
 
   it("writes changes back to 'package.json'", () => {
-    let didWriteToPath = false;
+    let destPath = "";
 
     mockfs.__setMockContent({
       ...mockManifest,
@@ -718,11 +724,11 @@ describe("checkPackageManifest({ kitType: 'library' }) (backwards compatibility)
       },
     });
     mockfs.__setMockFileWriter((p, _content) => {
-      didWriteToPath = p;
+      destPath = p.toString();
     });
 
     equal(checkPackageManifest("package.json", writeOptions), "success");
-    equal(didWriteToPath, "package.json");
+    equal(destPath, "package.json");
   });
 
   it("preserves indentation in 'package.json'", (t) => {
@@ -739,7 +745,7 @@ describe("checkPackageManifest({ kitType: 'library' }) (backwards compatibility)
       "\t"
     );
     mockfs.__setMockFileWriter((_, content) => {
-      output = content;
+      output = content.toString();
     });
 
     equal(checkPackageManifest("package.json", writeOptions), "success");


### PR DESCRIPTION
### Description

Automatically group log lines on GitHub Actions and Azure Pipelines.

Many thanks to @vivekjm for starting this work in #4150.

### Test plan

Example output:

```
% GITHUB_ACTIONS=true yarn rnx-align-deps
::group::incubator/polyfills/package.json
info incubator/polyfills/package.json: profiles resolved for the library:
     ├── Development: 0.85
     └── Production: 0.72, 0.73, 0.74, 0.75, 0.76, 0.77, 0.78, 0.79, 0.80, 0.81, 0.82, 0.83, 0.84, 0.85
::endgroup::
::group::packages/react-native-auth/package.json
info packages/react-native-auth/package.json: profiles resolved for the library:
     ├── Development: 0.85
     └── Production: 0.62, 0.63, 0.64, 0.65, 0.66, 0.67, 0.68, 0.69, 0.70, 0.71, 0.72, 0.73, 0.74, 0.75, 0.76, 0.77, 0.78, 0.79, 0.80, 0.81, 0.82, 0.83, 0.84, 0.85
::endgroup::
::group::packages/test-app/package.json
info packages/test-app/package.json: profiles resolved for the app: 0.85
error packages/test-app/package.json
      ├── dependencies["react-native"]: found "^0.86.0", expected "^0.85.0"
      └── Re-run with '--write' to fix them

::endgroup::
::group::packages/test-app-macos/package.json
info packages/test-app-macos/package.json: profiles resolved for the app: 0.81
::endgroup::
::group::packages/test-app-windows/package.json
info packages/test-app-windows/package.json: profiles resolved for the app: 0.82
::endgroup::
info Visit https://aka.ms/align-deps for more information about align-deps.
```