### PR TITLE
ci: enable trusted publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
     name: "Build and publish"
     permissions:
       contents: write # for GH releases and Git tags (Changesets)
+      id-token: write # enable use of OIDC for trusted publishing
     if: ${{ github.repository == 'microsoft/rnx-kit' }}
     runs-on: ubuntu-24.04
     steps:
@@ -45,7 +46,6 @@ jobs:
           # We cannot use the GHA generated tokens because we've disabled
           # creation of pull requests at the org level.
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   website:
     name: "Publish website"
     permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -159,7 +159,7 @@ jobs:
   build-ios-test-app:
     name: "Build iOS"
     permissions: {}
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -170,7 +170,6 @@ jobs:
         uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@5.1.5
         with:
           platform: ios
-          xcode-developer-dir: /Applications/Xcode_16.4.app
       - name: Install package dependencies
         run: |
           yarn
@@ -215,7 +214,6 @@ jobs:
         uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@5.1.5
         with:
           platform: macos
-          xcode-developer-dir: /Applications/Xcode_16.4.app
       - name: Install package dependencies
         run: |
           yarn


### PR DESCRIPTION
### Description

Set up OIDC for all packages using:

```sh
npm trust github $package --file=build.yml --repository=microsoft/rnx-kit --allow-publish --allow-stage-publish --yes
```

Docs for future reference: https://docs.npmjs.com/cli/v11/commands/npm-trust

### Test plan

This can only be tested in prod.