### PR TITLE
fix(tools-workspaces): use Yaml parser directly

### DIFF
--- a/.changeset/cold-paths-wave.md
+++ b/.changeset/cold-paths-wave.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-workspaces": patch
+---
+
+Use Yaml parser directly

--- a/packages/tools-workspaces/package.json
+++ b/packages/tools-workspaces/package.json
@@ -38,8 +38,8 @@
   "dependencies": {
     "fast-glob": "^3.2.7",
     "find-up": "^5.0.0",
+    "js-yaml": "^5.2.2",
     "micromatch": "^4.0.0",
-    "read-yaml-file": "^2.1.0",
     "strip-json-comments": "^3.1.1"
   },
   "devDependencies": {

--- a/packages/tools-workspaces/src/pnpm.ts
+++ b/packages/tools-workspaces/src/pnpm.ts
@@ -1,8 +1,5 @@
+import * as yaml from "js-yaml";
 import * as path from "node:path";
-import {
-  default as readYamlFile,
-  sync as readYamlFileSync,
-} from "read-yaml-file";
 import { findPackages, findPackagesSync } from "./common.ts";
 
 type Workspace = {
@@ -13,7 +10,7 @@ type Workspace = {
 export async function findWorkspacePackages(
   workspaceYaml: string
 ): Promise<string[]> {
-  const { packages } = await readYamlFile<Workspace>(workspaceYaml);
+  const { packages } = yaml.load(workspaceYaml) as Workspace;
   return await findPackages(packages, path.dirname(workspaceYaml));
 }
 
@@ -25,5 +22,5 @@ export function findWorkspacePackagesSync(workspaceYaml: string): string[] {
 }
 
 export function getPackageFilters(workspaceYaml: string): string[] | undefined {
-  return readYamlFileSync<Workspace>(workspaceYaml).packages;
+  return (yaml.load(workspaceYaml) as Workspace).packages;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6078,8 +6078,8 @@ __metadata:
     "@types/node": "npm:^24.0.0"
     fast-glob: "npm:^3.2.7"
     find-up: "npm:^5.0.0"
+    js-yaml: "npm:^5.2.2"
     micromatch: "npm:^4.0.0"
-    read-yaml-file: "npm:^2.1.0"
     strip-json-comments: "npm:^3.1.1"
   languageName: unknown
   linkType: soft
@@ -12548,7 +12548,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1, js-yaml@npm:^4.2.0":
+"js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1, js-yaml@npm:^4.2.0":
   version: 4.3.0
   resolution: "js-yaml@npm:4.3.0"
   dependencies:
@@ -12556,6 +12556,17 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^5.2.2":
+  version: 5.2.2
+  resolution: "js-yaml@npm:5.2.2"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.mjs
+  checksum: 10c0/e8ded203b235b3d562818c67bf362122abbcee89e507b62bddcdd3085b2f2dd866071e5e78f8e617d41d1a0c0baa1cec12a8fdec5859c571bf862adf585e2684
   languageName: node
   linkType: hard
 
@@ -15889,16 +15900,6 @@ __metadata:
     pify: "npm:^4.0.1"
     strip-bom: "npm:^3.0.0"
   checksum: 10c0/85a9ba08bb93f3c91089bab4f1603995ec7156ee595f8ce40ae9f49d841cbb586511508bd47b7cf78c97f678c679b2c6e2c0092e63f124214af41b6f8a25ca31
-  languageName: node
-  linkType: hard
-
-"read-yaml-file@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "read-yaml-file@npm:2.1.0"
-  dependencies:
-    js-yaml: "npm:^4.0.0"
-    strip-bom: "npm:^4.0.0"
-  checksum: 10c0/bad0673abe78a5bde7c53b22ee7cdd0dfe49ab7338a4ad8618be9fcd2fd25ab9ae60d395907fddbfb2e7fbbf494867aeec78295c2396bec2669fd7087d2734c1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Use Yaml parser directly. The need for stripping BOM separately is no longer necessary.

### Test plan

n/a