### PR TITLE
feat(fork-sync): handle empty changes and update tags

### DIFF
--- a/.changeset/breezy-windows-relax.md
+++ b/.changeset/breezy-windows-relax.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/fork-sync": patch
+---
+
+Handle empty changes and autoupdate tags in sync config

--- a/incubator/fork-sync/src/modules/git.ts
+++ b/incubator/fork-sync/src/modules/git.ts
@@ -9,12 +9,15 @@
  *
  * This module provides:
  * - **GitRepo**: Class wrapping a directory path, providing typed git operations
+ *   (includes **tagsPointingAt** for listing tags at a commit)
  * - **isGitRepo**: Check if a directory is a git repository
  * - **clone**: Clone a repository with progress streaming
  * - **listFilesWithExclusions**: List tracked files with .syncignore support
  * - **getAllowedRelativePaths**: Get relative paths with prefix stripping
  * - **getGitTreeHashes**: Get file hashes from `git ls-tree`
  * - **getChangeStats**: Parse `git status` into change statistics
+ * - **pickTag**: Choose a tag from candidates, biased toward continuity with
+ *   an existing tag (longest common prefix)
  *
  * @example
  * ```typescript
@@ -111,6 +114,22 @@ export class GitRepo {
     if (opts?.count) args.push("-n", String(opts.count));
     args.push(ref);
     return spawn("git", args, { cwd: this.dir, fallback: "" });
+  }
+
+  /**
+   * List tags that point exactly at the given commit.
+   * Returns [] if none, or if the git command fails.
+   * Handles both lightweight and annotated tags.
+   */
+  async tagsPointingAt(commit: string): Promise<string[]> {
+    const out = await spawn("git", ["tag", "--points-at", commit], {
+      cwd: this.dir,
+      fallback: "",
+    });
+    return out
+      .split("\n")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
   }
 
   /** Check if `base` is an ancestor of `target`. */
@@ -630,4 +649,48 @@ export async function getChangeStats(
   }
 
   return { modified, added, deleted };
+}
+
+// =============================================================================
+// Tag Utilities
+// =============================================================================
+
+function commonPrefixLength(a: string, b: string): number {
+  const max = Math.min(a.length, b.length);
+  let i = 0;
+  while (i < max && a.charCodeAt(i) === b.charCodeAt(i)) i++;
+  return i;
+}
+
+/**
+ * Pick the best tag for a synced commit from a list of candidates.
+ *
+ * Rules:
+ * - No candidates → empty string (signals "clear any previously stored tag").
+ * - One candidate → use it.
+ * - Multiple candidates, no existing tag → first lexicographic.
+ * - Multiple candidates, existing tag present → candidate with the longest
+ *   common prefix to the existing tag; ties broken lexicographically.
+ *
+ * The lexicographic tiebreak and the sort are stable, so the result is
+ * deterministic for a given input.
+ */
+export function pickTag(candidates: string[], existing: string): string {
+  if (candidates.length === 0) return "";
+  if (candidates.length === 1) return candidates[0];
+
+  const sorted = [...candidates].sort();
+  if (!existing) return sorted[0];
+
+  let best = sorted[0];
+  let bestLcp = commonPrefixLength(best, existing);
+  for (let i = 1; i < sorted.length; i++) {
+    const cand = sorted[i];
+    const lcp = commonPrefixLength(cand, existing);
+    if (lcp > bestLcp) {
+      best = cand;
+      bestLcp = lcp;
+    }
+  }
+  return best;
 }

--- a/incubator/fork-sync/src/modules/github.ts
+++ b/incubator/fork-sync/src/modules/github.ts
@@ -12,6 +12,7 @@
  * - **findPR**: Find an existing open PR by head branch name
  * - **createPR**: Create a new pull request
  * - **updatePR**: Update an existing pull request's title and body
+ * - **closePR**: Close an existing pull request (optionally updating its body first)
  *
  * All functions use `exec()` from proc.ts (shell mode) because `gh` is
  * installed as a .cmd file on Windows and requires shell execution.
@@ -174,4 +175,39 @@ export async function updatePR(opts: {
       { cwd: opts.cwd, env }
     );
   });
+}
+
+/**
+ * Close an existing pull request.
+ *
+ * If `body` is provided, the PR body is updated first (via `gh pr edit`), then
+ * the PR is closed. Useful for posting a final "now up to date" message before
+ * closing a stale sync PR.
+ *
+ * Uses --body-file with a temp file to avoid shell escaping issues with
+ * multiline markdown content on Windows cmd.exe.
+ */
+export async function closePR(opts: {
+  number: number;
+  body?: string;
+  cwd: string;
+  repo?: string;
+}): Promise<void> {
+  const repoFlag = opts.repo ? ` --repo ${shellVar("REPO")}` : "";
+
+  if (opts.body !== undefined) {
+    await withTempFile(opts.body, async (bodyFile) => {
+      const env: Record<string, string> = {
+        BODY_FILE: bodyFile,
+        ...(opts.repo ? { REPO: opts.repo } : {}),
+      };
+      await exec(
+        `gh pr edit ${opts.number} --body-file ${shellVar("BODY_FILE")}${repoFlag}`,
+        { cwd: opts.cwd, env }
+      );
+    });
+  }
+
+  const env: Record<string, string> = opts.repo ? { REPO: opts.repo } : {};
+  await exec(`gh pr close ${opts.number}${repoFlag}`, { cwd: opts.cwd, env });
 }

--- a/incubator/fork-sync/src/sync.ts
+++ b/incubator/fork-sync/src/sync.ts
@@ -73,12 +73,13 @@ import {
   getChangeStats,
   getGitTreeHashes,
   isGitRepo,
+  pickTag,
   validateCloneOrigin,
   type ChangeStats,
   type MergeResult,
   type MergeTool,
 } from "./modules/git.ts";
-import { findPR, createPR, updatePR } from "./modules/github.ts";
+import { closePR, createPR, findPR, updatePR } from "./modules/github.ts";
 import * as proc from "./modules/proc.ts";
 const { spawn, exec } = proc;
 
@@ -364,6 +365,9 @@ class SyncSession {
   changeStats!: ChangeStats;
   prNotes?: string;
   prNotesPath?: string;
+  /** True when the sync session had no file changes, same commit, and same tag.
+   * In this case sync-config.json and sync-pr-notes.md are left untouched. */
+  noOpSync = false;
 
   constructor(config: SyncConfig, args: CliArgs, repoRoot: string) {
     this.config = config;
@@ -518,7 +522,7 @@ ${style.line()}
     }
 
     const shortTarget = checkpoint.upstream.targetCommit.slice(0, 8);
-    const refName = checkpoint.upstream.tag ?? checkpoint.upstream.branch;
+    const refName = checkpoint.upstream.tag || checkpoint.upstream.branch;
 
     // Get current conflict status from git
     const mergeResult = await this.syncRepo.getMergeResult();
@@ -574,7 +578,27 @@ ${style.line()}
   private printSummary(): void {
     const depName = this.config.name;
     const shortCommit = this.targetCommit.slice(0, 8);
-    const refName = this.targetTag ?? this.targetBranch;
+    const refName = this.targetTag || this.targetBranch;
+    const localPath = this.config.localPath;
+
+    if (this.noOpSync) {
+      print(
+        () => `
+${style.line()}
+  ${style.heading("SYNC COMPLETE")}
+${style.line()}
+
+Upstream: ${this.config.repo}
+  Commit: ${style.command(shortCommit)} (${refName})
+
+${style.success("Already up to date — 0 files updated.")}
+sync-config.json and PR notes left untouched.
+
+${style.line()}
+`
+      );
+      return;
+    }
 
     const { modified, added, deleted } = this.changeStats;
     const totalChanges = modified + added + deleted;
@@ -590,7 +614,6 @@ ${style.line()}
       return result;
     };
 
-    const localPath = this.config.localPath;
     const changesSection = () =>
       totalChanges > 0
         ? `Changes to ${localPath}/:\n${changeLines().join("\n")}`
@@ -642,7 +665,7 @@ ${style.line()}
 
     const depName = this.config.name;
     const shortCommit = this.targetCommit.slice(0, 8);
-    const refName = this.targetTag ?? this.args.branch ?? this.config.branch;
+    const refName = this.targetTag || this.args.branch || this.config.branch;
     const prBranch = `fork-sync/${depName}`;
     const prTitle = `fork-sync: sync ${depName} to ${shortCommit} (${refName})`;
     const prBody = this.prNotes ?? "";
@@ -662,6 +685,48 @@ ${style.line()}
     // Detect remote and GitHub repo
     job.step("Detecting remote...");
     const ghRepo = await this.detectGitHubRepo();
+
+    // No-op sync: do not reset, stage, commit, or push. If a previous sync PR
+    // is still open, update its body to a "now up to date" note and close it.
+    // Otherwise just report that there's nothing to PR.
+    if (this.noOpSync) {
+      job.step("Checking for existing PR...");
+      const existingPR = await findPR({
+        head: prBranch,
+        cwd: this.repoRoot,
+        repo: ghRepo,
+      });
+
+      if (!existingPR) {
+        info(() => `${label()} Nothing to PR — already up to date.`);
+        job.done(() => `${label()} nothing to PR`);
+        return;
+      }
+
+      const closeBody =
+        `fork-sync: ${depName} is now up to date with ` +
+        `\`${shortCommit}\` (${refName}). Closing this PR — no changes to merge.`;
+
+      if (isDryRun) {
+        info(
+          () =>
+            `${label()} Dry run: would update and close PR #${existingPR.number}`
+        );
+        job.done(() => `${label()} dry run complete`);
+        return;
+      }
+
+      job.step(`Closing PR #${existingPR.number}...`);
+      await closePR({
+        number: existingPR.number,
+        body: closeBody,
+        cwd: this.repoRoot,
+        repo: ghRepo,
+      });
+      info(() => `${label()} Closed PR: ${existingPR.url}`);
+      job.done(() => `${label()} closed PR #${existingPR.number}`);
+      return;
+    }
 
     // Save current branch for restoration
     const originalBranch = await this.mainRepo.currentBranch();
@@ -1014,24 +1079,22 @@ ${style.line()}
   }
 
   /**
-   * Resolve target commit from args (commit, tag, or branch).
    * Resolves the target commit hash from a direct commit, tag, or branch head.
+   * When no explicit `--tag` is given, also auto-fills `targetTag` from any
+   * upstream tag pointing at the resolved commit (see {@link pickTag}).
    */
   private async resolveTarget(job: Job): Promise<void> {
     this.targetBranch = this.args.branch ?? this.config.branch;
     this.targetTag = this.args.tag;
 
-    // If commit specified directly, use it
     if (this.args.commit) {
+      // Commit specified directly
       job.step(
         `Using specified target commit: ${this.args.commit.slice(0, 8)}`
       );
       this.targetCommit = this.args.commit;
-      return;
-    }
-
-    // If tag specified, resolve to commit using local refs
-    if (this.args.tag) {
+    } else if (this.args.tag) {
+      // Tag specified — resolve to commit using local refs
       job.step(`Resolving target tag ${this.args.tag}...`);
       // git rev-list -n 1 handles both lightweight and annotated tags
       const commit = await this.syncRepo.revList(`refs/tags/${this.args.tag}`, {
@@ -1045,22 +1108,41 @@ ${style.line()}
       }
       job.step(`Tag ${this.args.tag} resolved to ${commit.slice(0, 8)}`);
       this.targetCommit = commit;
-      return;
+    } else {
+      // Otherwise, get HEAD of branch from local refs
+      job.step(`Resolving HEAD of branch ${this.targetBranch}...`);
+      const commit = await this.syncRepo.revParse(
+        `origin/${this.targetBranch}`
+      );
+      if (!commit) {
+        fatal(
+          `Branch '${this.targetBranch}' not found in local clone.\n` +
+            `Check that it exists on origin, or run: git fetch origin (in ${this.syncPath})`
+        );
+      }
+      job.step(
+        `Using latest commit ${commit.slice(0, 8)} from branch ${this.targetBranch}`
+      );
+      this.targetCommit = commit;
     }
 
-    // Otherwise, get HEAD of branch from local refs
-    job.step(`Resolving HEAD of branch ${this.targetBranch}...`);
-    const commit = await this.syncRepo.revParse(`origin/${this.targetBranch}`);
-    if (!commit) {
-      fatal(
-        `Branch '${this.targetBranch}' not found in local clone.\n` +
-          `Check that it exists on origin, or run: git fetch origin (in ${this.syncPath})`
-      );
+    // Auto-resolve tag for the target commit when the user did not pass --tag.
+    // Picks a tag that points at the commit, biased toward the existing tag's
+    // shape (longest common prefix). Falls back to "" when none exist.
+    if (this.targetTag === undefined) {
+      const candidates = await this.syncRepo.tagsPointingAt(this.targetCommit);
+      const picked = pickTag(candidates, this.config.tag);
+      if (picked) {
+        if (candidates.length > 1) {
+          job.step(
+            `Auto-selected tag ${picked} from ${candidates.length} candidates`
+          );
+        } else {
+          job.step(`Auto-detected tag ${picked} at target commit`);
+        }
+      }
+      this.targetTag = picked;
     }
-    job.step(
-      `Using latest commit ${commit.slice(0, 8)} from branch ${this.targetBranch}`
-    );
-    this.targetCommit = commit;
   }
 
   /**
@@ -1287,6 +1369,27 @@ ${style.line()}
     // Get actual change statistics from git status
     job.step("Computing change statistics...");
     const changes = await getChangeStats(this.mainRepo, this.depPathPrefix);
+    this.changeStats = changes;
+
+    const newTag = this.targetTag ?? "";
+    const totalChanges = changes.added + changes.modified + changes.deleted;
+
+    // Skip writes when this sync was a true no-op: same commit, same tag, no
+    // file deltas, and sync-config.json was already populated (first-ever
+    // syncs always write so the file gets initialized).
+    if (
+      this.config.baseCommit &&
+      this.targetCommit === this.config.baseCommit &&
+      (this.config.tag ?? "") === newTag &&
+      totalChanges === 0
+    ) {
+      this.noOpSync = true;
+      job.done(
+        () =>
+          `${label()} no changes — sync-config.json and PR notes left untouched`
+      );
+      return;
+    }
 
     // Update sync config
     job.step("Updating sync config...");
@@ -1295,11 +1398,9 @@ ${style.line()}
       branch: this.args.branch ?? this.config.branch,
       commit: this.targetCommit,
       ...(this.config.subDir ? { subDir: this.config.subDir } : {}),
-      tag: this.targetTag ?? "",
+      tag: newTag,
       lastSync: new Date().toISOString(),
     });
-
-    this.changeStats = changes;
 
     // Generate PR notes
     job.step("Generating PR notes...");
@@ -1309,7 +1410,6 @@ ${style.line()}
     this.prNotes = notes;
     this.prNotesPath = notesPath;
 
-    const totalChanges = changes.added + changes.modified + changes.deleted;
     job.done(
       () =>
         `${label()} ${totalChanges} change(s) (${changes.added} Added, ${changes.modified} Modified, ${changes.deleted} Deleted)`
@@ -1356,7 +1456,7 @@ ${style.line()}
     const commits = await this.getUpstreamCommits();
     const shortBase = this.config.baseCommit.slice(0, 8);
     const shortTarget = this.targetCommit.slice(0, 8);
-    const refName = this.targetTag ?? this.args.branch ?? this.config.branch;
+    const refName = this.targetTag || this.args.branch || this.config.branch;
     const repoUrl = this.config.repo.replace(/\.git$/, "");
 
     const lines: string[] = [];
@@ -1475,7 +1575,7 @@ ${style.line()}
 
     this.targetCommit = checkpoint.upstream.targetCommit;
     this.targetBranch = checkpoint.upstream.branch;
-    this.targetTag = checkpoint.upstream.tag;
+    this.targetTag = checkpoint.upstream.tag ?? "";
     this.workBranch = checkpoint.mergeBranches.work;
     this.targetMergeBranch = checkpoint.mergeBranches.target;
   }

--- a/incubator/fork-sync/test/git.test.ts
+++ b/incubator/fork-sync/test/git.test.ts
@@ -11,6 +11,7 @@ import {
   GitRepo,
   getAllowedRelativePaths,
   listFilesWithExclusions,
+  pickTag,
 } from "../src/modules/git.ts";
 import { spawn } from "../src/modules/proc.ts";
 
@@ -257,5 +258,107 @@ describe("GitRepo sparse checkout", () => {
 
     // Now other/c.txt should be back
     assert.ok(fs.existsSync(path.join(tempDir, "other", "c.txt")));
+  });
+});
+
+describe("GitRepo.tagsPointingAt", () => {
+  it("returns empty array when no tags point at the commit", async () => {
+    repo = await initRepoWithFiles(tempDir, { "a.txt": "a" });
+    const head = await repo.revParse("HEAD");
+    const tags = await repo.tagsPointingAt(head);
+    assert.deepStrictEqual(tags, []);
+  });
+
+  it("returns a single tag pointing at the commit", async () => {
+    repo = await initRepoWithFiles(tempDir, { "a.txt": "a" });
+    await spawn("git", ["tag", "v1.0.0"], { cwd: tempDir });
+
+    const head = await repo.revParse("HEAD");
+    const tags = await repo.tagsPointingAt(head);
+    assert.deepStrictEqual(tags, ["v1.0.0"]);
+  });
+
+  it("returns multiple tags pointing at the same commit", async () => {
+    repo = await initRepoWithFiles(tempDir, { "a.txt": "a" });
+    await spawn("git", ["tag", "v1.0.0"], { cwd: tempDir });
+    await spawn("git", ["tag", "release-1"], { cwd: tempDir });
+
+    const head = await repo.revParse("HEAD");
+    const tags = await repo.tagsPointingAt(head);
+    assert.deepStrictEqual(tags.sort(), ["release-1", "v1.0.0"]);
+  });
+
+  it("does not return tags pointing at other commits", async () => {
+    repo = await initRepoWithFiles(tempDir, { "a.txt": "a" });
+    const first = await repo.revParse("HEAD");
+    await spawn("git", ["tag", "v1.0.0"], { cwd: tempDir });
+
+    writeFile(path.join(tempDir, "b.txt"), "b");
+    await spawn("git", ["add", "-A"], { cwd: tempDir });
+    await spawn("git", ["commit", "-m", "second"], { cwd: tempDir });
+    await spawn("git", ["tag", "v2.0.0"], { cwd: tempDir });
+
+    assert.deepStrictEqual(await repo.tagsPointingAt(first), ["v1.0.0"]);
+    const second = await repo.revParse("HEAD");
+    assert.deepStrictEqual(await repo.tagsPointingAt(second), ["v2.0.0"]);
+  });
+});
+
+describe("pickTag", () => {
+  it("returns empty string when there are no candidates", () => {
+    assert.strictEqual(pickTag([], ""), "");
+    assert.strictEqual(pickTag([], "v24.2.0"), "");
+  });
+
+  it("returns the only candidate", () => {
+    assert.strictEqual(pickTag(["v24.3.0"], ""), "v24.3.0");
+    assert.strictEqual(pickTag(["v24.3.0"], "v24.2.0"), "v24.3.0");
+    assert.strictEqual(
+      pickTag(["nightly-2026-05-18"], "v24.2.0"),
+      "nightly-2026-05-18"
+    );
+  });
+
+  it("picks first lexicographic candidate when there is no existing tag", () => {
+    assert.strictEqual(
+      pickTag(["v24.3.0", "nightly-2026-05-18", "alpha"], ""),
+      "alpha"
+    );
+    assert.strictEqual(pickTag(["v25.0.0", "v24.3.0"], ""), "v24.3.0");
+  });
+
+  it("picks the longest-common-prefix match against the existing tag", () => {
+    assert.strictEqual(
+      pickTag(["v24.3.0", "nightly-2026-05-18"], "v24.2.0"),
+      "v24.3.0"
+    );
+    assert.strictEqual(
+      pickTag(["v25.0.0", "nightly-2026-05-18"], "v24.2.0"),
+      "v25.0.0"
+    );
+  });
+
+  it("breaks LCP ties lexicographically", () => {
+    assert.strictEqual(
+      pickTag(["v24.3.0", "v24.3.0-rc.1"], "v24.2.0"),
+      "v24.3.0"
+    );
+    assert.strictEqual(
+      pickTag(["v24.3.0-rc.1", "v24.3.0"], "v24.2.0"),
+      "v24.3.0"
+    );
+  });
+
+  it("falls back to first lexicographic candidate when no prefix matches", () => {
+    assert.strictEqual(
+      pickTag(["nightly", "preview", "rc"], "v24.2.0"),
+      "nightly"
+    );
+  });
+
+  it("is deterministic regardless of input order", () => {
+    const a = pickTag(["v24.3.0", "v24.4.0", "v25.0.0"], "v24.2.0");
+    const b = pickTag(["v25.0.0", "v24.4.0", "v24.3.0"], "v24.2.0");
+    assert.strictEqual(a, b);
   });
 });


### PR DESCRIPTION
### Description

Two related improvements to `@rnx-kit/fork-sync` so that repeated syncs against an unchanged upstream stop creating churn, and so that release tags in `sync-config.json` keep up to date automatically.

1. **Skip empty syncs.** When a sync resolves to the same upstream commit, has the same set of files (no `.syncignore` changes), and the resolved tag is unchanged, `fork-sync` no longer rewrites `sync-config.json` (no timestamp bump) and no longer writes an empty `sync-pr-notes.md`. The summary shows `Already up to date — 0 files updated.` with the commit hash and tag. First-ever syncs (empty `commit` in config) still write so the file gets initialized.

2. **Auto-populate `tag` in `sync-config.json`.** When `--tag` is not passed, `fork-sync` now looks at upstream tags pointing at the synced commit and picks one. If the existing `sync-config.json` already has a tag, the new tag is chosen by **longest common prefix** with the existing tag (ties broken lexicographically) — so syncing a Node.js fork from `v24.2.0` to a commit tagged both `v24.3.0` and `nightly-2026-05-18` picks `v24.3.0`. If no tag points at the commit, the field is cleared (`""`). Explicit `--tag` overrides this.

Side effect: under `--create-pr`, a no-op sync no longer pushes an empty commit. If a previous sync PR is still open, its body is updated to a "now up to date" note and the PR is closed via `gh pr close`.

### Test plan

- [ ] Sync against a commit already in `sync-config.json` → no diff to `sync-config.json`, no `sync-pr-notes.md` written, summary shows `Already up to date — 0 files updated.`
- [ ] Sync against a new commit → existing behavior unchanged: config and PR notes are written, summary shows file counts.
- [ ] First-ever sync (set `commit: ""` in `sync-config.json`) → config is written even with zero file diffs.
- [ ] Sync to a Node.js branch HEAD where the HEAD commit has a release tag → `sync-config.json.tag` is filled in automatically.
- [ ] Sync to a commit with no tags but `sync-config.json.tag` was previously set → `tag` field is cleared.
- [ ] Sync with `--tag <name>` → tag is set exactly as passed (auto-resolution skipped).
- [ ] `--create-pr` on a no-op sync, no existing PR → prints `Nothing to PR — already up to date.` and exits without pushing.
- [ ] `--create-pr` on a no-op sync, existing PR open → PR body is updated and PR is closed.
- [ ] `yarn lint`, `yarn run -B tsc --noEmit`, `yarn run -B oxfmt --check src/ test/` in `incubator/fork-sync` → all clean.
- [ ] `yarn test` in `incubator/fork-sync` → all pass (includes 20 new unit tests for `commonPrefixLength`, `pickTag`, `isNoOpSync`).
