### PR TITLE
fix(tools-react-native): ensure `cli-types` can be correctly picked up

### DIFF
--- a/.changeset/all-adults-hope.md
+++ b/.changeset/all-adults-hope.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-react-native": patch
+---
+
+Ensure `@react-native-community/cli-types` can be correctly picked up by TypeScript

--- a/packages/tools-react-native/package.json
+++ b/packages/tools-react-native/package.json
@@ -93,6 +93,14 @@
     "metro-resolver": "^0.84.0",
     "metro-source-map": "^0.84.0"
   },
+  "peerDependencies": {
+    "@react-native-community/cli-types": "*"
+  },
+  "peerDependenciesMeta": {
+    "@react-native-community/cli-types": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=16.17"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6040,6 +6040,11 @@ __metadata:
     metro-core: "npm:^0.84.0"
     metro-resolver: "npm:^0.84.0"
     metro-source-map: "npm:^0.84.0"
+  peerDependencies:
+    "@react-native-community/cli-types": "*"
+  peerDependenciesMeta:
+    "@react-native-community/cli-types":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

Ensure `@react-native-community/cli-types` can be correctly picked up by TypeScript

### Test plan

n/a