### PR TITLE
fix(android): only apply Kotlin plugin if not using built-in

### DIFF
--- a/.changeset/cuddly-vans-spend.md
+++ b/.changeset/cuddly-vans-spend.md
@@ -1,0 +1,5 @@
+---
+"@react-native-webapis/web-storage": patch
+---
+
+Only apply Kotlin plugin if not using built-in

--- a/incubator/@react-native-webapis/web-storage/android/build.gradle
+++ b/incubator/@react-native-webapis/web-storage/android/build.gradle
@@ -51,7 +51,15 @@ buildscript {
 
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.android") apply false
+}
+
+// Only apply Kotlin plugin if `android.builtInKotlin=false`
+// https://developer.android.com/build/migrate-to-built-in-kotlin#enable-built-in-kotlin
+def useBuiltInKotlin = parseVersion(gradle.gradleVersion) >= 9004000 &&
+                       project.findProperty("android.builtInKotlin") != "false"
+if (!useBuiltInKotlin) {
+    apply(plugin: "org.jetbrains.kotlin.android")
 }
 
 def reactNativePath = findNodeModulesPath("react-native")


### PR DESCRIPTION
### Description

Only apply Kotlin plugin if not using built-in

### Test plan

n/a