### PR TITLE
fix(changelog-generator): Update facebook/react-native references to point to new react org

### DIFF
--- a/.changeset/wild-bottles-cheer.md
+++ b/.changeset/wild-bottles-cheer.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/rn-changelog-generator": patch
+---
+
+Update `facebook/react-native` references to point to the new `react` org

--- a/incubator/rn-changelog-generator/README.md
+++ b/incubator/rn-changelog-generator/README.md
@@ -27,7 +27,7 @@ reasons:
   react-native repo.
 
 - Due to how react-native’s
-  [release process](https://github.com/facebook/react-native/wiki/Release-Process)
+  [release process](https://github.com/react/react-native/wiki/Release-Process)
   works, we want to be able to exclude previously cherry-picked commits from the
   changelog entry of the next version.
 
@@ -55,7 +55,7 @@ If you don’t already have a checkout of the react-native repo in a nearby
 folder:
 
 ```bash
-git clone https://github.com/facebook/react-native.git
+git clone https://github.com/react/react-native.git
 ```
 
 Ensure the repo is up-to-date:

--- a/incubator/rn-changelog-generator/src/utils/commits.ts
+++ b/incubator/rn-changelog-generator/src/utils/commits.ts
@@ -70,7 +70,7 @@ export function fetchCommits(
     const fetchPage = () => {
       fetchJSON<Commit[]>(
         token,
-        `/repos/facebook/react-native/commits?sha=${compare}&page=${page++}`
+        `/repos/react/react-native/commits?sha=${compare}&page=${page++}`
       )
         .then(({ json, headers }) => {
           for (const commit of json) {
@@ -98,7 +98,7 @@ export function fetchCommits(
 
 export function fetchCommit(token: string | null, sha: string) {
   return new Promise<Commit>((resolve, reject) => {
-    fetchJSON<Commit>(token, `/repos/facebook/react-native/commits/${sha}`)
+    fetchJSON<Commit>(token, `/repos/react/react-native/commits/${sha}`)
       .then(({ json }) => {
         resolve(json);
       })

--- a/incubator/rn-changelog-generator/src/utils/formatCommitLink.ts
+++ b/incubator/rn-changelog-generator/src/utils/formatCommitLink.ts
@@ -1,3 +1,3 @@
 export function formatCommitLink(sha: string) {
-  return `https://github.com/facebook/react-native/commit/${sha}`;
+  return `https://github.com/react/react-native/commit/${sha}`;
 }

--- a/incubator/rn-changelog-generator/test/__fixtures__/commit-internal.json
+++ b/incubator/rn-changelog-generator/test/__fixtures__/commit-internal.json
@@ -15,9 +15,9 @@
     "message": "Fix test_js/test_js_prev_lts\n\nSummary:\nChangelog: [Internal] Remove un-necessary package installs which was using `npm install flow-bin --save-dev` which was wiping out our `node_modules` from the circleCI yarn install.\n\nIt was un-necessary as we already have `flow-bin` as a dependency in our current set-up.\n\nIn addtion, we were running `npm pack` without properly copying over our package.json dependencies (which occurs in `prepare-package-for-release`) for a consumable react-native package.\n\nThis may not have caused issue but technically we were creating an \"incomplete\" package to do our e2e testing on.\n\nReviewed By: charlesbdudley\n\nDifferential Revision: D33197965\n\nfbshipit-source-id: 6583ef1f8e17333c0f27ecc37635c36ae5a0bb62",
     "tree": {
       "sha": "bc76306afa2dda29080c242f8fd999cf47499b1f",
-      "url": "https://api.github.com/repos/facebook/react-native/git/trees/bc76306afa2dda29080c242f8fd999cf47499b1f"
+      "url": "https://api.github.com/repos/react/react-native/git/trees/bc76306afa2dda29080c242f8fd999cf47499b1f"
     },
-    "url": "https://api.github.com/repos/facebook/react-native/git/commits/50e109c78d3ae9c10d8472d2f4888d7f59214fdd",
+    "url": "https://api.github.com/repos/react/react-native/git/commits/50e109c78d3ae9c10d8472d2f4888d7f59214fdd",
     "comment_count": 0,
     "verification": {
       "verified": false,
@@ -26,9 +26,9 @@
       "payload": null
     }
   },
-  "url": "https://api.github.com/repos/facebook/react-native/commits/50e109c78d3ae9c10d8472d2f4888d7f59214fdd",
-  "html_url": "https://github.com/facebook/react-native/commit/50e109c78d3ae9c10d8472d2f4888d7f59214fdd",
-  "comments_url": "https://api.github.com/repos/facebook/react-native/commits/50e109c78d3ae9c10d8472d2f4888d7f59214fdd/comments",
+  "url": "https://api.github.com/repos/react/react-native/commits/50e109c78d3ae9c10d8472d2f4888d7f59214fdd",
+  "html_url": "https://github.com/react/react-native/commit/50e109c78d3ae9c10d8472d2f4888d7f59214fdd",
+  "comments_url": "https://api.github.com/repos/react/react-native/commits/50e109c78d3ae9c10d8472d2f4888d7f59214fdd/comments",
   "author": {
     "login": "lunaleaps",
     "id": 1309636,
@@ -72,8 +72,8 @@
   "parents": [
     {
       "sha": "d1e359a15a9398ad64335b7e135c187bb7442373",
-      "url": "https://api.github.com/repos/facebook/react-native/commits/d1e359a15a9398ad64335b7e135c187bb7442373",
-      "html_url": "https://github.com/facebook/react-native/commit/d1e359a15a9398ad64335b7e135c187bb7442373"
+      "url": "https://api.github.com/repos/react/react-native/commits/d1e359a15a9398ad64335b7e135c187bb7442373",
+      "html_url": "https://github.com/react/react-native/commit/d1e359a15a9398ad64335b7e135c187bb7442373"
     }
   ],
   "stats": {
@@ -89,9 +89,9 @@
       "additions": 2,
       "deletions": 2,
       "changes": 4,
-      "blob_url": "https://github.com/facebook/react-native/blob/50e109c78d3ae9c10d8472d2f4888d7f59214fdd/.circleci/config.yml",
-      "raw_url": "https://github.com/facebook/react-native/raw/50e109c78d3ae9c10d8472d2f4888d7f59214fdd/.circleci/config.yml",
-      "contents_url": "https://api.github.com/repos/facebook/react-native/contents/.circleci/config.yml?ref=50e109c78d3ae9c10d8472d2f4888d7f59214fdd",
+      "blob_url": "https://github.com/react/react-native/blob/50e109c78d3ae9c10d8472d2f4888d7f59214fdd/.circleci/config.yml",
+      "raw_url": "https://github.com/react/react-native/raw/50e109c78d3ae9c10d8472d2f4888d7f59214fdd/.circleci/config.yml",
+      "contents_url": "https://api.github.com/repos/react/react-native/contents/.circleci/config.yml?ref=50e109c78d3ae9c10d8472d2f4888d7f59214fdd",
       "patch": "@@ -78,7 +78,7 @@ commands:\n     steps:\n       - restore_cache:\n           keys:\n-            - v4-yarn-cache-{{ arch }}-{{ checksum \"yarn.lock\" }}\n+            - v5-yarn-cache-{{ arch }}-{{ checksum \"yarn.lock\" }}\n       - run:\n           name: \"Yarn: Install Dependencies\"\n           command: |\n@@ -90,7 +90,7 @@ commands:\n       - save_cache:\n           paths:\n             - ~/.cache/yarn\n-          key: v4-yarn-cache-{{ arch }}-{{ checksum \"yarn.lock\" }}\n+          key: v5-yarn-cache-{{ arch }}-{{ checksum \"yarn.lock\" }}\n \n   install_buck_tooling:\n     steps:"
     },
     {
@@ -101,9 +101,9 @@
       "additions": 5,
       "deletions": 17,
       "changes": 22,
-      "blob_url": "https://github.com/facebook/react-native/blob/50e109c78d3ae9c10d8472d2f4888d7f59214fdd/scripts/run-ci-e2e-tests.js",
-      "raw_url": "https://github.com/facebook/react-native/raw/50e109c78d3ae9c10d8472d2f4888d7f59214fdd/scripts/run-ci-e2e-tests.js",
-      "contents_url": "https://api.github.com/repos/facebook/react-native/contents/scripts/run-ci-e2e-tests.js?ref=50e109c78d3ae9c10d8472d2f4888d7f59214fdd",
+      "blob_url": "https://github.com/react/react-native/blob/50e109c78d3ae9c10d8472d2f4888d7f59214fdd/scripts/run-ci-e2e-tests.js",
+      "raw_url": "https://github.com/react/react-native/raw/50e109c78d3ae9c10d8472d2f4888d7f59214fdd/scripts/run-ci-e2e-tests.js",
+      "contents_url": "https://api.github.com/repos/react/react-native/contents/scripts/run-ci-e2e-tests.js?ref=50e109c78d3ae9c10d8472d2f4888d7f59214fdd",
       "patch": "@@ -56,25 +56,13 @@ try {\n     }\n   }\n \n-  if (argv.js) {\n-    describe('Install Flow');\n-    if (\n-      tryExecNTimes(\n-        () => {\n-          return exec('npm install --save-dev flow-bin').code;\n-        },\n-        numberOfRetries,\n-        () => exec('sleep 10s'),\n-      )\n-    ) {\n-      echo('Failed to install Flow');\n-      echo('Most common reason is npm registry connectivity, try again');\n-      exitCode = 1;\n-      throw Error(exitCode);\n-    }\n+  describe('Create react-native package');\n+  if (exec('node ./scripts/set-rn-version.js --version 1000.0.0').code) {\n+    echo('Failed to set version and update package.json ready for release');\n+    exitCode = 1;\n+    throw Error(exitCode);\n   }\n \n-  describe('Create react-native package');\n   if (exec('npm pack').code) {\n     echo('Failed to pack react-native');\n     exitCode = 1;"
     }
   ]

--- a/incubator/rn-changelog-generator/test/__fixtures__/commits-v0.60.5-page-1.json
+++ b/incubator/rn-changelog-generator/test/__fixtures__/commits-v0.60.5-page-1.json
@@ -16,9 +16,9 @@
       "message": "[0.60.5] Bump version numbers",
       "tree": {
         "sha": "1e5090fb51da53614f1b323e74f626883f168a03",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/1e5090fb51da53614f1b323e74f626883f168a03"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/1e5090fb51da53614f1b323e74f626883f168a03"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/35300147ca66677f42e8544264be72ac0e9d1b45",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/35300147ca66677f42e8544264be72ac0e9d1b45",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -27,9 +27,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/35300147ca66677f42e8544264be72ac0e9d1b45",
-    "html_url": "https://github.com/facebook/react-native/commit/35300147ca66677f42e8544264be72ac0e9d1b45",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/35300147ca66677f42e8544264be72ac0e9d1b45/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/35300147ca66677f42e8544264be72ac0e9d1b45",
+    "html_url": "https://github.com/react/react-native/commit/35300147ca66677f42e8544264be72ac0e9d1b45",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/35300147ca66677f42e8544264be72ac0e9d1b45/comments",
     "author": {
       "login": "kelset",
       "id": 16104054,
@@ -73,8 +73,8 @@
     "parents": [
       {
         "sha": "1bb197afb191eab134354386700053914f1ac181",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/1bb197afb191eab134354386700053914f1ac181",
-        "html_url": "https://github.com/facebook/react-native/commit/1bb197afb191eab134354386700053914f1ac181"
+        "url": "https://api.github.com/repos/react/react-native/commits/1bb197afb191eab134354386700053914f1ac181",
+        "html_url": "https://github.com/react/react-native/commit/1bb197afb191eab134354386700053914f1ac181"
       }
     ]
   },
@@ -95,9 +95,9 @@
       "message": "[LOCAL] ensure right version of Metro bundler is used",
       "tree": {
         "sha": "15b44537fb21d5d687cdf07b491998652b06c216",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/15b44537fb21d5d687cdf07b491998652b06c216"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/15b44537fb21d5d687cdf07b491998652b06c216"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/1bb197afb191eab134354386700053914f1ac181",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/1bb197afb191eab134354386700053914f1ac181",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -106,9 +106,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/1bb197afb191eab134354386700053914f1ac181",
-    "html_url": "https://github.com/facebook/react-native/commit/1bb197afb191eab134354386700053914f1ac181",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/1bb197afb191eab134354386700053914f1ac181/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/1bb197afb191eab134354386700053914f1ac181",
+    "html_url": "https://github.com/react/react-native/commit/1bb197afb191eab134354386700053914f1ac181",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/1bb197afb191eab134354386700053914f1ac181/comments",
     "author": {
       "login": "kelset",
       "id": 16104054,
@@ -152,8 +152,8 @@
     "parents": [
       {
         "sha": "683908dedf36c22ba8f0524268c7f461bc8478fc",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/683908dedf36c22ba8f0524268c7f461bc8478fc",
-        "html_url": "https://github.com/facebook/react-native/commit/683908dedf36c22ba8f0524268c7f461bc8478fc"
+        "url": "https://api.github.com/repos/react/react-native/commits/683908dedf36c22ba8f0524268c7f461bc8478fc",
+        "html_url": "https://github.com/react/react-native/commit/683908dedf36c22ba8f0524268c7f461bc8478fc"
       }
     ]
   },
@@ -171,12 +171,12 @@
         "email": "grabbou@gmail.com",
         "date": "2019-08-07T17:17:06Z"
       },
-      "message": "Don't call sharedApplication in App Extension (#25769)\n\nSummary:\nFixes https://github.com/facebook/react-native/issues/25767 .\n\n## Changelog\n\n[iOS] [Fixed] - Don't call sharedApplication in App Extension\nPull Request resolved: https://github.com/facebook/react-native/pull/25769\n\nTest Plan: RN works in App Extension.\n\nReviewed By: cpojer\n\nDifferential Revision: D16516104\n\nPulled By: sammy-SC\n\nfbshipit-source-id: 446fd1d88724b783b2afb2369783b9a85b5cc178",
+      "message": "Don't call sharedApplication in App Extension (#25769)\n\nSummary:\nFixes https://github.com/react/react-native/issues/25767 .\n\n## Changelog\n\n[iOS] [Fixed] - Don't call sharedApplication in App Extension\nPull Request resolved: https://github.com/react/react-native/pull/25769\n\nTest Plan: RN works in App Extension.\n\nReviewed By: cpojer\n\nDifferential Revision: D16516104\n\nPulled By: sammy-SC\n\nfbshipit-source-id: 446fd1d88724b783b2afb2369783b9a85b5cc178",
       "tree": {
         "sha": "2aedf07c15e4224fd1a88ebc7535fe228f573ba1",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/2aedf07c15e4224fd1a88ebc7535fe228f573ba1"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/2aedf07c15e4224fd1a88ebc7535fe228f573ba1"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/683908dedf36c22ba8f0524268c7f461bc8478fc",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/683908dedf36c22ba8f0524268c7f461bc8478fc",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -185,9 +185,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/683908dedf36c22ba8f0524268c7f461bc8478fc",
-    "html_url": "https://github.com/facebook/react-native/commit/683908dedf36c22ba8f0524268c7f461bc8478fc",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/683908dedf36c22ba8f0524268c7f461bc8478fc/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/683908dedf36c22ba8f0524268c7f461bc8478fc",
+    "html_url": "https://github.com/react/react-native/commit/683908dedf36c22ba8f0524268c7f461bc8478fc",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/683908dedf36c22ba8f0524268c7f461bc8478fc/comments",
     "author": {
       "login": "zhongwuzw",
       "id": 5061845,
@@ -231,8 +231,8 @@
     "parents": [
       {
         "sha": "72473c7c3ec08623dbc7da83a7fa78eb5c796a17",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/72473c7c3ec08623dbc7da83a7fa78eb5c796a17",
-        "html_url": "https://github.com/facebook/react-native/commit/72473c7c3ec08623dbc7da83a7fa78eb5c796a17"
+        "url": "https://api.github.com/repos/react/react-native/commits/72473c7c3ec08623dbc7da83a7fa78eb5c796a17",
+        "html_url": "https://github.com/react/react-native/commit/72473c7c3ec08623dbc7da83a7fa78eb5c796a17"
       }
     ]
   },
@@ -250,12 +250,12 @@
         "email": "grabbou@gmail.com",
         "date": "2019-08-07T17:12:03Z"
       },
-      "message": "- Bump CLI to ^2.6.0 (#25666)\n\nSummary:\nBumps CLI to the latest, including automatic jetifier, prettierrc in template and more: https://github.com/react-native-community/cli/compare/v2.2.0...v2.6.0\n\n[Internal] [Changed] - Bump CLI to ^2.6.0\nPull Request resolved: https://github.com/facebook/react-native/pull/25666\n\nTest Plan: CI passes\n\nDifferential Revision: D16279319\n\nPulled By: cpojer\n\nfbshipit-source-id: d84e2e69a310ac3ef5722c22a17b12926a073097",
+      "message": "- Bump CLI to ^2.6.0 (#25666)\n\nSummary:\nBumps CLI to the latest, including automatic jetifier, prettierrc in template and more: https://github.com/react-native-community/cli/compare/v2.2.0...v2.6.0\n\n[Internal] [Changed] - Bump CLI to ^2.6.0\nPull Request resolved: https://github.com/react/react-native/pull/25666\n\nTest Plan: CI passes\n\nDifferential Revision: D16279319\n\nPulled By: cpojer\n\nfbshipit-source-id: d84e2e69a310ac3ef5722c22a17b12926a073097",
       "tree": {
         "sha": "756eb7d4bdf75fcd2e999495e455841b5c7b8d95",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/756eb7d4bdf75fcd2e999495e455841b5c7b8d95"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/756eb7d4bdf75fcd2e999495e455841b5c7b8d95"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/72473c7c3ec08623dbc7da83a7fa78eb5c796a17",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/72473c7c3ec08623dbc7da83a7fa78eb5c796a17",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -264,9 +264,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/72473c7c3ec08623dbc7da83a7fa78eb5c796a17",
-    "html_url": "https://github.com/facebook/react-native/commit/72473c7c3ec08623dbc7da83a7fa78eb5c796a17",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/72473c7c3ec08623dbc7da83a7fa78eb5c796a17/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/72473c7c3ec08623dbc7da83a7fa78eb5c796a17",
+    "html_url": "https://github.com/react/react-native/commit/72473c7c3ec08623dbc7da83a7fa78eb5c796a17",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/72473c7c3ec08623dbc7da83a7fa78eb5c796a17/comments",
     "author": {
       "login": "thymikee",
       "id": 5106466,
@@ -310,8 +310,8 @@
     "parents": [
       {
         "sha": "feb931f378ac1fe0193ba5084ebbf82da21216b5",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/feb931f378ac1fe0193ba5084ebbf82da21216b5",
-        "html_url": "https://github.com/facebook/react-native/commit/feb931f378ac1fe0193ba5084ebbf82da21216b5"
+        "url": "https://api.github.com/repos/react/react-native/commits/feb931f378ac1fe0193ba5084ebbf82da21216b5",
+        "html_url": "https://github.com/react/react-native/commit/feb931f378ac1fe0193ba5084ebbf82da21216b5"
       }
     ]
   },
@@ -329,12 +329,12 @@
         "email": "grabbou@gmail.com",
         "date": "2019-08-07T17:10:19Z"
       },
-      "message": "Properly set borderRadius on Android (#25626)\n\nSummary:\nIn order to properly set the view's borderRadius the inner*RadiusX/inner*RadiusY should not\nbe used, since their values are obtained via the following formula:\n\nint innerTopLeftRadiusX = Math.max(topLeftRadius - borderWidth.left, 0);\n\nIf topLeftRadius and borderWidth.left have the same value innerTopLeftRadiusX will\nbe zero and it will cause the top left radius to never be set since\n\"(innerTopLeftRadiusX > 0 ? extraRadiusForOutline : 0)\" will evaluate to zero.\nIn order to prevent this issue the condition will only consider topLeftRadius, topRightRadius, and etc.\n\nI took a closer look to see if this fix does not causes a regression in https://github.com/facebook/react-native/issues/22511\n\n[Android] [FIX] - Correctly set the border radius on android\nPull Request resolved: https://github.com/facebook/react-native/pull/25626\n\nTest Plan:\nUsing the following code and Android certify that the border radius is correctly applied.\n```javascript\nimport React from \"react\";\nimport { ScrollView, StyleSheet, Text, View } from \"react-native\";\n\nexport default class App extends React.Component<Props> {\n  render() {\n    return (\n      <ScrollView style={styles.container}>\n        <View style={styles.box1}>\n          <Text>borderWidth: 2</Text>\n          <Text>borderRadius: 2</Text>\n        </View>\n        <View style={styles.box2}>\n          <Text>borderWidth: 2</Text>\n          <Text>borderRadius: 2.000001</Text>\n        </View>\n        <View style={styles.box3}>\n          <Text>borderWidth: 5</Text>\n          <Text>borderRadius: 5</Text>\n        </View>\n        <View style={styles.box4}>\n          <Text>borderWidth: 5</Text>\n          <Text>borderRadius: 5.000001</Text>\n        </View>\n        <View style={styles.box5}>\n          <Text>borderWidth: 10</Text>\n          <Text>borderRadius: 10</Text>\n        </View>\n        <View style={styles.box6}>\n          <Text>borderWidth: 10</Text>\n          <Text>borderRadius: 11</Text>\n        </View>\n        <View style={styles.box7}>\n          <Text>borderWidth: 10</Text>\n          <Text>borderRadius: 5</Text>\n        </View>\n        <Text>Testing if this does not cause a regression in https://github.com/facebook/react-native/issues/22511</Text>\n        <View style={{\n          margin: 10,\n          backgroundColor: 'red',\n          width: 100,\n          height: 100,\n          borderWidth: 5,\n          borderBottomLeftRadius: 15,\n        }} />\n        <View style={{\n          margin: 10,\n          backgroundColor: 'green',\n          borderWidth: 5,\n          width: 100,\n          height: 100,\n        }} />\n      </ScrollView>\n    );\n  }\n}\n\nconst styles = StyleSheet.create({\n  container: {\n    flex: 1\n  },\n  box1: {\n    margin: 10,\n    height: 100,\n    borderRadius: 2,\n    borderWidth: 2,\n    borderColor: \"#000000\"\n  },\n  box2: {\n    margin: 10,\n    height: 100,\n    borderRadius: 2.000001,\n    borderWidth: 2,\n    borderColor: \"#000000\"\n  },\n  box3: {\n    margin: 10,\n    height: 100,\n    borderRadius: 5,\n    borderWidth: 5,\n    borderColor: \"#000000\"\n  },\n  box4: {\n    margin: 10,\n    height: 100,\n    borderRadius: 5.000001,\n    borderWidth: 5,\n    borderColor: \"#000000\"\n  },\n  box5: {\n    margin: 10,\n    height: 100,\n    borderRadius: 10,\n    borderWidth: 10,\n    borderColor: \"#000000\"\n  },\n  box6: {\n    margin: 10,\n    height: 100,\n    borderRadius: 11,\n    borderWidth: 10,\n    borderColor: \"#000000\"\n  },\n  box7: {\n    margin: 10,\n    height: 100,\n    borderRadius: 5,\n    borderWidth: 10,\n    borderColor: \"#000000\"\n  }\n});\n\n```\n\n![not-working](https://user-images.githubusercontent.com/984610/61164801-e1dc6580-a4ee-11e9-91f3-6ca2fab7c461.gif)\n\n![fixed](https://user-images.githubusercontent.com/984610/61164794-db4dee00-a4ee-11e9-88d7-367c29c785ec.gif)\n\nCloses https://github.com/facebook/react-native/issues/25591\n\nReviewed By: osdnk\n\nDifferential Revision: D16243602\n\nPulled By: mdvacca\n\nfbshipit-source-id: 1e16572fdf6936aa19c3d4c01ff6434028652942",
+      "message": "Properly set borderRadius on Android (#25626)\n\nSummary:\nIn order to properly set the view's borderRadius the inner*RadiusX/inner*RadiusY should not\nbe used, since their values are obtained via the following formula:\n\nint innerTopLeftRadiusX = Math.max(topLeftRadius - borderWidth.left, 0);\n\nIf topLeftRadius and borderWidth.left have the same value innerTopLeftRadiusX will\nbe zero and it will cause the top left radius to never be set since\n\"(innerTopLeftRadiusX > 0 ? extraRadiusForOutline : 0)\" will evaluate to zero.\nIn order to prevent this issue the condition will only consider topLeftRadius, topRightRadius, and etc.\n\nI took a closer look to see if this fix does not causes a regression in https://github.com/react/react-native/issues/22511\n\n[Android] [FIX] - Correctly set the border radius on android\nPull Request resolved: https://github.com/react/react-native/pull/25626\n\nTest Plan:\nUsing the following code and Android certify that the border radius is correctly applied.\n```javascript\nimport React from \"react\";\nimport { ScrollView, StyleSheet, Text, View } from \"react-native\";\n\nexport default class App extends React.Component<Props> {\n  render() {\n    return (\n      <ScrollView style={styles.container}>\n        <View style={styles.box1}>\n          <Text>borderWidth: 2</Text>\n          <Text>borderRadius: 2</Text>\n        </View>\n        <View style={styles.box2}>\n          <Text>borderWidth: 2</Text>\n          <Text>borderRadius: 2.000001</Text>\n        </View>\n        <View style={styles.box3}>\n          <Text>borderWidth: 5</Text>\n          <Text>borderRadius: 5</Text>\n        </View>\n        <View style={styles.box4}>\n          <Text>borderWidth: 5</Text>\n          <Text>borderRadius: 5.000001</Text>\n        </View>\n        <View style={styles.box5}>\n          <Text>borderWidth: 10</Text>\n          <Text>borderRadius: 10</Text>\n        </View>\n        <View style={styles.box6}>\n          <Text>borderWidth: 10</Text>\n          <Text>borderRadius: 11</Text>\n        </View>\n        <View style={styles.box7}>\n          <Text>borderWidth: 10</Text>\n          <Text>borderRadius: 5</Text>\n        </View>\n        <Text>Testing if this does not cause a regression in https://github.com/react/react-native/issues/22511</Text>\n        <View style={{\n          margin: 10,\n          backgroundColor: 'red',\n          width: 100,\n          height: 100,\n          borderWidth: 5,\n          borderBottomLeftRadius: 15,\n        }} />\n        <View style={{\n          margin: 10,\n          backgroundColor: 'green',\n          borderWidth: 5,\n          width: 100,\n          height: 100,\n        }} />\n      </ScrollView>\n    );\n  }\n}\n\nconst styles = StyleSheet.create({\n  container: {\n    flex: 1\n  },\n  box1: {\n    margin: 10,\n    height: 100,\n    borderRadius: 2,\n    borderWidth: 2,\n    borderColor: \"#000000\"\n  },\n  box2: {\n    margin: 10,\n    height: 100,\n    borderRadius: 2.000001,\n    borderWidth: 2,\n    borderColor: \"#000000\"\n  },\n  box3: {\n    margin: 10,\n    height: 100,\n    borderRadius: 5,\n    borderWidth: 5,\n    borderColor: \"#000000\"\n  },\n  box4: {\n    margin: 10,\n    height: 100,\n    borderRadius: 5.000001,\n    borderWidth: 5,\n    borderColor: \"#000000\"\n  },\n  box5: {\n    margin: 10,\n    height: 100,\n    borderRadius: 10,\n    borderWidth: 10,\n    borderColor: \"#000000\"\n  },\n  box6: {\n    margin: 10,\n    height: 100,\n    borderRadius: 11,\n    borderWidth: 10,\n    borderColor: \"#000000\"\n  },\n  box7: {\n    margin: 10,\n    height: 100,\n    borderRadius: 5,\n    borderWidth: 10,\n    borderColor: \"#000000\"\n  }\n});\n\n```\n\n![not-working](https://user-images.githubusercontent.com/984610/61164801-e1dc6580-a4ee-11e9-91f3-6ca2fab7c461.gif)\n\n![fixed](https://user-images.githubusercontent.com/984610/61164794-db4dee00-a4ee-11e9-88d7-367c29c785ec.gif)\n\nCloses https://github.com/react/react-native/issues/25591\n\nReviewed By: osdnk\n\nDifferential Revision: D16243602\n\nPulled By: mdvacca\n\nfbshipit-source-id: 1e16572fdf6936aa19c3d4c01ff6434028652942",
       "tree": {
         "sha": "3a0052fd408a3817827fcb5911eb268f488ed429",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/3a0052fd408a3817827fcb5911eb268f488ed429"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/3a0052fd408a3817827fcb5911eb268f488ed429"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/feb931f378ac1fe0193ba5084ebbf82da21216b5",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/feb931f378ac1fe0193ba5084ebbf82da21216b5",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -343,9 +343,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/feb931f378ac1fe0193ba5084ebbf82da21216b5",
-    "html_url": "https://github.com/facebook/react-native/commit/feb931f378ac1fe0193ba5084ebbf82da21216b5",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/feb931f378ac1fe0193ba5084ebbf82da21216b5/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/feb931f378ac1fe0193ba5084ebbf82da21216b5",
+    "html_url": "https://github.com/react/react-native/commit/feb931f378ac1fe0193ba5084ebbf82da21216b5",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/feb931f378ac1fe0193ba5084ebbf82da21216b5/comments",
     "author": {
       "login": "cabelitos",
       "id": 984610,
@@ -389,8 +389,8 @@
     "parents": [
       {
         "sha": "95c747e8a7b85d544fa384a21f3d31eb33dd3d40",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/95c747e8a7b85d544fa384a21f3d31eb33dd3d40",
-        "html_url": "https://github.com/facebook/react-native/commit/95c747e8a7b85d544fa384a21f3d31eb33dd3d40"
+        "url": "https://api.github.com/repos/react/react-native/commits/95c747e8a7b85d544fa384a21f3d31eb33dd3d40",
+        "html_url": "https://github.com/react/react-native/commit/95c747e8a7b85d544fa384a21f3d31eb33dd3d40"
       }
     ]
   },
@@ -411,9 +411,9 @@
       "message": "Delete fishhook\n\nSummary: Fishhook was used to try to hide the log messages from RCTReconnectingWebSocket but that doesn't really work anymore. Deleting it now to unblock people trying to build for iOS 13.\n\nReviewed By: cpojer\n\nDifferential Revision: D15779390\n\nfbshipit-source-id: ef18575d5d92ac374e189b1267dee3a9befc3551",
       "tree": {
         "sha": "b73de2032e5c8e07e8a5e37e91d1d38afc99170d",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/b73de2032e5c8e07e8a5e37e91d1d38afc99170d"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/b73de2032e5c8e07e8a5e37e91d1d38afc99170d"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/95c747e8a7b85d544fa384a21f3d31eb33dd3d40",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/95c747e8a7b85d544fa384a21f3d31eb33dd3d40",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -422,9 +422,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/95c747e8a7b85d544fa384a21f3d31eb33dd3d40",
-    "html_url": "https://github.com/facebook/react-native/commit/95c747e8a7b85d544fa384a21f3d31eb33dd3d40",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/95c747e8a7b85d544fa384a21f3d31eb33dd3d40/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/95c747e8a7b85d544fa384a21f3d31eb33dd3d40",
+    "html_url": "https://github.com/react/react-native/commit/95c747e8a7b85d544fa384a21f3d31eb33dd3d40",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/95c747e8a7b85d544fa384a21f3d31eb33dd3d40/comments",
     "author": {
       "login": "mmmulani",
       "id": 192928,
@@ -468,8 +468,8 @@
     "parents": [
       {
         "sha": "f4d5e8c23357dc006c7d237e8d6a6f85e3a704a1",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/f4d5e8c23357dc006c7d237e8d6a6f85e3a704a1",
-        "html_url": "https://github.com/facebook/react-native/commit/f4d5e8c23357dc006c7d237e8d6a6f85e3a704a1"
+        "url": "https://api.github.com/repos/react/react-native/commits/f4d5e8c23357dc006c7d237e8d6a6f85e3a704a1",
+        "html_url": "https://github.com/react/react-native/commit/f4d5e8c23357dc006c7d237e8d6a6f85e3a704a1"
       }
     ]
   },
@@ -487,12 +487,12 @@
         "email": "grabbou@gmail.com",
         "date": "2019-08-07T17:05:10Z"
       },
-      "message": "Fresh RN projects fails ESLint / Prettier by default (#25478)\n\nSummary:\nFixes https://github.com/facebook/react-native/issues/25477\n\nThis PR adds a `.prettierrc.js` config file to the HelloWorld template.\n\n`eslint-config-react-native-community` includes custom settings for some rules which conflict with Prettier's default settings.\n\nConsequently, if you run `eslint` immediately after scaffolding a new app you get errors (see linked issue).\n\nThis PR configures Prettier to be compatible with both the existing ESLint config and the existing project template (with no code changes to the latter).\n\n## Changelog\n\n[General] [Changed] - Added a default Prettier config for new projects\nPull Request resolved: https://github.com/facebook/react-native/pull/25478\n\nTest Plan:\n- The following screenshots show the output of `yarn lint` before and after these changes\n- These were run immediate after running `npx react-native-cli init RN060`\n\n### Without these changes\n\n- Linting errors on new projects\n- Unfixable automatically due to conflicting rules\n<img width=\"1116\" alt=\"Screenshot 2019-07-03 at 17 44 55\" src=\"https://user-images.githubusercontent.com/2393035/60610078-f6b44d00-9dba-11e9-826f-1524b949e4fd.png\">\n<img width=\"1116\" alt=\"Screenshot 2019-07-03 at 17 45 07\" src=\"https://user-images.githubusercontent.com/2393035/60610085-fb790100-9dba-11e9-9a9c-33f4cfefd51e.png\">\n\n### With these changes\n\n- Brand new projects will not produce lint errors out of the box\n<img width=\"1116\" alt=\"Screenshot 2019-07-03 at 17 48 25\" src=\"https://user-images.githubusercontent.com/2393035/60610266-57dc2080-9dbb-11e9-8a55-fd09f3549c17.png\">\n\nDifferential Revision: D16223094\n\nPulled By: cpojer\n\nfbshipit-source-id: bd2c00b1fcf27b1afcad8c18b357b95a3900bdf7",
+      "message": "Fresh RN projects fails ESLint / Prettier by default (#25478)\n\nSummary:\nFixes https://github.com/react/react-native/issues/25477\n\nThis PR adds a `.prettierrc.js` config file to the HelloWorld template.\n\n`eslint-config-react-native-community` includes custom settings for some rules which conflict with Prettier's default settings.\n\nConsequently, if you run `eslint` immediately after scaffolding a new app you get errors (see linked issue).\n\nThis PR configures Prettier to be compatible with both the existing ESLint config and the existing project template (with no code changes to the latter).\n\n## Changelog\n\n[General] [Changed] - Added a default Prettier config for new projects\nPull Request resolved: https://github.com/react/react-native/pull/25478\n\nTest Plan:\n- The following screenshots show the output of `yarn lint` before and after these changes\n- These were run immediate after running `npx react-native-cli init RN060`\n\n### Without these changes\n\n- Linting errors on new projects\n- Unfixable automatically due to conflicting rules\n<img width=\"1116\" alt=\"Screenshot 2019-07-03 at 17 44 55\" src=\"https://user-images.githubusercontent.com/2393035/60610078-f6b44d00-9dba-11e9-826f-1524b949e4fd.png\">\n<img width=\"1116\" alt=\"Screenshot 2019-07-03 at 17 45 07\" src=\"https://user-images.githubusercontent.com/2393035/60610085-fb790100-9dba-11e9-9a9c-33f4cfefd51e.png\">\n\n### With these changes\n\n- Brand new projects will not produce lint errors out of the box\n<img width=\"1116\" alt=\"Screenshot 2019-07-03 at 17 48 25\" src=\"https://user-images.githubusercontent.com/2393035/60610266-57dc2080-9dbb-11e9-8a55-fd09f3549c17.png\">\n\nDifferential Revision: D16223094\n\nPulled By: cpojer\n\nfbshipit-source-id: bd2c00b1fcf27b1afcad8c18b357b95a3900bdf7",
       "tree": {
         "sha": "a2813bc124af032972db4dd577c5b5768d1f2bff",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/a2813bc124af032972db4dd577c5b5768d1f2bff"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/a2813bc124af032972db4dd577c5b5768d1f2bff"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/f4d5e8c23357dc006c7d237e8d6a6f85e3a704a1",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/f4d5e8c23357dc006c7d237e8d6a6f85e3a704a1",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -501,9 +501,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/f4d5e8c23357dc006c7d237e8d6a6f85e3a704a1",
-    "html_url": "https://github.com/facebook/react-native/commit/f4d5e8c23357dc006c7d237e8d6a6f85e3a704a1",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/f4d5e8c23357dc006c7d237e8d6a6f85e3a704a1/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/f4d5e8c23357dc006c7d237e8d6a6f85e3a704a1",
+    "html_url": "https://github.com/react/react-native/commit/f4d5e8c23357dc006c7d237e8d6a6f85e3a704a1",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/f4d5e8c23357dc006c7d237e8d6a6f85e3a704a1/comments",
     "author": {
       "login": "jpdriver",
       "id": 2393035,
@@ -547,8 +547,8 @@
     "parents": [
       {
         "sha": "5a4fac77fbe3f45f966b5f784cfb828a1436c082",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/5a4fac77fbe3f45f966b5f784cfb828a1436c082",
-        "html_url": "https://github.com/facebook/react-native/commit/5a4fac77fbe3f45f966b5f784cfb828a1436c082"
+        "url": "https://api.github.com/repos/react/react-native/commits/5a4fac77fbe3f45f966b5f784cfb828a1436c082",
+        "html_url": "https://github.com/react/react-native/commit/5a4fac77fbe3f45f966b5f784cfb828a1436c082"
       }
     ]
   },
@@ -566,12 +566,12 @@
         "email": "grabbou@gmail.com",
         "date": "2019-08-07T17:05:05Z"
       },
-      "message": "Remove unnecessary flag when running JS server (#25517)\n\nSummary:\nThis removes the `--projectRoot` flag in `launchPackager.bat` as it was removed,  fixing [this bundler not opening issue on cli repo](https://github.com/react-native-community/cli/issues/484) when `yarn react-native run-android` is run.\n\nThis is Windows related only so should be only tested on Windows.\n\n## Changelog\n\n[Internal] [Fixed] - Fixed Metro Bundler not opening when running `yarn react-native run-android`\nPull Request resolved: https://github.com/facebook/react-native/pull/25517\n\nTest Plan:\n1. Create a new repo using `react-native init`\n2. Edit the `launchPackager.bat` file\n3. Run `yarn react-native run-android`\n\nDifferential Revision: D16162108\n\nPulled By: cpojer\n\nfbshipit-source-id: c12d9853ad49f00d56b9a8254a5b2c40a358cb2e",
+      "message": "Remove unnecessary flag when running JS server (#25517)\n\nSummary:\nThis removes the `--projectRoot` flag in `launchPackager.bat` as it was removed,  fixing [this bundler not opening issue on cli repo](https://github.com/react-native-community/cli/issues/484) when `yarn react-native run-android` is run.\n\nThis is Windows related only so should be only tested on Windows.\n\n## Changelog\n\n[Internal] [Fixed] - Fixed Metro Bundler not opening when running `yarn react-native run-android`\nPull Request resolved: https://github.com/react/react-native/pull/25517\n\nTest Plan:\n1. Create a new repo using `react-native init`\n2. Edit the `launchPackager.bat` file\n3. Run `yarn react-native run-android`\n\nDifferential Revision: D16162108\n\nPulled By: cpojer\n\nfbshipit-source-id: c12d9853ad49f00d56b9a8254a5b2c40a358cb2e",
       "tree": {
         "sha": "f53e7e408a1498332de7334e184e8c45600396c8",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/f53e7e408a1498332de7334e184e8c45600396c8"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/f53e7e408a1498332de7334e184e8c45600396c8"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/5a4fac77fbe3f45f966b5f784cfb828a1436c082",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/5a4fac77fbe3f45f966b5f784cfb828a1436c082",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -580,9 +580,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/5a4fac77fbe3f45f966b5f784cfb828a1436c082",
-    "html_url": "https://github.com/facebook/react-native/commit/5a4fac77fbe3f45f966b5f784cfb828a1436c082",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/5a4fac77fbe3f45f966b5f784cfb828a1436c082/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/5a4fac77fbe3f45f966b5f784cfb828a1436c082",
+    "html_url": "https://github.com/react/react-native/commit/5a4fac77fbe3f45f966b5f784cfb828a1436c082",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/5a4fac77fbe3f45f966b5f784cfb828a1436c082/comments",
     "author": {
       "login": "thecodrr",
       "id": 7473959,
@@ -626,8 +626,8 @@
     "parents": [
       {
         "sha": "7a0a11316f54104a1bfcf0a3338321a44c88685f",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/7a0a11316f54104a1bfcf0a3338321a44c88685f",
-        "html_url": "https://github.com/facebook/react-native/commit/7a0a11316f54104a1bfcf0a3338321a44c88685f"
+        "url": "https://api.github.com/repos/react/react-native/commits/7a0a11316f54104a1bfcf0a3338321a44c88685f",
+        "html_url": "https://github.com/react/react-native/commit/7a0a11316f54104a1bfcf0a3338321a44c88685f"
       }
     ]
   },
@@ -645,12 +645,12 @@
         "email": "grabbou@gmail.com",
         "date": "2019-08-07T17:05:01Z"
       },
-      "message": "- Bump CLI to ^2.2.0 (#25555)\n\nSummary:\nWe've released a bunch of versions since the initial 2.0 release, with a lot of bug fixes (especially for Windows) and some features added.\n\nChanges since 2.0: https://github.com/react-native-community/cli/compare/v2.0.1...v2.2.0\nLatest release: https://github.com/react-native-community/cli/releases/tag/v2.2.0\n\n## Changelog\n\n[Internal] [Changed] - Bump CLI to ^2.2.0\nPull Request resolved: https://github.com/facebook/react-native/pull/25555\n\nTest Plan: None\n\nDifferential Revision: D16161897\n\nPulled By: cpojer\n\nfbshipit-source-id: 542c4bffa7c6b0537f1c7135f43c98dd3db358e4",
+      "message": "- Bump CLI to ^2.2.0 (#25555)\n\nSummary:\nWe've released a bunch of versions since the initial 2.0 release, with a lot of bug fixes (especially for Windows) and some features added.\n\nChanges since 2.0: https://github.com/react-native-community/cli/compare/v2.0.1...v2.2.0\nLatest release: https://github.com/react-native-community/cli/releases/tag/v2.2.0\n\n## Changelog\n\n[Internal] [Changed] - Bump CLI to ^2.2.0\nPull Request resolved: https://github.com/react/react-native/pull/25555\n\nTest Plan: None\n\nDifferential Revision: D16161897\n\nPulled By: cpojer\n\nfbshipit-source-id: 542c4bffa7c6b0537f1c7135f43c98dd3db358e4",
       "tree": {
         "sha": "f0ac001c1e5d4e40e74b63b1720eeb959d9350b7",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/f0ac001c1e5d4e40e74b63b1720eeb959d9350b7"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/f0ac001c1e5d4e40e74b63b1720eeb959d9350b7"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/7a0a11316f54104a1bfcf0a3338321a44c88685f",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/7a0a11316f54104a1bfcf0a3338321a44c88685f",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -659,9 +659,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/7a0a11316f54104a1bfcf0a3338321a44c88685f",
-    "html_url": "https://github.com/facebook/react-native/commit/7a0a11316f54104a1bfcf0a3338321a44c88685f",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/7a0a11316f54104a1bfcf0a3338321a44c88685f/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/7a0a11316f54104a1bfcf0a3338321a44c88685f",
+    "html_url": "https://github.com/react/react-native/commit/7a0a11316f54104a1bfcf0a3338321a44c88685f",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/7a0a11316f54104a1bfcf0a3338321a44c88685f/comments",
     "author": {
       "login": "thymikee",
       "id": 5106466,
@@ -705,8 +705,8 @@
     "parents": [
       {
         "sha": "b476ca0b1cfde065ebf458e2ef2847871030c89f",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/b476ca0b1cfde065ebf458e2ef2847871030c89f",
-        "html_url": "https://github.com/facebook/react-native/commit/b476ca0b1cfde065ebf458e2ef2847871030c89f"
+        "url": "https://api.github.com/repos/react/react-native/commits/b476ca0b1cfde065ebf458e2ef2847871030c89f",
+        "html_url": "https://github.com/react/react-native/commit/b476ca0b1cfde065ebf458e2ef2847871030c89f"
       }
     ]
   },
@@ -724,12 +724,12 @@
         "email": "grabbou@gmail.com",
         "date": "2019-08-07T17:04:48Z"
       },
-      "message": "Add showSoftInputOnFocus to TextInput (#25028)\n\nSummary:\nAdd prop showSoftInputOnFocus to TextInput. This fixes #14045. This prop can be used to prevent the system keyboard from displaying at all when focusing an input text, for example if a custom keyboard component needs to be displayed instead.\n\nOn Android, currently TextInput always open the soft keyboard when focused. This is because `requestFocus` calls `showSoftKeyboard`, which in turn instructs `InputMethodManager` to show the soft keyboard.\n\nUnfortunately even if we were to define a new input type that extends ReactEditText, there is no way to overcome this issue.\nThis is because `showSoftKeyboard` is a private method so it can't be overriden. And at the same time `requestFocus` needs to invoke `super.requestFocus` to properly instruct Android that the field has gained focused, so overriding `requestFocus` in a subclass of ReactEditText is also not an option, as when invoking `super.requestFocus` we would end up calling again the one defined in ReactEditText.\n\nSo currently the only way of doing this is to basically add a listener on the focus event that will close the soft keyboard immediately after. But for a split second it will still be displayed.\n\nThe code in the PR changes `requestFocus` to honor showSoftInputOnFocus as defined in Android TextView, displaying the soft keyboard unless instructed otherwise.\n\n## Changelog\n\n[Android] [Added] - Add showSoftInputOnFocus to TextInput\nPull Request resolved: https://github.com/facebook/react-native/pull/25028\n\nDifferential Revision: D15503070\n\nPulled By: mdvacca\n\nfbshipit-source-id: db4616fa165643d6ef2b3185008c4d279ae08092",
+      "message": "Add showSoftInputOnFocus to TextInput (#25028)\n\nSummary:\nAdd prop showSoftInputOnFocus to TextInput. This fixes #14045. This prop can be used to prevent the system keyboard from displaying at all when focusing an input text, for example if a custom keyboard component needs to be displayed instead.\n\nOn Android, currently TextInput always open the soft keyboard when focused. This is because `requestFocus` calls `showSoftKeyboard`, which in turn instructs `InputMethodManager` to show the soft keyboard.\n\nUnfortunately even if we were to define a new input type that extends ReactEditText, there is no way to overcome this issue.\nThis is because `showSoftKeyboard` is a private method so it can't be overriden. And at the same time `requestFocus` needs to invoke `super.requestFocus` to properly instruct Android that the field has gained focused, so overriding `requestFocus` in a subclass of ReactEditText is also not an option, as when invoking `super.requestFocus` we would end up calling again the one defined in ReactEditText.\n\nSo currently the only way of doing this is to basically add a listener on the focus event that will close the soft keyboard immediately after. But for a split second it will still be displayed.\n\nThe code in the PR changes `requestFocus` to honor showSoftInputOnFocus as defined in Android TextView, displaying the soft keyboard unless instructed otherwise.\n\n## Changelog\n\n[Android] [Added] - Add showSoftInputOnFocus to TextInput\nPull Request resolved: https://github.com/react/react-native/pull/25028\n\nDifferential Revision: D15503070\n\nPulled By: mdvacca\n\nfbshipit-source-id: db4616fa165643d6ef2b3185008c4d279ae08092",
       "tree": {
         "sha": "b3224dd2dd082c9ff8d20d44e51a06e419a4ce50",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/b3224dd2dd082c9ff8d20d44e51a06e419a4ce50"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/b3224dd2dd082c9ff8d20d44e51a06e419a4ce50"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/b476ca0b1cfde065ebf458e2ef2847871030c89f",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/b476ca0b1cfde065ebf458e2ef2847871030c89f",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -738,9 +738,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/b476ca0b1cfde065ebf458e2ef2847871030c89f",
-    "html_url": "https://github.com/facebook/react-native/commit/b476ca0b1cfde065ebf458e2ef2847871030c89f",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/b476ca0b1cfde065ebf458e2ef2847871030c89f/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/b476ca0b1cfde065ebf458e2ef2847871030c89f",
+    "html_url": "https://github.com/react/react-native/commit/b476ca0b1cfde065ebf458e2ef2847871030c89f",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/b476ca0b1cfde065ebf458e2ef2847871030c89f/comments",
     "author": null,
     "committer": {
       "login": "grabbou",
@@ -765,8 +765,8 @@
     "parents": [
       {
         "sha": "812abfdbba7c27978a5c2b7041fc4a900f3203ae",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/812abfdbba7c27978a5c2b7041fc4a900f3203ae",
-        "html_url": "https://github.com/facebook/react-native/commit/812abfdbba7c27978a5c2b7041fc4a900f3203ae"
+        "url": "https://api.github.com/repos/react/react-native/commits/812abfdbba7c27978a5c2b7041fc4a900f3203ae",
+        "html_url": "https://github.com/react/react-native/commit/812abfdbba7c27978a5c2b7041fc4a900f3203ae"
       }
     ]
   },
@@ -787,9 +787,9 @@
       "message": "Fix addition of comma at the end of accessibility labels on Android. (#25963)",
       "tree": {
         "sha": "12310a1eea03ec4e567abe7226d56819594e90a2",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/12310a1eea03ec4e567abe7226d56819594e90a2"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/12310a1eea03ec4e567abe7226d56819594e90a2"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/812abfdbba7c27978a5c2b7041fc4a900f3203ae",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/812abfdbba7c27978a5c2b7041fc4a900f3203ae",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -798,9 +798,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/812abfdbba7c27978a5c2b7041fc4a900f3203ae",
-    "html_url": "https://github.com/facebook/react-native/commit/812abfdbba7c27978a5c2b7041fc4a900f3203ae",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/812abfdbba7c27978a5c2b7041fc4a900f3203ae/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/812abfdbba7c27978a5c2b7041fc4a900f3203ae",
+    "html_url": "https://github.com/react/react-native/commit/812abfdbba7c27978a5c2b7041fc4a900f3203ae",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/812abfdbba7c27978a5c2b7041fc4a900f3203ae/comments",
     "author": {
       "login": "marcmulcahy",
       "id": 44851143,
@@ -844,8 +844,8 @@
     "parents": [
       {
         "sha": "ffdf3f22c68583fe77517f78dd97bd2e97ff1b9e",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/ffdf3f22c68583fe77517f78dd97bd2e97ff1b9e",
-        "html_url": "https://github.com/facebook/react-native/commit/ffdf3f22c68583fe77517f78dd97bd2e97ff1b9e"
+        "url": "https://api.github.com/repos/react/react-native/commits/ffdf3f22c68583fe77517f78dd97bd2e97ff1b9e",
+        "html_url": "https://github.com/react/react-native/commit/ffdf3f22c68583fe77517f78dd97bd2e97ff1b9e"
       }
     ]
   },
@@ -866,9 +866,9 @@
       "message": "Fix `ClassNotFound` exception in Android during Release builds (#25912)\n\n* Add DoNotStrip annotation for Hermes\r\n\r\nThis adds the @DoNotStrip annotation to disallow Proguard/R8 from stripping the AndroidUnicodeUtils class during release build and causing a `ClassNotFound` crash.\r\n\r\n* Add @DoNotStrip annotations on all methods\r\n\r\n* Update AndroidUnicodeUtils.java",
       "tree": {
         "sha": "30ad1a100c5838396e0a829695daeddc6f34e948",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/30ad1a100c5838396e0a829695daeddc6f34e948"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/30ad1a100c5838396e0a829695daeddc6f34e948"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/ffdf3f22c68583fe77517f78dd97bd2e97ff1b9e",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/ffdf3f22c68583fe77517f78dd97bd2e97ff1b9e",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -877,9 +877,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/ffdf3f22c68583fe77517f78dd97bd2e97ff1b9e",
-    "html_url": "https://github.com/facebook/react-native/commit/ffdf3f22c68583fe77517f78dd97bd2e97ff1b9e",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/ffdf3f22c68583fe77517f78dd97bd2e97ff1b9e/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/ffdf3f22c68583fe77517f78dd97bd2e97ff1b9e",
+    "html_url": "https://github.com/react/react-native/commit/ffdf3f22c68583fe77517f78dd97bd2e97ff1b9e",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/ffdf3f22c68583fe77517f78dd97bd2e97ff1b9e/comments",
     "author": {
       "login": "thecodrr",
       "id": 7473959,
@@ -923,8 +923,8 @@
     "parents": [
       {
         "sha": "eec4dc6b7287c5a3536ca18b553e3153a0aba103",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/eec4dc6b7287c5a3536ca18b553e3153a0aba103",
-        "html_url": "https://github.com/facebook/react-native/commit/eec4dc6b7287c5a3536ca18b553e3153a0aba103"
+        "url": "https://api.github.com/repos/react/react-native/commits/eec4dc6b7287c5a3536ca18b553e3153a0aba103",
+        "html_url": "https://github.com/react/react-native/commit/eec4dc6b7287c5a3536ca18b553e3153a0aba103"
       }
     ]
   },
@@ -945,9 +945,9 @@
       "message": "[0.60.4] Bump version numbers",
       "tree": {
         "sha": "cb1d8776382020240a6b3bb5a1a5719d71a18408",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/cb1d8776382020240a6b3bb5a1a5719d71a18408"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/cb1d8776382020240a6b3bb5a1a5719d71a18408"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/eec4dc6b7287c5a3536ca18b553e3153a0aba103",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/eec4dc6b7287c5a3536ca18b553e3153a0aba103",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -956,9 +956,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/eec4dc6b7287c5a3536ca18b553e3153a0aba103",
-    "html_url": "https://github.com/facebook/react-native/commit/eec4dc6b7287c5a3536ca18b553e3153a0aba103",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/eec4dc6b7287c5a3536ca18b553e3153a0aba103/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/eec4dc6b7287c5a3536ca18b553e3153a0aba103",
+    "html_url": "https://github.com/react/react-native/commit/eec4dc6b7287c5a3536ca18b553e3153a0aba103",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/eec4dc6b7287c5a3536ca18b553e3153a0aba103/comments",
     "author": {
       "login": "cpojer",
       "id": 13352,
@@ -1002,8 +1002,8 @@
     "parents": [
       {
         "sha": "60e75dc1ab73b2893ec2e25c0320f32b3cf12b80",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/60e75dc1ab73b2893ec2e25c0320f32b3cf12b80",
-        "html_url": "https://github.com/facebook/react-native/commit/60e75dc1ab73b2893ec2e25c0320f32b3cf12b80"
+        "url": "https://api.github.com/repos/react/react-native/commits/60e75dc1ab73b2893ec2e25c0320f32b3cf12b80",
+        "html_url": "https://github.com/react/react-native/commit/60e75dc1ab73b2893ec2e25c0320f32b3cf12b80"
       }
     ]
   },
@@ -1024,9 +1024,9 @@
       "message": "[Android] Generate source maps outside of assets/ (#25710)",
       "tree": {
         "sha": "689490903de0aedcc92f636e03a9156e86a9f671",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/689490903de0aedcc92f636e03a9156e86a9f671"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/689490903de0aedcc92f636e03a9156e86a9f671"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/60e75dc1ab73b2893ec2e25c0320f32b3cf12b80",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/60e75dc1ab73b2893ec2e25c0320f32b3cf12b80",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1035,9 +1035,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/60e75dc1ab73b2893ec2e25c0320f32b3cf12b80",
-    "html_url": "https://github.com/facebook/react-native/commit/60e75dc1ab73b2893ec2e25c0320f32b3cf12b80",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/60e75dc1ab73b2893ec2e25c0320f32b3cf12b80/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/60e75dc1ab73b2893ec2e25c0320f32b3cf12b80",
+    "html_url": "https://github.com/react/react-native/commit/60e75dc1ab73b2893ec2e25c0320f32b3cf12b80",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/60e75dc1ab73b2893ec2e25c0320f32b3cf12b80/comments",
     "author": {
       "login": "motiz88",
       "id": 2246565,
@@ -1081,8 +1081,8 @@
     "parents": [
       {
         "sha": "b1f81be4bc21eb9baa39dd7ef97709d9927ad407",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/b1f81be4bc21eb9baa39dd7ef97709d9927ad407",
-        "html_url": "https://github.com/facebook/react-native/commit/b1f81be4bc21eb9baa39dd7ef97709d9927ad407"
+        "url": "https://api.github.com/repos/react/react-native/commits/b1f81be4bc21eb9baa39dd7ef97709d9927ad407",
+        "html_url": "https://github.com/react/react-native/commit/b1f81be4bc21eb9baa39dd7ef97709d9927ad407"
       }
     ]
   },
@@ -1103,9 +1103,9 @@
       "message": "Generate correct source map if hermes not enabled (#25700)",
       "tree": {
         "sha": "a635d1f8758183f8d35c28c5a06517f628ed26f0",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/a635d1f8758183f8d35c28c5a06517f628ed26f0"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/a635d1f8758183f8d35c28c5a06517f628ed26f0"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/b1f81be4bc21eb9baa39dd7ef97709d9927ad407",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/b1f81be4bc21eb9baa39dd7ef97709d9927ad407",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1114,9 +1114,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/b1f81be4bc21eb9baa39dd7ef97709d9927ad407",
-    "html_url": "https://github.com/facebook/react-native/commit/b1f81be4bc21eb9baa39dd7ef97709d9927ad407",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/b1f81be4bc21eb9baa39dd7ef97709d9927ad407/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/b1f81be4bc21eb9baa39dd7ef97709d9927ad407",
+    "html_url": "https://github.com/react/react-native/commit/b1f81be4bc21eb9baa39dd7ef97709d9927ad407",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/b1f81be4bc21eb9baa39dd7ef97709d9927ad407/comments",
     "author": {
       "login": "HazAT",
       "id": 363802,
@@ -1160,8 +1160,8 @@
     "parents": [
       {
         "sha": "0190c9c97b598b782d677e748d211437b4b85dd1",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/0190c9c97b598b782d677e748d211437b4b85dd1",
-        "html_url": "https://github.com/facebook/react-native/commit/0190c9c97b598b782d677e748d211437b4b85dd1"
+        "url": "https://api.github.com/repos/react/react-native/commits/0190c9c97b598b782d677e748d211437b4b85dd1",
+        "html_url": "https://github.com/react/react-native/commit/0190c9c97b598b782d677e748d211437b4b85dd1"
       }
     ]
   },
@@ -1182,9 +1182,9 @@
       "message": "[0.60.3] Bump version numbers",
       "tree": {
         "sha": "d49114dda96aa7eb68bfdbbf5b9768ff621c59ad",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/d49114dda96aa7eb68bfdbbf5b9768ff621c59ad"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/d49114dda96aa7eb68bfdbbf5b9768ff621c59ad"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/0190c9c97b598b782d677e748d211437b4b85dd1",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/0190c9c97b598b782d677e748d211437b4b85dd1",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1193,9 +1193,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/0190c9c97b598b782d677e748d211437b4b85dd1",
-    "html_url": "https://github.com/facebook/react-native/commit/0190c9c97b598b782d677e748d211437b4b85dd1",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/0190c9c97b598b782d677e748d211437b4b85dd1/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/0190c9c97b598b782d677e748d211437b4b85dd1",
+    "html_url": "https://github.com/react/react-native/commit/0190c9c97b598b782d677e748d211437b4b85dd1",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/0190c9c97b598b782d677e748d211437b4b85dd1/comments",
     "author": {
       "login": "kelset",
       "id": 16104054,
@@ -1239,8 +1239,8 @@
     "parents": [
       {
         "sha": "348b8f0082cb9b019ecc05d703e1ab8c155a9185",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/348b8f0082cb9b019ecc05d703e1ab8c155a9185",
-        "html_url": "https://github.com/facebook/react-native/commit/348b8f0082cb9b019ecc05d703e1ab8c155a9185"
+        "url": "https://api.github.com/repos/react/react-native/commits/348b8f0082cb9b019ecc05d703e1ab8c155a9185",
+        "html_url": "https://github.com/react/react-native/commit/348b8f0082cb9b019ecc05d703e1ab8c155a9185"
       }
     ]
   },
@@ -1261,9 +1261,9 @@
       "message": "Fix Hermes binary path (#25598)",
       "tree": {
         "sha": "52bf30f34d784abe4182bbe1967ceb8888422475",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/52bf30f34d784abe4182bbe1967ceb8888422475"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/52bf30f34d784abe4182bbe1967ceb8888422475"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/348b8f0082cb9b019ecc05d703e1ab8c155a9185",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/348b8f0082cb9b019ecc05d703e1ab8c155a9185",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1272,9 +1272,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/348b8f0082cb9b019ecc05d703e1ab8c155a9185",
-    "html_url": "https://github.com/facebook/react-native/commit/348b8f0082cb9b019ecc05d703e1ab8c155a9185",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/348b8f0082cb9b019ecc05d703e1ab8c155a9185/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/348b8f0082cb9b019ecc05d703e1ab8c155a9185",
+    "html_url": "https://github.com/react/react-native/commit/348b8f0082cb9b019ecc05d703e1ab8c155a9185",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/348b8f0082cb9b019ecc05d703e1ab8c155a9185/comments",
     "author": {
       "login": "zoontek",
       "id": 1902323,
@@ -1318,8 +1318,8 @@
     "parents": [
       {
         "sha": "b867cf8974e07c0b752d54727311a6f74a450ad9",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/b867cf8974e07c0b752d54727311a6f74a450ad9",
-        "html_url": "https://github.com/facebook/react-native/commit/b867cf8974e07c0b752d54727311a6f74a450ad9"
+        "url": "https://api.github.com/repos/react/react-native/commits/b867cf8974e07c0b752d54727311a6f74a450ad9",
+        "html_url": "https://github.com/react/react-native/commit/b867cf8974e07c0b752d54727311a6f74a450ad9"
       }
     ]
   },
@@ -1340,9 +1340,9 @@
       "message": "[0.60.2] Bump version numbers",
       "tree": {
         "sha": "278545749ccbfb55e31d858abc42fe8a9a415779",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/278545749ccbfb55e31d858abc42fe8a9a415779"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/278545749ccbfb55e31d858abc42fe8a9a415779"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/b867cf8974e07c0b752d54727311a6f74a450ad9",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/b867cf8974e07c0b752d54727311a6f74a450ad9",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1351,9 +1351,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/b867cf8974e07c0b752d54727311a6f74a450ad9",
-    "html_url": "https://github.com/facebook/react-native/commit/b867cf8974e07c0b752d54727311a6f74a450ad9",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/b867cf8974e07c0b752d54727311a6f74a450ad9/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/b867cf8974e07c0b752d54727311a6f74a450ad9",
+    "html_url": "https://github.com/react/react-native/commit/b867cf8974e07c0b752d54727311a6f74a450ad9",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/b867cf8974e07c0b752d54727311a6f74a450ad9/comments",
     "author": {
       "login": "cpojer",
       "id": 13352,
@@ -1397,8 +1397,8 @@
     "parents": [
       {
         "sha": "0738fe5738c21463da93e3551f8f78ddcb6545e3",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/0738fe5738c21463da93e3551f8f78ddcb6545e3",
-        "html_url": "https://github.com/facebook/react-native/commit/0738fe5738c21463da93e3551f8f78ddcb6545e3"
+        "url": "https://api.github.com/repos/react/react-native/commits/0738fe5738c21463da93e3551f8f78ddcb6545e3",
+        "html_url": "https://github.com/react/react-native/commit/0738fe5738c21463da93e3551f8f78ddcb6545e3"
       }
     ]
   },
@@ -1419,9 +1419,9 @@
       "message": "Fix path to Hermes package.",
       "tree": {
         "sha": "abec2da5445eb929f3b6a89983665af081533965",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/abec2da5445eb929f3b6a89983665af081533965"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/abec2da5445eb929f3b6a89983665af081533965"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/0738fe5738c21463da93e3551f8f78ddcb6545e3",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/0738fe5738c21463da93e3551f8f78ddcb6545e3",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1430,9 +1430,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/0738fe5738c21463da93e3551f8f78ddcb6545e3",
-    "html_url": "https://github.com/facebook/react-native/commit/0738fe5738c21463da93e3551f8f78ddcb6545e3",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/0738fe5738c21463da93e3551f8f78ddcb6545e3/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/0738fe5738c21463da93e3551f8f78ddcb6545e3",
+    "html_url": "https://github.com/react/react-native/commit/0738fe5738c21463da93e3551f8f78ddcb6545e3",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/0738fe5738c21463da93e3551f8f78ddcb6545e3/comments",
     "author": {
       "login": "cpojer",
       "id": 13352,
@@ -1476,8 +1476,8 @@
     "parents": [
       {
         "sha": "8dd8ec7cb01d9bb07ff0f540ab44f41441716258",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/8dd8ec7cb01d9bb07ff0f540ab44f41441716258",
-        "html_url": "https://github.com/facebook/react-native/commit/8dd8ec7cb01d9bb07ff0f540ab44f41441716258"
+        "url": "https://api.github.com/repos/react/react-native/commits/8dd8ec7cb01d9bb07ff0f540ab44f41441716258",
+        "html_url": "https://github.com/react/react-native/commit/8dd8ec7cb01d9bb07ff0f540ab44f41441716258"
       }
     ]
   },
@@ -1498,9 +1498,9 @@
       "message": "[0.60.1] Bump version numbers",
       "tree": {
         "sha": "2b3f0f6cc175469a1e32be058bfa45a9314fdda5",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/2b3f0f6cc175469a1e32be058bfa45a9314fdda5"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/2b3f0f6cc175469a1e32be058bfa45a9314fdda5"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/8dd8ec7cb01d9bb07ff0f540ab44f41441716258",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/8dd8ec7cb01d9bb07ff0f540ab44f41441716258",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1509,9 +1509,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/8dd8ec7cb01d9bb07ff0f540ab44f41441716258",
-    "html_url": "https://github.com/facebook/react-native/commit/8dd8ec7cb01d9bb07ff0f540ab44f41441716258",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/8dd8ec7cb01d9bb07ff0f540ab44f41441716258/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/8dd8ec7cb01d9bb07ff0f540ab44f41441716258",
+    "html_url": "https://github.com/react/react-native/commit/8dd8ec7cb01d9bb07ff0f540ab44f41441716258",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/8dd8ec7cb01d9bb07ff0f540ab44f41441716258/comments",
     "author": {
       "login": "cpojer",
       "id": 13352,
@@ -1555,8 +1555,8 @@
     "parents": [
       {
         "sha": "e857d7066be504a9e90042be8ff919d62939895f",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/e857d7066be504a9e90042be8ff919d62939895f",
-        "html_url": "https://github.com/facebook/react-native/commit/e857d7066be504a9e90042be8ff919d62939895f"
+        "url": "https://api.github.com/repos/react/react-native/commits/e857d7066be504a9e90042be8ff919d62939895f",
+        "html_url": "https://github.com/react/react-native/commit/e857d7066be504a9e90042be8ff919d62939895f"
       }
     ]
   },
@@ -1577,9 +1577,9 @@
       "message": "Add Hermes support to React Native 0.60",
       "tree": {
         "sha": "54941bdce91311a6ff4522b22e93ba39577c4db7",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/54941bdce91311a6ff4522b22e93ba39577c4db7"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/54941bdce91311a6ff4522b22e93ba39577c4db7"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/e857d7066be504a9e90042be8ff919d62939895f",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/e857d7066be504a9e90042be8ff919d62939895f",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1588,9 +1588,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/e857d7066be504a9e90042be8ff919d62939895f",
-    "html_url": "https://github.com/facebook/react-native/commit/e857d7066be504a9e90042be8ff919d62939895f",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/e857d7066be504a9e90042be8ff919d62939895f/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/e857d7066be504a9e90042be8ff919d62939895f",
+    "html_url": "https://github.com/react/react-native/commit/e857d7066be504a9e90042be8ff919d62939895f",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/e857d7066be504a9e90042be8ff919d62939895f/comments",
     "author": {
       "login": "cpojer",
       "id": 13352,
@@ -1634,8 +1634,8 @@
     "parents": [
       {
         "sha": "769e35ba5f4c31ef913035a5cc8bc0e88546ca55",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/769e35ba5f4c31ef913035a5cc8bc0e88546ca55",
-        "html_url": "https://github.com/facebook/react-native/commit/769e35ba5f4c31ef913035a5cc8bc0e88546ca55"
+        "url": "https://api.github.com/repos/react/react-native/commits/769e35ba5f4c31ef913035a5cc8bc0e88546ca55",
+        "html_url": "https://github.com/react/react-native/commit/769e35ba5f4c31ef913035a5cc8bc0e88546ca55"
       }
     ]
   },
@@ -1656,9 +1656,9 @@
       "message": "[0.60.0] Bump version numbers",
       "tree": {
         "sha": "82e9151fca3d9bcfdff7144180e8a666caf20221",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/82e9151fca3d9bcfdff7144180e8a666caf20221"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/82e9151fca3d9bcfdff7144180e8a666caf20221"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/769e35ba5f4c31ef913035a5cc8bc0e88546ca55",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/769e35ba5f4c31ef913035a5cc8bc0e88546ca55",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1667,9 +1667,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/769e35ba5f4c31ef913035a5cc8bc0e88546ca55",
-    "html_url": "https://github.com/facebook/react-native/commit/769e35ba5f4c31ef913035a5cc8bc0e88546ca55",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/769e35ba5f4c31ef913035a5cc8bc0e88546ca55/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/769e35ba5f4c31ef913035a5cc8bc0e88546ca55",
+    "html_url": "https://github.com/react/react-native/commit/769e35ba5f4c31ef913035a5cc8bc0e88546ca55",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/769e35ba5f4c31ef913035a5cc8bc0e88546ca55/comments",
     "author": {
       "login": "kelset",
       "id": 16104054,
@@ -1713,8 +1713,8 @@
     "parents": [
       {
         "sha": "35aeb8c027583010956e2670a5cb924cc079859e",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/35aeb8c027583010956e2670a5cb924cc079859e",
-        "html_url": "https://github.com/facebook/react-native/commit/35aeb8c027583010956e2670a5cb924cc079859e"
+        "url": "https://api.github.com/repos/react/react-native/commits/35aeb8c027583010956e2670a5cb924cc079859e",
+        "html_url": "https://github.com/react/react-native/commit/35aeb8c027583010956e2670a5cb924cc079859e"
       }
     ]
   },
@@ -1735,9 +1735,9 @@
       "message": "[LOCAL] bump CLI",
       "tree": {
         "sha": "88758ac011868967206a7658ac62e5247f51c728",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/88758ac011868967206a7658ac62e5247f51c728"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/88758ac011868967206a7658ac62e5247f51c728"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/35aeb8c027583010956e2670a5cb924cc079859e",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/35aeb8c027583010956e2670a5cb924cc079859e",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1746,9 +1746,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/35aeb8c027583010956e2670a5cb924cc079859e",
-    "html_url": "https://github.com/facebook/react-native/commit/35aeb8c027583010956e2670a5cb924cc079859e",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/35aeb8c027583010956e2670a5cb924cc079859e/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/35aeb8c027583010956e2670a5cb924cc079859e",
+    "html_url": "https://github.com/react/react-native/commit/35aeb8c027583010956e2670a5cb924cc079859e",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/35aeb8c027583010956e2670a5cb924cc079859e/comments",
     "author": {
       "login": "kelset",
       "id": 16104054,
@@ -1792,8 +1792,8 @@
     "parents": [
       {
         "sha": "8fdecf30101c76b2810fb649d45ca0071199c7c7",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/8fdecf30101c76b2810fb649d45ca0071199c7c7",
-        "html_url": "https://github.com/facebook/react-native/commit/8fdecf30101c76b2810fb649d45ca0071199c7c7"
+        "url": "https://api.github.com/repos/react/react-native/commits/8fdecf30101c76b2810fb649d45ca0071199c7c7",
+        "html_url": "https://github.com/react/react-native/commit/8fdecf30101c76b2810fb649d45ca0071199c7c7"
       }
     ]
   },
@@ -1811,12 +1811,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-07-03T10:56:25Z"
       },
-      "message": "- Publish `react-native.config.js` (#25436)\n\nSummary:\nLooks we forgot to add this file to publish list. By adding it, we can remove some code in CLI that special-cases `react-native` package, since it now announces itself as a proper platform.\n\ncc kelset, we'd like to have this cherry-picked for 0.60.\n\n## Changelog\n\n[Internal] [Fixed] - Publish `react-native.config.js`\nPull Request resolved: https://github.com/facebook/react-native/pull/25436\n\nTest Plan: `npm pack` shows `react-native.config.js`\n\nDifferential Revision: D16071113\n\nPulled By: cpojer\n\nfbshipit-source-id: df18affbb9a0ad7f2cfdd1a4cc93191aa5ffadeb",
+      "message": "- Publish `react-native.config.js` (#25436)\n\nSummary:\nLooks we forgot to add this file to publish list. By adding it, we can remove some code in CLI that special-cases `react-native` package, since it now announces itself as a proper platform.\n\ncc kelset, we'd like to have this cherry-picked for 0.60.\n\n## Changelog\n\n[Internal] [Fixed] - Publish `react-native.config.js`\nPull Request resolved: https://github.com/react/react-native/pull/25436\n\nTest Plan: `npm pack` shows `react-native.config.js`\n\nDifferential Revision: D16071113\n\nPulled By: cpojer\n\nfbshipit-source-id: df18affbb9a0ad7f2cfdd1a4cc93191aa5ffadeb",
       "tree": {
         "sha": "ba4279077b3db7bfd299c98d44adee2da2f1e63f",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/ba4279077b3db7bfd299c98d44adee2da2f1e63f"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/ba4279077b3db7bfd299c98d44adee2da2f1e63f"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/8fdecf30101c76b2810fb649d45ca0071199c7c7",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/8fdecf30101c76b2810fb649d45ca0071199c7c7",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1825,9 +1825,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/8fdecf30101c76b2810fb649d45ca0071199c7c7",
-    "html_url": "https://github.com/facebook/react-native/commit/8fdecf30101c76b2810fb649d45ca0071199c7c7",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/8fdecf30101c76b2810fb649d45ca0071199c7c7/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/8fdecf30101c76b2810fb649d45ca0071199c7c7",
+    "html_url": "https://github.com/react/react-native/commit/8fdecf30101c76b2810fb649d45ca0071199c7c7",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/8fdecf30101c76b2810fb649d45ca0071199c7c7/comments",
     "author": {
       "login": "thymikee",
       "id": 5106466,
@@ -1871,8 +1871,8 @@
     "parents": [
       {
         "sha": "ff9855cc3b62466a390f2c7ebeb178cde5fff4a6",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/ff9855cc3b62466a390f2c7ebeb178cde5fff4a6",
-        "html_url": "https://github.com/facebook/react-native/commit/ff9855cc3b62466a390f2c7ebeb178cde5fff4a6"
+        "url": "https://api.github.com/repos/react/react-native/commits/ff9855cc3b62466a390f2c7ebeb178cde5fff4a6",
+        "html_url": "https://github.com/react/react-native/commit/ff9855cc3b62466a390f2c7ebeb178cde5fff4a6"
       }
     ]
   },
@@ -1890,12 +1890,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-07-03T10:55:29Z"
       },
-      "message": "Check if mCurrentActivity is set according to LifecycleState (#23336)\n\nSummary:\nIssues: Related to  #13439\nreact-native-website:Related to PR [#792](https://github.com/facebook/react-native-website/pull/792)\nsolution: https://github.com/facebook/react-native/issues/13439#issuecomment-400256114\n\nWhen we integration with Existing  Android Apps.and set LifecycleState  is `LifecycleState.RESUMED`.\nIt's lead to `mCurrentActivity`  is null .\n\nAt this time , the behave of set `mCurrentActivity ` which  is unexpectedly.\n\n## Changelog\n[Android] [Fixed] - Check if mCurrentActivity is set according to LifecycleState\nPull Request resolved: https://github.com/facebook/react-native/pull/23336\n\nDifferential Revision: D14298654\n\nPulled By: cpojer\n\nfbshipit-source-id: 5cc17539a51154faeb838349b068d92511946f79",
+      "message": "Check if mCurrentActivity is set according to LifecycleState (#23336)\n\nSummary:\nIssues: Related to  #13439\nreact-native-website:Related to PR [#792](https://github.com/react/react-native-website/pull/792)\nsolution: https://github.com/react/react-native/issues/13439#issuecomment-400256114\n\nWhen we integration with Existing  Android Apps.and set LifecycleState  is `LifecycleState.RESUMED`.\nIt's lead to `mCurrentActivity`  is null .\n\nAt this time , the behave of set `mCurrentActivity ` which  is unexpectedly.\n\n## Changelog\n[Android] [Fixed] - Check if mCurrentActivity is set according to LifecycleState\nPull Request resolved: https://github.com/react/react-native/pull/23336\n\nDifferential Revision: D14298654\n\nPulled By: cpojer\n\nfbshipit-source-id: 5cc17539a51154faeb838349b068d92511946f79",
       "tree": {
         "sha": "14efaa679614e5256826def079f74bf1f559a8dc",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/14efaa679614e5256826def079f74bf1f559a8dc"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/14efaa679614e5256826def079f74bf1f559a8dc"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/ff9855cc3b62466a390f2c7ebeb178cde5fff4a6",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/ff9855cc3b62466a390f2c7ebeb178cde5fff4a6",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1904,9 +1904,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/ff9855cc3b62466a390f2c7ebeb178cde5fff4a6",
-    "html_url": "https://github.com/facebook/react-native/commit/ff9855cc3b62466a390f2c7ebeb178cde5fff4a6",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/ff9855cc3b62466a390f2c7ebeb178cde5fff4a6/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/ff9855cc3b62466a390f2c7ebeb178cde5fff4a6",
+    "html_url": "https://github.com/react/react-native/commit/ff9855cc3b62466a390f2c7ebeb178cde5fff4a6",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/ff9855cc3b62466a390f2c7ebeb178cde5fff4a6/comments",
     "author": {
       "login": "RoJoHub",
       "id": 15648309,
@@ -1950,8 +1950,8 @@
     "parents": [
       {
         "sha": "8a43321271bd58bbe0bca27593e121077d7a4065",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/8a43321271bd58bbe0bca27593e121077d7a4065",
-        "html_url": "https://github.com/facebook/react-native/commit/8a43321271bd58bbe0bca27593e121077d7a4065"
+        "url": "https://api.github.com/repos/react/react-native/commits/8a43321271bd58bbe0bca27593e121077d7a4065",
+        "html_url": "https://github.com/react/react-native/commit/8a43321271bd58bbe0bca27593e121077d7a4065"
       }
     ]
   },
@@ -1972,9 +1972,9 @@
       "message": "[0.60.0-rc.3] Bump version numbers",
       "tree": {
         "sha": "81af31ddc5bceb0d3655f0e521ab852526197db8",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/81af31ddc5bceb0d3655f0e521ab852526197db8"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/81af31ddc5bceb0d3655f0e521ab852526197db8"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/8a43321271bd58bbe0bca27593e121077d7a4065",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/8a43321271bd58bbe0bca27593e121077d7a4065",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1983,9 +1983,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/8a43321271bd58bbe0bca27593e121077d7a4065",
-    "html_url": "https://github.com/facebook/react-native/commit/8a43321271bd58bbe0bca27593e121077d7a4065",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/8a43321271bd58bbe0bca27593e121077d7a4065/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/8a43321271bd58bbe0bca27593e121077d7a4065",
+    "html_url": "https://github.com/react/react-native/commit/8a43321271bd58bbe0bca27593e121077d7a4065",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/8a43321271bd58bbe0bca27593e121077d7a4065/comments",
     "author": {
       "login": "kelset",
       "id": 16104054,
@@ -2029,8 +2029,8 @@
     "parents": [
       {
         "sha": "db1d60fa95586929cf90a918e6af0e5a90f1db89",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/db1d60fa95586929cf90a918e6af0e5a90f1db89",
-        "html_url": "https://github.com/facebook/react-native/commit/db1d60fa95586929cf90a918e6af0e5a90f1db89"
+        "url": "https://api.github.com/repos/react/react-native/commits/db1d60fa95586929cf90a918e6af0e5a90f1db89",
+        "html_url": "https://github.com/react/react-native/commit/db1d60fa95586929cf90a918e6af0e5a90f1db89"
       }
     ]
   },
@@ -2051,9 +2051,9 @@
       "message": "bump jsc dep",
       "tree": {
         "sha": "67e4b3b42eabb905ec9e3de36451d8c167033f9e",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/67e4b3b42eabb905ec9e3de36451d8c167033f9e"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/67e4b3b42eabb905ec9e3de36451d8c167033f9e"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/db1d60fa95586929cf90a918e6af0e5a90f1db89",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/db1d60fa95586929cf90a918e6af0e5a90f1db89",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -2062,9 +2062,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/db1d60fa95586929cf90a918e6af0e5a90f1db89",
-    "html_url": "https://github.com/facebook/react-native/commit/db1d60fa95586929cf90a918e6af0e5a90f1db89",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/db1d60fa95586929cf90a918e6af0e5a90f1db89/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/db1d60fa95586929cf90a918e6af0e5a90f1db89",
+    "html_url": "https://github.com/react/react-native/commit/db1d60fa95586929cf90a918e6af0e5a90f1db89",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/db1d60fa95586929cf90a918e6af0e5a90f1db89/comments",
     "author": {
       "login": "kelset",
       "id": 16104054,
@@ -2108,8 +2108,8 @@
     "parents": [
       {
         "sha": "93c83181fbb479836f407051bdcc4d2749bd78ad",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/93c83181fbb479836f407051bdcc4d2749bd78ad",
-        "html_url": "https://github.com/facebook/react-native/commit/93c83181fbb479836f407051bdcc4d2749bd78ad"
+        "url": "https://api.github.com/repos/react/react-native/commits/93c83181fbb479836f407051bdcc4d2749bd78ad",
+        "html_url": "https://github.com/react/react-native/commit/93c83181fbb479836f407051bdcc4d2749bd78ad"
       }
     ]
   },
@@ -2130,9 +2130,9 @@
       "message": "bump CLI rc",
       "tree": {
         "sha": "ca8d50f613c7abbcef43124b6ba36bd3a63d3d0a",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/ca8d50f613c7abbcef43124b6ba36bd3a63d3d0a"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/ca8d50f613c7abbcef43124b6ba36bd3a63d3d0a"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/93c83181fbb479836f407051bdcc4d2749bd78ad",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/93c83181fbb479836f407051bdcc4d2749bd78ad",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -2141,9 +2141,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/93c83181fbb479836f407051bdcc4d2749bd78ad",
-    "html_url": "https://github.com/facebook/react-native/commit/93c83181fbb479836f407051bdcc4d2749bd78ad",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/93c83181fbb479836f407051bdcc4d2749bd78ad/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/93c83181fbb479836f407051bdcc4d2749bd78ad",
+    "html_url": "https://github.com/react/react-native/commit/93c83181fbb479836f407051bdcc4d2749bd78ad",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/93c83181fbb479836f407051bdcc4d2749bd78ad/comments",
     "author": {
       "login": "kelset",
       "id": 16104054,
@@ -2187,8 +2187,8 @@
     "parents": [
       {
         "sha": "9837d2480c2d5d279e18ee9be2daa7ae20006dbb",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/9837d2480c2d5d279e18ee9be2daa7ae20006dbb",
-        "html_url": "https://github.com/facebook/react-native/commit/9837d2480c2d5d279e18ee9be2daa7ae20006dbb"
+        "url": "https://api.github.com/repos/react/react-native/commits/9837d2480c2d5d279e18ee9be2daa7ae20006dbb",
+        "html_url": "https://github.com/react/react-native/commit/9837d2480c2d5d279e18ee9be2daa7ae20006dbb"
       }
     ]
   },
@@ -2206,12 +2206,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-28T07:38:26Z"
       },
-      "message": "Fix some languages wrapped texts are cut off on android (#25306)\n\nSummary:\nFix wrapped some languages (like Japanese, Chinese) texts are cut off on android. This p-r is based on linjson [patch](https://github.com/facebook/react-native/issues/25275#issuecomment-502548807).\n\n- related (maybe)\n    - https://github.com/facebook/react-native/issues/25297\n    - https://github.com/facebook/react-native/issues/25275\n    - https://github.com/facebook/react-native/issues/24837\n    - https://github.com/facebook/react-native/issues/25155\n\n`setUseLineSpacingFromFallbacks` is recommended to set true on [document](https://developer.android.com/reference/android/text/StaticLayout.Builder#setUseLineSpacingFromFallbacks(boolean))\n\n>For backward compatibility reasons, the default is false, but setting this to true is strongly recommended. It is required to be true if text could be in languages like Burmese or Tibetan where text is typically much taller or deeper than Latin text.\n\n## Changelog\n\n[Android] [Fixed] - Fix some languages wrapped texts are cut off.\nPull Request resolved: https://github.com/facebook/react-native/pull/25306\n\nTest Plan:\nSet the target SDK to 28 in ``fbsource/fbandroid/java/com/facebook/catalyst/shell/AndroidManifest.xml``:\n```\n<uses-sdk android:minSdkVersion=\"16\" android:targetSdkVersion=\"28\"/>\n```\n\nInsert the following code into Playground.js: P67720709\n\nStart the Catalyst Android app and navigate to the playground:\n\n`buck install -r catalyst`\n\n|Before|After|\n|{F163482789}|{F163481060}|\n\nReviewed By: cpojer\n\nDifferential Revision: D15985809\n\nPulled By: makovkastar\n\nfbshipit-source-id: 0f98760b7a7fe4689fa3fe90ca747e9bf9fc4780",
+      "message": "Fix some languages wrapped texts are cut off on android (#25306)\n\nSummary:\nFix wrapped some languages (like Japanese, Chinese) texts are cut off on android. This p-r is based on linjson [patch](https://github.com/react/react-native/issues/25275#issuecomment-502548807).\n\n- related (maybe)\n    - https://github.com/react/react-native/issues/25297\n    - https://github.com/react/react-native/issues/25275\n    - https://github.com/react/react-native/issues/24837\n    - https://github.com/react/react-native/issues/25155\n\n`setUseLineSpacingFromFallbacks` is recommended to set true on [document](https://developer.android.com/reference/android/text/StaticLayout.Builder#setUseLineSpacingFromFallbacks(boolean))\n\n>For backward compatibility reasons, the default is false, but setting this to true is strongly recommended. It is required to be true if text could be in languages like Burmese or Tibetan where text is typically much taller or deeper than Latin text.\n\n## Changelog\n\n[Android] [Fixed] - Fix some languages wrapped texts are cut off.\nPull Request resolved: https://github.com/react/react-native/pull/25306\n\nTest Plan:\nSet the target SDK to 28 in ``fbsource/fbandroid/java/com/facebook/catalyst/shell/AndroidManifest.xml``:\n```\n<uses-sdk android:minSdkVersion=\"16\" android:targetSdkVersion=\"28\"/>\n```\n\nInsert the following code into Playground.js: P67720709\n\nStart the Catalyst Android app and navigate to the playground:\n\n`buck install -r catalyst`\n\n|Before|After|\n|{F163482789}|{F163481060}|\n\nReviewed By: cpojer\n\nDifferential Revision: D15985809\n\nPulled By: makovkastar\n\nfbshipit-source-id: 0f98760b7a7fe4689fa3fe90ca747e9bf9fc4780",
       "tree": {
         "sha": "65381a8f0d79292c081fff935f30426ab6b8822e",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/65381a8f0d79292c081fff935f30426ab6b8822e"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/65381a8f0d79292c081fff935f30426ab6b8822e"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/9837d2480c2d5d279e18ee9be2daa7ae20006dbb",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/9837d2480c2d5d279e18ee9be2daa7ae20006dbb",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -2220,9 +2220,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/9837d2480c2d5d279e18ee9be2daa7ae20006dbb",
-    "html_url": "https://github.com/facebook/react-native/commit/9837d2480c2d5d279e18ee9be2daa7ae20006dbb",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/9837d2480c2d5d279e18ee9be2daa7ae20006dbb/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/9837d2480c2d5d279e18ee9be2daa7ae20006dbb",
+    "html_url": "https://github.com/react/react-native/commit/9837d2480c2d5d279e18ee9be2daa7ae20006dbb",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/9837d2480c2d5d279e18ee9be2daa7ae20006dbb/comments",
     "author": {
       "login": "soh335",
       "id": 31937,
@@ -2266,8 +2266,8 @@
     "parents": [
       {
         "sha": "b68966ec7b2bf97223c5430d0381facc00bad057",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/b68966ec7b2bf97223c5430d0381facc00bad057",
-        "html_url": "https://github.com/facebook/react-native/commit/b68966ec7b2bf97223c5430d0381facc00bad057"
+        "url": "https://api.github.com/repos/react/react-native/commits/b68966ec7b2bf97223c5430d0381facc00bad057",
+        "html_url": "https://github.com/react/react-native/commit/b68966ec7b2bf97223c5430d0381facc00bad057"
       }
     ]
   },
@@ -2285,12 +2285,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-28T07:38:17Z"
       },
-      "message": "Use CALayers to draw text (#24387)\n\nSummary:\nThe current technique we use to draw text uses linear memory, which means that when text is too long the UIView layer is unable to draw it. This causes the issue described [here](https://github.com/facebook/react-native/issues/19453). On an iOS simulator the bug happens at around 500 lines which is quite annoying. It can also happen on a real device but requires a lot more text.\n\nTo be more specific the amount of text doesn't actually matter, it is the size of the UIView that we use to draw the text. When we use `[drawRect:]` the view creates a bitmap to send to the gpu to render, if that bitmap is too big it cannot render.\n\nTo fix this we can use `CATiledLayer` which will split drawing into smaller parts, that gets executed when the content is about to be visible. This drawing is also async which means the text can seem to appear during scroll. See https://developer.apple.com/documentation/quartzcore/calayer?language=objc.\n\n`CATiledLayer` also adds some overhead that we don't want when rendering small amount of text. To fix this we can use either a regular `CALayer` or a `CATiledLayer` depending on the size of the view containing the text. I picked 1024 as the threshold which is about 1 screen and a half, and is still smaller than the height needed for the bug to occur when using a regular `CALayer` on a iOS simulator.\n\nAlso found this which addresses the problem in a similar manner and took some inspiration from the code linked there https://github.com/GitHawkApp/StyledTextKit/issues/14#issuecomment-395234885\n\nFixes https://github.com/facebook/react-native/issues/19453\n\n## Changelog\n\n[iOS] [Fixed] - Use CALayers to draw text, fixes rendering for long text\nPull Request resolved: https://github.com/facebook/react-native/pull/24387\n\nTest Plan:\n- Added the example I was using to verify the fix to RNTester.\n- Made sure all other examples are still rendering properly.\n- Tested text selection\n\nReviewed By: shergin\n\nDifferential Revision: D15918277\n\nPulled By: sammy-SC\n\nfbshipit-source-id: c45409a8413e6e3ad272be39ba527a4e8d349e28",
+      "message": "Use CALayers to draw text (#24387)\n\nSummary:\nThe current technique we use to draw text uses linear memory, which means that when text is too long the UIView layer is unable to draw it. This causes the issue described [here](https://github.com/react/react-native/issues/19453). On an iOS simulator the bug happens at around 500 lines which is quite annoying. It can also happen on a real device but requires a lot more text.\n\nTo be more specific the amount of text doesn't actually matter, it is the size of the UIView that we use to draw the text. When we use `[drawRect:]` the view creates a bitmap to send to the gpu to render, if that bitmap is too big it cannot render.\n\nTo fix this we can use `CATiledLayer` which will split drawing into smaller parts, that gets executed when the content is about to be visible. This drawing is also async which means the text can seem to appear during scroll. See https://developer.apple.com/documentation/quartzcore/calayer?language=objc.\n\n`CATiledLayer` also adds some overhead that we don't want when rendering small amount of text. To fix this we can use either a regular `CALayer` or a `CATiledLayer` depending on the size of the view containing the text. I picked 1024 as the threshold which is about 1 screen and a half, and is still smaller than the height needed for the bug to occur when using a regular `CALayer` on a iOS simulator.\n\nAlso found this which addresses the problem in a similar manner and took some inspiration from the code linked there https://github.com/GitHawkApp/StyledTextKit/issues/14#issuecomment-395234885\n\nFixes https://github.com/react/react-native/issues/19453\n\n## Changelog\n\n[iOS] [Fixed] - Use CALayers to draw text, fixes rendering for long text\nPull Request resolved: https://github.com/react/react-native/pull/24387\n\nTest Plan:\n- Added the example I was using to verify the fix to RNTester.\n- Made sure all other examples are still rendering properly.\n- Tested text selection\n\nReviewed By: shergin\n\nDifferential Revision: D15918277\n\nPulled By: sammy-SC\n\nfbshipit-source-id: c45409a8413e6e3ad272be39ba527a4e8d349e28",
       "tree": {
         "sha": "aec74d5391771a6a4a78e3e0140e40dceb4cf947",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/aec74d5391771a6a4a78e3e0140e40dceb4cf947"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/aec74d5391771a6a4a78e3e0140e40dceb4cf947"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/b68966ec7b2bf97223c5430d0381facc00bad057",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/b68966ec7b2bf97223c5430d0381facc00bad057",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -2299,9 +2299,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/b68966ec7b2bf97223c5430d0381facc00bad057",
-    "html_url": "https://github.com/facebook/react-native/commit/b68966ec7b2bf97223c5430d0381facc00bad057",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/b68966ec7b2bf97223c5430d0381facc00bad057/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/b68966ec7b2bf97223c5430d0381facc00bad057",
+    "html_url": "https://github.com/react/react-native/commit/b68966ec7b2bf97223c5430d0381facc00bad057",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/b68966ec7b2bf97223c5430d0381facc00bad057/comments",
     "author": {
       "login": "janicduplessis",
       "id": 2677334,
@@ -2345,8 +2345,8 @@
     "parents": [
       {
         "sha": "99bc31cfa609e838779c29343684365a2ed6169f",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/99bc31cfa609e838779c29343684365a2ed6169f",
-        "html_url": "https://github.com/facebook/react-native/commit/99bc31cfa609e838779c29343684365a2ed6169f"
+        "url": "https://api.github.com/repos/react/react-native/commits/99bc31cfa609e838779c29343684365a2ed6169f",
+        "html_url": "https://github.com/react/react-native/commit/99bc31cfa609e838779c29343684365a2ed6169f"
       }
     ]
   }

--- a/incubator/rn-changelog-generator/test/__fixtures__/commits-v0.60.5-page-2.json
+++ b/incubator/rn-changelog-generator/test/__fixtures__/commits-v0.60.5-page-2.json
@@ -13,12 +13,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-28T07:38:10Z"
       },
-      "message": "Fix regression of improper assets copy (revert #24518 #24778) (#25363)\n\nSummary:\nPull requests https://github.com/facebook/react-native/issues/24518 #24778 make Gradle copy all **generated** assets and resources into `android/app/src/res`, which is a bad behavior, because `src/res` goes into version control and should hold only those **original** resource files.\n\nThese changes in https://github.com/facebook/react-native/issues/24518 #24778 were merged into 0.60.0-rc release and cause regression.\n\nThis pull request will:\n\n- Revert pull requests https://github.com/facebook/react-native/issues/24518 #24778\n- Close https://github.com/facebook/react-native/issues/25325\n\n## Changelog\n\n[Android] [Fixed] - Fix regression of improper assets copy (revert https://github.com/facebook/react-native/issues/24518 #24778)\nPull Request resolved: https://github.com/facebook/react-native/pull/25363\n\nTest Plan: It is a revert pull request and the reverted script should work the same as it has in 0.59.x.\n\nDifferential Revision: D15963329\n\nPulled By: cpojer\n\nfbshipit-source-id: 5619a318dbdb40e816e37b6e37d4fe32caa46e9e",
+      "message": "Fix regression of improper assets copy (revert #24518 #24778) (#25363)\n\nSummary:\nPull requests https://github.com/react/react-native/issues/24518 #24778 make Gradle copy all **generated** assets and resources into `android/app/src/res`, which is a bad behavior, because `src/res` goes into version control and should hold only those **original** resource files.\n\nThese changes in https://github.com/react/react-native/issues/24518 #24778 were merged into 0.60.0-rc release and cause regression.\n\nThis pull request will:\n\n- Revert pull requests https://github.com/react/react-native/issues/24518 #24778\n- Close https://github.com/react/react-native/issues/25325\n\n## Changelog\n\n[Android] [Fixed] - Fix regression of improper assets copy (revert https://github.com/react/react-native/issues/24518 #24778)\nPull Request resolved: https://github.com/react/react-native/pull/25363\n\nTest Plan: It is a revert pull request and the reverted script should work the same as it has in 0.59.x.\n\nDifferential Revision: D15963329\n\nPulled By: cpojer\n\nfbshipit-source-id: 5619a318dbdb40e816e37b6e37d4fe32caa46e9e",
       "tree": {
         "sha": "b8213b190bc1547c90ae48fb5dbfd3017d5e2be2",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/b8213b190bc1547c90ae48fb5dbfd3017d5e2be2"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/b8213b190bc1547c90ae48fb5dbfd3017d5e2be2"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/99bc31cfa609e838779c29343684365a2ed6169f",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/99bc31cfa609e838779c29343684365a2ed6169f",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -27,9 +27,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/99bc31cfa609e838779c29343684365a2ed6169f",
-    "html_url": "https://github.com/facebook/react-native/commit/99bc31cfa609e838779c29343684365a2ed6169f",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/99bc31cfa609e838779c29343684365a2ed6169f/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/99bc31cfa609e838779c29343684365a2ed6169f",
+    "html_url": "https://github.com/react/react-native/commit/99bc31cfa609e838779c29343684365a2ed6169f",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/99bc31cfa609e838779c29343684365a2ed6169f/comments",
     "author": {
       "login": "robertying",
       "id": 22592111,
@@ -73,8 +73,8 @@
     "parents": [
       {
         "sha": "c36c481016dc008ffe92883697d72251c3f97ba2",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/c36c481016dc008ffe92883697d72251c3f97ba2",
-        "html_url": "https://github.com/facebook/react-native/commit/c36c481016dc008ffe92883697d72251c3f97ba2"
+        "url": "https://api.github.com/repos/react/react-native/commits/c36c481016dc008ffe92883697d72251c3f97ba2",
+        "html_url": "https://github.com/react/react-native/commit/c36c481016dc008ffe92883697d72251c3f97ba2"
       }
     ]
   },
@@ -92,12 +92,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-28T07:38:01Z"
       },
-      "message": "bump fresco to 2.0.0, supports AndroidX (#25358)\n\nSummary:\nBump Fresco to 2.0.0, which supports AndroidX. We should cherry-pick to 0.60 release, to support brown field apps but also native components.\n\n## Changelog\n\n[Android] [Changed] - Bump Fresco to 2.0.0, supports AndroidX\nPull Request resolved: https://github.com/facebook/react-native/pull/25358\n\nTest Plan: CI is green, and RNTester builds and runs as expected.\n\nDifferential Revision: D15959443\n\nPulled By: mdvacca\n\nfbshipit-source-id: 58ba2c3e4d1342014d6ea632cd865b4f413548d9",
+      "message": "bump fresco to 2.0.0, supports AndroidX (#25358)\n\nSummary:\nBump Fresco to 2.0.0, which supports AndroidX. We should cherry-pick to 0.60 release, to support brown field apps but also native components.\n\n## Changelog\n\n[Android] [Changed] - Bump Fresco to 2.0.0, supports AndroidX\nPull Request resolved: https://github.com/react/react-native/pull/25358\n\nTest Plan: CI is green, and RNTester builds and runs as expected.\n\nDifferential Revision: D15959443\n\nPulled By: mdvacca\n\nfbshipit-source-id: 58ba2c3e4d1342014d6ea632cd865b4f413548d9",
       "tree": {
         "sha": "f4d901c309883463aaca8e0ea090c74f1917d83e",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/f4d901c309883463aaca8e0ea090c74f1917d83e"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/f4d901c309883463aaca8e0ea090c74f1917d83e"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/c36c481016dc008ffe92883697d72251c3f97ba2",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/c36c481016dc008ffe92883697d72251c3f97ba2",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -106,9 +106,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/c36c481016dc008ffe92883697d72251c3f97ba2",
-    "html_url": "https://github.com/facebook/react-native/commit/c36c481016dc008ffe92883697d72251c3f97ba2",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/c36c481016dc008ffe92883697d72251c3f97ba2/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/c36c481016dc008ffe92883697d72251c3f97ba2",
+    "html_url": "https://github.com/react/react-native/commit/c36c481016dc008ffe92883697d72251c3f97ba2",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/c36c481016dc008ffe92883697d72251c3f97ba2/comments",
     "author": {
       "login": "dulmandakh",
       "id": 178494,
@@ -152,8 +152,8 @@
     "parents": [
       {
         "sha": "13f4fa024568ab1c84beb140ee5c35b1950692f2",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/13f4fa024568ab1c84beb140ee5c35b1950692f2",
-        "html_url": "https://github.com/facebook/react-native/commit/13f4fa024568ab1c84beb140ee5c35b1950692f2"
+        "url": "https://api.github.com/repos/react/react-native/commits/13f4fa024568ab1c84beb140ee5c35b1950692f2",
+        "html_url": "https://github.com/react/react-native/commit/13f4fa024568ab1c84beb140ee5c35b1950692f2"
       }
     ]
   },
@@ -171,12 +171,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-28T07:37:51Z"
       },
-      "message": "custom fontWeight numeric values for Text on Android (#25341)\n\nSummary:\nI found that on Android we only support 2 fontWeight options, either **normal** or **bold**, even developer can set any numeric value. But iOS supports all possible numeric values. This PR tries to add support for all possible numeric values on Android, even if it's supported only on Android P(28) and above.\n\nThis change might break texts where fontWeight use improperly, because this PR removes conversion of values above 500 to BOLD and below 500 to normal.\n\nFYI, also moved **mCustomTypefaceCache** usage up because it was working after unnecessary mFontCache usage.\n\n## Changelog\n\n[Android] [Changed] - add custom font weight support to Text component on Android, only on P(API 28) and above versions.\nPull Request resolved: https://github.com/facebook/react-native/pull/25341\n\nTest Plan: RNTester app's Text examples will show Rubik Regular, Rubik Light, Rubik Bold, Rubik Medium and Rubik Medium Italic texts in corresponding font family, style and weights.\n\nDifferential Revision: D15956350\n\nPulled By: mdvacca\n\nfbshipit-source-id: 61079d953c65fb34ab4497d44c22317912a5a616",
+      "message": "custom fontWeight numeric values for Text on Android (#25341)\n\nSummary:\nI found that on Android we only support 2 fontWeight options, either **normal** or **bold**, even developer can set any numeric value. But iOS supports all possible numeric values. This PR tries to add support for all possible numeric values on Android, even if it's supported only on Android P(28) and above.\n\nThis change might break texts where fontWeight use improperly, because this PR removes conversion of values above 500 to BOLD and below 500 to normal.\n\nFYI, also moved **mCustomTypefaceCache** usage up because it was working after unnecessary mFontCache usage.\n\n## Changelog\n\n[Android] [Changed] - add custom font weight support to Text component on Android, only on P(API 28) and above versions.\nPull Request resolved: https://github.com/react/react-native/pull/25341\n\nTest Plan: RNTester app's Text examples will show Rubik Regular, Rubik Light, Rubik Bold, Rubik Medium and Rubik Medium Italic texts in corresponding font family, style and weights.\n\nDifferential Revision: D15956350\n\nPulled By: mdvacca\n\nfbshipit-source-id: 61079d953c65fb34ab4497d44c22317912a5a616",
       "tree": {
         "sha": "22849e68113ba7d9935cae4a7e2dcb20bf9e2c9e",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/22849e68113ba7d9935cae4a7e2dcb20bf9e2c9e"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/22849e68113ba7d9935cae4a7e2dcb20bf9e2c9e"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/13f4fa024568ab1c84beb140ee5c35b1950692f2",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/13f4fa024568ab1c84beb140ee5c35b1950692f2",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -185,9 +185,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/13f4fa024568ab1c84beb140ee5c35b1950692f2",
-    "html_url": "https://github.com/facebook/react-native/commit/13f4fa024568ab1c84beb140ee5c35b1950692f2",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/13f4fa024568ab1c84beb140ee5c35b1950692f2/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/13f4fa024568ab1c84beb140ee5c35b1950692f2",
+    "html_url": "https://github.com/react/react-native/commit/13f4fa024568ab1c84beb140ee5c35b1950692f2",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/13f4fa024568ab1c84beb140ee5c35b1950692f2/comments",
     "author": {
       "login": "dulmandakh",
       "id": 178494,
@@ -231,8 +231,8 @@
     "parents": [
       {
         "sha": "9792f2c9d7f47b1f66e196c7f70497d3253ef6e6",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/9792f2c9d7f47b1f66e196c7f70497d3253ef6e6",
-        "html_url": "https://github.com/facebook/react-native/commit/9792f2c9d7f47b1f66e196c7f70497d3253ef6e6"
+        "url": "https://api.github.com/repos/react/react-native/commits/9792f2c9d7f47b1f66e196c7f70497d3253ef6e6",
+        "html_url": "https://github.com/react/react-native/commit/9792f2c9d7f47b1f66e196c7f70497d3253ef6e6"
       }
     ]
   },
@@ -253,9 +253,9 @@
       "message": "[0.60.0-rc.2] Bump version numbers",
       "tree": {
         "sha": "9c86f048938e74c1f725ad2fddf55a92681c1936",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/9c86f048938e74c1f725ad2fddf55a92681c1936"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/9c86f048938e74c1f725ad2fddf55a92681c1936"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/9792f2c9d7f47b1f66e196c7f70497d3253ef6e6",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/9792f2c9d7f47b1f66e196c7f70497d3253ef6e6",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -264,9 +264,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/9792f2c9d7f47b1f66e196c7f70497d3253ef6e6",
-    "html_url": "https://github.com/facebook/react-native/commit/9792f2c9d7f47b1f66e196c7f70497d3253ef6e6",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/9792f2c9d7f47b1f66e196c7f70497d3253ef6e6/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/9792f2c9d7f47b1f66e196c7f70497d3253ef6e6",
+    "html_url": "https://github.com/react/react-native/commit/9792f2c9d7f47b1f66e196c7f70497d3253ef6e6",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/9792f2c9d7f47b1f66e196c7f70497d3253ef6e6/comments",
     "author": {
       "login": "kelset",
       "id": 16104054,
@@ -310,8 +310,8 @@
     "parents": [
       {
         "sha": "53cec2dc1f1f5d143d0bb9752629b72350ebd112",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/53cec2dc1f1f5d143d0bb9752629b72350ebd112",
-        "html_url": "https://github.com/facebook/react-native/commit/53cec2dc1f1f5d143d0bb9752629b72350ebd112"
+        "url": "https://api.github.com/repos/react/react-native/commits/53cec2dc1f1f5d143d0bb9752629b72350ebd112",
+        "html_url": "https://github.com/react/react-native/commit/53cec2dc1f1f5d143d0bb9752629b72350ebd112"
       }
     ]
   },
@@ -332,9 +332,9 @@
       "message": "[LOCAL] bump version in template to match repo",
       "tree": {
         "sha": "bae1a6004e27dddbb9cc827c65a01749ace2b10b",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/bae1a6004e27dddbb9cc827c65a01749ace2b10b"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/bae1a6004e27dddbb9cc827c65a01749ace2b10b"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/53cec2dc1f1f5d143d0bb9752629b72350ebd112",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/53cec2dc1f1f5d143d0bb9752629b72350ebd112",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -343,9 +343,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/53cec2dc1f1f5d143d0bb9752629b72350ebd112",
-    "html_url": "https://github.com/facebook/react-native/commit/53cec2dc1f1f5d143d0bb9752629b72350ebd112",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/53cec2dc1f1f5d143d0bb9752629b72350ebd112/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/53cec2dc1f1f5d143d0bb9752629b72350ebd112",
+    "html_url": "https://github.com/react/react-native/commit/53cec2dc1f1f5d143d0bb9752629b72350ebd112",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/53cec2dc1f1f5d143d0bb9752629b72350ebd112/comments",
     "author": {
       "login": "kelset",
       "id": 16104054,
@@ -389,8 +389,8 @@
     "parents": [
       {
         "sha": "b4f3d4b92e8db8d230fc2b46fc083c4bd5617558",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/b4f3d4b92e8db8d230fc2b46fc083c4bd5617558",
-        "html_url": "https://github.com/facebook/react-native/commit/b4f3d4b92e8db8d230fc2b46fc083c4bd5617558"
+        "url": "https://api.github.com/repos/react/react-native/commits/b4f3d4b92e8db8d230fc2b46fc083c4bd5617558",
+        "html_url": "https://github.com/react/react-native/commit/b4f3d4b92e8db8d230fc2b46fc083c4bd5617558"
       }
     ]
   },
@@ -411,9 +411,9 @@
       "message": "Move scheduler to dependencies\n\nSummary: Fixes https://github.com/react-native-community/releases/issues/116#issuecomment-503449687\n\nReviewed By: gaearon\n\nDifferential Revision: D15901557\n\nfbshipit-source-id: 653119c181585cf9a4a561b350c66bd10cb674bd",
       "tree": {
         "sha": "ab401c6ffce39ad8174f536f09414cef86c4ae6b",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/ab401c6ffce39ad8174f536f09414cef86c4ae6b"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/ab401c6ffce39ad8174f536f09414cef86c4ae6b"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/b4f3d4b92e8db8d230fc2b46fc083c4bd5617558",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/b4f3d4b92e8db8d230fc2b46fc083c4bd5617558",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -422,9 +422,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/b4f3d4b92e8db8d230fc2b46fc083c4bd5617558",
-    "html_url": "https://github.com/facebook/react-native/commit/b4f3d4b92e8db8d230fc2b46fc083c4bd5617558",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/b4f3d4b92e8db8d230fc2b46fc083c4bd5617558/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/b4f3d4b92e8db8d230fc2b46fc083c4bd5617558",
+    "html_url": "https://github.com/react/react-native/commit/b4f3d4b92e8db8d230fc2b46fc083c4bd5617558",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/b4f3d4b92e8db8d230fc2b46fc083c4bd5617558/comments",
     "author": {
       "login": "rickhanlonii",
       "id": 2440089,
@@ -468,8 +468,8 @@
     "parents": [
       {
         "sha": "e741488659cb786f78f42d5e285d628026d2cd7f",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/e741488659cb786f78f42d5e285d628026d2cd7f",
-        "html_url": "https://github.com/facebook/react-native/commit/e741488659cb786f78f42d5e285d628026d2cd7f"
+        "url": "https://api.github.com/repos/react/react-native/commits/e741488659cb786f78f42d5e285d628026d2cd7f",
+        "html_url": "https://github.com/react/react-native/commit/e741488659cb786f78f42d5e285d628026d2cd7f"
       }
     ]
   },
@@ -487,12 +487,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-19T13:10:57Z"
       },
-      "message": "Implement changes to enable native modules auto linking (#24506)\n\nSummary:\nReplaces #24099 (original PR became detached for some reason)\n\nImplements the template changes required to enable native modules auto-linking for both Android & iOS.\n\nRequires the following to be merged first and an updated CLI to be published:\n\n- [x] https://github.com/react-native-community/react-native-cli/pull/254\n- [x] https://github.com/react-native-community/react-native-cli/pull/256\n- [x] https://github.com/react-native-community/react-native-cli/pull/258\n\ncc grabbou thymikee orta for review\n\n- [ ] https://github.com/facebook/react-native/pull/24517 update CLI version)\n\n[TEMPLATE] [FEATURE] - Enable auto-initialization/linking of react native modules for new projects\nPull Request resolved: https://github.com/facebook/react-native/pull/24506\n\nDifferential Revision: D15062701\n\nPulled By: cpojer\n\nfbshipit-source-id: 65296cbec2925405fe8033de71910325e0c719bc\n\n# Conflicts:\n#\ttemplate/ios/Podfile",
+      "message": "Implement changes to enable native modules auto linking (#24506)\n\nSummary:\nReplaces #24099 (original PR became detached for some reason)\n\nImplements the template changes required to enable native modules auto-linking for both Android & iOS.\n\nRequires the following to be merged first and an updated CLI to be published:\n\n- [x] https://github.com/react-native-community/react-native-cli/pull/254\n- [x] https://github.com/react-native-community/react-native-cli/pull/256\n- [x] https://github.com/react-native-community/react-native-cli/pull/258\n\ncc grabbou thymikee orta for review\n\n- [ ] https://github.com/react/react-native/pull/24517 update CLI version)\n\n[TEMPLATE] [FEATURE] - Enable auto-initialization/linking of react native modules for new projects\nPull Request resolved: https://github.com/react/react-native/pull/24506\n\nDifferential Revision: D15062701\n\nPulled By: cpojer\n\nfbshipit-source-id: 65296cbec2925405fe8033de71910325e0c719bc\n\n# Conflicts:\n#\ttemplate/ios/Podfile",
       "tree": {
         "sha": "7eb731c58302e230d94e0950569a5ddd4a203a64",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/7eb731c58302e230d94e0950569a5ddd4a203a64"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/7eb731c58302e230d94e0950569a5ddd4a203a64"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/e741488659cb786f78f42d5e285d628026d2cd7f",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/e741488659cb786f78f42d5e285d628026d2cd7f",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -501,9 +501,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/e741488659cb786f78f42d5e285d628026d2cd7f",
-    "html_url": "https://github.com/facebook/react-native/commit/e741488659cb786f78f42d5e285d628026d2cd7f",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/e741488659cb786f78f42d5e285d628026d2cd7f/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/e741488659cb786f78f42d5e285d628026d2cd7f",
+    "html_url": "https://github.com/react/react-native/commit/e741488659cb786f78f42d5e285d628026d2cd7f",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/e741488659cb786f78f42d5e285d628026d2cd7f/comments",
     "author": {
       "login": "Salakar",
       "id": 5347038,
@@ -547,8 +547,8 @@
     "parents": [
       {
         "sha": "bf4ee6f5c1879948f4bd4f7ef3d60d88b6269e43",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/bf4ee6f5c1879948f4bd4f7ef3d60d88b6269e43",
-        "html_url": "https://github.com/facebook/react-native/commit/bf4ee6f5c1879948f4bd4f7ef3d60d88b6269e43"
+        "url": "https://api.github.com/repos/react/react-native/commits/bf4ee6f5c1879948f4bd4f7ef3d60d88b6269e43",
+        "html_url": "https://github.com/react/react-native/commit/bf4ee6f5c1879948f4bd4f7ef3d60d88b6269e43"
       }
     ]
   },
@@ -566,12 +566,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-19T11:54:50Z"
       },
-      "message": "Bump CLI to 2.0.0-rc.2 (#25241)\n\nSummary:\nFixing Metro validation issue. Hope that helps with fixing the CI �.\n\n## Changelog\n\n[General] [Changed] - Bump CLI to 2.0.0-rc.2\nPull Request resolved: https://github.com/facebook/react-native/pull/25241\n\nDifferential Revision: D15803610\n\nPulled By: cpojer\n\nfbshipit-source-id: 22136db1583f8cf5a40afd5d8a561d98cb6de982",
+      "message": "Bump CLI to 2.0.0-rc.2 (#25241)\n\nSummary:\nFixing Metro validation issue. Hope that helps with fixing the CI �.\n\n## Changelog\n\n[General] [Changed] - Bump CLI to 2.0.0-rc.2\nPull Request resolved: https://github.com/react/react-native/pull/25241\n\nDifferential Revision: D15803610\n\nPulled By: cpojer\n\nfbshipit-source-id: 22136db1583f8cf5a40afd5d8a561d98cb6de982",
       "tree": {
         "sha": "ed6a75a547892def1c82a3f5179299da69eb5b26",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/ed6a75a547892def1c82a3f5179299da69eb5b26"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/ed6a75a547892def1c82a3f5179299da69eb5b26"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/bf4ee6f5c1879948f4bd4f7ef3d60d88b6269e43",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/bf4ee6f5c1879948f4bd4f7ef3d60d88b6269e43",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -580,9 +580,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/bf4ee6f5c1879948f4bd4f7ef3d60d88b6269e43",
-    "html_url": "https://github.com/facebook/react-native/commit/bf4ee6f5c1879948f4bd4f7ef3d60d88b6269e43",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/bf4ee6f5c1879948f4bd4f7ef3d60d88b6269e43/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/bf4ee6f5c1879948f4bd4f7ef3d60d88b6269e43",
+    "html_url": "https://github.com/react/react-native/commit/bf4ee6f5c1879948f4bd4f7ef3d60d88b6269e43",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/bf4ee6f5c1879948f4bd4f7ef3d60d88b6269e43/comments",
     "author": {
       "login": "thymikee",
       "id": 5106466,
@@ -626,8 +626,8 @@
     "parents": [
       {
         "sha": "cecba01b71045920892560f53676381462c11598",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/cecba01b71045920892560f53676381462c11598",
-        "html_url": "https://github.com/facebook/react-native/commit/cecba01b71045920892560f53676381462c11598"
+        "url": "https://api.github.com/repos/react/react-native/commits/cecba01b71045920892560f53676381462c11598",
+        "html_url": "https://github.com/react/react-native/commit/cecba01b71045920892560f53676381462c11598"
       }
     ]
   },
@@ -645,12 +645,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-19T11:54:39Z"
       },
-      "message": "Removed autoresizing mask for modal host container view (#25150)\n\nSummary:\nFixes #18177 . Related #24497. Autoresizing mask would conflict with `AutoLayout`. For example , it would impact `SafeAreaView`. And actually we don't need to use autoresizing mask,  we observe the bounds change notification and [update the frame manually](https://github.com/facebook/react-native/blob/1151c096dab17e5d9a6ac05b61aacecd4305f3db/React/Views/RCTModalHostView.m#L59).\n\n## Changelog\n\n[iOS] [Fixed] - Removed autoresizing mask for modal host container view\nPull Request resolved: https://github.com/facebook/react-native/pull/25150\n\nDifferential Revision: D15645148\n\nPulled By: cpojer\n\nfbshipit-source-id: 95d5f40feaa980b959a3de6e273dccac8158c57b",
+      "message": "Removed autoresizing mask for modal host container view (#25150)\n\nSummary:\nFixes #18177 . Related #24497. Autoresizing mask would conflict with `AutoLayout`. For example , it would impact `SafeAreaView`. And actually we don't need to use autoresizing mask,  we observe the bounds change notification and [update the frame manually](https://github.com/react/react-native/blob/1151c096dab17e5d9a6ac05b61aacecd4305f3db/React/Views/RCTModalHostView.m#L59).\n\n## Changelog\n\n[iOS] [Fixed] - Removed autoresizing mask for modal host container view\nPull Request resolved: https://github.com/react/react-native/pull/25150\n\nDifferential Revision: D15645148\n\nPulled By: cpojer\n\nfbshipit-source-id: 95d5f40feaa980b959a3de6e273dccac8158c57b",
       "tree": {
         "sha": "326ea411d5454cb6299f8bb1b495e10c646e12e7",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/326ea411d5454cb6299f8bb1b495e10c646e12e7"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/326ea411d5454cb6299f8bb1b495e10c646e12e7"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/cecba01b71045920892560f53676381462c11598",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/cecba01b71045920892560f53676381462c11598",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -659,9 +659,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/cecba01b71045920892560f53676381462c11598",
-    "html_url": "https://github.com/facebook/react-native/commit/cecba01b71045920892560f53676381462c11598",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/cecba01b71045920892560f53676381462c11598/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/cecba01b71045920892560f53676381462c11598",
+    "html_url": "https://github.com/react/react-native/commit/cecba01b71045920892560f53676381462c11598",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/cecba01b71045920892560f53676381462c11598/comments",
     "author": {
       "login": "zhongwuzw",
       "id": 5061845,
@@ -705,8 +705,8 @@
     "parents": [
       {
         "sha": "06fffc204252eb0b4ca3524768c6fbd4d78d79ab",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/06fffc204252eb0b4ca3524768c6fbd4d78d79ab",
-        "html_url": "https://github.com/facebook/react-native/commit/06fffc204252eb0b4ca3524768c6fbd4d78d79ab"
+        "url": "https://api.github.com/repos/react/react-native/commits/06fffc204252eb0b4ca3524768c6fbd4d78d79ab",
+        "html_url": "https://github.com/react/react-native/commit/06fffc204252eb0b4ca3524768c6fbd4d78d79ab"
       }
     ]
   },
@@ -727,9 +727,9 @@
       "message": "[0.60.0-rc.1] Bump version numbers",
       "tree": {
         "sha": "454312a1f5c1d88a27d929e2ca206f34592c42e1",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/454312a1f5c1d88a27d929e2ca206f34592c42e1"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/454312a1f5c1d88a27d929e2ca206f34592c42e1"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/06fffc204252eb0b4ca3524768c6fbd4d78d79ab",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/06fffc204252eb0b4ca3524768c6fbd4d78d79ab",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -738,9 +738,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/06fffc204252eb0b4ca3524768c6fbd4d78d79ab",
-    "html_url": "https://github.com/facebook/react-native/commit/06fffc204252eb0b4ca3524768c6fbd4d78d79ab",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/06fffc204252eb0b4ca3524768c6fbd4d78d79ab/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/06fffc204252eb0b4ca3524768c6fbd4d78d79ab",
+    "html_url": "https://github.com/react/react-native/commit/06fffc204252eb0b4ca3524768c6fbd4d78d79ab",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/06fffc204252eb0b4ca3524768c6fbd4d78d79ab/comments",
     "author": {
       "login": "kelset",
       "id": 16104054,
@@ -784,8 +784,8 @@
     "parents": [
       {
         "sha": "5ecc87bf3e9a8b5e87048c47d5027c02a573f0a1",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/5ecc87bf3e9a8b5e87048c47d5027c02a573f0a1",
-        "html_url": "https://github.com/facebook/react-native/commit/5ecc87bf3e9a8b5e87048c47d5027c02a573f0a1"
+        "url": "https://api.github.com/repos/react/react-native/commits/5ecc87bf3e9a8b5e87048c47d5027c02a573f0a1",
+        "html_url": "https://github.com/react/react-native/commit/5ecc87bf3e9a8b5e87048c47d5027c02a573f0a1"
       }
     ]
   },
@@ -806,9 +806,9 @@
       "message": "bump versions to match the requirements",
       "tree": {
         "sha": "6514cffff62ac2b181891ba9991c62c4c5a9dd05",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/6514cffff62ac2b181891ba9991c62c4c5a9dd05"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/6514cffff62ac2b181891ba9991c62c4c5a9dd05"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/5ecc87bf3e9a8b5e87048c47d5027c02a573f0a1",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/5ecc87bf3e9a8b5e87048c47d5027c02a573f0a1",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -817,9 +817,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/5ecc87bf3e9a8b5e87048c47d5027c02a573f0a1",
-    "html_url": "https://github.com/facebook/react-native/commit/5ecc87bf3e9a8b5e87048c47d5027c02a573f0a1",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/5ecc87bf3e9a8b5e87048c47d5027c02a573f0a1/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/5ecc87bf3e9a8b5e87048c47d5027c02a573f0a1",
+    "html_url": "https://github.com/react/react-native/commit/5ecc87bf3e9a8b5e87048c47d5027c02a573f0a1",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/5ecc87bf3e9a8b5e87048c47d5027c02a573f0a1/comments",
     "author": {
       "login": "kelset",
       "id": 16104054,
@@ -863,8 +863,8 @@
     "parents": [
       {
         "sha": "7082c3e44979e0b83fcf67c0e90f92e7d670f60d",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/7082c3e44979e0b83fcf67c0e90f92e7d670f60d",
-        "html_url": "https://github.com/facebook/react-native/commit/7082c3e44979e0b83fcf67c0e90f92e7d670f60d"
+        "url": "https://api.github.com/repos/react/react-native/commits/7082c3e44979e0b83fcf67c0e90f92e7d670f60d",
+        "html_url": "https://github.com/react/react-native/commit/7082c3e44979e0b83fcf67c0e90f92e7d670f60d"
       }
     ]
   },
@@ -885,9 +885,9 @@
       "message": "re-add the hasteImpl",
       "tree": {
         "sha": "2046b49d64701c2d69aa6fe957769fe893e26695",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/2046b49d64701c2d69aa6fe957769fe893e26695"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/2046b49d64701c2d69aa6fe957769fe893e26695"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/7082c3e44979e0b83fcf67c0e90f92e7d670f60d",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/7082c3e44979e0b83fcf67c0e90f92e7d670f60d",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -896,9 +896,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/7082c3e44979e0b83fcf67c0e90f92e7d670f60d",
-    "html_url": "https://github.com/facebook/react-native/commit/7082c3e44979e0b83fcf67c0e90f92e7d670f60d",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/7082c3e44979e0b83fcf67c0e90f92e7d670f60d/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/7082c3e44979e0b83fcf67c0e90f92e7d670f60d",
+    "html_url": "https://github.com/react/react-native/commit/7082c3e44979e0b83fcf67c0e90f92e7d670f60d",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/7082c3e44979e0b83fcf67c0e90f92e7d670f60d/comments",
     "author": {
       "login": "kelset",
       "id": 16104054,
@@ -942,8 +942,8 @@
     "parents": [
       {
         "sha": "39ce412b254fb7c0f9f23926575a105cbc114b48",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/39ce412b254fb7c0f9f23926575a105cbc114b48",
-        "html_url": "https://github.com/facebook/react-native/commit/39ce412b254fb7c0f9f23926575a105cbc114b48"
+        "url": "https://api.github.com/repos/react/react-native/commits/39ce412b254fb7c0f9f23926575a105cbc114b48",
+        "html_url": "https://github.com/react/react-native/commit/39ce412b254fb7c0f9f23926575a105cbc114b48"
       }
     ]
   },
@@ -961,12 +961,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-07T14:14:32Z"
       },
-      "message": "Bump CLI to 2.0.0-rc.0 (#25175)\n\nSummary:\nUpgrading the CLI to the latest with a bunch of fixes and features included.\n\n## Changelog\n\n[General] [Changed] - Bump CLI to 2.0.0-rc.0\nPull Request resolved: https://github.com/facebook/react-native/pull/25175\n\nDifferential Revision: D15694764\n\nPulled By: cpojer\n\nfbshipit-source-id: 25fbf1c275ed5379e1cdb372512b6bb6327dea92\n\n# Conflicts:\n#\tjest/hasteImpl.js\n#\tpackage.json\n#\tyarn.lock",
+      "message": "Bump CLI to 2.0.0-rc.0 (#25175)\n\nSummary:\nUpgrading the CLI to the latest with a bunch of fixes and features included.\n\n## Changelog\n\n[General] [Changed] - Bump CLI to 2.0.0-rc.0\nPull Request resolved: https://github.com/react/react-native/pull/25175\n\nDifferential Revision: D15694764\n\nPulled By: cpojer\n\nfbshipit-source-id: 25fbf1c275ed5379e1cdb372512b6bb6327dea92\n\n# Conflicts:\n#\tjest/hasteImpl.js\n#\tpackage.json\n#\tyarn.lock",
       "tree": {
         "sha": "fa74021ed717ff8aea99dcca2e9844824f4e0708",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/fa74021ed717ff8aea99dcca2e9844824f4e0708"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/fa74021ed717ff8aea99dcca2e9844824f4e0708"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/39ce412b254fb7c0f9f23926575a105cbc114b48",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/39ce412b254fb7c0f9f23926575a105cbc114b48",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -975,9 +975,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/39ce412b254fb7c0f9f23926575a105cbc114b48",
-    "html_url": "https://github.com/facebook/react-native/commit/39ce412b254fb7c0f9f23926575a105cbc114b48",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/39ce412b254fb7c0f9f23926575a105cbc114b48/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/39ce412b254fb7c0f9f23926575a105cbc114b48",
+    "html_url": "https://github.com/react/react-native/commit/39ce412b254fb7c0f9f23926575a105cbc114b48",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/39ce412b254fb7c0f9f23926575a105cbc114b48/comments",
     "author": {
       "login": "thymikee",
       "id": 5106466,
@@ -1021,8 +1021,8 @@
     "parents": [
       {
         "sha": "00c7cf3d682953c17e3f14f88528a975d894217d",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/00c7cf3d682953c17e3f14f88528a975d894217d",
-        "html_url": "https://github.com/facebook/react-native/commit/00c7cf3d682953c17e3f14f88528a975d894217d"
+        "url": "https://api.github.com/repos/react/react-native/commits/00c7cf3d682953c17e3f14f88528a975d894217d",
+        "html_url": "https://github.com/react/react-native/commit/00c7cf3d682953c17e3f14f88528a975d894217d"
       }
     ]
   },
@@ -1040,12 +1040,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-07T14:13:00Z"
       },
-      "message": "Fix: RefreshControl in FlatList makes borderWidth not working (#24411)\n\nSummary:\nFixes #22752\n\nOn line 1021 you are passing base style to props:\n`style: [baseStyle, this.props.style],`\n\nExplicitly passing base style to ScrollView just overrides this line and doesn't let developers to customise style of any inheritors of ScrollView (not only FlatList) with custom RefreshControl.\n\nSo this line (1113) seems to be removed.\n\n## Changelog\n\n[GENERAL] [Fixed] - fix of Android's bug that doesn't let override ScrollView's Style with custom RefreshControl.\nPull Request resolved: https://github.com/facebook/react-native/pull/24411\n\nDifferential Revision: D15713061\n\nPulled By: cpojer\n\nfbshipit-source-id: 461259800f867af15e53e0743a5057ea4528ae69",
+      "message": "Fix: RefreshControl in FlatList makes borderWidth not working (#24411)\n\nSummary:\nFixes #22752\n\nOn line 1021 you are passing base style to props:\n`style: [baseStyle, this.props.style],`\n\nExplicitly passing base style to ScrollView just overrides this line and doesn't let developers to customise style of any inheritors of ScrollView (not only FlatList) with custom RefreshControl.\n\nSo this line (1113) seems to be removed.\n\n## Changelog\n\n[GENERAL] [Fixed] - fix of Android's bug that doesn't let override ScrollView's Style with custom RefreshControl.\nPull Request resolved: https://github.com/react/react-native/pull/24411\n\nDifferential Revision: D15713061\n\nPulled By: cpojer\n\nfbshipit-source-id: 461259800f867af15e53e0743a5057ea4528ae69",
       "tree": {
         "sha": "1aa3416c7b83af6255c05a7baee7e6be58f085df",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/1aa3416c7b83af6255c05a7baee7e6be58f085df"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/1aa3416c7b83af6255c05a7baee7e6be58f085df"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/00c7cf3d682953c17e3f14f88528a975d894217d",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/00c7cf3d682953c17e3f14f88528a975d894217d",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1054,9 +1054,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/00c7cf3d682953c17e3f14f88528a975d894217d",
-    "html_url": "https://github.com/facebook/react-native/commit/00c7cf3d682953c17e3f14f88528a975d894217d",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/00c7cf3d682953c17e3f14f88528a975d894217d/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/00c7cf3d682953c17e3f14f88528a975d894217d",
+    "html_url": "https://github.com/react/react-native/commit/00c7cf3d682953c17e3f14f88528a975d894217d",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/00c7cf3d682953c17e3f14f88528a975d894217d/comments",
     "author": {
       "login": "Nizarius",
       "id": 20745917,
@@ -1100,8 +1100,8 @@
     "parents": [
       {
         "sha": "a916dd6632a5e206ab0dbecb89bac8886e1257a5",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/a916dd6632a5e206ab0dbecb89bac8886e1257a5",
-        "html_url": "https://github.com/facebook/react-native/commit/a916dd6632a5e206ab0dbecb89bac8886e1257a5"
+        "url": "https://api.github.com/repos/react/react-native/commits/a916dd6632a5e206ab0dbecb89bac8886e1257a5",
+        "html_url": "https://github.com/react/react-native/commit/a916dd6632a5e206ab0dbecb89bac8886e1257a5"
       }
     ]
   },
@@ -1119,12 +1119,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-07T14:12:11Z"
       },
-      "message": "Android Fix for 9145: No longer hard code build port (#23616)\n\nSummary:\n### Problem\n\nAccording to https://github.com/facebook/react-native/issues/9145, the `--port` setting is not respected when executing `react-native run-android`. The templates that report things like what port the dev server runs on are hard coded as well.\n\n### Solution\n\nThis commit replaces the hardcoded instances of port 8081 on Android with a build configuration property. This allows setting of the port React Native Android connects to for the local build server.\n\nFor this change to work, there must also be an update to the react native CLI to pass along this setting:\n\nhttps://github.com/react-native-community/react-native-cli/compare/master...nhunzaker:9145-android-no-port-hardcode-cli\n\nTo avoid some noise on their end, I figured I wouldn't submit a PR until it's this approach is deemed workable.\n\n## Changelog\n\n[Android][fixed] - `react-native run-android --port <x>` correctly connects to dev server and related error messages display the correct port\nPull Request resolved: https://github.com/facebook/react-native/pull/23616\n\nDifferential Revision: D15645200\n\nPulled By: cpojer\n\nfbshipit-source-id: 3bdfd458b8ac3ec78290736c9ed0db2e5776ed46",
+      "message": "Android Fix for 9145: No longer hard code build port (#23616)\n\nSummary:\n### Problem\n\nAccording to https://github.com/react/react-native/issues/9145, the `--port` setting is not respected when executing `react-native run-android`. The templates that report things like what port the dev server runs on are hard coded as well.\n\n### Solution\n\nThis commit replaces the hardcoded instances of port 8081 on Android with a build configuration property. This allows setting of the port React Native Android connects to for the local build server.\n\nFor this change to work, there must also be an update to the react native CLI to pass along this setting:\n\nhttps://github.com/react-native-community/react-native-cli/compare/master...nhunzaker:9145-android-no-port-hardcode-cli\n\nTo avoid some noise on their end, I figured I wouldn't submit a PR until it's this approach is deemed workable.\n\n## Changelog\n\n[Android][fixed] - `react-native run-android --port <x>` correctly connects to dev server and related error messages display the correct port\nPull Request resolved: https://github.com/react/react-native/pull/23616\n\nDifferential Revision: D15645200\n\nPulled By: cpojer\n\nfbshipit-source-id: 3bdfd458b8ac3ec78290736c9ed0db2e5776ed46",
       "tree": {
         "sha": "5a40b6762385c0808d973bda58b07a83b5f98f2b",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/5a40b6762385c0808d973bda58b07a83b5f98f2b"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/5a40b6762385c0808d973bda58b07a83b5f98f2b"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/a916dd6632a5e206ab0dbecb89bac8886e1257a5",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/a916dd6632a5e206ab0dbecb89bac8886e1257a5",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1133,9 +1133,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/a916dd6632a5e206ab0dbecb89bac8886e1257a5",
-    "html_url": "https://github.com/facebook/react-native/commit/a916dd6632a5e206ab0dbecb89bac8886e1257a5",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/a916dd6632a5e206ab0dbecb89bac8886e1257a5/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/a916dd6632a5e206ab0dbecb89bac8886e1257a5",
+    "html_url": "https://github.com/react/react-native/commit/a916dd6632a5e206ab0dbecb89bac8886e1257a5",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/a916dd6632a5e206ab0dbecb89bac8886e1257a5/comments",
     "author": {
       "login": "nhunzaker",
       "id": 590904,
@@ -1179,8 +1179,8 @@
     "parents": [
       {
         "sha": "eb73dbe24e76c028f406039d4a809eaf2b263f1e",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/eb73dbe24e76c028f406039d4a809eaf2b263f1e",
-        "html_url": "https://github.com/facebook/react-native/commit/eb73dbe24e76c028f406039d4a809eaf2b263f1e"
+        "url": "https://api.github.com/repos/react/react-native/commits/eb73dbe24e76c028f406039d4a809eaf2b263f1e",
+        "html_url": "https://github.com/react/react-native/commit/eb73dbe24e76c028f406039d4a809eaf2b263f1e"
       }
     ]
   },
@@ -1198,12 +1198,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-07T14:12:03Z"
       },
-      "message": "Fix Xcode 11 build (#25146)\n\nSummary:\nFixes build in Xcode 11 beta, the signature for `__unused` was changed. This adds a new check for the new style.\n\n## Changelog\n\n[iOS] [Fixed] - Xcode 11 beta build\nPull Request resolved: https://github.com/facebook/react-native/pull/25146\n\nDifferential Revision: D15628404\n\nPulled By: cpojer\n\nfbshipit-source-id: 781a188a0e1562a3316fbe62920b12b03a44e4a7",
+      "message": "Fix Xcode 11 build (#25146)\n\nSummary:\nFixes build in Xcode 11 beta, the signature for `__unused` was changed. This adds a new check for the new style.\n\n## Changelog\n\n[iOS] [Fixed] - Xcode 11 beta build\nPull Request resolved: https://github.com/react/react-native/pull/25146\n\nDifferential Revision: D15628404\n\nPulled By: cpojer\n\nfbshipit-source-id: 781a188a0e1562a3316fbe62920b12b03a44e4a7",
       "tree": {
         "sha": "590fc8e8b8fe0b6eec9bbe510cf0ce625ac068a4",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/590fc8e8b8fe0b6eec9bbe510cf0ce625ac068a4"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/590fc8e8b8fe0b6eec9bbe510cf0ce625ac068a4"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/eb73dbe24e76c028f406039d4a809eaf2b263f1e",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/eb73dbe24e76c028f406039d4a809eaf2b263f1e",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1212,9 +1212,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/eb73dbe24e76c028f406039d4a809eaf2b263f1e",
-    "html_url": "https://github.com/facebook/react-native/commit/eb73dbe24e76c028f406039d4a809eaf2b263f1e",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/eb73dbe24e76c028f406039d4a809eaf2b263f1e/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/eb73dbe24e76c028f406039d4a809eaf2b263f1e",
+    "html_url": "https://github.com/react/react-native/commit/eb73dbe24e76c028f406039d4a809eaf2b263f1e",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/eb73dbe24e76c028f406039d4a809eaf2b263f1e/comments",
     "author": {
       "login": "ericlewis",
       "id": 674503,
@@ -1258,8 +1258,8 @@
     "parents": [
       {
         "sha": "bcc9fcf1c747cc55e55834486beb0dc125befe08",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/bcc9fcf1c747cc55e55834486beb0dc125befe08",
-        "html_url": "https://github.com/facebook/react-native/commit/bcc9fcf1c747cc55e55834486beb0dc125befe08"
+        "url": "https://api.github.com/repos/react/react-native/commits/bcc9fcf1c747cc55e55834486beb0dc125befe08",
+        "html_url": "https://github.com/react/react-native/commit/bcc9fcf1c747cc55e55834486beb0dc125befe08"
       }
     ]
   },
@@ -1277,12 +1277,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-07T14:11:56Z"
       },
-      "message": "Fix accessibilityActions accessors (#25134)\n\nSummary:\nThe accessibilityActions accessors  in UIView+React.m are not aligned with the property declaration in the header file.\n\n## Changelog\n\n[General] [Fixed] - Fix accessibilityActions accessors\nPull Request resolved: https://github.com/facebook/react-native/pull/25134\n\nDifferential Revision: D15621848\n\nPulled By: cpojer\n\nfbshipit-source-id: f344689292ae7988e46d0d4263980306d364366b",
+      "message": "Fix accessibilityActions accessors (#25134)\n\nSummary:\nThe accessibilityActions accessors  in UIView+React.m are not aligned with the property declaration in the header file.\n\n## Changelog\n\n[General] [Fixed] - Fix accessibilityActions accessors\nPull Request resolved: https://github.com/react/react-native/pull/25134\n\nDifferential Revision: D15621848\n\nPulled By: cpojer\n\nfbshipit-source-id: f344689292ae7988e46d0d4263980306d364366b",
       "tree": {
         "sha": "e35166068e54d2fb2bc27167420af2cb8dd0a33e",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/e35166068e54d2fb2bc27167420af2cb8dd0a33e"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/e35166068e54d2fb2bc27167420af2cb8dd0a33e"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/bcc9fcf1c747cc55e55834486beb0dc125befe08",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/bcc9fcf1c747cc55e55834486beb0dc125befe08",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1291,9 +1291,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/bcc9fcf1c747cc55e55834486beb0dc125befe08",
-    "html_url": "https://github.com/facebook/react-native/commit/bcc9fcf1c747cc55e55834486beb0dc125befe08",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/bcc9fcf1c747cc55e55834486beb0dc125befe08/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/bcc9fcf1c747cc55e55834486beb0dc125befe08",
+    "html_url": "https://github.com/react/react-native/commit/bcc9fcf1c747cc55e55834486beb0dc125befe08",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/bcc9fcf1c747cc55e55834486beb0dc125befe08/comments",
     "author": {
       "login": "xuelgong",
       "id": 45978880,
@@ -1337,8 +1337,8 @@
     "parents": [
       {
         "sha": "3e937eac2b2cb22673ac0824123bf6881b4fbac3",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/3e937eac2b2cb22673ac0824123bf6881b4fbac3",
-        "html_url": "https://github.com/facebook/react-native/commit/3e937eac2b2cb22673ac0824123bf6881b4fbac3"
+        "url": "https://api.github.com/repos/react/react-native/commits/3e937eac2b2cb22673ac0824123bf6881b4fbac3",
+        "html_url": "https://github.com/react/react-native/commit/3e937eac2b2cb22673ac0824123bf6881b4fbac3"
       }
     ]
   },
@@ -1356,12 +1356,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-07T14:11:50Z"
       },
-      "message": "fix indexed RAM bundle (#24967)\n\nSummary:\nCo-Authored: zamotany\nWith React Native 0.59.8 the app keeps crashing with indexed RAM bundle on Android with the following error:\n\n```\n2019-05-09 11:58:06.684 2793-2856/? E/AndroidRuntime: FATAL EXCEPTION: mqt_js\n    Process: com.ramtestapp, PID: 2793\n    com.facebook.jni.CppException: getPropertyAsObject: property '__fbRequireBatchedBridge' is not an Object\n\n    no stack\n        at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)\n        at android.os.Handler.handleCallback(Handler.java:873)\n        at android.os.Handler.dispatchMessage(Handler.java:99)\n        at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:29)\n        at android.os.Looper.loop(Looper.java:193)\n        at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:232)\n        at java.lang.Thread.run(Thread.java:764)\n```\n\nAfter investigation we found that when using any bundle, let it be non-ram, FIle RAM bundle or Index RAM bundle, the `CatalystInstanceImpl.java` is always using `loadScriptsFromAsset`, which is calling `CatalystInstanceImpl::jniLoadScriptFromAssets` in C++. This method when checking if bundle is a RAM bundle, uses `JniJSModulesUnbundle::isUnbundle` which only check for js-modules/UNBUNDLE - file generated when building File RAM bundle. There is no other logic to handle Indexed RAM bundle, so it figures that the bundle is not RAM, cause there is no js-modules/UNBUNDLE file and tries to load as regular bundle and fails.\n\nIn this PR we added check if it is indexed RAM bundle in `jniLoadScriptFromAssets` and handle it if it is.\n## Changelog\n[Android] [Fixed] fix indexed RAM bundle\n\nSolves https://github.com/facebook/react-native/issues/21282\nPull Request resolved: https://github.com/facebook/react-native/pull/24967\n\nDifferential Revision: D15575924\n\nPulled By: cpojer\n\nfbshipit-source-id: 5ea428e0b793edd8242243f39f933d1092b35260",
+      "message": "fix indexed RAM bundle (#24967)\n\nSummary:\nCo-Authored: zamotany\nWith React Native 0.59.8 the app keeps crashing with indexed RAM bundle on Android with the following error:\n\n```\n2019-05-09 11:58:06.684 2793-2856/? E/AndroidRuntime: FATAL EXCEPTION: mqt_js\n    Process: com.ramtestapp, PID: 2793\n    com.facebook.jni.CppException: getPropertyAsObject: property '__fbRequireBatchedBridge' is not an Object\n\n    no stack\n        at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)\n        at android.os.Handler.handleCallback(Handler.java:873)\n        at android.os.Handler.dispatchMessage(Handler.java:99)\n        at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:29)\n        at android.os.Looper.loop(Looper.java:193)\n        at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:232)\n        at java.lang.Thread.run(Thread.java:764)\n```\n\nAfter investigation we found that when using any bundle, let it be non-ram, FIle RAM bundle or Index RAM bundle, the `CatalystInstanceImpl.java` is always using `loadScriptsFromAsset`, which is calling `CatalystInstanceImpl::jniLoadScriptFromAssets` in C++. This method when checking if bundle is a RAM bundle, uses `JniJSModulesUnbundle::isUnbundle` which only check for js-modules/UNBUNDLE - file generated when building File RAM bundle. There is no other logic to handle Indexed RAM bundle, so it figures that the bundle is not RAM, cause there is no js-modules/UNBUNDLE file and tries to load as regular bundle and fails.\n\nIn this PR we added check if it is indexed RAM bundle in `jniLoadScriptFromAssets` and handle it if it is.\n## Changelog\n[Android] [Fixed] fix indexed RAM bundle\n\nSolves https://github.com/react/react-native/issues/21282\nPull Request resolved: https://github.com/react/react-native/pull/24967\n\nDifferential Revision: D15575924\n\nPulled By: cpojer\n\nfbshipit-source-id: 5ea428e0b793edd8242243f39f933d1092b35260",
       "tree": {
         "sha": "c6c352408419572ed1c77d1c1c0b5b3021186b44",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/c6c352408419572ed1c77d1c1c0b5b3021186b44"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/c6c352408419572ed1c77d1c1c0b5b3021186b44"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/3e937eac2b2cb22673ac0824123bf6881b4fbac3",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/3e937eac2b2cb22673ac0824123bf6881b4fbac3",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1370,9 +1370,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/3e937eac2b2cb22673ac0824123bf6881b4fbac3",
-    "html_url": "https://github.com/facebook/react-native/commit/3e937eac2b2cb22673ac0824123bf6881b4fbac3",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/3e937eac2b2cb22673ac0824123bf6881b4fbac3/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/3e937eac2b2cb22673ac0824123bf6881b4fbac3",
+    "html_url": "https://github.com/react/react-native/commit/3e937eac2b2cb22673ac0824123bf6881b4fbac3",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/3e937eac2b2cb22673ac0824123bf6881b4fbac3/comments",
     "author": {
       "login": "dratwas",
       "id": 16336501,
@@ -1416,8 +1416,8 @@
     "parents": [
       {
         "sha": "0d05051f3cb324688797274b892c611f88a6bd60",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/0d05051f3cb324688797274b892c611f88a6bd60",
-        "html_url": "https://github.com/facebook/react-native/commit/0d05051f3cb324688797274b892c611f88a6bd60"
+        "url": "https://api.github.com/repos/react/react-native/commits/0d05051f3cb324688797274b892c611f88a6bd60",
+        "html_url": "https://github.com/react/react-native/commit/0d05051f3cb324688797274b892c611f88a6bd60"
       }
     ]
   },
@@ -1435,12 +1435,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-07T14:11:43Z"
       },
-      "message": "- Fix missing whitespace in debug instructions (#25122)\n\nSummary:\nFixes minor whitespace issue with the new new-app template.\n\n## Changelog\n\n[Android] [Fixed] - Fix missing whitespace in debug instructions\nPull Request resolved: https://github.com/facebook/react-native/pull/25122\n\nDifferential Revision: D15602100\n\nPulled By: cpojer\n\nfbshipit-source-id: 07c51c6359e37826941de659bcedea692ff3315a",
+      "message": "- Fix missing whitespace in debug instructions (#25122)\n\nSummary:\nFixes minor whitespace issue with the new new-app template.\n\n## Changelog\n\n[Android] [Fixed] - Fix missing whitespace in debug instructions\nPull Request resolved: https://github.com/react/react-native/pull/25122\n\nDifferential Revision: D15602100\n\nPulled By: cpojer\n\nfbshipit-source-id: 07c51c6359e37826941de659bcedea692ff3315a",
       "tree": {
         "sha": "4c49c2c8dfef31801e933857504abfa5acb1eee8",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/4c49c2c8dfef31801e933857504abfa5acb1eee8"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/4c49c2c8dfef31801e933857504abfa5acb1eee8"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/0d05051f3cb324688797274b892c611f88a6bd60",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/0d05051f3cb324688797274b892c611f88a6bd60",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1449,9 +1449,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/0d05051f3cb324688797274b892c611f88a6bd60",
-    "html_url": "https://github.com/facebook/react-native/commit/0d05051f3cb324688797274b892c611f88a6bd60",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/0d05051f3cb324688797274b892c611f88a6bd60/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/0d05051f3cb324688797274b892c611f88a6bd60",
+    "html_url": "https://github.com/react/react-native/commit/0d05051f3cb324688797274b892c611f88a6bd60",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/0d05051f3cb324688797274b892c611f88a6bd60/comments",
     "author": {
       "login": "mjmasn",
       "id": 2977095,
@@ -1495,8 +1495,8 @@
     "parents": [
       {
         "sha": "54471963e02e15e42d48764de9dfc67aab23c2fb",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/54471963e02e15e42d48764de9dfc67aab23c2fb",
-        "html_url": "https://github.com/facebook/react-native/commit/54471963e02e15e42d48764de9dfc67aab23c2fb"
+        "url": "https://api.github.com/repos/react/react-native/commits/54471963e02e15e42d48764de9dfc67aab23c2fb",
+        "html_url": "https://github.com/react/react-native/commit/54471963e02e15e42d48764de9dfc67aab23c2fb"
       }
     ]
   },
@@ -1514,12 +1514,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-07T14:11:36Z"
       },
-      "message": "Remove vendored fetch polyfill, update to whatwg-fetch@3.0 (#24418)\n\nSummary:\nThe original reason for vendoring the fetch polyfill was to remove the default blob response type but this was reverted.\n\nHere's a little history around the fetch polyfill and the blob issue:\n\n- Original commit introducing the vendored polyfill: #19333, the goal was to fix a memory leak because our blob implementation doesn't release resources automatically. Not an ideal fix but since the issue was pretty severe and the infra for a proper fix was not in place.\n- This introduced an issue when downloading images using `fetch` which was fixed by #22063 which re-added the default blob content type. However that re-introduced the original fetch memory leak.\n- We have better infra now with jsi and I was able to get blob deallocation working, see #24405\n\nCurrently the vendored fetch polyfill is useless since it was changed back to the original version. We can just use the npm version again. I also updated to 3.0 which brings better spec compliance and support for cancellation via `AbortController`, https://github.com/github/fetch/releases/tag/v3.0.0.\n\n## Changelog\n\n[General] [Changed] - Remove vendored fetch polyfill, update to whatwg-fetch@3.0\nPull Request resolved: https://github.com/facebook/react-native/pull/24418\n\nDifferential Revision: D14932683\n\nPulled By: cpojer\n\nfbshipit-source-id: 915e3d25978e8b9d7507ed807e7fba45aa88385a",
+      "message": "Remove vendored fetch polyfill, update to whatwg-fetch@3.0 (#24418)\n\nSummary:\nThe original reason for vendoring the fetch polyfill was to remove the default blob response type but this was reverted.\n\nHere's a little history around the fetch polyfill and the blob issue:\n\n- Original commit introducing the vendored polyfill: #19333, the goal was to fix a memory leak because our blob implementation doesn't release resources automatically. Not an ideal fix but since the issue was pretty severe and the infra for a proper fix was not in place.\n- This introduced an issue when downloading images using `fetch` which was fixed by #22063 which re-added the default blob content type. However that re-introduced the original fetch memory leak.\n- We have better infra now with jsi and I was able to get blob deallocation working, see #24405\n\nCurrently the vendored fetch polyfill is useless since it was changed back to the original version. We can just use the npm version again. I also updated to 3.0 which brings better spec compliance and support for cancellation via `AbortController`, https://github.com/github/fetch/releases/tag/v3.0.0.\n\n## Changelog\n\n[General] [Changed] - Remove vendored fetch polyfill, update to whatwg-fetch@3.0\nPull Request resolved: https://github.com/react/react-native/pull/24418\n\nDifferential Revision: D14932683\n\nPulled By: cpojer\n\nfbshipit-source-id: 915e3d25978e8b9d7507ed807e7fba45aa88385a",
       "tree": {
         "sha": "807a241a9eaf595eecb833991795979d38281746",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/807a241a9eaf595eecb833991795979d38281746"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/807a241a9eaf595eecb833991795979d38281746"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/54471963e02e15e42d48764de9dfc67aab23c2fb",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/54471963e02e15e42d48764de9dfc67aab23c2fb",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1528,9 +1528,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/54471963e02e15e42d48764de9dfc67aab23c2fb",
-    "html_url": "https://github.com/facebook/react-native/commit/54471963e02e15e42d48764de9dfc67aab23c2fb",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/54471963e02e15e42d48764de9dfc67aab23c2fb/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/54471963e02e15e42d48764de9dfc67aab23c2fb",
+    "html_url": "https://github.com/react/react-native/commit/54471963e02e15e42d48764de9dfc67aab23c2fb",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/54471963e02e15e42d48764de9dfc67aab23c2fb/comments",
     "author": {
       "login": "janicduplessis",
       "id": 2677334,
@@ -1574,8 +1574,8 @@
     "parents": [
       {
         "sha": "1b8f7e7a366cb69155ef930dfb581969a5389ad0",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/1b8f7e7a366cb69155ef930dfb581969a5389ad0",
-        "html_url": "https://github.com/facebook/react-native/commit/1b8f7e7a366cb69155ef930dfb581969a5389ad0"
+        "url": "https://api.github.com/repos/react/react-native/commits/1b8f7e7a366cb69155ef930dfb581969a5389ad0",
+        "html_url": "https://github.com/react/react-native/commit/1b8f7e7a366cb69155ef930dfb581969a5389ad0"
       }
     ]
   },
@@ -1593,12 +1593,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-07T14:11:29Z"
       },
-      "message": "Don't reference null android.ndkDirectory in build.gradle (#25088)\n\nSummary:\nIf you (try to) build React Native for Android without having the NDK properly installed and referenced, you get the following error:\n\n>A problem occurred evaluating project ':ReactAndroid'.\n\\> Cannot get property 'absolutePath' on null object\n\nThis is not an overly helpful diagnostic. This PR results in this message instead:\n\n>ndk-build binary cannot be found, check if you've set $ANDROID_NDK environment variable correctly or if ndk.dir is setup in local.properties\n\nFixes #25087\n\n## Changelog\n\n[Android] [Fixed] - Show proper error message instead of throwing a NullReferenceException if Gradle cannot find the NDK\nPull Request resolved: https://github.com/facebook/react-native/pull/25088\n\nDifferential Revision: D15559271\n\nPulled By: cpojer\n\nfbshipit-source-id: 35c9a9321af4e4a34bf519144ada48884b48352d",
+      "message": "Don't reference null android.ndkDirectory in build.gradle (#25088)\n\nSummary:\nIf you (try to) build React Native for Android without having the NDK properly installed and referenced, you get the following error:\n\n>A problem occurred evaluating project ':ReactAndroid'.\n\\> Cannot get property 'absolutePath' on null object\n\nThis is not an overly helpful diagnostic. This PR results in this message instead:\n\n>ndk-build binary cannot be found, check if you've set $ANDROID_NDK environment variable correctly or if ndk.dir is setup in local.properties\n\nFixes #25087\n\n## Changelog\n\n[Android] [Fixed] - Show proper error message instead of throwing a NullReferenceException if Gradle cannot find the NDK\nPull Request resolved: https://github.com/react/react-native/pull/25088\n\nDifferential Revision: D15559271\n\nPulled By: cpojer\n\nfbshipit-source-id: 35c9a9321af4e4a34bf519144ada48884b48352d",
       "tree": {
         "sha": "ac293b232d9b86503f711a6fe7acea6866372e01",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/ac293b232d9b86503f711a6fe7acea6866372e01"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/ac293b232d9b86503f711a6fe7acea6866372e01"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/1b8f7e7a366cb69155ef930dfb581969a5389ad0",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/1b8f7e7a366cb69155ef930dfb581969a5389ad0",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1607,9 +1607,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/1b8f7e7a366cb69155ef930dfb581969a5389ad0",
-    "html_url": "https://github.com/facebook/react-native/commit/1b8f7e7a366cb69155ef930dfb581969a5389ad0",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/1b8f7e7a366cb69155ef930dfb581969a5389ad0/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/1b8f7e7a366cb69155ef930dfb581969a5389ad0",
+    "html_url": "https://github.com/react/react-native/commit/1b8f7e7a366cb69155ef930dfb581969a5389ad0",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/1b8f7e7a366cb69155ef930dfb581969a5389ad0/comments",
     "author": {
       "login": "petterh",
       "id": 3366765,
@@ -1653,8 +1653,8 @@
     "parents": [
       {
         "sha": "46500b3e36df6f54e216382bc7ab257d45d7a2cc",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/46500b3e36df6f54e216382bc7ab257d45d7a2cc",
-        "html_url": "https://github.com/facebook/react-native/commit/46500b3e36df6f54e216382bc7ab257d45d7a2cc"
+        "url": "https://api.github.com/repos/react/react-native/commits/46500b3e36df6f54e216382bc7ab257d45d7a2cc",
+        "html_url": "https://github.com/react/react-native/commit/46500b3e36df6f54e216382bc7ab257d45d7a2cc"
       }
     ]
   },
@@ -1672,12 +1672,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-07T14:11:22Z"
       },
-      "message": "Linking.getInitialURL() to work with NFC tags on Android (#25055)\n\nSummary:\nThis PR solves bug https://github.com/facebook/react-native/issues/24393 for Android. Allows an app to be opened with an NFC tag and getting the url trough Linking.getInitialURL()\n\n## Changelog\n[Android] [Fixed] - This branch checks also for `ACTION_NDEF_DISCOVERED` intent matches to set the initialURL\nPull Request resolved: https://github.com/facebook/react-native/pull/25055\n\nDifferential Revision: D15516873\n\nPulled By: cpojer\n\nfbshipit-source-id: e8803738d857a69e1063e926fc3858a416a0b25e",
+      "message": "Linking.getInitialURL() to work with NFC tags on Android (#25055)\n\nSummary:\nThis PR solves bug https://github.com/react/react-native/issues/24393 for Android. Allows an app to be opened with an NFC tag and getting the url trough Linking.getInitialURL()\n\n## Changelog\n[Android] [Fixed] - This branch checks also for `ACTION_NDEF_DISCOVERED` intent matches to set the initialURL\nPull Request resolved: https://github.com/react/react-native/pull/25055\n\nDifferential Revision: D15516873\n\nPulled By: cpojer\n\nfbshipit-source-id: e8803738d857a69e1063e926fc3858a416a0b25e",
       "tree": {
         "sha": "6860de6792bc237ef54da08f661527c970b50efa",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/6860de6792bc237ef54da08f661527c970b50efa"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/6860de6792bc237ef54da08f661527c970b50efa"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/46500b3e36df6f54e216382bc7ab257d45d7a2cc",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/46500b3e36df6f54e216382bc7ab257d45d7a2cc",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1686,9 +1686,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/46500b3e36df6f54e216382bc7ab257d45d7a2cc",
-    "html_url": "https://github.com/facebook/react-native/commit/46500b3e36df6f54e216382bc7ab257d45d7a2cc",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/46500b3e36df6f54e216382bc7ab257d45d7a2cc/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/46500b3e36df6f54e216382bc7ab257d45d7a2cc",
+    "html_url": "https://github.com/react/react-native/commit/46500b3e36df6f54e216382bc7ab257d45d7a2cc",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/46500b3e36df6f54e216382bc7ab257d45d7a2cc/comments",
     "author": {
       "login": "cimitan",
       "id": 2470182,
@@ -1732,8 +1732,8 @@
     "parents": [
       {
         "sha": "ed40f382e82ec7976f070e87ddb96a77cb6ca016",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/ed40f382e82ec7976f070e87ddb96a77cb6ca016",
-        "html_url": "https://github.com/facebook/react-native/commit/ed40f382e82ec7976f070e87ddb96a77cb6ca016"
+        "url": "https://api.github.com/repos/react/react-native/commits/ed40f382e82ec7976f070e87ddb96a77cb6ca016",
+        "html_url": "https://github.com/react/react-native/commit/ed40f382e82ec7976f070e87ddb96a77cb6ca016"
       }
     ]
   },
@@ -1754,9 +1754,9 @@
       "message": "Fix backgroundColor top level prop of TextInput\n\nSummary:\nChangelog: [Android] [FIXED] - Fix backgroundColor top level prop of TextInput\n\nThis diff fixes two issues with the `backgroundColor` top level property of TextInput on Android:\n * Now it is possible to set a **string** value for the top-level `backgroundColor` property of TextInput (crashed the app previously):\n```\n<TextInput backgroundColor=\"#ffccbb\">Hello, React Native</TextInput>\n```\n* Now it's possible to set an **integer** value for the top-level `backgroundColor` property of TextInput (had no effect previously):\n```\n<TextInput backgroundColor={0xffccbbff}>Hello, React Native</TextInput>\n```\n\nA `customType = \"Color\"` annotation parameter must be provided for `ReactBaseTextShadowNode.setBackgroundColor(...)` since the color value must be previously processed in JS before sending it over the bridge to the native code. The JS code will parse the color value and return the proper ARGB color integer to the native platforms (https://fburl.com/uqup52tn).\n\nWithout providing the custom type for the background color, if a string value is set for the top-level `backgroundColor` property in the JS code, the Android code will crash since it expects an integer value for the color in `ReactBaseTextShadowNode.setBackgroundColor(...)`, but a string will be passed from JS without any conversion and there will be a `ClassCastException` thrown. If an integer value without the alpha component (like `0xffccbb`) is set, the Android native view would get an integer color value with its alpha component set to `0x00`, which means a transparent color.\n\nOn a side note: the alpha component of a color must always be set when using an integer value for `backgroundColor` since the JS code, while processing the color type, shifts the rightmost 8 bytes (alpha component) to the leftmost position. If those 8 bytes are not the alpha component, you will get the wrong color in the end. It doesn't seem to be a problem for string values of `backgroundColor` though.\n\nReviewed By: mdvacca\n\nDifferential Revision: D15453980\n\nfbshipit-source-id: f3f5d9c9877cdbce79a67f2ed93ad4589576d166",
       "tree": {
         "sha": "55069244e82883927e8cfd50be320693aa771888",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/55069244e82883927e8cfd50be320693aa771888"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/55069244e82883927e8cfd50be320693aa771888"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/ed40f382e82ec7976f070e87ddb96a77cb6ca016",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/ed40f382e82ec7976f070e87ddb96a77cb6ca016",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1765,9 +1765,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/ed40f382e82ec7976f070e87ddb96a77cb6ca016",
-    "html_url": "https://github.com/facebook/react-native/commit/ed40f382e82ec7976f070e87ddb96a77cb6ca016",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/ed40f382e82ec7976f070e87ddb96a77cb6ca016/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/ed40f382e82ec7976f070e87ddb96a77cb6ca016",
+    "html_url": "https://github.com/react/react-native/commit/ed40f382e82ec7976f070e87ddb96a77cb6ca016",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/ed40f382e82ec7976f070e87ddb96a77cb6ca016/comments",
     "author": {
       "login": "makovkastar",
       "id": 1076309,
@@ -1811,8 +1811,8 @@
     "parents": [
       {
         "sha": "8d61a4e5f90893b3d7baec1d6a76603786ea7a1c",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/8d61a4e5f90893b3d7baec1d6a76603786ea7a1c",
-        "html_url": "https://github.com/facebook/react-native/commit/8d61a4e5f90893b3d7baec1d6a76603786ea7a1c"
+        "url": "https://api.github.com/repos/react/react-native/commits/8d61a4e5f90893b3d7baec1d6a76603786ea7a1c",
+        "html_url": "https://github.com/react/react-native/commit/8d61a4e5f90893b3d7baec1d6a76603786ea7a1c"
       }
     ]
   },
@@ -1830,12 +1830,12 @@
         "email": "lorenzo.sciandra@gmail.com",
         "date": "2019-06-07T14:11:05Z"
       },
-      "message": "bump android gradle plugin to 3.4.1 (#24883)\n\nSummary:\nbump android gradle plugin to 3.4.1, includes many fixes and improvements.\n\n## Changelog\n\n[Android] [Changed] - bump android gradle plugin to 3.4.1\nPull Request resolved: https://github.com/facebook/react-native/pull/24883\n\nDifferential Revision: D15474556\n\nPulled By: hramos\n\nfbshipit-source-id: 8d1eb91855b9f416ed3380c61f34672deded26c1",
+      "message": "bump android gradle plugin to 3.4.1 (#24883)\n\nSummary:\nbump android gradle plugin to 3.4.1, includes many fixes and improvements.\n\n## Changelog\n\n[Android] [Changed] - bump android gradle plugin to 3.4.1\nPull Request resolved: https://github.com/react/react-native/pull/24883\n\nDifferential Revision: D15474556\n\nPulled By: hramos\n\nfbshipit-source-id: 8d1eb91855b9f416ed3380c61f34672deded26c1",
       "tree": {
         "sha": "cf7ac90dfc0bfcbeadc2ec5d99289e632f28eb70",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/cf7ac90dfc0bfcbeadc2ec5d99289e632f28eb70"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/cf7ac90dfc0bfcbeadc2ec5d99289e632f28eb70"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/8d61a4e5f90893b3d7baec1d6a76603786ea7a1c",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/8d61a4e5f90893b3d7baec1d6a76603786ea7a1c",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1844,9 +1844,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/8d61a4e5f90893b3d7baec1d6a76603786ea7a1c",
-    "html_url": "https://github.com/facebook/react-native/commit/8d61a4e5f90893b3d7baec1d6a76603786ea7a1c",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/8d61a4e5f90893b3d7baec1d6a76603786ea7a1c/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/8d61a4e5f90893b3d7baec1d6a76603786ea7a1c",
+    "html_url": "https://github.com/react/react-native/commit/8d61a4e5f90893b3d7baec1d6a76603786ea7a1c",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/8d61a4e5f90893b3d7baec1d6a76603786ea7a1c/comments",
     "author": {
       "login": "dulmandakh",
       "id": 178494,
@@ -1890,8 +1890,8 @@
     "parents": [
       {
         "sha": "55332afb2901c975381c78adcd572ede6218915a",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/55332afb2901c975381c78adcd572ede6218915a",
-        "html_url": "https://github.com/facebook/react-native/commit/55332afb2901c975381c78adcd572ede6218915a"
+        "url": "https://api.github.com/repos/react/react-native/commits/55332afb2901c975381c78adcd572ede6218915a",
+        "html_url": "https://github.com/react/react-native/commit/55332afb2901c975381c78adcd572ede6218915a"
       }
     ]
   },
@@ -1912,9 +1912,9 @@
       "message": "[0.60.0-rc.0] Bump version numbers",
       "tree": {
         "sha": "ef68c1468523a95848c6507f0c7f5a009e1d9fd1",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/ef68c1468523a95848c6507f0c7f5a009e1d9fd1"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/ef68c1468523a95848c6507f0c7f5a009e1d9fd1"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/55332afb2901c975381c78adcd572ede6218915a",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/55332afb2901c975381c78adcd572ede6218915a",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -1923,9 +1923,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/55332afb2901c975381c78adcd572ede6218915a",
-    "html_url": "https://github.com/facebook/react-native/commit/55332afb2901c975381c78adcd572ede6218915a",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/55332afb2901c975381c78adcd572ede6218915a/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/55332afb2901c975381c78adcd572ede6218915a",
+    "html_url": "https://github.com/react/react-native/commit/55332afb2901c975381c78adcd572ede6218915a",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/55332afb2901c975381c78adcd572ede6218915a/comments",
     "author": {
       "login": "hramos",
       "id": 165856,
@@ -1969,8 +1969,8 @@
     "parents": [
       {
         "sha": "d014fc71539f7d44049754c43a9d605cd6e94b8c",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/d014fc71539f7d44049754c43a9d605cd6e94b8c",
-        "html_url": "https://github.com/facebook/react-native/commit/d014fc71539f7d44049754c43a9d605cd6e94b8c"
+        "url": "https://api.github.com/repos/react/react-native/commits/d014fc71539f7d44049754c43a9d605cd6e94b8c",
+        "html_url": "https://github.com/react/react-native/commit/d014fc71539f7d44049754c43a9d605cd6e94b8c"
       }
     ]
   },
@@ -1991,9 +1991,9 @@
       "message": "Use newer Docker container, with ssl support",
       "tree": {
         "sha": "eb941125861f6f1940ca0a9fdf93136c7405328a",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/eb941125861f6f1940ca0a9fdf93136c7405328a"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/eb941125861f6f1940ca0a9fdf93136c7405328a"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/d014fc71539f7d44049754c43a9d605cd6e94b8c",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/d014fc71539f7d44049754c43a9d605cd6e94b8c",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -2002,9 +2002,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/d014fc71539f7d44049754c43a9d605cd6e94b8c",
-    "html_url": "https://github.com/facebook/react-native/commit/d014fc71539f7d44049754c43a9d605cd6e94b8c",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/d014fc71539f7d44049754c43a9d605cd6e94b8c/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/d014fc71539f7d44049754c43a9d605cd6e94b8c",
+    "html_url": "https://github.com/react/react-native/commit/d014fc71539f7d44049754c43a9d605cd6e94b8c",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/d014fc71539f7d44049754c43a9d605cd6e94b8c/comments",
     "author": {
       "login": "hramos",
       "id": 165856,
@@ -2048,8 +2048,8 @@
     "parents": [
       {
         "sha": "29496ede07dc57b70d646d75037769d00ce8b49c",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/29496ede07dc57b70d646d75037769d00ce8b49c",
-        "html_url": "https://github.com/facebook/react-native/commit/29496ede07dc57b70d646d75037769d00ce8b49c"
+        "url": "https://api.github.com/repos/react/react-native/commits/29496ede07dc57b70d646d75037769d00ce8b49c",
+        "html_url": "https://github.com/react/react-native/commit/29496ede07dc57b70d646d75037769d00ce8b49c"
       }
     ]
   },
@@ -2070,9 +2070,9 @@
       "message": "Revert \"[0.60.0-rc.0] Bump version numbers\"\n\nThis reverts commit f4508a67653e99b59414b6e0d07f65b1052a7d46.",
       "tree": {
         "sha": "49ea6f6154522c85e15e5c0371a17bc1fe3eb015",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/49ea6f6154522c85e15e5c0371a17bc1fe3eb015"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/49ea6f6154522c85e15e5c0371a17bc1fe3eb015"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/29496ede07dc57b70d646d75037769d00ce8b49c",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/29496ede07dc57b70d646d75037769d00ce8b49c",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -2081,9 +2081,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/29496ede07dc57b70d646d75037769d00ce8b49c",
-    "html_url": "https://github.com/facebook/react-native/commit/29496ede07dc57b70d646d75037769d00ce8b49c",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/29496ede07dc57b70d646d75037769d00ce8b49c/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/29496ede07dc57b70d646d75037769d00ce8b49c",
+    "html_url": "https://github.com/react/react-native/commit/29496ede07dc57b70d646d75037769d00ce8b49c",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/29496ede07dc57b70d646d75037769d00ce8b49c/comments",
     "author": {
       "login": "hramos",
       "id": 165856,
@@ -2127,8 +2127,8 @@
     "parents": [
       {
         "sha": "f4508a67653e99b59414b6e0d07f65b1052a7d46",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/f4508a67653e99b59414b6e0d07f65b1052a7d46",
-        "html_url": "https://github.com/facebook/react-native/commit/f4508a67653e99b59414b6e0d07f65b1052a7d46"
+        "url": "https://api.github.com/repos/react/react-native/commits/f4508a67653e99b59414b6e0d07f65b1052a7d46",
+        "html_url": "https://github.com/react/react-native/commit/f4508a67653e99b59414b6e0d07f65b1052a7d46"
       }
     ]
   },
@@ -2149,9 +2149,9 @@
       "message": "[0.60.0-rc.0] Bump version numbers",
       "tree": {
         "sha": "58f8a9c35922cc9207bb251545508983ebb3cc62",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/58f8a9c35922cc9207bb251545508983ebb3cc62"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/58f8a9c35922cc9207bb251545508983ebb3cc62"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/f4508a67653e99b59414b6e0d07f65b1052a7d46",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/f4508a67653e99b59414b6e0d07f65b1052a7d46",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -2160,9 +2160,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/f4508a67653e99b59414b6e0d07f65b1052a7d46",
-    "html_url": "https://github.com/facebook/react-native/commit/f4508a67653e99b59414b6e0d07f65b1052a7d46",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/f4508a67653e99b59414b6e0d07f65b1052a7d46/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/f4508a67653e99b59414b6e0d07f65b1052a7d46",
+    "html_url": "https://github.com/react/react-native/commit/f4508a67653e99b59414b6e0d07f65b1052a7d46",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/f4508a67653e99b59414b6e0d07f65b1052a7d46/comments",
     "author": {
       "login": "grabbou",
       "id": 2464966,
@@ -2206,8 +2206,8 @@
     "parents": [
       {
         "sha": "53e32a47e4062f428f8d714333236cedbe05b482",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/53e32a47e4062f428f8d714333236cedbe05b482",
-        "html_url": "https://github.com/facebook/react-native/commit/53e32a47e4062f428f8d714333236cedbe05b482"
+        "url": "https://api.github.com/repos/react/react-native/commits/53e32a47e4062f428f8d714333236cedbe05b482",
+        "html_url": "https://github.com/react/react-native/commit/53e32a47e4062f428f8d714333236cedbe05b482"
       }
     ]
   },
@@ -2228,9 +2228,9 @@
       "message": "Remove duplicate Android SDK steps already present in container",
       "tree": {
         "sha": "49ea6f6154522c85e15e5c0371a17bc1fe3eb015",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/49ea6f6154522c85e15e5c0371a17bc1fe3eb015"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/49ea6f6154522c85e15e5c0371a17bc1fe3eb015"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/53e32a47e4062f428f8d714333236cedbe05b482",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/53e32a47e4062f428f8d714333236cedbe05b482",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -2239,9 +2239,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/53e32a47e4062f428f8d714333236cedbe05b482",
-    "html_url": "https://github.com/facebook/react-native/commit/53e32a47e4062f428f8d714333236cedbe05b482",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/53e32a47e4062f428f8d714333236cedbe05b482/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/53e32a47e4062f428f8d714333236cedbe05b482",
+    "html_url": "https://github.com/react/react-native/commit/53e32a47e4062f428f8d714333236cedbe05b482",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/53e32a47e4062f428f8d714333236cedbe05b482/comments",
     "author": {
       "login": "hramos",
       "id": 165856,
@@ -2285,8 +2285,8 @@
     "parents": [
       {
         "sha": "41742b3fe3d21a9e1554d096ab46929593ba744e",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/41742b3fe3d21a9e1554d096ab46929593ba744e",
-        "html_url": "https://github.com/facebook/react-native/commit/41742b3fe3d21a9e1554d096ab46929593ba744e"
+        "url": "https://api.github.com/repos/react/react-native/commits/41742b3fe3d21a9e1554d096ab46929593ba744e",
+        "html_url": "https://github.com/react/react-native/commit/41742b3fe3d21a9e1554d096ab46929593ba744e"
       }
     ]
   },
@@ -2307,9 +2307,9 @@
       "message": "Fix config for 0.60 release",
       "tree": {
         "sha": "5f28b65092723aa9ae931bb6c16018a2eb6ae221",
-        "url": "https://api.github.com/repos/facebook/react-native/git/trees/5f28b65092723aa9ae931bb6c16018a2eb6ae221"
+        "url": "https://api.github.com/repos/react/react-native/git/trees/5f28b65092723aa9ae931bb6c16018a2eb6ae221"
       },
-      "url": "https://api.github.com/repos/facebook/react-native/git/commits/41742b3fe3d21a9e1554d096ab46929593ba744e",
+      "url": "https://api.github.com/repos/react/react-native/git/commits/41742b3fe3d21a9e1554d096ab46929593ba744e",
       "comment_count": 0,
       "verification": {
         "verified": false,
@@ -2318,9 +2318,9 @@
         "payload": null
       }
     },
-    "url": "https://api.github.com/repos/facebook/react-native/commits/41742b3fe3d21a9e1554d096ab46929593ba744e",
-    "html_url": "https://github.com/facebook/react-native/commit/41742b3fe3d21a9e1554d096ab46929593ba744e",
-    "comments_url": "https://api.github.com/repos/facebook/react-native/commits/41742b3fe3d21a9e1554d096ab46929593ba744e/comments",
+    "url": "https://api.github.com/repos/react/react-native/commits/41742b3fe3d21a9e1554d096ab46929593ba744e",
+    "html_url": "https://github.com/react/react-native/commit/41742b3fe3d21a9e1554d096ab46929593ba744e",
+    "comments_url": "https://api.github.com/repos/react/react-native/commits/41742b3fe3d21a9e1554d096ab46929593ba744e/comments",
     "author": {
       "login": "hramos",
       "id": 165856,
@@ -2364,8 +2364,8 @@
     "parents": [
       {
         "sha": "5be47faff7788728dfc1820df5e40d8a29c7fa71",
-        "url": "https://api.github.com/repos/facebook/react-native/commits/5be47faff7788728dfc1820df5e40d8a29c7fa71",
-        "html_url": "https://github.com/facebook/react-native/commit/5be47faff7788728dfc1820df5e40d8a29c7fa71"
+        "url": "https://api.github.com/repos/react/react-native/commits/5be47faff7788728dfc1820df5e40d8a29c7fa71",
+        "html_url": "https://github.com/react/react-native/commit/5be47faff7788728dfc1820df5e40d8a29c7fa71"
       }
     ]
   }

--- a/incubator/rn-changelog-generator/test/__snapshots__/generator.test.ts.snap
+++ b/incubator/rn-changelog-generator/test/__snapshots__/generator.test.ts.snap
@@ -19,11 +19,11 @@ exports[`functions that hit GitHub's commits API run fetches commits, filters th
 
 ### Added
 
-- Added a default Prettier config for new projects ([7254bab0b3](https://github.com/facebook/react-native/commit/7254bab0b3fa129cd238783ab993fbae1102d60a) by [@jpdriver](https://github.com/jpdriver))
+- Added a default Prettier config for new projects ([7254bab0b3](https://github.com/react/react-native/commit/7254bab0b3fa129cd238783ab993fbae1102d60a) by [@jpdriver](https://github.com/jpdriver))
 
 #### Android specific
 
-- Add showSoftInputOnFocus to TextInput ([d88e4701fc](https://github.com/facebook/react-native/commit/d88e4701fc46b028861ddcfa3e6ffb141b3ede3d))
+- Add showSoftInputOnFocus to TextInput ([d88e4701fc](https://github.com/react/react-native/commit/d88e4701fc46b028861ddcfa3e6ffb141b3ede3d))
 
 #### iOS specific
 
@@ -31,15 +31,15 @@ exports[`functions that hit GitHub's commits API run fetches commits, filters th
 
 ### Changed
 
-- Bump CLI to 2.0.0-rc.2 ([6c0eccd46d](https://github.com/facebook/react-native/commit/6c0eccd46d157804fde767263ec8856ff8c99cfb) by [@thymikee](https://github.com/thymikee))
-- Bump CLI to 2.0.0-rc.0 ([ea090a10e6](https://github.com/facebook/react-native/commit/ea090a10e63bb75ab9446ed2bd84647bf3d28bd7) by [@thymikee](https://github.com/thymikee))
-- Remove vendored fetch polyfill, update to whatwg-fetch@3.0 ([bccc92dfdd](https://github.com/facebook/react-native/commit/bccc92dfdd2d85933f2a9cb5c8d1773affb7acba) by [@janicduplessis](https://github.com/janicduplessis))
+- Bump CLI to 2.0.0-rc.2 ([6c0eccd46d](https://github.com/react/react-native/commit/6c0eccd46d157804fde767263ec8856ff8c99cfb) by [@thymikee](https://github.com/thymikee))
+- Bump CLI to 2.0.0-rc.0 ([ea090a10e6](https://github.com/react/react-native/commit/ea090a10e63bb75ab9446ed2bd84647bf3d28bd7) by [@thymikee](https://github.com/thymikee))
+- Remove vendored fetch polyfill, update to whatwg-fetch@3.0 ([bccc92dfdd](https://github.com/react/react-native/commit/bccc92dfdd2d85933f2a9cb5c8d1773affb7acba) by [@janicduplessis](https://github.com/janicduplessis))
 
 #### Android specific
 
-- Bump Fresco to 2.0.0, supports AndroidX ([0af25a8ea5](https://github.com/facebook/react-native/commit/0af25a8ea56e38b6306737a55ce8bfd98edf1cfb) by [@dulmandakh](https://github.com/dulmandakh))
-- Add custom font weight support to Text component on Android, only on P(API 28) and above versions. ([3915c0fa61](https://github.com/facebook/react-native/commit/3915c0fa6178fbb8aa9b8bd54881cfdbde8fde70) by [@dulmandakh](https://github.com/dulmandakh))
-- Bump android gradle plugin to 3.4.1 ([fbc6d8caff](https://github.com/facebook/react-native/commit/fbc6d8caff3f40996ec8b8918625ef2ed864a824) by [@dulmandakh](https://github.com/dulmandakh))
+- Bump Fresco to 2.0.0, supports AndroidX ([0af25a8ea5](https://github.com/react/react-native/commit/0af25a8ea56e38b6306737a55ce8bfd98edf1cfb) by [@dulmandakh](https://github.com/dulmandakh))
+- Add custom font weight support to Text component on Android, only on P(API 28) and above versions. ([3915c0fa61](https://github.com/react/react-native/commit/3915c0fa6178fbb8aa9b8bd54881cfdbde8fde70) by [@dulmandakh](https://github.com/dulmandakh))
+- Bump android gradle plugin to 3.4.1 ([fbc6d8caff](https://github.com/react/react-native/commit/fbc6d8caff3f40996ec8b8918625ef2ed864a824) by [@dulmandakh](https://github.com/dulmandakh))
 
 #### iOS specific
 
@@ -71,26 +71,26 @@ exports[`functions that hit GitHub's commits API run fetches commits, filters th
 
 ### Fixed
 
-- Fix of Android's bug that doesn't let override ScrollView's Style with custom RefreshControl. ([d9a8ac5071](https://github.com/facebook/react-native/commit/d9a8ac5071d23275c5d4a8e9936f391b967416d7) by [@Nizarius](https://github.com/Nizarius))
-- Fix accessibilityActions accessors ([afc142bc76](https://github.com/facebook/react-native/commit/afc142bc76d5cfddcacf55a1f3770e6b6ea15996) by [@xuelgong](https://github.com/xuelgong))
+- Fix of Android's bug that doesn't let override ScrollView's Style with custom RefreshControl. ([d9a8ac5071](https://github.com/react/react-native/commit/d9a8ac5071d23275c5d4a8e9936f391b967416d7) by [@Nizarius](https://github.com/Nizarius))
+- Fix accessibilityActions accessors ([afc142bc76](https://github.com/react/react-native/commit/afc142bc76d5cfddcacf55a1f3770e6b6ea15996) by [@xuelgong](https://github.com/xuelgong))
 
 #### Android specific
 
-- Check if mCurrentActivity is set according to LifecycleState ([fb550e9e84](https://github.com/facebook/react-native/commit/fb550e9e8405870167dea9bd3bc3f50fbbae5ae5) by [@RoJoHub](https://github.com/RoJoHub))
-- Fix some languages wrapped texts are cut off. ([76c50c1db1](https://github.com/facebook/react-native/commit/76c50c1db15a1040b185770072d960652e7974a3) by [@soh335](https://github.com/soh335))
-- \`react-native run-android --port <x>\` correctly connects to dev server and related error messages display the correct port ([995b4d3049](https://github.com/facebook/react-native/commit/995b4d30491d2336fed4a975e965668d9c8d5b7c) by [@nhunzaker](https://github.com/nhunzaker))
-- Fix indexed RAM bundle ([d8fa1206c3](https://github.com/facebook/react-native/commit/d8fa1206c3fecd494b0f6abb63c66488e6ced5e0) by [@dratwas](https://github.com/dratwas))
-- Fix missing whitespace in debug instructions ([b45d3b8697](https://github.com/facebook/react-native/commit/b45d3b8697c6ed2ce5c6e4eac7bfd14553c79ed8) by [@mjmasn](https://github.com/mjmasn))
-- Show proper error message instead of throwing a NullReferenceException if Gradle cannot find the NDK ([2aca234dee](https://github.com/facebook/react-native/commit/2aca234dee6a4c1e710b93dce341528279797c34) by [@petterh](https://github.com/petterh))
-- This branch checks also for \`ACTION_NDEF_DISCOVERED\` intent matches to set the initialURL ([54abe1f599](https://github.com/facebook/react-native/commit/54abe1f5990b8f5f57da3231d1bb1fd83966f064) by [@cimitan](https://github.com/cimitan))
-- Fix backgroundColor top level prop of TextInput ([fb6cf2552a](https://github.com/facebook/react-native/commit/fb6cf2552a0ab19d4e96d7d3a586de36c792c1a4) by [@makovkastar](https://github.com/makovkastar))
+- Check if mCurrentActivity is set according to LifecycleState ([fb550e9e84](https://github.com/react/react-native/commit/fb550e9e8405870167dea9bd3bc3f50fbbae5ae5) by [@RoJoHub](https://github.com/RoJoHub))
+- Fix some languages wrapped texts are cut off. ([76c50c1db1](https://github.com/react/react-native/commit/76c50c1db15a1040b185770072d960652e7974a3) by [@soh335](https://github.com/soh335))
+- \`react-native run-android --port <x>\` correctly connects to dev server and related error messages display the correct port ([995b4d3049](https://github.com/react/react-native/commit/995b4d30491d2336fed4a975e965668d9c8d5b7c) by [@nhunzaker](https://github.com/nhunzaker))
+- Fix indexed RAM bundle ([d8fa1206c3](https://github.com/react/react-native/commit/d8fa1206c3fecd494b0f6abb63c66488e6ced5e0) by [@dratwas](https://github.com/dratwas))
+- Fix missing whitespace in debug instructions ([b45d3b8697](https://github.com/react/react-native/commit/b45d3b8697c6ed2ce5c6e4eac7bfd14553c79ed8) by [@mjmasn](https://github.com/mjmasn))
+- Show proper error message instead of throwing a NullReferenceException if Gradle cannot find the NDK ([2aca234dee](https://github.com/react/react-native/commit/2aca234dee6a4c1e710b93dce341528279797c34) by [@petterh](https://github.com/petterh))
+- This branch checks also for \`ACTION_NDEF_DISCOVERED\` intent matches to set the initialURL ([54abe1f599](https://github.com/react/react-native/commit/54abe1f5990b8f5f57da3231d1bb1fd83966f064) by [@cimitan](https://github.com/cimitan))
+- Fix backgroundColor top level prop of TextInput ([fb6cf2552a](https://github.com/react/react-native/commit/fb6cf2552a0ab19d4e96d7d3a586de36c792c1a4) by [@makovkastar](https://github.com/makovkastar))
 
 #### iOS specific
 
-- Don't call sharedApplication in App Extension ([c5ea18f738](https://github.com/facebook/react-native/commit/c5ea18f7389fe821e7a9882e4b1b30b0a1b266f4) by [@zhongwuzw](https://github.com/zhongwuzw))
-- Use CALayers to draw text, fixes rendering for long text ([690e85db04](https://github.com/facebook/react-native/commit/690e85db0487c10ec3880c503632548aca65ff1c) by [@janicduplessis](https://github.com/janicduplessis))
-- Removed autoresizing mask for modal host container view ([2dd7dd8e45](https://github.com/facebook/react-native/commit/2dd7dd8e45f9d4a1086f84d5b70ea66406d98439) by [@zhongwuzw](https://github.com/zhongwuzw))
-- Xcode 11 beta build ([46c7ada535](https://github.com/facebook/react-native/commit/46c7ada535f8d87f325ccbd96c24993dd522165d) by [@ericlewis](https://github.com/ericlewis))
+- Don't call sharedApplication in App Extension ([c5ea18f738](https://github.com/react/react-native/commit/c5ea18f7389fe821e7a9882e4b1b30b0a1b266f4) by [@zhongwuzw](https://github.com/zhongwuzw))
+- Use CALayers to draw text, fixes rendering for long text ([690e85db04](https://github.com/react/react-native/commit/690e85db0487c10ec3880c503632548aca65ff1c) by [@janicduplessis](https://github.com/janicduplessis))
+- Removed autoresizing mask for modal host container view ([2dd7dd8e45](https://github.com/react/react-native/commit/2dd7dd8e45f9d4a1086f84d5b70ea66406d98439) by [@zhongwuzw](https://github.com/zhongwuzw))
+- Xcode 11 beta build ([46c7ada535](https://github.com/react/react-native/commit/46c7ada535f8d87f325ccbd96c24993dd522165d) by [@ericlewis](https://github.com/ericlewis))
 
 ### Security
 
@@ -106,31 +106,31 @@ exports[`functions that hit GitHub's commits API run fetches commits, filters th
 
 ### Unknown
 
-- Ensure right version of Metro bundler is used ([1bb197afb1](https://github.com/facebook/react-native/commit/1bb197afb191eab134354386700053914f1ac181) by [@kelset](https://github.com/kelset))
-- Generate correct source map if hermes not enabled ([b1f81be4bc](https://github.com/facebook/react-native/commit/b1f81be4bc21eb9baa39dd7ef97709d9927ad407) by [@HazAT](https://github.com/HazAT))
-- Fix Hermes binary path ([348b8f0082](https://github.com/facebook/react-native/commit/348b8f0082cb9b019ecc05d703e1ab8c155a9185) by [@zoontek](https://github.com/zoontek))
-- Fix path to Hermes package. ([0738fe5738](https://github.com/facebook/react-native/commit/0738fe5738c21463da93e3551f8f78ddcb6545e3) by [@cpojer](https://github.com/cpojer))
-- Add Hermes support to React Native 0.60 ([e857d7066b](https://github.com/facebook/react-native/commit/e857d7066be504a9e90042be8ff919d62939895f) by [@cpojer](https://github.com/cpojer))
-- Bump CLI ([35aeb8c027](https://github.com/facebook/react-native/commit/35aeb8c027583010956e2670a5cb924cc079859e) by [@kelset](https://github.com/kelset))
-- Bump jsc dep ([db1d60fa95](https://github.com/facebook/react-native/commit/db1d60fa95586929cf90a918e6af0e5a90f1db89) by [@kelset](https://github.com/kelset))
-- Bump CLI rc ([93c83181fb](https://github.com/facebook/react-native/commit/93c83181fbb479836f407051bdcc4d2749bd78ad) by [@kelset](https://github.com/kelset))
-- Bump version in template to match repo ([53cec2dc1f](https://github.com/facebook/react-native/commit/53cec2dc1f1f5d143d0bb9752629b72350ebd112) by [@kelset](https://github.com/kelset))
-- Move scheduler to dependencies ([503df2c69a](https://github.com/facebook/react-native/commit/503df2c69ab793bca1d055700a328e3214e456ad) by [@rickhanlonii](https://github.com/rickhanlonii))
-- Bump versions to match the requirements ([5ecc87bf3e](https://github.com/facebook/react-native/commit/5ecc87bf3e9a8b5e87048c47d5027c02a573f0a1) by [@kelset](https://github.com/kelset))
-- Re-add the hasteImpl ([7082c3e449](https://github.com/facebook/react-native/commit/7082c3e44979e0b83fcf67c0e90f92e7d670f60d) by [@kelset](https://github.com/kelset))
+- Ensure right version of Metro bundler is used ([1bb197afb1](https://github.com/react/react-native/commit/1bb197afb191eab134354386700053914f1ac181) by [@kelset](https://github.com/kelset))
+- Generate correct source map if hermes not enabled ([b1f81be4bc](https://github.com/react/react-native/commit/b1f81be4bc21eb9baa39dd7ef97709d9927ad407) by [@HazAT](https://github.com/HazAT))
+- Fix Hermes binary path ([348b8f0082](https://github.com/react/react-native/commit/348b8f0082cb9b019ecc05d703e1ab8c155a9185) by [@zoontek](https://github.com/zoontek))
+- Fix path to Hermes package. ([0738fe5738](https://github.com/react/react-native/commit/0738fe5738c21463da93e3551f8f78ddcb6545e3) by [@cpojer](https://github.com/cpojer))
+- Add Hermes support to React Native 0.60 ([e857d7066b](https://github.com/react/react-native/commit/e857d7066be504a9e90042be8ff919d62939895f) by [@cpojer](https://github.com/cpojer))
+- Bump CLI ([35aeb8c027](https://github.com/react/react-native/commit/35aeb8c027583010956e2670a5cb924cc079859e) by [@kelset](https://github.com/kelset))
+- Bump jsc dep ([db1d60fa95](https://github.com/react/react-native/commit/db1d60fa95586929cf90a918e6af0e5a90f1db89) by [@kelset](https://github.com/kelset))
+- Bump CLI rc ([93c83181fb](https://github.com/react/react-native/commit/93c83181fbb479836f407051bdcc4d2749bd78ad) by [@kelset](https://github.com/kelset))
+- Bump version in template to match repo ([53cec2dc1f](https://github.com/react/react-native/commit/53cec2dc1f1f5d143d0bb9752629b72350ebd112) by [@kelset](https://github.com/kelset))
+- Move scheduler to dependencies ([503df2c69a](https://github.com/react/react-native/commit/503df2c69ab793bca1d055700a328e3214e456ad) by [@rickhanlonii](https://github.com/rickhanlonii))
+- Bump versions to match the requirements ([5ecc87bf3e](https://github.com/react/react-native/commit/5ecc87bf3e9a8b5e87048c47d5027c02a573f0a1) by [@kelset](https://github.com/kelset))
+- Re-add the hasteImpl ([7082c3e449](https://github.com/react/react-native/commit/7082c3e44979e0b83fcf67c0e90f92e7d670f60d) by [@kelset](https://github.com/kelset))
 
 #### Android Unknown
 
-- Correctly set the border radius on android ([b432b8f13b](https://github.com/facebook/react-native/commit/b432b8f13b4871dcafd690e57d37298662712b50) by [@cabelitos](https://github.com/cabelitos))
-- Fix addition of comma at the end of accessibility labels on Android. ([812abfdbba](https://github.com/facebook/react-native/commit/812abfdbba7c27978a5c2b7041fc4a900f3203ae) by [@marcmulcahy](https://github.com/marcmulcahy))
-- Fix \`ClassNotFound\` exception in Android during Release builds ([ffdf3f22c6](https://github.com/facebook/react-native/commit/ffdf3f22c68583fe77517f78dd97bd2e97ff1b9e) by [@thecodrr](https://github.com/thecodrr))
-- Generate source maps outside of assets/ ([60e75dc1ab](https://github.com/facebook/react-native/commit/60e75dc1ab73b2893ec2e25c0320f32b3cf12b80) by [@motiz88](https://github.com/motiz88))
-- Implement changes to enable native modules auto linking ([261197d857](https://github.com/facebook/react-native/commit/261197d85705dad1a362cc4637aa308c0382dcbe) by [@Salakar](https://github.com/Salakar))
-- Remove duplicate Android SDK steps already present in container ([53e32a47e4](https://github.com/facebook/react-native/commit/53e32a47e4062f428f8d714333236cedbe05b482) by [@hramos](https://github.com/hramos))
+- Correctly set the border radius on android ([b432b8f13b](https://github.com/react/react-native/commit/b432b8f13b4871dcafd690e57d37298662712b50) by [@cabelitos](https://github.com/cabelitos))
+- Fix addition of comma at the end of accessibility labels on Android. ([812abfdbba](https://github.com/react/react-native/commit/812abfdbba7c27978a5c2b7041fc4a900f3203ae) by [@marcmulcahy](https://github.com/marcmulcahy))
+- Fix \`ClassNotFound\` exception in Android during Release builds ([ffdf3f22c6](https://github.com/react/react-native/commit/ffdf3f22c68583fe77517f78dd97bd2e97ff1b9e) by [@thecodrr](https://github.com/thecodrr))
+- Generate source maps outside of assets/ ([60e75dc1ab](https://github.com/react/react-native/commit/60e75dc1ab73b2893ec2e25c0320f32b3cf12b80) by [@motiz88](https://github.com/motiz88))
+- Implement changes to enable native modules auto linking ([261197d857](https://github.com/react/react-native/commit/261197d85705dad1a362cc4637aa308c0382dcbe) by [@Salakar](https://github.com/Salakar))
+- Remove duplicate Android SDK steps already present in container ([53e32a47e4](https://github.com/react/react-native/commit/53e32a47e4062f428f8d714333236cedbe05b482) by [@hramos](https://github.com/hramos))
 
 #### iOS Unknown
 
-- Delete fishhook ([46bdb4161c](https://github.com/facebook/react-native/commit/46bdb4161c84b33f1d0612e9c7cdd824462a31fd) by [@mmmulani](https://github.com/mmmulani))
+- Delete fishhook ([46bdb4161c](https://github.com/react/react-native/commit/46bdb4161c84b33f1d0612e9c7cdd824462a31fd) by [@mmmulani](https://github.com/mmmulani))
 
 #### Failed to parse
 

--- a/incubator/rn-changelog-generator/test/generator.test.ts
+++ b/incubator/rn-changelog-generator/test/generator.test.ts
@@ -103,12 +103,12 @@ describe("functions that hit GitHub's commits API", () => {
     const getMock = jest.fn((uri) => {
       if (
         uri.path ===
-        `/repos/facebook/react-native/commits?sha=${compare}&page=1`
+        `/repos/react/react-native/commits?sha=${compare}&page=1`
       ) {
         return requestWithFixtureResponse("commits-v0.60.5-page-1.json");
       } else if (
         uri.path ===
-        `/repos/facebook/react-native/commits?sha=${compare}&page=2`
+        `/repos/react/react-native/commits?sha=${compare}&page=2`
       ) {
         return requestWithFixtureResponse("commits-v0.60.5-page-2.json");
       } else {
@@ -127,7 +127,7 @@ describe("functions that hit GitHub's commits API", () => {
         gitDir: RN_REPO,
         maxWorkers: 10,
         existingChangelogData:
-          "- Bla bla bla ([ffdf3f2](https://github.com/facebook/react-native/commit/ffdf3f2)",
+          "- Bla bla bla ([ffdf3f2](https://github.com/react/react-native/commit/ffdf3f2)",
       }).then((changelog) => {
         expect(changelog).toMatchSnapshot();
       });
@@ -166,7 +166,7 @@ describe("commit resolving,formatting and attribution regression tests", () => {
       {
         fixed: {
           android: [
-            "- View.getGlobalVisibleRect() clips result rect properly when overflow is 'hidden' ([df9abf7983](https://github.com/facebook/react-native/commit/df9abf798351c43253c449fe2c83c2cca0479d80))",
+            "- View.getGlobalVisibleRect() clips result rect properly when overflow is 'hidden' ([df9abf7983](https://github.com/react/react-native/commit/df9abf798351c43253c449fe2c83c2cca0479d80))",
           ],
         },
       },

--- a/incubator/rn-changelog-generator/test/generator.test.ts
+++ b/incubator/rn-changelog-generator/test/generator.test.ts
@@ -102,13 +102,11 @@ describe("functions that hit GitHub's commits API", () => {
   beforeAll(() => {
     const getMock = jest.fn((uri) => {
       if (
-        uri.path ===
-        `/repos/react/react-native/commits?sha=${compare}&page=1`
+        uri.path === `/repos/react/react-native/commits?sha=${compare}&page=1`
       ) {
         return requestWithFixtureResponse("commits-v0.60.5-page-1.json");
       } else if (
-        uri.path ===
-        `/repos/react/react-native/commits?sha=${compare}&page=2`
+        uri.path === `/repos/react/react-native/commits?sha=${compare}&page=2`
       ) {
         return requestWithFixtureResponse("commits-v0.60.5-page-2.json");
       } else {

--- a/incubator/rn-changelog-generator/test/utils/commits.test.ts
+++ b/incubator/rn-changelog-generator/test/utils/commits.test.ts
@@ -42,16 +42,16 @@ describe("functions that hit GitHub's commits API", () => {
     const getMock = jest.fn((uri) => {
       if (
         uri.path ===
-        `/repos/facebook/react-native/commits?sha=${compare}&page=1`
+        `/repos/react/react-native/commits?sha=${compare}&page=1`
       ) {
         return requestWithFixtureResponse("commits-v0.60.5-page-1.json");
       } else if (
         uri.path ===
-        `/repos/facebook/react-native/commits?sha=${compare}&page=2`
+        `/repos/react/react-native/commits?sha=${compare}&page=2`
       ) {
         return requestWithFixtureResponse("commits-v0.60.5-page-2.json");
       } else if (
-        uri.path === `/repos/facebook/react-native/commits/${internalCommit}`
+        uri.path === `/repos/react/react-native/commits/${internalCommit}`
       ) {
         return requestWithFixtureResponse("commit-internal.json");
       } else {

--- a/incubator/rn-changelog-generator/test/utils/commits.test.ts
+++ b/incubator/rn-changelog-generator/test/utils/commits.test.ts
@@ -41,13 +41,11 @@ describe("functions that hit GitHub's commits API", () => {
   beforeAll(() => {
     const getMock = jest.fn((uri) => {
       if (
-        uri.path ===
-        `/repos/react/react-native/commits?sha=${compare}&page=1`
+        uri.path === `/repos/react/react-native/commits?sha=${compare}&page=1`
       ) {
         return requestWithFixtureResponse("commits-v0.60.5-page-1.json");
       } else if (
-        uri.path ===
-        `/repos/react/react-native/commits?sha=${compare}&page=2`
+        uri.path === `/repos/react/react-native/commits?sha=${compare}&page=2`
       ) {
         return requestWithFixtureResponse("commits-v0.60.5-page-2.json");
       } else if (

--- a/incubator/rn-changelog-generator/test/utils/getChangeMessage.test.ts
+++ b/incubator/rn-changelog-generator/test/utils/getChangeMessage.test.ts
@@ -19,7 +19,7 @@ describe(getChangeMessage, () => {
         author: { login: "alloy" },
       })
     ).toEqual(
-      "- Some great fixes! ([abcde12345](https://github.com/facebook/react-native/commit/abcde123456789) by [@alloy](https://github.com/alloy))"
+      "- Some great fixes! ([abcde12345](https://github.com/react/react-native/commit/abcde123456789) by [@alloy](https://github.com/alloy))"
     );
   });
   it("formats a changelog entry with author name", () => {
@@ -36,7 +36,7 @@ describe(getChangeMessage, () => {
         author: undefined,
       })
     ).toEqual(
-      "- Some great fixes! ([abcde12345](https://github.com/facebook/react-native/commit/abcde123456789) by First Last)"
+      "- Some great fixes! ([abcde12345](https://github.com/react/react-native/commit/abcde123456789) by First Last)"
     );
   });
   it("formats a changelog entry without author", () => {
@@ -50,7 +50,7 @@ describe(getChangeMessage, () => {
         author: undefined,
       })
     ).toEqual(
-      "- Some great fixes! ([abcde12345](https://github.com/facebook/react-native/commit/abcde123456789))"
+      "- Some great fixes! ([abcde12345](https://github.com/react/react-native/commit/abcde123456789))"
     );
   });
 });


### PR DESCRIPTION
### Description

React Native's repo moved to the new `react` organization, and old `facebook/react-native` URLs now redirect. 
This PR updates the changelog generator to fetch `react/react-native` directly because the GitHub API endpoints for querying commits fail to fetch facebook/react-native.

```
  Fetch commit data
    https://api.github.com/repos/facebook/react-native/commits?sha=v0.83.10&page=1
  Error: [!] Got HTTP status: 301
```

This also updates fixtures and snapshots 


### Test plan

- `yarn test` in `incubator/rn-changelog-generator`
- Generate a changelog for 0.83.10
