### PR TITLE
chore: prevent accidental Node version downgrades

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -77,6 +77,9 @@ jobs:
             git diff | yarn suggestion-bot
           fi
           git diff --exit-code
+      - name: Report Node minimum version inconsistencies
+        run: |
+          node scripts/lint-node-version.ts
       - name: Report @rnx-kit/build workflow inconsistencies
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/lint-node-version.ts
+++ b/scripts/lint-node-version.ts
@@ -1,0 +1,87 @@
+import { spawnSync } from "node:child_process";
+import changesetsConfig from "../.changeset/config.json" with { type: "json" };
+
+function git(...args: string[]): string {
+  const { stderr, stdout } = spawnSync("git", args);
+  const message = stderr.toString().trim();
+  if (message) {
+    console.error(message);
+  }
+  return stdout.toString().trim();
+}
+
+function getDefaultBranch(): string {
+  if (process.env["CI"]) {
+    // CIs don't clone the repo, but use a different way to checkout a branch.
+    // This means that `origin/HEAD` is never created, which in turn means that
+    // we don't have a reliable way to get the default branch. For now, just
+    // return a hard-coded value.
+    return changesetsConfig.baseBranch ?? "origin/main";
+  }
+
+  const defaultBranch = git("rev-parse", "--abbrev-ref", "origin/HEAD");
+  if (!defaultBranch) {
+    throw new Error("Failed to determine default branch");
+  }
+
+  return defaultBranch;
+}
+
+function getBaseCommit(targetBranch: string | undefined): string {
+  targetBranch =
+    !targetBranch || targetBranch.endsWith("/")
+      ? getDefaultBranch()
+      : targetBranch;
+  const base = git("merge-base", "--fork-point", targetBranch);
+  if (!base) {
+    console.error("❌ Failed to determine base commit");
+  }
+  return base;
+}
+
+function getChangedFiles(since: string): string[] {
+  const changedFiles = git("diff", "--name-only", since);
+  if (!changedFiles) {
+    return [];
+  }
+  return changedFiles.split("\n");
+}
+
+function parseVersion(version: string): number {
+  const [major, minor = 0, patch = 0] = version.split(".");
+  return Number(major) * 1000000 + Number(minor) * 1000 + Number(patch);
+}
+
+function main(targetBranch: string | undefined): number {
+  const baseCommit = getBaseCommit(targetBranch);
+  if (!baseCommit) {
+    return 1;
+  }
+
+  let errors = 0;
+  for (const file of getChangedFiles(baseCommit)) {
+    if (!file.endsWith("package.json")) {
+      continue;
+    }
+
+    const diff = git("diff", baseCommit, file);
+    const matches = Array.from(diff.matchAll(/"node": "[^\d]*([.\d]+)"/g));
+    if (matches.length < 2) {
+      continue;
+    }
+
+    const prev = matches[0][1];
+    const next = matches[1][1];
+    if (parseVersion(next) < parseVersion(prev)) {
+      errors++;
+      console.error(
+        `❌ ${file}: minimum Node version downgraded from ${prev} to ${next}`
+      );
+    }
+  }
+
+  return errors;
+}
+
+const { [2]: targetBranch } = process.argv;
+process.exitCode = main(targetBranch);

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -31,13 +31,11 @@
     "markdown-table": "^3.0.0",
     "oxfmt": "catalog:",
     "typedoc": "^0.28.0",
-    "typescript": "catalog:",
-    "yargs": "^16.0.0"
+    "typescript": "catalog:"
   },
   "devDependencies": {
     "@rnx-kit/tsconfig": "workspace:*",
     "@types/jest": "^29.2.1",
-    "@types/node": "^24.0.0",
-    "@types/yargs": "^16.0.0"
+    "@types/node": "^24.0.0"
   }
 }

--- a/scripts/src/process.js
+++ b/scripts/src/process.js
@@ -1,7 +1,6 @@
 // @ts-check
 
 /**
- * @typedef {(args?: import("yargs").Arguments, rawArgs?: string[]) => Promise<void>} Command
  * @typedef {import("node:child_process").SpawnOptions} SpawnOptions
  */
 

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -2,7 +2,6 @@
 
 /** @type {import("@yarnpkg/types")} */
 const { defineConfig } = require("@yarnpkg/types");
-const { getRootEnginesField } = require("./scripts/src/rootWorkspace.js");
 
 module.exports = defineConfig({
   constraints: async ({ Yarn }) => {
@@ -11,7 +10,7 @@ module.exports = defineConfig({
       throw new Error("Root workspace not found");
     }
 
-    const { author, repository: origin } = root.manifest;
+    const { author, repository: origin, engines } = root.manifest;
 
     for (const workspace of Yarn.workspaces()) {
       const { name, private: isPrivate, experimental } = workspace.manifest;
@@ -36,7 +35,6 @@ module.exports = defineConfig({
       }
 
       if (name.startsWith("@rnx-kit/yarn-plugin-")) {
-        const engines = getRootEnginesField();
         workspace.set("engines.node", engines.node);
         workspace.set("engines.yarn", ">=4.0");
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5698,7 +5698,6 @@ __metadata:
     "@rnx-kit/tsconfig": "workspace:*"
     "@types/jest": "npm:^29.2.1"
     "@types/node": "npm:^24.0.0"
-    "@types/yargs": "npm:^16.0.0"
     "@typescript/native-preview": "catalog:"
     "@yarnpkg/cli": "npm:^4.6.0"
     clipanion: "npm:^4.0.0-rc.4"
@@ -5708,7 +5707,6 @@ __metadata:
     oxfmt: "catalog:"
     typedoc: "npm:^0.28.0"
     typescript: "catalog:"
-    yargs: "npm:^16.0.0"
   bin:
     rnx-kit-scripts: src/index.js
   languageName: unknown


### PR DESCRIPTION
### Description

Prevent accidental Node version downgrades (see #4157)

### Test plan

```
% git diff
diff --git a/packages/cli/package.json b/packages/cli/package.json
index 94e8524ca..cef38a5ce 100644
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -99,6 +99,6 @@
     "preset": "@rnx-kit/jest-preset/private"
   },
   "engines": {
-    "node": ">=20.18"
+    "node": ">=20.17"
   }
 }

% node scripts/lint-node-version.ts
❌ packages/cli/package.json: minimum Node version downgraded from 20.18 to 20.17
```