### PR TITLE
fix(metro-serializer-esbuild): preserve class syntax for Hermes

### DIFF
--- a/.changeset/salty-colts-turn.md
+++ b/.changeset/salty-colts-turn.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-serializer-esbuild": patch
+---
+
+Preserve `class` syntax for Hermes

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -116,7 +116,7 @@ jobs:
           yarn bundle:ci --base origin/${{ github.base_ref }}
       - name: Bundle test apps with esbuild
         run: |
-          yarn nx affected --base origin/${{ github.base_ref }} --target bundle+esbuild
+          yarn nx affected --base origin/${{ github.base_ref }} --target bundle+esbuild -- --dev false
         shell: bash
     timeout-minutes: 60
   build-android-test-app:

--- a/packages/metro-serializer-esbuild/src/index.ts
+++ b/packages/metro-serializer-esbuild/src/index.ts
@@ -281,6 +281,7 @@ export function MetroSerializer(
           // https://github.com/evanw/esbuild/releases/tag/v0.14.49).
           return {
             arrow: true,
+            class: true, // Introduced in 1.0, handled by Babel otherwise
             "default-argument": true,
             destructuring: true,
             generator: true,

--- a/packages/metro-serializer-esbuild/src/targets.ts
+++ b/packages/metro-serializer-esbuild/src/targets.ts
@@ -9,7 +9,9 @@ export function inferBuildTarget(projectRoot = process.cwd()): string {
     const { version } = JSON.parse(manifest);
     const versionNum = v(version);
 
-    if (versionNum >= v("0.83.0")) {
+    if (versionNum >= v("0.85.0")) {
+      return "hermes1";
+    } else if (versionNum >= v("0.83.0")) {
       return "hermes0.14";
     } else if (versionNum >= v("0.75.0")) {
       return "hermes0.13";

--- a/packages/tools-node/test/package.test.ts
+++ b/packages/tools-node/test/package.test.ts
@@ -1,10 +1,10 @@
+import type { PackageManifest } from "@rnx-kit/types-node";
 import { deepEqual, equal, ok, throws } from "node:assert/strict";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, before, beforeEach, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
-import type { PackageManifest } from "../src/package.ts";
 import {
   findPackage,
   findPackageDependencyDir,

--- a/packages/types-metro-serializer-esbuild/src/index.ts
+++ b/packages/types-metro-serializer-esbuild/src/index.ts
@@ -1,7 +1,8 @@
 /**
  * Plugin options for @rnx-kit/metro-serializer-esbuild.
  *
- * These options are a combinations of a subset of esbuild's BuildOptions and additional options specific to the plugin.
+ * These options are a combinations of a subset of esbuild's BuildOptions and
+ * additional options specific to the plugin.
  */
 
 /**
@@ -11,8 +12,8 @@ type Drop = "console" | "debugger";
 type LogLevel = "verbose" | "debug" | "info" | "warning" | "error" | "silent";
 
 /**
- * Options redefined from esbuild's BuildOptions, separated so type level compatibility
- * can be checked at build time
+ * Options redefined from esbuild's BuildOptions, separated so type level
+ * compatibility can be checked at build time.
  */
 export type BaseBuildOptions = {
   drop?: Drop[];


### PR DESCRIPTION
### Description

See https://github.com/facebook/react-native/commit/d5278940ab91818b67e417b510f03a288bd7f645

### Test plan

CI was previously not exercising the correct path. It should now.