### PR TITLE
fix(lint-lockfile): address CVE-2026-53550

### DIFF
--- a/.changeset/silent-crabs-feel.md
+++ b/.changeset/silent-crabs-feel.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/lint-lockfile": patch
+---
+
+Bumps `js-yaml` to address CVE-2026-53550

--- a/incubator/lint-lockfile/package.json
+++ b/incubator/lint-lockfile/package.json
@@ -29,12 +29,12 @@
     "@rnx-kit/config": "^0.9.0",
     "@rnx-kit/tools-workspaces": "^0.2.3",
     "@rnx-kit/types-kit-config": "^1.0.0",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.2.0"
   },
   "devDependencies": {
     "@rnx-kit/scripts": "*",
     "@rnx-kit/tsconfig": "*",
-    "@types/js-yaml": "^4.0.5"
+    "@types/js-yaml": "^4.0.9"
   },
   "engines": {
     "node": ">=20.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5348,8 +5348,8 @@ __metadata:
     "@rnx-kit/tools-workspaces": "npm:^0.2.3"
     "@rnx-kit/tsconfig": "npm:*"
     "@rnx-kit/types-kit-config": "npm:^1.0.0"
-    "@types/js-yaml": "npm:^4.0.5"
-    js-yaml: "npm:^4.1.1"
+    "@types/js-yaml": "npm:^4.0.9"
+    js-yaml: "npm:^4.2.0"
   bin:
     lint-lockfile: lib/cli.js
   languageName: unknown
@@ -6812,7 +6812,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/js-yaml@npm:^4.0.5":
+"@types/js-yaml@npm:^4.0.5, @types/js-yaml@npm:^4.0.9":
   version: 4.0.9
   resolution: "@types/js-yaml@npm:4.0.9"
   checksum: 10c0/24de857aa8d61526bbfbbaa383aa538283ad17363fcd5bb5148e2c7f604547db36646440e739d78241ed008702a8920665d1add5618687b6743858fae00da211
@@ -12580,14 +12580,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1, js-yaml@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "js-yaml@npm:4.2.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Bumps `js-yaml` to address CVE-2026-53550

### Test plan

n/a