### PR TITLE
fix(metro-resolver-symlinks): fix ignored packages

### DIFF
--- a/.changeset/gold-rings-act.md
+++ b/.changeset/gold-rings-act.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-resolver-symlinks": patch
+---
+
+Fixed ignored packages not being handled correctly

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -93,7 +93,7 @@ export default {
       ignoreDependencies: jestDependencies,
     },
     "packages/metro-resolver-symlinks": {
-      entry: ["jest.config.js", allTests],
+      entry: ["jest.config.js", allFixtures, allTests],
       ignoreDependencies: jestDependencies,
     },
     "packages/metro-serializer-esbuild": {

--- a/packages/metro-resolver-symlinks/src/resolvers/empty-module.ts
+++ b/packages/metro-resolver-symlinks/src/resolvers/empty-module.ts
@@ -1,0 +1,1 @@
+export const EMPTY_MODULE = { type: "empty" } as const;

--- a/packages/metro-resolver-symlinks/src/resolvers/enhanced-resolve.ts
+++ b/packages/metro-resolver-symlinks/src/resolvers/enhanced-resolve.ts
@@ -7,6 +7,7 @@ import {
   makeEnhancedResolveOptions,
 } from "../utils/enhancedResolveHelpers.ts";
 import { importResolver } from "../utils/package.ts";
+import { EMPTY_MODULE } from "./empty-module.ts";
 
 const getEnhancedResolver = (() => {
   const resolvers: Record<string, ResolveFunction> = {};
@@ -27,13 +28,13 @@ export function applyEnhancedResolver(
   platform: string
 ): Resolution {
   if (!platform) {
-    return { type: "empty" };
+    return EMPTY_MODULE;
   }
 
   const enhancedResolve = getEnhancedResolver(context, platform);
   const filePath = enhancedResolve(getFromDir(context), moduleName);
   if (filePath === false) {
-    return { type: "empty" };
+    return EMPTY_MODULE;
   }
 
   if (isAssetFile(context, moduleName)) {

--- a/packages/metro-resolver-symlinks/src/resolvers/metro-resolver.ts
+++ b/packages/metro-resolver-symlinks/src/resolvers/metro-resolver.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import type { ModuleResolver, ResolutionContextCompat } from "../types.ts";
 import { supportsSymlinks } from "../utils/metro.ts";
 import { resolveFrom } from "../utils/package.ts";
+import { EMPTY_MODULE } from "./empty-module.ts";
 
 export const resolveModulePath: ModuleResolver = (
   { extraNodeModules, originModulePath },
@@ -41,7 +42,7 @@ function applyMetroResolverLegacy(
   // https://github.com/react/metro/blob/v0.76.7/docs/Resolution.md#redirectmodulepath-string--string--false
   const realModuleName = ctx.redirectModulePath(moduleName);
   if (realModuleName === false) {
-    return { type: "empty" };
+    return EMPTY_MODULE;
   }
 
   const modifiedModuleName = resolveModulePath(ctx, realModuleName, platform);
@@ -59,7 +60,7 @@ function applyMetroResolver_0_81(
   // https://github.com/react/metro/blob/v0.76.7/docs/Resolution.md#redirectmodulepath-string--string--false
   const realModuleName = ctx.redirectModulePath(moduleName);
   if (realModuleName === false) {
-    return { type: "empty" };
+    return EMPTY_MODULE;
   }
 
   return resolve(ctx, realModuleName, platform);

--- a/packages/metro-resolver-symlinks/src/resolvers/oxc-resolver.ts
+++ b/packages/metro-resolver-symlinks/src/resolvers/oxc-resolver.ts
@@ -8,6 +8,7 @@ import {
   makeEnhancedResolveOptions,
 } from "../utils/enhancedResolveHelpers.ts";
 import { importResolver } from "../utils/package.ts";
+import { EMPTY_MODULE } from "./empty-module.ts";
 
 function makeOxcResolverOptions(
   context: ResolutionContextCompat,
@@ -59,13 +60,21 @@ export function applyOxcResolver(
   platform: string
 ): Resolution {
   if (!platform) {
-    return { type: "empty" };
+    return EMPTY_MODULE;
   }
 
   const oxcResolve = getOxcResolver(context, platform);
   const fromDir = getFromDir(context);
   const { error, path: filePath } = oxcResolve.sync(fromDir, moduleName);
   if (error) {
+    // A module is ignored when it is mapped to `false` in the `browser`
+    // field of `package.json`. This is not an error; Metro expects an empty
+    // module in this case.
+    // https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module
+    if (error.startsWith("Path is ignored")) {
+      return EMPTY_MODULE;
+    }
+
     const { originModulePath } = context;
     const origin = originModulePath
       ? path.relative(process.cwd(), originModulePath)
@@ -74,7 +83,7 @@ export function applyOxcResolver(
   }
 
   if (!filePath) {
-    return { type: "empty" };
+    return EMPTY_MODULE;
   }
 
   if (isAssetFile(context, moduleName)) {

--- a/packages/metro-resolver-symlinks/test/__fixtures__/ignored-module/ignored.js
+++ b/packages/metro-resolver-symlinks/test/__fixtures__/ignored-module/ignored.js
@@ -1,0 +1,1 @@
+module.exports = "should be ignored on native";

--- a/packages/metro-resolver-symlinks/test/__fixtures__/ignored-module/index.js
+++ b/packages/metro-resolver-symlinks/test/__fixtures__/ignored-module/index.js
@@ -1,0 +1,1 @@
+module.exports = require("./ignored");

--- a/packages/metro-resolver-symlinks/test/__fixtures__/ignored-module/package.json
+++ b/packages/metro-resolver-symlinks/test/__fixtures__/ignored-module/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@rnx-kit/metro-resolver-symlinks/ignored-module",
+  "version": "0.0.0-dev",
+  "private": true,
+  "browser": {
+    "./ignored": false
+  },
+  "engines": {
+    "node": "Do not install; for testing purposes only"
+  }
+}

--- a/packages/metro-resolver-symlinks/test/__fixtures__/remap-platforms/package.json
+++ b/packages/metro-resolver-symlinks/test/__fixtures__/remap-platforms/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@rnx-kit/metro-resolver-symlinks/remap-tests",
   "version": "0.0.0-dev",
+  "private": true,
   "dependencies": {
     "@office-iss/react-native-win32": "0.0.0-dev",
     "react-native": "0.0.0-dev",

--- a/packages/metro-resolver-symlinks/test/remappers/remapImportPath.test.ts
+++ b/packages/metro-resolver-symlinks/test/remappers/remapImportPath.test.ts
@@ -1,10 +1,11 @@
 import * as path from "node:path";
 import { remapImportPath } from "../../src/remappers/remapImportPath.ts";
+import type { ResolutionContextCompat } from "../../src/types.ts";
 
 describe("remap-import-path", () => {
   const mockContext = {
     originModulePath: "",
-  };
+  } as ResolutionContextCompat;
 
   const plugin = remapImportPath({
     test: (source) => source.startsWith("@contoso/"),

--- a/packages/metro-resolver-symlinks/test/remappers/remapReactNative.test.ts
+++ b/packages/metro-resolver-symlinks/test/remappers/remapReactNative.test.ts
@@ -1,4 +1,5 @@
 import { remapReactNativeModule } from "../../src/remappers/remapReactNative.ts";
+import type { ResolutionContextCompat } from "../../src/types.ts";
 import { useFixture } from "../fixtures.ts";
 
 const AVAILABLE_PLATFORMS = {
@@ -10,7 +11,7 @@ const AVAILABLE_PLATFORMS = {
 describe("remapReactNativeModule", () => {
   const context = {
     originModulePath: "",
-  };
+  } as ResolutionContextCompat;
 
   const currentDir = process.cwd();
 

--- a/packages/metro-resolver-symlinks/test/resolvers/enhanced-resolve.test.ts
+++ b/packages/metro-resolver-symlinks/test/resolvers/enhanced-resolve.test.ts
@@ -1,0 +1,6 @@
+import { applyEnhancedResolver } from "../../src/resolvers/enhanced-resolve.ts";
+import { makeResolverTest } from "./helper.ts";
+
+makeResolverTest("applyEnhancedResolver", applyEnhancedResolver, {
+  failed: "Can't resolve",
+});

--- a/packages/metro-resolver-symlinks/test/resolvers/helper.ts
+++ b/packages/metro-resolver-symlinks/test/resolvers/helper.ts
@@ -1,0 +1,57 @@
+import { resolve as metroResolver } from "metro-resolver";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { CallResolver, ResolutionContextCompat } from "../../src/types.ts";
+import { useFixture } from "../fixtures.ts";
+
+export function makeResolverTest(
+  name: string,
+  resolver: CallResolver,
+  errors: { failed: string }
+) {
+  const ignoredFixture = path.join(useFixture("ignored-module"), "index.js");
+
+  function makeContext(originModulePath: string): ResolutionContextCompat {
+    return {
+      originModulePath,
+      fileSystemLookup: (absoluteOrProjectRelativePath: string) => {
+        if (!fs.existsSync(absoluteOrProjectRelativePath)) {
+          return { exists: false };
+        }
+
+        const stat = fs.statSync(absoluteOrProjectRelativePath);
+        return {
+          exists: true,
+          type: stat.isFile() ? "f" : "d",
+          realPath: path.resolve(absoluteOrProjectRelativePath),
+        };
+      },
+      getPackageForModule: (absoluteModulePath: string) => {
+        return absoluteModulePath ? undefined : null;
+      },
+      mainFields: ["react-native", "browser", "main"],
+      redirectModulePath: (modulePath: string) => {
+        return modulePath !== "./ignored" && modulePath;
+      },
+      sourceExts: ["js"],
+    } as unknown as ResolutionContextCompat;
+  }
+
+  function resolve(context: ResolutionContextCompat, moduleName: string) {
+    return resolver(metroResolver, context, moduleName, "ios");
+  }
+
+  describe(name, () => {
+    test("throws when a module cannot be found", () => {
+      const context = makeContext(ignoredFixture);
+
+      expect(() => resolve(context, "./does-not-exist")).toThrow(errors.failed);
+    });
+
+    test("returns an empty module for paths ignored by the `browser` field", () => {
+      const context = makeContext(ignoredFixture);
+
+      expect(resolve(context, "./ignored")).toEqual({ type: "empty" });
+    });
+  });
+}

--- a/packages/metro-resolver-symlinks/test/resolvers/metro-resolver.test.ts
+++ b/packages/metro-resolver-symlinks/test/resolvers/metro-resolver.test.ts
@@ -1,10 +1,19 @@
 import * as path from "node:path";
-import { resolveModulePath } from "../../src/resolvers/metro-resolver.ts";
+import {
+  applyMetroResolver,
+  resolveModulePath,
+} from "../../src/resolvers/metro-resolver.ts";
+import type { ResolutionContextCompat } from "../../src/types.ts";
 import { useFixture } from "../fixtures.ts";
+import { makeResolverTest } from "./helper.ts";
+
+makeResolverTest("applyMetroResolver", applyMetroResolver, {
+  failed: "The module could not be resolved",
+});
 
 describe("resolveModulePath", () => {
-  function makeContext(originModulePath: string) {
-    return { originModulePath };
+  function makeContext(originModulePath: string): ResolutionContextCompat {
+    return { originModulePath } as ResolutionContextCompat;
   }
 
   test("returns absolute/relative modules as is", () => {

--- a/packages/metro-resolver-symlinks/test/resolvers/oxc-resolver.test.ts
+++ b/packages/metro-resolver-symlinks/test/resolvers/oxc-resolver.test.ts
@@ -1,0 +1,6 @@
+import { applyOxcResolver } from "../../src/resolvers/oxc-resolver.ts";
+import { makeResolverTest } from "./helper.ts";
+
+makeResolverTest("applyOxcResolver", applyOxcResolver, {
+  failed: "Cannot find module",
+});


### PR DESCRIPTION
### Description

Fixed ignored packages not being handled correctly.

```
~/.store/@rnx-kit-metro-resolver-symlinks@0.3.1-f18d2e7d84ea9c756962/node_modules/@rnx-kit/metro-resolver-symlinks/lib/resolvers/oxc-resolver.js:87
        throw new Error(`${origin}: ${error}`);
              ^
 
Error: ../../.store/postcss@8.5.15-1aa6daee72e40ed47612/node_modules/postcss/lib/css-syntax-error.js: Path is ignored ~/.store/postcss@8.5.15-1aa6daee72e40ed47612/node_modules/postcss/lib/terminal-highlight
    at applyOxcResolver (~/.store/@rnx-kit-metro-resolver-symlinks@0.3.1-f18d2e7d84ea9c756962/node_modules/@rnx-kit/metro-resolver-symlinks/lib/resolvers/oxc-resolver.js:87:15)
    at symlinkResolver (~/.store/@rnx-kit-metro-resolver-symlinks@0.3.1-f18d2e7d84ea9c756962/node_modules/@rnx-kit/metro-resolver-symlinks/lib/symlinkResolver.js:49:20)
```

### Test plan

Tests were added.