### PR TITLE
fix(tools-git): fix exports key not being prefixed with `.`

### DIFF
--- a/.changeset/fair-papers-fry.md
+++ b/.changeset/fair-papers-fry.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-git": patch
+---
+
+Fixed exports keys not being prefixed with `.`

--- a/incubator/tools-git/package.json
+++ b/incubator/tools-git/package.json
@@ -26,7 +26,7 @@
       "typescript": "./src/index.ts",
       "default": "./lib/index.js"
     },
-    "package.json": "./package.json"
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "rnx-kit-scripts build",


### PR DESCRIPTION
### Description

npm really should've caught this but it apparently does zero checks.

The actual error message:
`Error [ERR_INVALID_PACKAGE_CONFIG]: Invalid package config /~/node_modules/@rnx-kit/tools-git/package.json while importing file:///~/scripts/affected.mts. "exports" cannot contain some keys starting with '.' and some not. The exports object must either be an object of package subpath keys or an object of main entry condition name keys only.`

### Test plan

n/a