### PR TITLE
refactor: `node-fetch` is no longer required

### DIFF
--- a/.changeset/lovely-insects-join.md
+++ b/.changeset/lovely-insects-join.md
@@ -1,0 +1,6 @@
+---
+"@rnx-kit/metro-service": patch
+"@rnx-kit/build": patch
+---
+
+`node-fetch` is no longer required

--- a/incubator/build/package.json
+++ b/incubator/build/package.json
@@ -84,7 +84,6 @@
     "@rnx-kit/tools-shell": "^0.2.0",
     "@rnx-kit/tools-windows": "^0.2.0",
     "git-url-parse": "^16.0.0",
-    "node-fetch": "^3.3.2",
     "ora": "^8.0.0",
     "qrcode": "^1.5.0",
     "yargs": "^16.0.0"

--- a/incubator/build/src/remotes/github.ts
+++ b/incubator/build/src/remotes/github.ts
@@ -5,7 +5,6 @@ import { restEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
 import { RequestError } from "@octokit/request-error";
 import { idle, once, withRetry } from "@rnx-kit/tools-shell/async";
 import parseGitURL from "git-url-parse";
-import fetch from "node-fetch";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as readline from "node:readline";
@@ -42,12 +41,7 @@ function createOctokitClient(auth?: unknown) {
   }
 
   const RestClient = Octokit.plugin(restEndpointMethods);
-  return new RestClient({
-    auth,
-    // Use `node-fetch` only if Node doesn't implement Fetch API:
-    // https://github.com/octokit/request.js/blob/v8.1.1/src/fetch-wrapper.ts#L28-L31
-    request: "fetch" in globalThis ? undefined : { fetch },
-  });
+  return new RestClient({ auth });
 }
 
 let octokit = once(createOctokitClient);

--- a/packages/metro-service/package.json
+++ b/packages/metro-service/package.json
@@ -36,15 +36,13 @@
   "dependencies": {
     "@rnx-kit/console": "^3.0.0",
     "@rnx-kit/tools-node": "^3.0.3",
-    "@rnx-kit/tools-react-native": "^2.3.5",
-    "node-fetch": "^2.6.7"
+    "@rnx-kit/tools-react-native": "^2.3.5"
   },
   "devDependencies": {
     "@react-native-community/cli-types": "^20.1.0",
     "@rnx-kit/scripts": "*",
     "@rnx-kit/tsconfig": "*",
     "@types/node": "^24.0.0",
-    "@types/node-fetch": "^2.6.5",
     "metro": "^0.84.0",
     "metro-config": "^0.84.0",
     "metro-core": "^0.84.0",

--- a/packages/metro-service/src/server.ts
+++ b/packages/metro-service/src/server.ts
@@ -5,17 +5,6 @@ import { importMetroForProject } from "./metro.ts";
 
 type ServerStatus = "not_running" | "already_running" | "in_use" | "unknown";
 
-function getFetchImpl(): (url: string | URL) => Promise<Response> {
-  if ("fetch" in globalThis) {
-    return fetch;
-  }
-
-  // TODO: Remove `node-fetch` when we drop support for Node 16
-  return (...args) =>
-    // @ts-expect-error To be removed when Node 16 is no longer supported
-    import("node-fetch").then(({ default: fetch }) => fetch(...args));
-}
-
 /**
  * Returns whether the specified host:port is occupied.
  *
@@ -59,9 +48,8 @@ export async function isDevServerRunning(
       return "not_running";
     }
 
-    const ftch = getFetchImpl();
     const statusUrl = `${scheme}://${host || "localhost"}:${port}/status`;
-    const statusResponse = await ftch(statusUrl);
+    const statusResponse = await fetch(statusUrl);
     const body = await statusResponse.text();
 
     return body === "packager-status:running" &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -5096,7 +5096,6 @@ __metadata:
     "@types/qrcode": "npm:^1.4.2"
     "@types/yargs": "npm:^16.0.0"
     git-url-parse: "npm:^16.0.0"
-    node-fetch: "npm:^3.3.2"
     ora: "npm:^8.0.0"
     qrcode: "npm:^1.5.0"
     yargs: "npm:^16.0.0"
@@ -5516,13 +5515,11 @@ __metadata:
     "@rnx-kit/tools-react-native": "npm:^2.3.5"
     "@rnx-kit/tsconfig": "npm:*"
     "@types/node": "npm:^24.0.0"
-    "@types/node-fetch": "npm:^2.6.5"
     metro: "npm:^0.84.0"
     metro-config: "npm:^0.84.0"
     metro-core: "npm:^0.84.0"
     metro-resolver: "npm:^0.84.0"
     metro-runtime: "npm:^0.84.0"
-    node-fetch: "npm:^2.6.7"
   peerDependencies:
     "@office-iss/react-native-win32": "*"
     "@react-native/metro-config": "*"
@@ -6833,16 +6830,6 @@ __metadata:
   dependencies:
     "@types/braces": "npm:*"
   checksum: 10c0/dc424e0f9ed1a4f22dbed5048ac698d089d4628dd8a41a056b2eb12782cfda85bf06fccc0be341ce9af7345858eb07a27757ca023664cfb8bde235212795d295
-  languageName: node
-  linkType: hard
-
-"@types/node-fetch@npm:^2.6.5":
-  version: 2.6.13
-  resolution: "@types/node-fetch@npm:2.6.13"
-  dependencies:
-    "@types/node": "npm:*"
-    form-data: "npm:^4.0.4"
-  checksum: 10c0/6313c89f62c50bd0513a6839cdff0a06727ac5495ccbb2eeda51bb2bbbc4f3c0a76c0393a491b7610af703d3d2deb6cf60e37e59c81ceeca803ffde745dbf309
   languageName: node
   linkType: hard
 
@@ -9301,13 +9288,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"data-uri-to-buffer@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "data-uri-to-buffer@npm:4.0.1"
-  checksum: 10c0/20a6b93107597530d71d4cb285acee17f66bcdfc03fd81040921a81252f19db27588d87fc8fc69e1950c55cfb0bf8ae40d0e5e21d907230813eb5d5a7f9eb45b
-  languageName: node
-  linkType: hard
-
 "data-view-buffer@npm:^1.0.2":
   version: 1.0.2
   resolution: "data-view-buffer@npm:1.0.2"
@@ -10518,16 +10498,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fetch-blob@npm:^3.1.2, fetch-blob@npm:^3.1.4":
-  version: 3.2.0
-  resolution: "fetch-blob@npm:3.2.0"
-  dependencies:
-    node-domexception: "npm:^1.0.0"
-    web-streams-polyfill: "npm:^3.0.3"
-  checksum: 10c0/60054bf47bfa10fb0ba6cb7742acec2f37c1f56344f79a70bb8b1c48d77675927c720ff3191fa546410a0442c998d27ab05e9144c32d530d8a52fbe68f843b69
-  languageName: node
-  linkType: hard
-
 "figures@npm:^3.2.0":
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
@@ -10652,7 +10622,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.4, form-data@npm:^4.0.6":
+"form-data@npm:^4.0.6":
   version: 4.0.6
   resolution: "form-data@npm:4.0.6"
   dependencies:
@@ -10673,15 +10643,6 @@ __metadata:
   bin:
     formatly: bin/index.mjs
   checksum: 10c0/ef9dbd3cdaee649e9604ea060d8d62d8131eb81117634336592ee2193fc7c98a3f1f1b5d09a045dbd36287ba88edf868ef179d39fbda2f34fbe2be70c42dd014
-  languageName: node
-  linkType: hard
-
-"formdata-polyfill@npm:^4.0.10":
-  version: 4.0.10
-  resolution: "formdata-polyfill@npm:4.0.10"
-  dependencies:
-    fetch-blob: "npm:^3.1.2"
-  checksum: 10c0/5392ec484f9ce0d5e0d52fb5a78e7486637d516179b0eb84d81389d7eccf9ca2f663079da56f761355c0a65792810e3b345dc24db9a8bbbcf24ef3c8c88570c6
   languageName: node
   linkType: hard
 
@@ -13848,38 +13809,6 @@ __metadata:
   version: 3.0.4
   resolution: "nocache@npm:3.0.4"
   checksum: 10c0/66e5db1206bee44173358c2264ae9742259273e9719535077fe27807441bad58f0deeadf3cec2aa62d4f86ccb8a0e067c9a64b6329684ddc30a57e377ec458ee
-  languageName: node
-  linkType: hard
-
-"node-domexception@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "node-domexception@npm:1.0.0"
-  checksum: 10c0/5e5d63cda29856402df9472335af4bb13875e1927ad3be861dc5ebde38917aecbf9ae337923777af52a48c426b70148815e890a5d72760f1b4d758cc671b1a2b
-  languageName: node
-  linkType: hard
-
-"node-fetch@npm:^2.6.7":
-  version: 2.7.0
-  resolution: "node-fetch@npm:2.7.0"
-  dependencies:
-    whatwg-url: "npm:^5.0.0"
-  peerDependencies:
-    encoding: ^0.1.0
-  peerDependenciesMeta:
-    encoding:
-      optional: true
-  checksum: 10c0/b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
-  languageName: node
-  linkType: hard
-
-"node-fetch@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "node-fetch@npm:3.3.2"
-  dependencies:
-    data-uri-to-buffer: "npm:^4.0.0"
-    fetch-blob: "npm:^3.1.4"
-    formdata-polyfill: "npm:^4.0.10"
-  checksum: 10c0/f3d5e56190562221398c9f5750198b34cf6113aa304e34ee97c94fd300ec578b25b2c2906edba922050fce983338fde0d5d34fcb0fc3336ade5bd0e429ad7538
   languageName: node
   linkType: hard
 
@@ -17248,13 +17177,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tr46@npm:~0.0.3":
-  version: 0.0.3
-  resolution: "tr46@npm:0.0.3"
-  checksum: 10c0/047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
-  languageName: node
-  linkType: hard
-
 "tree-dump@npm:^1.0.3, tree-dump@npm:^1.1.0":
   version: 1.1.0
   resolution: "tree-dump@npm:1.1.0"
@@ -17801,34 +17723,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web-streams-polyfill@npm:^3.0.3":
-  version: 3.2.1
-  resolution: "web-streams-polyfill@npm:3.2.1"
-  checksum: 10c0/70ed6b5708e14afa2ab699221ea197d7c68ec0c8274bbe0181aecc5ba636ca27cbd383d2049f0eb9d529e738f5c088825502b317f3df24d18a278e4cc9a10e8b
-  languageName: node
-  linkType: hard
-
-"webidl-conversions@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "webidl-conversions@npm:3.0.1"
-  checksum: 10c0/5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
-  languageName: node
-  linkType: hard
-
 "whatwg-fetch@npm:^3.0.0":
   version: 3.6.2
   resolution: "whatwg-fetch@npm:3.6.2"
   checksum: 10c0/cc10f6893fe71839250b6e2fa9bc293bcf0ca5b93129712a7d1097fb7528b3ff617eb065098dc972e74d1455378e514aa34c0901ded41584be16508db63477c8
-  languageName: node
-  linkType: hard
-
-"whatwg-url@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "whatwg-url@npm:5.0.0"
-  dependencies:
-    tr46: "npm:~0.0.3"
-    webidl-conversions: "npm:^3.0.0"
-  checksum: 10c0/1588bed84d10b72d5eec1d0faa0722ba1962f1821e7539c535558fb5398d223b0c50d8acab950b8c488b4ba69043fd833cc2697056b167d8ad46fac3995a55d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

`node-fetch` is no longer required since Node 18+

### Test plan

n/a