### PR TITLE
fix(react-native-host): use `ReactNativeFeatureFlagsOverridesOSSStable` when available

### DIFF
--- a/.changeset/common-badgers-take.md
+++ b/.changeset/common-badgers-take.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/react-native-host": patch
+---
+
+Use `ReactNativeFeatureFlagsOverridesOSSStable` when available

--- a/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
+++ b/packages/react-native-host/cocoa/RNXBridgelessHeaders.h
@@ -21,8 +21,11 @@
 #endif  // USE_REACT_NATIVE_CONFIG
 
 #ifdef USE_FEATURE_FLAGS
-#import <react/featureflags/ReactNativeFeatureFlags.h>
+#ifdef USE_FEATURE_FLAGS_OSS_OVERRIDES
+#include <react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h>
+#else  //  USE_FEATURE_FLAGS_OSS_OVERRIDES
 #import <react/featureflags/ReactNativeFeatureFlagsDefaults.h>
+#endif  // USE_FEATURE_FLAGS_OSS_OVERRIDES
 #endif  // USE_FEATURE_FLAGS
 
 #ifdef USE_CODEGEN_PROVIDER
@@ -61,6 +64,11 @@ using SharedJSRuntimeFactory = std::shared_ptr<facebook::react::JSRuntimeFactory
 @end
 
 #ifdef USE_FEATURE_FLAGS
+#ifdef USE_FEATURE_FLAGS_OSS_OVERRIDES
+
+using RNXBridgelessFeatureFlags = facebook::react::ReactNativeFeatureFlagsOverridesOSSStable;
+
+#else                             // USE_FEATURE_FLAGS_OSS_OVERRIDES
 
 // https://github.com/react/react-native/blob/0.80-stable/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h
 class RNXBridgelessFeatureFlags : public facebook::react::ReactNativeFeatureFlagsDefaults
@@ -72,7 +80,6 @@ public:
         return true;
     }
 
-#ifndef RCT_REMOVE_LEGACY_ARCH
     bool enableFabricRenderer() override
     {
         return true;
@@ -82,7 +89,6 @@ public:
     {
         return true;
     }
-#endif  // !RCT_REMOVE_LEGACY_ARCH
 
     bool useNativeViewConfigsInBridgelessMode() override
     {
@@ -94,15 +100,15 @@ public:
     {
         return true;
     }
-#endif  // USE_VIEW_COMMAND_RACE_FIX
+#endif                         // USE_VIEW_COMMAND_RACE_FIX
 
 #if USE_UPDATE_RUNTIME_SHADOW_NODE_REFS_ON_COMMIT  // >= 0.79
     bool useShadowNodeStateOnClone() override
     {
         return true;
     }
-#endif  // USE_UPDATE_RUNTIME_SHADOW_NODE_REFS_ON_COMMIT
-#else   // < 0.77
+#endif                                             // USE_UPDATE_RUNTIME_SHADOW_NODE_REFS_ON_COMMIT
+#else                                              // < 0.77
     bool useModernRuntimeScheduler() override
     {
         return true;
@@ -117,9 +123,10 @@ public:
     {
         return true;
     }
-#endif  // USE_UNIFIED_FEATURE_FLAGS
+#endif                                             // USE_UNIFIED_FEATURE_FLAGS
 };
-#endif  // USE_FEATURE_FLAGS
+#endif                                             // USE_FEATURE_FLAGS_OSS_OVERRIDES
+#endif                                             // USE_FEATURE_FLAGS
 
 #elif USE_FABRIC
 

--- a/packages/react-native-host/cocoa/RNXFeatureMacros.h
+++ b/packages/react-native-host/cocoa/RNXFeatureMacros.h
@@ -39,10 +39,12 @@
 
 #ifdef USE_FEATURE_FLAGS
 
-// TODO: `RCTArchConfiguratorProtocol.h` was removed in 0.87
-#if __has_include(<React-RCTAppDelegate/RCTArchConfiguratorProtocol.h>) || __has_include(<React_RCTAppDelegate/RCTArchConfiguratorProtocol.h>)
+#if __has_include(<react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h>)  // >= 0.80
+#define USE_FEATURE_FLAGS_OSS_OVERRIDES 1
 #define USE_UNIFIED_FEATURE_FLAGS 1
-#endif  // __has_include(<React-RCTAppDelegate/RCTArchConfiguratorProtocol.h>)
+#elif __has_include(<React-RCTAppDelegate/RCTArchConfiguratorProtocol.h>) || __has_include(<React_RCTAppDelegate/RCTArchConfiguratorProtocol.h>)
+#define USE_UNIFIED_FEATURE_FLAGS 1
+#endif  // __has_include(<react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h>)
 
 #if !__has_include(<React-RCTAppDelegate/RCTReactNativeFactory.h>) && !__has_include(<React_RCTAppDelegate/RCTReactNativeFactory.h>)
 #define USE_VIEW_COMMAND_RACE_FIX 1
@@ -55,9 +57,6 @@
 
 #if REACT_NATIVE_VERSION >= 87000
 #define RCT_REMOVE_LEGACY_ARCH 1
-#ifndef USE_UNIFIED_FEATURE_FLAGS
-#define USE_UNIFIED_FEATURE_FLAGS 1
-#endif
 #endif  // REACT_NATIVE_VERSION >= 87000
 
 #endif  // USE_FEATURE_FLAGS

--- a/packages/test-app-macos/macos/Podfile.lock
+++ b/packages/test-app-macos/macos/Podfile.lock
@@ -2292,7 +2292,7 @@ PODS:
   - ReactTestApp-MSAL (5.1.0):
     - MSAL
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNWWebStorage (0.4.5):
+  - RNWWebStorage (0.4.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2645,7 +2645,7 @@ SPEC CHECKSUMS:
   ReactTestApp-DevSupport: d9358fe3b2dc09399c15731ed8c17bd8388cf512
   ReactTestApp-MSAL: 431747d2fa56b5f59c8ecf3778a2f97715aff617
   ReactTestApp-Resources: 73ed16e66e4d7bcb2d98d5c81619e2bc7563d37d
-  RNWWebStorage: 8ec03f8288c1e212518f662f44ec223603bbe74c
+  RNWWebStorage: 8bc155b048a2d1ee1db5f63b1b9c5705434d48db
   RNXAuth: a54c1a2349766f9d0876d23d90a206a73ddd7d87
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 9f9bacf26f441fa32d25c32e5583ff72f6d2806d

--- a/packages/test-app/ios/Podfile.lock
+++ b/packages/test-app/ios/Podfile.lock
@@ -1780,7 +1780,7 @@ PODS:
   - ReactTestApp-MSAL (5.1.0):
     - MSAL
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNWWebStorage (0.4.5):
+  - RNWWebStorage (0.4.6):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2132,7 +2132,7 @@ SPEC CHECKSUMS:
   ReactTestApp-DevSupport: d9358fe3b2dc09399c15731ed8c17bd8388cf512
   ReactTestApp-MSAL: 431747d2fa56b5f59c8ecf3778a2f97715aff617
   ReactTestApp-Resources: 70da1d78d943a1fdff6362ce3f778e5b4560c95a
-  RNWWebStorage: e01ec77abc9866d80b0c1b0d57914cce11ab747b
+  RNWWebStorage: a3612eab23117c5bf9d18faa213565409a376ef1
   RNXAuth: a54c1a2349766f9d0876d23d90a206a73ddd7d87
   Yoga: 04bb4bfeb02c0000b940c1e6e89e856cd8de5a71
 


### PR DESCRIPTION
### Description

Use `ReactNativeFeatureFlagsOverridesOSSStable` when available. This way we don't have to keep our set in sync with upstream.

### Test plan

CI should pass.