### PR TITLE
feat(fork-sync): support initial sync and sparse dirs

### DIFF
--- a/.changeset/smart-swans-drum.md
+++ b/.changeset/smart-swans-drum.md
@@ -1,0 +1,8 @@
+---
+"@rnx-kit/fork-sync": minor
+---
+
+Add support for vendoring a subset of very large upstream repos:
+- `sparsePaths` — vendor multiple upstream directories via sparse-checkout (identity-mapped, so each keeps its repo-relative path under the local path). Mutually exclusive with `subDir`. When set, the clone uses `--no-checkout` so the whole default branch isn't materialized before sparse-checkout narrows it.
+- `cloneFilter` — partial-clone filter (default `blob:none`); set `tree:0` to also defer trees, which with `sparsePaths` shrinks the initial clone of a huge repo by orders of magnitude.
+- First-time syncs from an empty `commit` are now supported as a direct import (no base, no merge).

--- a/.changeset/smart-swans-drum.md
+++ b/.changeset/smart-swans-drum.md
@@ -3,6 +3,7 @@
 ---
 
 Add support for vendoring a subset of very large upstream repos:
+
 - `sparsePaths` — vendor multiple upstream directories via sparse-checkout (identity-mapped, so each keeps its repo-relative path under the local path). Mutually exclusive with `subDir`. When set, the clone uses `--no-checkout` so the whole default branch isn't materialized before sparse-checkout narrows it.
 - `cloneFilter` — partial-clone filter (default `blob:none`); set `tree:0` to also defer trees, which with `sparsePaths` shrinks the initial clone of a huge repo by orders of magnitude.
 - First-time syncs from an empty `commit` are now supported as a direct import (no base, no merge).

--- a/incubator/fork-sync/README.md
+++ b/incubator/fork-sync/README.md
@@ -122,14 +122,26 @@ after each successful sync.
 }
 ```
 
-| Field      | Description                                                                |
-| ---------- | -------------------------------------------------------------------------- |
-| `repo`     | Full HTTPS URL of the upstream repository                                  |
-| `branch`   | Upstream branch to track                                                   |
-| `commit`   | Last synced upstream commit hash (empty string for first sync)             |
-| `subDir`   | Subfolder within the upstream repo to sync (optional, omit for whole repo) |
-| `tag`      | Tag name if synced to a tag (empty string otherwise)                       |
-| `lastSync` | ISO timestamp of last sync (empty string if never synced)                  |
+| Field         | Description                                                                    |
+| ------------- | ------------------------------------------------------------------------------ |
+| `repo`        | Full HTTPS URL of the upstream repository                                      |
+| `branch`      | Upstream branch to track                                                       |
+| `commit`      | Last synced upstream commit hash (empty/absent for the first sync)             |
+| `subDir`      | Single subfolder within the upstream repo to sync, prefix-stripped (optional)  |
+| `sparsePaths` | Multiple upstream directories to vendor, identity-mapped (optional; see below) |
+| `cloneFilter` | Partial-clone filter, `git --filter=<value>` (optional; default `blob:none`)   |
+| `tag`         | Tag name if synced to a tag (empty string otherwise)                           |
+| `lastSync`    | ISO timestamp of last sync (empty string if never synced)                      |
+
+> `subDir` and `sparsePaths` are mutually exclusive. Omit both to sync the whole repo.
+
+#### First sync (initial import)
+
+To vendor a dependency for the first time, create its `sync-config.json` with an
+**empty (or absent) `commit`** and run `fork-sync --dep <name>` (optionally with
+`--tag`/`--commit`/`--branch`). fork-sync imports the upstream content directly —
+there is no base to merge against — and writes the resolved commit/tag back into
+`sync-config.json`. Subsequent syncs use the normal 3-way merge.
 
 #### Subfolder sync with `subDir`
 
@@ -159,6 +171,54 @@ When `subDir` is set:
 
 When `subDir` is omitted or empty, the entire upstream repo is synced (default
 behavior).
+
+#### Multiple directories with `sparsePaths`
+
+When you need to vendor **several top-level directories** from a large upstream
+repo (and `subDir`'s single prefix-stripped folder doesn't fit), set
+`sparsePaths` to a list of directories. For example, to vendor Chromium's `base`,
+`sandbox`, `build`, and `buildtools` into `deps/chromium/`:
+
+```json
+{
+  "repo": "https://chromium.googlesource.com/chromium/src",
+  "branch": "main",
+  "commit": "",
+  "tag": "149.0.7827.149",
+  "sparsePaths": ["base", "sandbox", "build", "buildtools"]
+}
+```
+
+When `sparsePaths` is set:
+
+- **Sparse checkout** materializes only the listed directories on disk, so the
+  rest of a huge upstream tree is never checked out.
+- **Identity path mapping** — unlike `subDir`, each path keeps its repo-relative
+  location under `localPath` (`base/` → `deps/chromium/base/`). This preserves the
+  upstream layout, which matters when vendored build files use absolute, repo-root
+  paths (e.g. GN's `//base`).
+- **`.syncignore` still applies** for fine-grained trimming _within_ the selected
+  directories (e.g. drop `base/test/`).
+- It is **mutually exclusive** with `subDir`.
+- The clone uses **`--no-checkout`** so the entire default branch is never
+  materialized before sparse-checkout narrows it; hydration happens once, at the
+  sparse target checkout.
+
+#### Treeless clones for very large repos (`cloneFilter`)
+
+By default fork-sync clones with `--filter=blob:none` (file contents fetched on
+demand). For a **huge** upstream where you only vendor a small subset, the trees
+themselves dominate the download. Set `cloneFilter` to `tree:0` to defer trees as
+well — combined with `sparsePaths`, only the trees/blobs along the selected paths
+are ever fetched, shrinking the initial clone by orders of magnitude:
+
+```json
+{ "cloneFilter": "tree:0", "sparsePaths": ["base", "sandbox"] }
+```
+
+Trade-off: `tree:0` makes later **history-walking** operations (the 3-way-merge
+re-sync, PR-note `git log`) fetch trees on demand, so they are slower. A **first
+sync** runs no merge, so `tree:0` is essentially free for the initial import.
 
 ### .syncignore
 

--- a/incubator/fork-sync/src/modules/git.ts
+++ b/incubator/fork-sync/src/modules/git.ts
@@ -221,12 +221,13 @@ export class GitRepo {
   /** Run `git ls-tree -r` and return raw output. */
   async lsTree(
     ref: string,
-    opts?: { format?: string; pathspec?: string }
+    opts?: { format?: string; pathspec?: string | string[] }
   ): Promise<string> {
     const args = ["ls-tree", "-r"];
     if (opts?.format) args.push(`--format=${opts.format}`);
     args.push(ref);
-    if (opts?.pathspec) args.push("--", opts.pathspec);
+    const pathspecs = toPathspecList(opts?.pathspec);
+    if (pathspecs.length) args.push("--", ...pathspecs);
     return spawn("git", args, { cwd: this.dir });
   }
 
@@ -447,10 +448,14 @@ export async function discoverRepoRoot(cwd?: string): Promise<string | null> {
 export function clone(
   url: string,
   targetDir: string,
-  opts?: { filter?: string; cwd?: string }
+  opts?: { filter?: string; cwd?: string; noCheckout?: boolean }
 ): AsyncIterable<OutputChunk> {
   const args = ["clone"];
   if (opts?.filter) args.push(`--filter=${opts.filter}`);
+  // Skip the initial working-tree checkout. Used with sparse-checkout so the
+  // expensive hydration happens once, at the later sparse target checkout,
+  // instead of materializing the whole default branch first.
+  if (opts?.noCheckout) args.push("--no-checkout");
   args.push(url, targetDir);
   return spawn("git", args, {
     cwd: opts?.cwd ?? process.cwd(),
@@ -511,6 +516,19 @@ export async function validateCloneOrigin(
 // =============================================================================
 
 /**
+ * Normalize an optional pathspec argument (a single path or a list) into a
+ * clean list of non-empty paths, suitable for appending after a `--` separator.
+ * Returns `[]` for `undefined`, an empty string, or a list of only empties — so
+ * callers fall through to "no pathspec" (whole-repo) behavior, matching the
+ * prior single-string semantics.
+ */
+function toPathspecList(pathspec?: string | string[]): string[] {
+  if (!pathspec) return [];
+  const list = Array.isArray(pathspec) ? pathspec : [pathspec];
+  return list.filter((p) => p.length > 0);
+}
+
+/**
  * List files in a git directory, excluding patterns from an exclude file.
  *
  * Uses `--exclude-per-directory=.syncignore` so that patterns in the file are
@@ -519,15 +537,18 @@ export async function validateCloneOrigin(
  *
  * @param repo - Git repository to list files from
  * @param excludeFile - Path to a .syncignore file; used as existence check only
- * @param pathspec - Optional pathspec to scope listing to a subfolder
+ * @param pathspec - Optional pathspec(s) to scope listing to one or more
+ *   subfolders. Accepts a single path or a list (e.g. `sparsePaths`); empty
+ *   entries are ignored.
  * @returns Array of relative file paths
  */
 export async function listFilesWithExclusions(
   repo: GitRepo,
   excludeFile?: string,
-  pathspec?: string
+  pathspec?: string | string[]
 ): Promise<string[]> {
-  const pathspecArgs = pathspec ? ["--", pathspec] : [];
+  const pathspecs = toPathspecList(pathspec);
+  const pathspecArgs = pathspecs.length ? ["--", ...pathspecs] : [];
   const allFiles = await repo.lsFiles(pathspecArgs);
 
   if (!excludeFile || !(await exists(excludeFile))) {
@@ -556,7 +577,7 @@ export async function getAllowedRelativePaths(
   repo: GitRepo,
   excludeFile?: string,
   prefixToStrip?: string,
-  pathspec?: string
+  pathspec?: string | string[]
 ): Promise<string[]> {
   const files = await listFilesWithExclusions(repo, excludeFile, pathspec);
   const result: string[] = [];
@@ -589,7 +610,7 @@ export async function getGitTreeHashes(
   repo: GitRepo,
   allowedPaths: Set<string>,
   prefixToStrip?: string,
-  pathspec?: string
+  pathspec?: string | string[]
 ): Promise<Map<string, string>> {
   const output = await repo.lsTree("HEAD", {
     format: "%(objectname) %(path)",

--- a/incubator/fork-sync/src/sync.ts
+++ b/incubator/fork-sync/src/sync.ts
@@ -128,6 +128,9 @@ const SYNC_CHECKPOINT_FILE = ".sync-checkpoint.json";
 /** PR notes filename, written alongside sync-config.json */
 const SYNC_PR_NOTES_FILE = "sync-pr-notes.md";
 
+/** Merge result for paths that never run a merge (e.g. a first sync). */
+const EMPTY_MERGE_RESULT: MergeResult = { resolved: [], conflicts: [] };
+
 /** AI merge script filename */
 const AI_MERGE_SCRIPT = import.meta.url.endsWith(".ts")
   ? "ai-merge.ts"
@@ -268,8 +271,18 @@ export interface SyncManifest {
 interface SyncConfigFile {
   repo: string; // Full HTTPS URL, e.g., "https://github.com/nodejs/node"
   branch: string; // Target branch name
-  commit: string; // Last synced upstream commit hash (empty string for first sync)
+  commit?: string; // Last synced upstream commit hash (empty/absent = first sync)
   subDir?: string; // Subfolder within upstream repo (empty/absent = whole repo)
+  // Multiple upstream directories to vendor, identity-mapped (each keeps its
+  // repo-relative path under localPath). Materialized via sparse-checkout.
+  // Mutually exclusive with subDir. Empty/absent = not used.
+  sparsePaths?: string[];
+  // Partial-clone filter for the upstream clone (git --filter=<value>).
+  // Defaults to "blob:none". For very large repos vendored as a small subset,
+  // "tree:0" defers trees too (fetched on demand at the sparse checkout), which
+  // dramatically shrinks the initial clone — at the cost of on-demand fetches
+  // during later history-walking operations (merge re-syncs, PR-note logs).
+  cloneFilter?: string;
   tag: string; // Tag name if synced to a tag (empty string otherwise)
   lastSync: string; // ISO timestamp of last sync (empty string if never synced)
 }
@@ -291,10 +304,12 @@ interface SyncConfig {
   // From sync-config.json
   repo: string;
   branch: string;
-  baseCommit: string;
+  baseCommit: string; // Empty string = first sync (no prior vendored content)
   tag: string;
   lastSync: string;
   subDir: string; // Normalized subfolder path, empty string = whole repo
+  sparsePaths: string[]; // Normalized sparse-checkout paths, [] = not used
+  cloneFilter: string; // git partial-clone filter, defaults to "blob:none"
 }
 
 /**
@@ -350,6 +365,11 @@ class SyncSession {
   readonly depPathPrefix: string;
   readonly subDirPrefix: string;
   readonly syncSubPath: string;
+  /** Sparse-checkout paths (identity-mapped), empty when not used. */
+  readonly sparsePaths: string[];
+  /** Pathspec(s) scoping listing on the upstream (sync) side: the sparse paths
+   * when set, else the single subDir, else [] (whole repo). */
+  readonly syncPathspecs: string[];
 
   // === Git repo wrapper for the sync directory ===
   readonly syncRepo: GitRepo;
@@ -385,6 +405,20 @@ class SyncSession {
     this.syncSubPath = config.subDir
       ? path.join(this.syncPath, config.subDir)
       : this.syncPath;
+    // sparsePaths are identity-mapped: no prefix stripping (syncSubPath stays at
+    // the repo root), but the listing is scoped to the sparse paths.
+    this.sparsePaths = config.sparsePaths;
+    this.syncPathspecs =
+      this.sparsePaths.length > 0
+        ? this.sparsePaths
+        : this.subDirPrefix
+          ? [this.subDirPrefix]
+          : [];
+  }
+
+  /** True for the initial import of a dependency with no prior vendored content. */
+  get isFirstSync(): boolean {
+    return !this.config.baseCommit;
   }
 
   /**
@@ -429,22 +463,32 @@ class SyncSession {
 
       this.printHeader("new");
       await this.ensureUpstreamClone();
-      this.generateBranchNames();
-      await this.createTargetBranch();
-      await this.createWorkBranch();
-      await this.performMerge();
+
+      if (this.isFirstSync) {
+        // === FIRST SYNC: direct import, no base commit, no 3-way merge ===
+        await this.performFirstSync();
+        this.mergeResult = EMPTY_MERGE_RESULT;
+      } else {
+        this.generateBranchNames();
+        await this.createTargetBranch();
+        await this.createWorkBranch();
+        await this.performMerge();
+      }
     } else {
       // === CONTINUE: validate existing checkpoint ===
       await this.applySyncCheckpoint();
       this.printHeader("resume");
     }
 
-    if (!(await this.resolveConflictsOrPause())) {
-      await this.printStatus();
-      return;
+    // A first sync cannot produce conflicts and has no merge commit to make.
+    if (!this.isFirstSync) {
+      if (!(await this.resolveConflictsOrPause())) {
+        await this.printStatus();
+        return;
+      }
+      await this.commitMergeIfNeeded();
     }
 
-    await this.commitMergeIfNeeded();
     await this.applyChanges();
     this.printSummary();
 
@@ -629,6 +673,14 @@ ${style.line()}
         ? `Use ${style.command(`git diff ${localPath}/`)} to review changes.`
         : style.success("Already up to date.");
 
+    // A first sync runs no 3-way merge, so there are no merge branches to keep.
+    const mergeBranchesSection = () =>
+      this.isFirstSync
+        ? ""
+        : `\nMerge branches preserved in .sync/${depName}/:\n` +
+          `  - ${this.workBranch} (work branch — merge result)\n` +
+          `  - ${this.targetMergeBranch} (target branch)\n`;
+
     print(
       () => `
 ${style.line()}
@@ -639,11 +691,7 @@ Upstream: ${this.config.repo}
   Commit: ${style.command(shortCommit)} (${refName})
 
 ${changesSection()}${resolvedSection()}
-
-Merge branches preserved in .sync/${depName}/:
-  - ${this.workBranch} (work branch — merge result)
-  - ${this.targetMergeBranch} (target branch)
-
+${mergeBranchesSection()}
 ${style.line()}
 ${footerMessage()}
 ${style.line()}
@@ -991,11 +1039,11 @@ ${style.line()}
       job.step("Fetching latest from upstream...");
       await this.syncRepo.fetch();
 
-      // Configure sparse checkout for subDir (if applicable)
-      if (this.subDirPrefix) {
+      // Configure sparse checkout for subDir / sparsePaths (if applicable)
+      if (this.syncPathspecs.length > 0) {
         job.step("Configuring sparse checkout...");
         await this.syncRepo.sparseCheckoutInit();
-        await this.syncRepo.sparseCheckoutSet(this.subDirPrefix);
+        await this.syncRepo.sparseCheckoutSet(...this.syncPathspecs);
       }
 
       job.done(() => `${label()} fetched latest from ${this.config.repo}`);
@@ -1006,20 +1054,27 @@ ${style.line()}
         : `${this.config.repo}.git`;
 
       await ensureDir(path.dirname(this.syncPath));
-      // Clone without blobs to reduce initial download. Show progress via interactive mode.
+      // Partial clone to reduce initial download (default blob:none; "tree:0"
+      // for huge repos vendored as a small subset). When sparse paths are
+      // configured, skip the initial checkout so the whole default branch isn't
+      // materialized before sparse-checkout narrows it — the hydration then
+      // happens once, at the later sparse target checkout. Show progress via
+      // interactive mode.
+      const useSparse = this.syncPathspecs.length > 0;
       const cloneStep = job.step("Cloning repository...");
       for await (const chunk of clone(cloneUrl, this.syncPath, {
-        filter: "blob:none",
+        filter: this.config.cloneFilter,
+        noCheckout: useSparse,
         cwd: this.repoRoot,
       })) {
         cloneStep.update(chunk.text.trim());
       }
 
-      // Configure sparse checkout for subDir (if applicable)
-      if (this.subDirPrefix) {
+      // Configure sparse checkout for subDir / sparsePaths (if applicable)
+      if (this.syncPathspecs.length > 0) {
         job.step("Configuring sparse checkout...");
         await this.syncRepo.sparseCheckoutInit();
-        await this.syncRepo.sparseCheckoutSet(this.subDirPrefix);
+        await this.syncRepo.sparseCheckoutSet(...this.syncPathspecs);
       }
 
       job.done(() => `${label()} cloned ${this.config.repo}`);
@@ -1035,6 +1090,34 @@ ${style.line()}
     this.targetMergeBranch = `target_${syncId}`;
     debug(`Work branch:   ${this.workBranch}`);
     debug(`Target branch: ${this.targetMergeBranch}`);
+  }
+
+  /**
+   * Perform a first sync: the initial import of a dependency with no prior
+   * vendored content (empty base commit). There is no base to diff against and
+   * no 3-way merge — we just resolve the target, check it out (the sparse cone,
+   * if any, is already configured), and let {@link applyChanges} copy the
+   * selected files into the local path. `.syncignore` still applies.
+   */
+  private async performFirstSync(): Promise<void> {
+    const label = () => style.label("First sync:");
+    using job = jobs.addJob("first-sync", () => `${label()} importing...`);
+
+    await this.resolveTarget(job);
+
+    job.step(`Checking out target commit ${this.targetCommit.slice(0, 8)}...`);
+    await this.syncRepo.checkout(this.targetCommit);
+
+    // Make .syncignore visible inside the sync repo so applyChanges' listing
+    // honors exclusions (matches createWorkBranch for the merge path).
+    await this.copySyncIgnoreToSyncRepo();
+
+    job.done(
+      () =>
+        `${label()} imported upstream at ${this.targetCommit.slice(0, 8)}${
+          this.targetTag ? ` (${this.targetTag})` : ""
+        }`
+    );
   }
 
   /**
@@ -1331,7 +1414,7 @@ ${style.line()}
         this.syncRepo,
         this.syncIgnorePath,
         this.subDirPrefix,
-        this.subDirPrefix
+        this.syncPathspecs
       )
     );
     const localFiles = await getAllowedRelativePaths(
@@ -1398,6 +1481,12 @@ ${style.line()}
       branch: this.args.branch ?? this.config.branch,
       commit: this.targetCommit,
       ...(this.config.subDir ? { subDir: this.config.subDir } : {}),
+      ...(this.config.sparsePaths.length
+        ? { sparsePaths: this.config.sparsePaths }
+        : {}),
+      ...(this.config.cloneFilter !== "blob:none"
+        ? { cloneFilter: this.config.cloneFilter }
+        : {}),
       tag: newTag,
       lastSync: new Date().toISOString(),
     });
@@ -1425,6 +1514,9 @@ ${style.line()}
    * Parses `git log --format="%H%x09%an%x09%s"` output into structured data.
    */
   private async getUpstreamCommits(): Promise<UpstreamCommit[]> {
+    // First sync has no base commit, so `base..target` is not a valid range.
+    if (this.isFirstSync) return [];
+
     const range = `${this.config.baseCommit}..${this.targetCommit}`;
     const output = await this.syncRepo.log({
       format: "%H%x09%an%x09%s",
@@ -1753,7 +1845,7 @@ ${style.line()}
         this.syncRepo,
         this.syncIgnorePath,
         this.subDirPrefix,
-        this.subDirPrefix
+        this.syncPathspecs
       )
     );
     return {
@@ -1767,7 +1859,7 @@ ${style.line()}
         this.syncRepo,
         allowedSync,
         this.subDirPrefix,
-        this.subDirPrefix
+        this.syncPathspecs
       ),
     };
   }
@@ -1951,11 +2043,8 @@ async function loadSyncConfig(
     );
   }
 
-  if (!configFile.commit) {
-    return fatal(
-      `Missing 'commit' in ${configPath}. Please set the last synced upstream commit hash.`
-    );
-  }
+  // 'commit' is intentionally optional: an empty/absent commit marks a first
+  // sync (initial import of a dependency with no prior vendored content).
 
   if (configFile.subDir) {
     const normalized = normalizePath(configFile.subDir);
@@ -1963,6 +2052,37 @@ async function loadSyncConfig(
       return fatal(
         `Invalid 'subDir' in ${configPath}: must be a relative path within the upstream repo (got "${configFile.subDir}").`
       );
+    }
+  }
+
+  if (configFile.subDir && configFile.sparsePaths?.length) {
+    return fatal(
+      `Invalid sync config at ${configPath}: 'subDir' and 'sparsePaths' are mutually exclusive. ` +
+        `Use 'subDir' for a single prefix-stripped subfolder, or 'sparsePaths' for multiple ` +
+        `identity-mapped directories.`
+    );
+  }
+
+  const sparsePaths: string[] = [];
+  if (configFile.sparsePaths) {
+    if (!Array.isArray(configFile.sparsePaths)) {
+      return fatal(
+        `Invalid 'sparsePaths' in ${configPath}: must be an array of relative paths.`
+      );
+    }
+    for (const raw of configFile.sparsePaths) {
+      const normalized = normalizePath(raw).replace(/\/+$/, "");
+      if (
+        !normalized ||
+        normalized.startsWith("/") ||
+        normalized.includes("..")
+      ) {
+        return fatal(
+          `Invalid entry in 'sparsePaths' at ${configPath}: each must be a non-empty ` +
+            `relative path within the upstream repo (got "${raw}").`
+        );
+      }
+      sparsePaths.push(normalized);
     }
   }
 
@@ -1979,12 +2099,14 @@ async function loadSyncConfig(
     // From sync-config.json
     repo: configFile.repo,
     branch: configFile.branch,
-    baseCommit: configFile.commit,
+    baseCommit: configFile.commit ?? "",
     tag: configFile.tag,
     lastSync: configFile.lastSync,
     subDir: configFile.subDir
       ? normalizePath(configFile.subDir).replace(/\/+$/, "")
       : "",
+    sparsePaths,
+    cloneFilter: configFile.cloneFilter?.trim() || "blob:none",
   };
 }
 

--- a/incubator/fork-sync/test/git.test.ts
+++ b/incubator/fork-sync/test/git.test.ts
@@ -166,6 +166,47 @@ describe("listFilesWithExclusions", () => {
     const files = await listFilesWithExclusions(repo, syncIgnorePath, "sub");
     assert.deepStrictEqual(files.sort(), ["sub/deep/top.txt", "sub/other.txt"]);
   });
+
+  it("scopes listing to multiple pathspecs (sparsePaths)", async () => {
+    repo = await initRepoWithFiles(tempDir, {
+      "base/a.cc": "a",
+      "base/deep/b.cc": "b",
+      "sandbox/c.cc": "c",
+      "build/d.gn": "d",
+      "other/e.txt": "e",
+      "root.txt": "root",
+    });
+
+    const files = await listFilesWithExclusions(repo, undefined, [
+      "base",
+      "sandbox",
+    ]);
+    assert.deepStrictEqual(files.sort(), [
+      "base/a.cc",
+      "base/deep/b.cc",
+      "sandbox/c.cc",
+    ]);
+  });
+
+  it("ignores empty pathspec entries", async () => {
+    repo = await initRepoWithFiles(tempDir, {
+      "sub/a.txt": "a",
+      "other/b.txt": "b",
+    });
+
+    const files = await listFilesWithExclusions(repo, undefined, ["", "sub"]);
+    assert.deepStrictEqual(files.sort(), ["sub/a.txt"]);
+  });
+
+  it("treats an all-empty pathspec list as whole-repo", async () => {
+    repo = await initRepoWithFiles(tempDir, {
+      "a.txt": "a",
+      "sub/b.txt": "b",
+    });
+
+    const files = await listFilesWithExclusions(repo, undefined, [""]);
+    assert.deepStrictEqual(files.sort(), ["a.txt", "sub/b.txt"]);
+  });
 });
 
 describe("getAllowedRelativePaths", () => {
@@ -221,6 +262,46 @@ describe("getAllowedRelativePaths", () => {
     );
     assert.deepStrictEqual(paths.sort(), ["a.txt", "deep/c.txt"]);
   });
+
+  it("multiple pathspecs with no prefix stripping (identity-mapped sparsePaths)", async () => {
+    repo = await initRepoWithFiles(tempDir, {
+      "base/a.cc": "a",
+      "base/deep/b.cc": "b",
+      "sandbox/c.cc": "c",
+      "other/d.txt": "d",
+    });
+
+    // sparsePaths semantics: prefixToStrip = "" (identity), pathspecs = the dirs.
+    const paths = await getAllowedRelativePaths(repo, undefined, "", [
+      "base",
+      "sandbox",
+    ]);
+    assert.deepStrictEqual(paths.sort(), [
+      "base/a.cc",
+      "base/deep/b.cc",
+      "sandbox/c.cc",
+    ]);
+  });
+
+  it("multiple pathspecs honor .syncignore within the selected dirs", async () => {
+    repo = await initRepoWithFiles(tempDir, {
+      "base/a.cc": "a",
+      "base/test/skip.cc": "skip",
+      "sandbox/c.cc": "c",
+      "other/d.txt": "d",
+    });
+
+    // .syncignore at repo root (identity mapping) trims within the selection.
+    writeFile(path.join(tempDir, ".syncignore"), "base/test/\n");
+
+    const paths = await getAllowedRelativePaths(
+      repo,
+      path.join(tempDir, ".syncignore"),
+      "",
+      ["base", "sandbox"]
+    );
+    assert.deepStrictEqual(paths.sort(), ["base/a.cc", "sandbox/c.cc"]);
+  });
 });
 
 describe("GitRepo sparse checkout", () => {
@@ -258,6 +339,33 @@ describe("GitRepo sparse checkout", () => {
 
     // Now other/c.txt should be back
     assert.ok(fs.existsSync(path.join(tempDir, "other", "c.txt")));
+  });
+
+  it("multi-path sparse checkout materializes only the listed dirs, and pathspec-scoped listing matches (sparsePaths flow)", async () => {
+    repo = await initRepoWithFiles(tempDir, {
+      "base/a.cc": "a",
+      "sandbox/b.cc": "b",
+      "build/c.gn": "c",
+      "other/d.txt": "d",
+    });
+
+    await repo.sparseCheckoutInit();
+    await repo.sparseCheckoutSet("base", "sandbox");
+
+    // Only base/ and sandbox/ materialize on disk.
+    assert.ok(fs.existsSync(path.join(tempDir, "base", "a.cc")));
+    assert.ok(fs.existsSync(path.join(tempDir, "sandbox", "b.cc")));
+    assert.ok(!fs.existsSync(path.join(tempDir, "build", "c.gn")));
+    assert.ok(!fs.existsSync(path.join(tempDir, "other", "d.txt")));
+
+    // git ls-files still reports the whole index (skip-worktree entries), so
+    // scoping the listing to the same pathspecs keeps the copy set within what
+    // was actually materialized.
+    const files = await listFilesWithExclusions(repo, undefined, [
+      "base",
+      "sandbox",
+    ]);
+    assert.deepStrictEqual(files.sort(), ["base/a.cc", "sandbox/b.cc"]);
   });
 });
 


### PR DESCRIPTION
### What

Lets `fork-sync` vendor a **subset of a very large upstream repo** (e.g. Chromium's `base/` +
`sandbox/` + build deps) into a fork. Three new capabilities, all driven from `sync-config.json`:

- **First sync** — an empty/absent `commit` now does a **direct import** (resolve target →
  checkout → copy → write config), instead of being rejected. No base, no 3-way merge, no
  conflicts. Previously the documented "first sync" state was impossible without a throwaway
  script.
- **`sparsePaths: string[]`** — vendor **multiple directories** via sparse-checkout,
  **identity-mapped** (each keeps its repo-relative path: `base/` → `<localPath>/base/`). Unlike
  `subDir` (single folder, prefix-stripped), it preserves layout so absolute build labels (GN's
  `//base`) keep resolving, and never materializes the whole tree. Mutually exclusive with
  `subDir`; `.syncignore` still trims within.
- **`cloneFilter: string`** — partial-clone filter (default `blob:none`). Set `"tree:0"` to defer
  trees too; combined with `sparsePaths` this shrinks the initial clone of a huge repo by orders
  of magnitude. (Trade-off: later history-walking fetches trees on demand — but a first sync runs
  no merge, so it's essentially free for the initial import.)

```jsonc
{
  "repo": "https://chromium.googlesource.com/chromium/src",
  "branch": "main",
  "commit": "",                                   // first sync
  "tag": "149.0.7827.149",
  "sparsePaths": ["base", "sandbox", "build", "buildtools"],
  "cloneFilter": "tree:0"
}
```

One subtlety worth knowing when reviewing: `git ls-files` reports the **whole index** regardless
of the sparse cone, so the selected paths are also passed as ls-files **pathspecs** to keep the
copy set within what was actually materialized.

### Where to look

- **`src/sync.ts`** — config parsing/validation (optional `commit`; `sparsePaths`/`cloneFilter`;
  reject `subDir`+`sparsePaths`), a `syncPathspecs` field unifying sparse/subDir/whole-repo, and
  an `isFirstSync` branch in `run()` that takes the new `performFirstSync()` path and skips the
  merge machinery.
- **`src/modules/git.ts`** — listing helpers (`listFilesWithExclusions`,
  `getAllowedRelativePaths`, `getGitTreeHashes`, `lsTree`) now accept `string | string[]`
  pathspecs via a `toPathspecList()` helper; `clone()` gains `--no-checkout`. Back-compat: single
  string/`subDir` callers unchanged.
- **`README.md`** — docs for all three. **`.changeset/`** — `minor` changeset (Changesets repo,
  so no hand-edited `package.json`/`CHANGELOG.md`).

### Test plan

- `yarn test` passes. New `test/git.test.ts` cases cover multi-pathspec listing (union under the
  given paths, `.syncignore` honored, empty entries ignored, all-empty → whole-repo) and that a
  multi-path sparse checkout materializes only the listed dirs.
- Manually validated end-to-end against a fixture upstream: first sync with
  `sparsePaths: ["base","sandbox"]` imports only those dirs (identity-mapped), writes the resolved
  commit/tag back, makes no merge branches; files outside the selection are skipped. Existing
  `subDir`/whole-repo syncs unaffected.