### PR TITLE
fix(align-deps): cache read manifests

### DIFF
--- a/.changeset/small-files-pay.md
+++ b/.changeset/small-files-pay.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": patch
+---
+
+Cache read package manifests to avoid re-reading and parsing the same `package.json` files while iterating over dependencies

--- a/packages/align-deps/src/cache.ts
+++ b/packages/align-deps/src/cache.ts
@@ -1,0 +1,45 @@
+const MAX_CACHE_ENTRIES = 10_000;
+
+export class BoundedCache<K, V> {
+  private map: Map<K, V>;
+  private maxEntries: number;
+
+  constructor(maxEntries = MAX_CACHE_ENTRIES) {
+    this.map = new Map<K, V>();
+    this.maxEntries = maxEntries;
+  }
+
+  get(key: K): V | undefined {
+    const value = this.map.get(key);
+    if (value !== undefined) {
+      this.update(key, value);
+    }
+    return value;
+  }
+
+  has(key: K): boolean {
+    return this.map.has(key);
+  }
+
+  set(key: K, value: V): void {
+    this.update(key, value);
+    if (this.map.size > this.maxEntries) {
+      const lruKey = this.leastRecentlyUsed();
+      if (lruKey !== undefined) {
+        this.map.delete(lruKey);
+      }
+    }
+  }
+
+  private leastRecentlyUsed(): K | undefined {
+    // Least recently used items bubble towards the front
+    return this.map.keys().next().value;
+  }
+
+  private update(key: K, value: V): void {
+    // By deleting and re-inserting the value, we ensure the entry remains at
+    // the end and treated as most recently used
+    this.map.delete(key);
+    this.map.set(key, value);
+  }
+}

--- a/packages/align-deps/src/commands/exportCatalogs.ts
+++ b/packages/align-deps/src/commands/exportCatalogs.ts
@@ -1,4 +1,3 @@
-import * as yaml from "js-yaml";
 import * as nodefs from "node:fs";
 import * as path from "node:path";
 import { isMetaPackage } from "../capabilities.ts";
@@ -50,6 +49,7 @@ function parseFile(filename: string, fs: typeof nodefs): Config {
     // pnpm v9.5.0+ and Yarn v4.10.0+
     case ".yaml":
     case ".yml": {
+      const yaml = require("js-yaml");
       const data = content
         ? (yaml.load(content) as Record<string, unknown>)
         : {};

--- a/packages/align-deps/src/commands/setVersion.ts
+++ b/packages/align-deps/src/commands/setVersion.ts
@@ -1,7 +1,7 @@
 import { keysOf } from "@rnx-kit/tools-language/properties";
 import type { PackageManifest } from "@rnx-kit/types-node";
 import * as nodefs from "node:fs";
-import prompts from "prompts";
+import type prompts from "prompts";
 import semverCoerce from "semver/functions/coerce.js";
 import { transformConfig } from "../compatibility/config.ts";
 import { defaultConfig, loadConfig } from "../config.ts";
@@ -51,6 +51,7 @@ async function parseInput(versions: string | number): Promise<{
     return { supportedVersions: supportedVersions.sort(), targetVersion };
   }
 
+  const prompts = require("prompts");
   const { supportedVersions } = await prompts({
     type: "multiselect",
     name: "supportedVersions",

--- a/packages/align-deps/src/dependencies.ts
+++ b/packages/align-deps/src/dependencies.ts
@@ -6,6 +6,7 @@ import {
 } from "@rnx-kit/tools-node/package";
 import type { Capability } from "@rnx-kit/types-kit-config";
 import type { PackageManifest } from "@rnx-kit/types-node";
+import { BoundedCache } from "./cache.ts";
 import { filterPreset } from "./preset.ts";
 import type { Options, Preset, Profile } from "./types.ts";
 
@@ -14,6 +15,8 @@ type Trace = {
   requirements: string[];
   profiles: string[];
 };
+
+const manifestCache = new BoundedCache<string, PackageManifest>();
 
 function isCoreCapability(capability: Capability): boolean {
   return capability.startsWith("core-");
@@ -24,6 +27,17 @@ function isDevOnlyCapability(
   profiles: Partial<Profile>[]
 ): boolean {
   return profiles.some((profile) => profile[capability]?.devOnly);
+}
+
+function readManifestFromDir(packageDir: string): PackageManifest {
+  const cached = manifestCache.get(packageDir);
+  if (cached) {
+    return cached;
+  }
+
+  const manifest = readPackage(packageDir);
+  manifestCache.set(packageDir, manifest);
+  return manifest;
 }
 
 export function visitDependencies(
@@ -56,7 +70,7 @@ export function visitDependencies(
       continue;
     }
 
-    const manifest = readPackage(packageDir);
+    const manifest = readManifestFromDir(packageDir);
     visitor(dependency, packageDir, manifest);
     visitDependencies(manifest, packageDir, visitor, visited);
   }

--- a/packages/align-deps/test/cache.test.ts
+++ b/packages/align-deps/test/cache.test.ts
@@ -1,0 +1,49 @@
+import { equal } from "node:assert/strict";
+import { describe, it } from "node:test";
+import { BoundedCache } from "../src/cache.ts";
+
+describe("BoundedCache", () => {
+  it("stores and retrieves values", () => {
+    const cache = new BoundedCache<string, number>(2);
+    cache.set("a", 1);
+
+    equal(cache.has("a"), true);
+    equal(cache.get("a"), 1);
+    equal(cache.has("b"), false);
+    equal(cache.get("b"), undefined);
+  });
+
+  it("evicts the least recently used entry once max size is exceeded", () => {
+    const cache = new BoundedCache<string, number>(2);
+    cache.set("a", 1);
+    cache.set("b", 2);
+
+    equal(cache.get("a"), 1);
+    equal(cache.get("b"), 2);
+
+    cache.set("c", 3);
+
+    // "a" was the least recently used entry when "c" was inserted, so it
+    // should have been evicted.
+    equal(cache.has("a"), false);
+    equal(cache.get("b"), 2);
+    equal(cache.get("c"), 3);
+  });
+
+  it("treats reads as usage", () => {
+    const cache = new BoundedCache<string, number>(2);
+    cache.set("a", 1);
+    cache.set("b", 2);
+
+    // Accessing "a" makes it the most-recently used entry.
+    equal(cache.get("a"), 1);
+
+    cache.set("c", 3);
+
+    // "b" was the least recently used entry, so it should have been evicted
+    // instead of "a".
+    equal(cache.has("b"), false);
+    equal(cache.get("a"), 1);
+    equal(cache.get("c"), 3);
+  });
+});

--- a/packages/align-deps/test/capabilities.test.ts
+++ b/packages/align-deps/test/capabilities.test.ts
@@ -1,4 +1,4 @@
-import type { Capability } from "@rnx-kit/config";
+import type { Capability } from "@rnx-kit/types-kit-config";
 import { deepEqual, equal } from "node:assert/strict";
 import { describe, it } from "node:test";
 import { capabilitiesFor, resolveCapabilities } from "../src/capabilities.ts";

--- a/packages/align-deps/test/helpers.ts
+++ b/packages/align-deps/test/helpers.ts
@@ -1,4 +1,4 @@
-import type { Capability } from "@rnx-kit/config";
+import type { Capability } from "@rnx-kit/types-kit-config";
 import { createRequire } from "node:module";
 import { URL } from "node:url";
 import type { Package, Profile } from "../src/types.ts";


### PR DESCRIPTION
### Description

Cache read package manifests to avoid re-reading and parsing the same `package.json` files while iterating over dependencies.

Number of packages read in rnx-kit:

- **Before:** 931
- **After:** 503

### Test plan

n/a