### PR TITLE
fix(align-deps): avoid parsing manifest twice

### DIFF
--- a/.changeset/soft-sites-agree.md
+++ b/.changeset/soft-sites-agree.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": patch
+---
+
+Avoid parsing package manifest a second time when an `align-deps` config is not found the first time

--- a/.changeset/sour-eagles-dance.md
+++ b/.changeset/sour-eagles-dance.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": patch
+---
+
+Avoid parsing package manifest twice while gathering requirements from transitive dependencies

--- a/packages/align-deps/src/commands/check.ts
+++ b/packages/align-deps/src/commands/check.ts
@@ -126,18 +126,24 @@ export function makeCheckCommand(options: Options): Command {
     return (manifest: string) => checkPackageManifest(manifest, options);
   }
 
-  return (manifest: string) => {
-    const inputConfig = loadConfig(manifest, options);
+  return (manifestPath: string) => {
+    const manifest = readPackage(manifestPath);
+    const inputConfig = loadConfig({ path: manifestPath, manifest }, options);
     const config = isError(inputConfig)
       ? inputConfig
-      : migrateConfig(inputConfig, manifest, options);
+      : migrateConfig(inputConfig, manifestPath, options);
 
     // If the package is configured, run the normal check first.
     if (!isError(config)) {
-      return withGroupReporter(manifest, (reporter) => {
-        const res1 = checkPackageManifest(manifest, options, config, reporter);
+      return withGroupReporter(manifestPath, (reporter) => {
+        const res1 = checkPackageManifest(
+          manifestPath,
+          options,
+          config,
+          reporter
+        );
         const res2 = checkPackageManifestUnconfigured(
-          manifest,
+          manifestPath,
           options,
           config,
           reporter
@@ -150,9 +156,9 @@ export function makeCheckCommand(options: Options): Command {
     if (config === "invalid-configuration" || config === "not-configured") {
       // In "vigilant" mode, we allow packages to declare which presets should
       // be used in config, overriding the `--presets` flag.
-      return withGroupReporter(manifest, (reporter) => {
+      return withGroupReporter(manifestPath, (reporter) => {
         return checkPackageManifestUnconfigured(
-          manifest,
+          manifestPath,
           options,
           {
             kitType: "library",
@@ -161,7 +167,7 @@ export function makeCheckCommand(options: Options): Command {
               requirements,
               capabilities: [],
             },
-            manifest: readPackage(manifest),
+            manifest,
           },
           reporter
         );

--- a/packages/align-deps/src/config.ts
+++ b/packages/align-deps/src/config.ts
@@ -77,16 +77,22 @@ export function sanitizeCapabilities(
 
 /**
  * Loads configuration from the specified package manifest.
- * @param manifestPath The path to the package manifest to load configuration from
+ * @param manifestOrPath The path to the package manifest to load configuration
+ *                       from or an already parsed manifest object
  * @param options Command line options
  * @returns The configuration; otherwise an error code
  */
 export function loadConfig(
-  manifestPath: string,
+  manifestOrPath: string | { path: string; manifest: PackageManifest },
   { excludePackages }: Pick<Options, "excludePackages">,
   /** @internal */ fs = nodefs
 ): ConfigResult {
-  const manifest = readPackage(manifestPath, fs);
+  const manifestPath =
+    typeof manifestOrPath === "string" ? manifestOrPath : manifestOrPath.path;
+  const manifest =
+    typeof manifestOrPath === "string"
+      ? readPackage(manifestPath, fs)
+      : manifestOrPath.manifest;
   if (!isPackageManifest(manifest)) {
     return "invalid-manifest";
   }

--- a/packages/align-deps/src/dependencies.ts
+++ b/packages/align-deps/src/dependencies.ts
@@ -1,4 +1,4 @@
-import { getKitConfig } from "@rnx-kit/config";
+import { getKitConfigFromPackageManifest } from "@rnx-kit/config";
 import { error, warn } from "@rnx-kit/console";
 import {
   findPackageDependencyDir,
@@ -29,7 +29,11 @@ function isDevOnlyCapability(
 export function visitDependencies(
   { dependencies }: PackageManifest,
   projectRoot: string,
-  visitor: (module: string, modulePath: string) => void,
+  visitor: (
+    module: string,
+    modulePath: string,
+    manifest: PackageManifest
+  ) => void,
   visited: Set<string> = new Set<string>()
 ): void {
   if (!dependencies) {
@@ -52,9 +56,8 @@ export function visitDependencies(
       continue;
     }
 
-    visitor(dependency, packageDir);
-
     const manifest = readPackage(packageDir);
+    visitor(dependency, packageDir, manifest);
     visitDependencies(manifest, packageDir, visitor, visited);
   }
 }
@@ -86,8 +89,8 @@ export function gatherRequirements(
     },
   ];
 
-  visitDependencies(manifest, projectRoot, (module, modulePath) => {
-    const kitConfig = getKitConfig({ cwd: modulePath });
+  visitDependencies(manifest, projectRoot, (module, modulePath, manifest) => {
+    const kitConfig = getKitConfigFromPackageManifest(manifest, modulePath);
     if (!kitConfig) {
       return;
     }


### PR DESCRIPTION
### Description

- Avoid parsing package manifest twice while gathering requirements from transitive dependencies
- Avoid parsing package manifest a second time when an `align-deps` config is not found the first time

### Test plan

n/a