### PR TITLE
fix(tools-typescript): don't let BatchWriter.finish() wait forever

### DIFF
--- a/.changeset/quiet-donkeys-repeat.md
+++ b/.changeset/quiet-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-typescript": patch
+---
+
+Fixed `BatchWriter.finish()` hanging when every queued write had already completed

--- a/incubator/tools-typescript/src/files.ts
+++ b/incubator/tools-typescript/src/files.ts
@@ -177,8 +177,11 @@ class BatchWriter implements AsyncWriter {
       }
     });
 
-    // if the queue never started write emit the done event so that we don't wait forever
-    if (this.queued === 0) {
+    // The done event is emitted as soon as the last write settles, which may
+    // have happened before anyone started listening for it. Re-emit it if the
+    // batch has already drained so that we don't wait forever. This also covers
+    // the case where the queue never started.
+    if (this.queued === this.written) {
       this.emitter.emit("done");
     }
     // now wait on the done event

--- a/incubator/tools-typescript/test/files.test.ts
+++ b/incubator/tools-typescript/test/files.test.ts
@@ -92,6 +92,19 @@ describe("BatchWriter", () => {
     expect(fileStats.maxActive).toBe(2);
   });
 
+  it("should return when all writes finished before finish was called", async () => {
+    const writer = createAsyncWriter("rootDir", throttler);
+    writer.writeFile("file1.txt", "content1");
+    writer.writeFile("file2.txt", "content2");
+    await awaitableTimeout(30);
+    expect(fileStats.written).toBe(2);
+
+    await writer.finish();
+
+    expect(fileStats.active).toBe(0);
+    expect(fileStats.written).toBe(2);
+  });
+
   it("should return when nothing is written", async () => {
     const writer = createAsyncWriter("rootDir", throttler);
     await writer.finish();


### PR DESCRIPTION
`writeFinished()` emits `done` the moment the last queued write settles. If nothing is listening at that point the event is dropped, and a later `finish()` starts listening for an event that will never come again. Any caller that writes some files, awaits unrelated work, and then calls `finish()` without queueing anything new hangs there.

`finish()` only guarded against the empty queue, so it re-emitted `done` when nothing had been written but not when everything had. Compare `queued` against `written` instead, which covers both cases: `written` only reaches `queued` once every write has settled.

### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Test plan

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout are required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
