### PR TITLE
chore: fix `format` command not running on Windows

### DIFF
--- a/scripts/src/commands/format.js
+++ b/scripts/src/commands/format.js
@@ -24,7 +24,7 @@ export class FormatCommand extends Command {
       "!{#archived,__fixtures__,lib}",
       "!{CHANGELOG,CODE_OF_CONDUCT,SECURITY}.md",
     ];
-    await import(oxfmt);
+    await import(url.toString());
     return 0;
   }
 }


### PR DESCRIPTION
### Description

Fix `format` command not running on Windows

### Test plan

n/a