### PR TITLE
fix(tools-git): fix cannot find base commit from a fork

### DIFF
--- a/.changeset/better-ties-juggle.md
+++ b/.changeset/better-ties-juggle.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-git": patch
+---
+
+Fixed cannot find base commit from a fork

--- a/incubator/tools-git/src/branch.ts
+++ b/incubator/tools-git/src/branch.ts
@@ -37,5 +37,5 @@ export function getBaseCommit(
     targetBranch && verifyRef(targetBranch)
       ? targetBranch
       : getDefaultBranch(fallback);
-  return git("merge-base", "--fork-point", targetBranch) || undefined;
+  return git("merge-base", targetBranch, "HEAD") || undefined;
 }


### PR DESCRIPTION
### Description

Attempts to fix CI not being able to find base commit when a PR comes from a fork.

<img width="502" height="133" alt="image" src="https://github.com/user-attachments/assets/05133a73-67d8-4f69-bac8-faca3fdf6d27" />

Note that this seems to only happen with PRs from Dependabot:

<img width="802" height="471" alt="image" src="https://github.com/user-attachments/assets/71a19d9a-718e-4b17-bf2e-4d796dd0eb35" />

### Test plan

CI should pass.