### PR TITLE
fix(metro-resolver-symlinks): don't ignore errors when using `oxc-resolver`

### DIFF
--- a/.changeset/cool-falcons-relate.md
+++ b/.changeset/cool-falcons-relate.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Provide default fallbacks for condition names when using `oxc-resolver`

--- a/.changeset/plain-states-smash.md
+++ b/.changeset/plain-states-smash.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Don't ignore errors when using `oxc-resolver`

--- a/packages/metro-resolver-symlinks/src/resolvers/oxc-resolver.ts
+++ b/packages/metro-resolver-symlinks/src/resolvers/oxc-resolver.ts
@@ -13,7 +13,16 @@ function makeOxcResolverOptions(
   context: ResolutionContextCompat,
   platform = "common"
 ): NapiResolveOptions {
-  const { alias, ...config } = makeEnhancedResolveOptions(context, platform);
+  const { alias, conditionNames, ...config } = makeEnhancedResolveOptions(
+    context,
+    platform
+  );
+  if (conditionNames.length === 1 && conditionNames[0] === "react-native") {
+    // By default, `react-native` is the only condition name provided.
+    // oxc-resolver does not provide fallbacks; we have to add them explicitly.
+    // https://github.com/facebook/react-native/blob/v0.85.3/packages/metro-config/src/index.flow.js#L59
+    conditionNames.push("import", "require", "default");
+  }
   return {
     ...config,
     alias: alias
@@ -21,6 +30,7 @@ function makeOxcResolverOptions(
           Object.entries(alias).map(([name, alias]) => [name, [alias]])
         )
       : {},
+    conditionNames,
   };
 }
 

--- a/packages/metro-resolver-symlinks/src/resolvers/oxc-resolver.ts
+++ b/packages/metro-resolver-symlinks/src/resolvers/oxc-resolver.ts
@@ -1,4 +1,5 @@
 import type { CustomResolver, Resolution } from "metro-resolver";
+import * as path from "node:path";
 import type { NapiResolveOptions, ResolverFactory } from "oxc-resolver";
 import type { ResolutionContextCompat } from "../types.ts";
 import { isAssetFile, resolveAsset } from "../utils/assets.ts";
@@ -52,7 +53,16 @@ export function applyOxcResolver(
   }
 
   const oxcResolve = getOxcResolver(context, platform);
-  const { path: filePath } = oxcResolve.sync(getFromDir(context), moduleName);
+  const fromDir = getFromDir(context);
+  const { error, path: filePath } = oxcResolve.sync(fromDir, moduleName);
+  if (error) {
+    const { originModulePath } = context;
+    const origin = originModulePath
+      ? path.relative(process.cwd(), originModulePath)
+      : ".";
+    throw new Error(`${origin}: ${error}`);
+  }
+
   if (!filePath) {
     return { type: "empty" };
   }


### PR DESCRIPTION
### Description

As opposed to `enhanced-resolver`, `oxc-resolver` does not throw whenever it hits an error. Instead, it returns an error field that we have to handle ourselves.

### Test plan

```
info Note: Oxc Resolver support is still experimental
info Bundling win32...
                Welcome to Metro v0.83.7
              Fast - Scalable - Integrated


/Users/tido/Source/fluentui-react-native/node_modules/.store/@rnx-kit-metro-resolver-symlinks-virtual-25deb31b78/package/lib/resolvers/oxc-resolver.js:42
    throw new Error(`${origin}: ${error}`);
          ^

Error: ../../packages/components/Avatar/src/useAvatar.ts: "./grapheme" is not exported under the condition "react-native" from package /~/packages/components/Avatar/node_modules/unicode-segmenter (see exports field in /~/packages/components/Avatar/node_modules/unicode-segmenter/package.json)
    at applyOxcResolver (/~/node_modules/.store/@rnx-kit-metro-resolver-symlinks-virtual-25deb31b78/package/lib/resolvers/oxc-resolver.js:42:11)
    ...
```