### PR TITLE
fix(react-native-host): handle removal of legacy arch code

### DIFF
--- a/.changeset/funny-monkeys-cover.md
+++ b/.changeset/funny-monkeys-cover.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Handle removal of `RCTEnableTurboModuleInteropBridgeProxy` and New Arch flags in `ReactNativeFeatureFlags`

--- a/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
+++ b/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
@@ -71,24 +71,31 @@ public:
     {
         return true;
     }
+
+#ifndef RCT_REMOVE_LEGACY_ARCH
     bool enableFabricRenderer() override
     {
         return true;
     }
+
     bool useTurboModules() override
     {
         return true;
     }
+#endif  // !RCT_REMOVE_LEGACY_ARCH
+
     bool useNativeViewConfigsInBridgelessMode() override
     {
         return true;
     }
+
 #if USE_VIEW_COMMAND_RACE_FIX  // 0.77
     bool enableFixForViewCommandRace() override
     {
         return true;
     }
-#endif                                             // USE_VIEW_COMMAND_RACE_FIX
+#endif  // USE_VIEW_COMMAND_RACE_FIX
+
 #if USE_UPDATE_RUNTIME_SHADOW_NODE_REFS_ON_COMMIT  // >= 0.79
     bool useShadowNodeStateOnClone() override
     {

--- a/packages/react-native-host/cocoa/RNXFeatureMacros.h
+++ b/packages/react-native-host/cocoa/RNXFeatureMacros.h
@@ -52,6 +52,10 @@
 #define USE_UPDATE_RUNTIME_SHADOW_NODE_REFS_ON_COMMIT 1
 #endif  // __has_include(<React-RCTAppDelegate/RCTJSRuntimeConfiguratorProtocol.h>)
 
+#if !__has_include(<React/RCTCxxMethod.h>)  // >=0.87
+#define RCT_REMOVE_LEGACY_ARCH 1
+#endif  // !__has_include(<React/RCTCxxMethod.h>)
+
 #endif  // USE_FEATURE_FLAGS
 
 #endif  // USE_BRIDGELESS

--- a/packages/react-native-host/cocoa/ReactNativeHost.mm
+++ b/packages/react-native-host/cocoa/ReactNativeHost.mm
@@ -282,8 +282,12 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
 #ifndef USE_UNIFIED_FEATURE_FLAGS
     RCTSetUseNativeViewConfigsInBridgelessMode(YES);
 #endif
+
     RCTEnableTurboModuleInterop(YES);
+
+#ifndef RCT_REMOVE_LEGACY_ARCH
     RCTEnableTurboModuleInteropBridgeProxy(YES);
+#endif  // !RCT_REMOVE_LEGACY_ARCH
 
 #ifdef USE_REACT_NATIVE_CONFIG
     _reactNativeConfig = std::make_shared<ReactNativeConfig>();
@@ -307,10 +311,9 @@ using ReactNativeConfig = facebook::react::EmptyReactNativeConfig const;
     };
 
     __weak __typeof(self) weakSelf = self;
-    if ([RCTHost instancesRespondToSelector:@selector
-                 (initWithBundleURLProvider:
-                               hostDelegate:turboModuleManagerDelegate:jsEngineProvider
-                                           :launchOptions:)]) {
+    if ([RCTHost instancesRespondToSelector:
+                     @selector(initWithBundleURLProvider:hostDelegate:turboModuleManagerDelegate:
+                               jsEngineProvider:launchOptions:)]) {
         _reactHost = [[RCTHost alloc]
              initWithBundleURLProvider:^{
                return [weakSelf sourceURLForBridge:nil];

--- a/packages/test-app/ios/Podfile.lock
+++ b/packages/test-app/ios/Podfile.lock
@@ -1750,7 +1750,7 @@ PODS:
     - React-utils (= 0.85.2)
     - ReactNativeDependencies
   - ReactNativeDependencies (0.85.2)
-  - ReactNativeHost (0.5.16):
+  - ReactNativeHost (0.5.17):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2128,7 +2128,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 4accda6590329e2bbb1f1381b39b77d64490c7f4
   ReactCommon: a804bb8d1dcf3ecdec3a77eb8bba19b7863bbbdb
   ReactNativeDependencies: 91cc996bd7c2c58741b96d60817f51ad6692f404
-  ReactNativeHost: 60fee0812001bb7fe6b917c3bd75744c05034950
+  ReactNativeHost: bfc03f71af9ea8533b3f77493ca49d6c40093397
   ReactTestApp-DevSupport: d9358fe3b2dc09399c15731ed8c17bd8388cf512
   ReactTestApp-MSAL: 778502496ada0c04f0a96cbcc8359d681c458ace
   ReactTestApp-Resources: 70da1d78d943a1fdff6362ce3f778e5b4560c95a


### PR DESCRIPTION
### Description

Handle removal of `RCTEnableTurboModuleInteropBridgeProxy` and New Arch flags in `ReactNativeFeatureFlags`

### Test plan

In [RNTA](https://github.com/microsoft/react-native-test-app):

```
cd packages/app
node --run set-react-version -- nightly
yarn
rm ios/Podfile.lock
pod install --project-directory=ios

yarn ios
# Build will fail
# Apply changes in this PR manually and try again
```

### Screenshots

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/7f848d99-f976-4c53-add1-86b341fe98c6" />
