### PR TITLE
fix(apple): don't include bridge code in bridgeless mode

### DIFF
--- a/.changeset/rare-planets-notice.md
+++ b/.changeset/rare-planets-notice.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Don't include bridge code in bridgeless mode

--- a/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
+++ b/packages/react-native-host/cocoa/RNXTurboModuleAdapter.mm
@@ -80,6 +80,7 @@
 }
 #endif  // USE_FABRIC
 
+#if !USE_BRIDGELESS
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:
     (RCTBridge *)bridge
 {
@@ -96,6 +97,7 @@
     return nullptr;
 #endif  // USE_FABRIC
 }
+#endif  // !USE_BRIDGELESS
 
 #if USE_FABRIC
 
@@ -131,6 +133,7 @@
 
 // MARK: - Private
 
+#if !USE_BRIDGELESS
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)initJsExecutorFactoryWithBridge:
     (RCTBridge *)bridge
 {
@@ -150,6 +153,7 @@
     return RCTAppSetupDefaultJsExecutorFactory(bridge, _turboModuleManager);
 #endif  // USE_RUNTIME_SCHEDULER
 }
+#endif  // !USE_BRIDGELESS
 
 - (void)onRuntimeReady:(NSNotification *)note
 {


### PR DESCRIPTION
### Description

Don't include bridge code in bridgeless mode

### Test plan

See #2775

### Screenshots

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-19 at 15 48 18" src="https://github.com/user-attachments/assets/254b3e32-6973-43a9-93e5-0565db2e4309" />
