### PR TITLE
fix(cli): disable TypeScript plugin by default

### DIFF
--- a/.changeset/new-deer-begin.md
+++ b/.changeset/new-deer-begin.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+TypeScript plugin is now disabled by default because 1) it degrades performance during bundling and 2) the new TypeScript 7.0 is now fast enough that running it beforehand is better.

--- a/packages/cli/src/bundle/defaultPlugins.ts
+++ b/packages/cli/src/bundle/defaultPlugins.ts
@@ -6,7 +6,6 @@ const defaultPlugins: DefaultPlugins = {
   plugins: [
     "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
     "@rnx-kit/metro-plugin-duplicates-checker",
-    "@rnx-kit/metro-plugin-typescript",
   ],
   treeShake: false,
 };

--- a/packages/cli/test/bundle/kit-config.test.ts
+++ b/packages/cli/test/bundle/kit-config.test.ts
@@ -37,7 +37,6 @@ describe("bundle/kit-config/getCliPlatformBundleConfigs()", () => {
     plugins: [
       "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
       "@rnx-kit/metro-plugin-duplicates-checker",
-      "@rnx-kit/metro-plugin-typescript",
     ],
   };
 

--- a/packages/cli/test/bundle/metro.test.ts
+++ b/packages/cli/test/bundle/metro.test.ts
@@ -29,7 +29,6 @@ describe("bundle/metro/metroBundle()", () => {
     plugins: [
       "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
       "@rnx-kit/metro-plugin-duplicates-checker",
-      "@rnx-kit/metro-plugin-typescript",
     ],
   };
 

--- a/packages/cli/test/bundle/overrides.test.ts
+++ b/packages/cli/test/bundle/overrides.test.ts
@@ -13,7 +13,6 @@ describe("bundle/overrides/applyCommandLineOverrides()", () => {
     plugins: [
       "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
       "@rnx-kit/metro-plugin-duplicates-checker",
-      "@rnx-kit/metro-plugin-typescript",
     ],
     indexedRamBundle: false,
     platform: "ios",

--- a/packages/cli/test/helpers/metro-config.test.ts
+++ b/packages/cli/test/helpers/metro-config.test.ts
@@ -66,9 +66,7 @@ describe("cli/metro-config/customizeMetroConfig()", () => {
       transformer: {},
     });
     expect(typeof inputConfig.serializer.customSerializer).toBe("function");
-    expect(typeof inputConfig.serializer.experimentalSerializerHook).toBe(
-      "function"
-    );
+    expect(inputConfig.serializer.experimentalSerializerHook).toBe(false);
     expect(toMock(CyclicDependencies).__context).toEqual({ timesCalled: 1 });
     expect(toMock(DuplicateDependencies).__context).toEqual({ timesCalled: 1 });
   });
@@ -96,23 +94,18 @@ describe("cli/metro-config/customizeMetroConfig()", () => {
   test("returns a config with only duplicates plugin", () => {
     const inputConfig = makeMockConfig();
     customizeMetroConfig(inputConfig, {
-      plugins: [
-        "@rnx-kit/metro-plugin-duplicates-checker",
-        "@rnx-kit/metro-plugin-typescript",
-      ],
+      plugins: ["@rnx-kit/metro-plugin-duplicates-checker"],
     });
 
     expect(inputConfig).toEqual({
       serializer: {
         customSerializer: expect.anything(),
-        experimentalSerializerHook: expect.anything(),
+        experimentalSerializerHook: false,
       },
       transformer: {},
     });
     expect(typeof inputConfig.serializer.customSerializer).toBe("function");
-    expect(typeof inputConfig.serializer.experimentalSerializerHook).toBe(
-      "function"
-    );
+    expect(inputConfig.serializer.experimentalSerializerHook).toBe(false);
     expect(toMock(CyclicDependencies).__context).toEqual({ timesCalled: 0 });
     expect(toMock(DuplicateDependencies).__context).toEqual({ timesCalled: 1 });
   });
@@ -120,23 +113,18 @@ describe("cli/metro-config/customizeMetroConfig()", () => {
   test("returns a config with only cyclic dependencies plugin", () => {
     const inputConfig = makeMockConfig();
     customizeMetroConfig(inputConfig, {
-      plugins: [
-        "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
-        "@rnx-kit/metro-plugin-typescript",
-      ],
+      plugins: ["@rnx-kit/metro-plugin-cyclic-dependencies-detector"],
     });
 
     expect(inputConfig).toEqual({
       serializer: {
         customSerializer: expect.anything(),
-        experimentalSerializerHook: expect.anything(),
+        experimentalSerializerHook: false,
       },
       transformer: {},
     });
     expect(typeof inputConfig.serializer.customSerializer).toBe("function");
-    expect(typeof inputConfig.serializer.experimentalSerializerHook).toBe(
-      "function"
-    );
+    expect(inputConfig.serializer.experimentalSerializerHook).toBe(false);
     expect(toMock(CyclicDependencies).__context).toEqual({ timesCalled: 1 });
     expect(toMock(DuplicateDependencies).__context).toEqual({ timesCalled: 0 });
   });

--- a/packages/metro-serializer-esbuild/README.md
+++ b/packages/metro-serializer-esbuild/README.md
@@ -179,7 +179,9 @@ See the full documentation at https://esbuild.github.io/api/#target.
 Values: Any JS language version string such as `es6` or `esnext`. You can also
 use environment names. See the full documentation for a list of supported names.
 
-Defaults to `hermes0.7.0`.
+By default, the target is inferred using React Native version
+([see code](https://github.com/microsoft/rnx-kit/blob/main/packages/metro-serializer-esbuild/src/targets.ts)).
+Failing that, it falls back to `hermes0.7`.
 
 ### `fabric`
 

--- a/packages/types-bundle-config/src/bundleConfig.ts
+++ b/packages/types-bundle-config/src/bundleConfig.ts
@@ -84,8 +84,7 @@ export type BundleParameters = BundlerPlugins &
      *
      * @default [
      *   "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
-     *   "@rnx-kit/metro-plugin-duplicates-checker",
-     *   "@rnx-kit/metro-plugin-typescript"
+     *   "@rnx-kit/metro-plugin-duplicates-checker"
      * ]
      */
     plugins?: Plugin[];

--- a/packages/types-bundle-config/src/serverConfig.ts
+++ b/packages/types-bundle-config/src/serverConfig.ts
@@ -29,8 +29,7 @@ export type ServerConfig = BundlerPlugins & {
    *
    * @default [
    *   "@rnx-kit/metro-plugin-cyclic-dependencies-detector",
-   *   "@rnx-kit/metro-plugin-duplicates-checker",
-   *   "@rnx-kit/metro-plugin-typescript"
+   *   "@rnx-kit/metro-plugin-duplicates-checker"
    * ]
    */
   plugins?: Plugin[];


### PR DESCRIPTION
### Description

TypeScript plugin is now disabled by default because 1) it degrades performance during bundling and 2) the new TypeScript 7.0 is now fast enough that running it beforehand is better.

### Test plan

n/a