### PR TITLE
fix(metro-resolver-symlinks): key `remapImportPath` resolvers by platform

### DIFF
--- a/.changeset/olive-pumas-repeat.md
+++ b/.changeset/olive-pumas-repeat.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Fixed `remapImportPath` reusing the resolver of the first platform it saw for every other platform

--- a/packages/metro-resolver-symlinks/src/remappers/remapImportPath.ts
+++ b/packages/metro-resolver-symlinks/src/remappers/remapImportPath.ts
@@ -108,14 +108,20 @@ export function remapImportPath(pluginOptions: Options): ModuleResolver {
 
   const getResolver = (() => {
     const { extensions, mainFields } = resolverOptions;
-    let resolve: Resolver;
+    // The extension list is platform specific, so resolvers cannot be shared
+    // across platforms. Keep one per platform instead.
+    const resolvers = new Map<string, Resolver>();
     return (platform: string) => {
-      if (!resolve) {
-        resolve = require("enhanced-resolve").create.sync({
-          extensions: expandPlatformExtensions(platform, extensions),
-          mainFields,
-        });
+      const cached = resolvers.get(platform);
+      if (cached) {
+        return cached;
       }
+
+      const resolve: Resolver = require("enhanced-resolve").create.sync({
+        extensions: expandPlatformExtensions(platform, extensions),
+        mainFields,
+      });
+      resolvers.set(platform, resolve);
       return resolve;
     };
   })();

--- a/packages/metro-resolver-symlinks/test/remappers/remapImportPath.test.ts
+++ b/packages/metro-resolver-symlinks/test/remappers/remapImportPath.test.ts
@@ -1,5 +1,19 @@
+import { create } from "enhanced-resolve";
 import * as path from "node:path";
 import { remapImportPath } from "../../src/remappers/remapImportPath.ts";
+
+// `create.sync` is a non-configurable getter, so it cannot be spied on
+// directly. Wrap it in a mock that still delegates to the real implementation.
+jest.mock("enhanced-resolve", () => {
+  const actual =
+    jest.requireActual<typeof import("enhanced-resolve")>("enhanced-resolve");
+  const create = (...args: Parameters<typeof actual.create>) =>
+    actual.create(...args);
+  create.sync = jest.fn((...args: Parameters<typeof actual.create.sync>) =>
+    actual.create.sync(...args)
+  );
+  return { ...actual, create };
+});
 
 describe("remap-import-path", () => {
   const mockContext = {
@@ -69,10 +83,14 @@ describe("remap-import-path", () => {
       ["win32", "win"],
       ["windows", "windows"],
     ] as const;
+
+    // A single plugin instance serves every platform that a Metro server is
+    // asked to bundle for, so exercise all of them through one instance.
+    const plugin = remapImportPath({
+      test: (source) => source.startsWith("@contoso/"),
+    });
+
     for (const [platform, expected] of cases) {
-      const plugin = remapImportPath({
-        test: (source) => source.startsWith("@contoso/"),
-      });
       const result = plugin(
         mockContext,
         "@contoso/platform/lib/index",
@@ -90,6 +108,25 @@ describe("remap-import-path", () => {
         )
       );
     }
+  });
+
+  test("reuses the resolver when the platform is unchanged", () => {
+    const createSync = jest.mocked(create.sync);
+    createSync.mockClear();
+
+    const plugin = remapImportPath({
+      test: (source) => source.startsWith("@contoso/"),
+    });
+
+    plugin(mockContext, "@contoso/platform/lib/index", "ios");
+    plugin(mockContext, "@contoso/platform/lib/index", "ios");
+    expect(createSync).toHaveBeenCalledTimes(1);
+
+    plugin(mockContext, "@contoso/platform/lib/index", "android");
+    expect(createSync).toHaveBeenCalledTimes(2);
+
+    plugin(mockContext, "@contoso/platform/lib/index", "android");
+    expect(createSync).toHaveBeenCalledTimes(2);
   });
 
   test("resolves with custom main fields", () => {


### PR DESCRIPTION
### Description

`remapImportPath` builds an `enhanced-resolve` resolver whose extension list comes from `expandPlatformExtensions(platform, extensions)`, so the resolver is only valid for the platform it was created for. It was memoized in a single closure variable and returned for every later call regardless of platform:

```ts
let resolve: Resolver;
return (platform: string) => {
  if (!resolve) {
    resolve = require("enhanced-resolve").create.sync({
      extensions: expandPlatformExtensions(platform, extensions),
      mainFields,
    });
  }
  return resolve;
};
```

The cache lives on the object returned by `remapImportPath()`, which is created once per Metro config. A dev server that is asked for more than one platform shares that one instance, so whichever platform is resolved first wins and every other platform gets its extension list. Resolving `@contoso/platform/lib/index` for `ios` and then for `android` through the same instance returns `src/index.ios.ts` both times.

This is not a redundant cache miss; the second platform gets a different file than the one it asked for, and Metro will happily serve it.

The fix keys the cache on the platform so each one keeps its own resolver. Resolvers are still created lazily and still reused for repeated requests on the same platform.

### Test plan

`yarn test` in `packages/metro-resolver-symlinks` — 15 tests pass, previously 14.

The existing "resolves platform extensions" test constructed a fresh plugin inside its loop, so it never exercised the shared instance and could not catch this. It now creates one plugin and drives all five platforms through it, which is what a real Metro server does. Reverting the source change makes it fail with `Received: .../src/index.android.ts` where `index.ios.ts` was expected.

One test is new, `reuses the resolver when the platform is unchanged`. It counts calls to `enhanced-resolve`'s `create.sync` and asserts that two `ios` requests build one resolver and a following `android` request builds a second. Without that assertion a fix that simply dropped the cache would look identical to a correct one; with it, the same-platform cache hit is pinned down. `create.sync` is a non-configurable getter and cannot be passed to `jest.spyOn`, hence the small module factory mock that delegates to the real implementation.