### PR TITLE
fix(tools-react-native): cache `readReactNativeConfig` calls

### DIFF
--- a/.changeset/little-ends-poke.md
+++ b/.changeset/little-ends-poke.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/tools-react-native": patch
+---
+
+Cache `readReactNativeConfig` calls to speed up subsequent calls

--- a/packages/tools-react-native/src/cache.ts
+++ b/packages/tools-react-native/src/cache.ts
@@ -1,4 +1,3 @@
-import type { Config } from "@react-native-community/cli-types";
 import { ensureDirSync } from "@rnx-kit/tools-filesystem";
 import { findUp } from "@rnx-kit/tools-node/path";
 import * as crypto from "node:crypto";
@@ -6,6 +5,7 @@ import * as nodefs from "node:fs";
 import * as path from "node:path";
 import { REACT_NATIVE_CONFIG_FILES } from "./context.ts";
 
+export const CONFIG_CACHE_KEY = "config";
 const HASH_ALGO = "sha256";
 const UTF8 = { encoding: "utf-8" as const };
 
@@ -13,12 +13,12 @@ function makeCachePath(projectRoot: string, filename: string): string {
   return path.join(projectRoot, "node_modules", ".cache", "rnx-kit", filename);
 }
 
-function cacheStatePath(projectRoot: string): string {
-  return makeCachePath(projectRoot, `config.${HASH_ALGO}`);
+function cacheStatePath(projectRoot: string, key: string): string {
+  return makeCachePath(projectRoot, `${key}.${HASH_ALGO}`);
 }
 
-function configCachePath(projectRoot: string): string {
-  return makeCachePath(projectRoot, "config.json");
+function configCachePath(projectRoot: string, key: string): string {
+  return makeCachePath(projectRoot, `${key}.json`);
 }
 
 function updateHash(
@@ -60,25 +60,28 @@ export function getCurrentState(projectRoot: string): string {
 
 export function getSavedState(
   projectRoot: string,
+  key = CONFIG_CACHE_KEY,
   /** @internal */ fs = nodefs
 ): string | false {
-  const stateFile = cacheStatePath(projectRoot);
+  const stateFile = cacheStatePath(projectRoot, key);
   return fs.existsSync(stateFile) && fs.readFileSync(stateFile, UTF8);
 }
 
 export function invalidateState(
   projectRoot = process.cwd(),
+  key = CONFIG_CACHE_KEY,
   /** @internal */ fs = nodefs
 ) {
-  fs.rmSync(configCachePath(projectRoot));
-  fs.rmSync(cacheStatePath(projectRoot));
+  fs.rmSync(configCachePath(projectRoot, key));
+  fs.rmSync(cacheStatePath(projectRoot, key));
 }
 
-export function loadConfigFromCache(
+export function loadConfigFromCache<T>(
   projectRoot: string,
+  key = CONFIG_CACHE_KEY,
   /** @internal */ fs = nodefs
-): Config | null {
-  const cacheFile = configCachePath(projectRoot);
+): T | null {
+  const cacheFile = configCachePath(projectRoot, key);
   if (!fs.existsSync(cacheFile)) {
     return null;
   }
@@ -87,17 +90,18 @@ export function loadConfigFromCache(
   return JSON.parse(config);
 }
 
-export function saveConfigToCache(
+export function saveConfigToCache<T>(
   projectRoot: string,
   state: string,
-  config: Config,
+  config: T,
+  key = CONFIG_CACHE_KEY,
   /** @internal */ fs = nodefs
 ): void {
   const data = JSON.stringify(config);
 
-  const configPath = configCachePath(projectRoot);
+  const configPath = configCachePath(projectRoot, key);
   ensureDirSync(path.dirname(configPath), fs);
 
   fs.writeFileSync(configPath, data, UTF8);
-  fs.writeFileSync(cacheStatePath(projectRoot), state, UTF8);
+  fs.writeFileSync(cacheStatePath(projectRoot, key), state, UTF8);
 }

--- a/packages/tools-react-native/src/context.ts
+++ b/packages/tools-react-native/src/context.ts
@@ -8,6 +8,7 @@ import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import {
+  CONFIG_CACHE_KEY,
   getCurrentState,
   getSavedState,
   loadConfigFromCache,
@@ -45,10 +46,13 @@ function findStartDir(root: string, reactNativePath = ""): string {
   return toNumber(version) < RN_CLI_DECOUPLED ? reactNative : root;
 }
 
-function getConfigOrState(projectRoot: string): Config | string {
+function getConfigOrState<T = Config>(
+  projectRoot: string,
+  key = CONFIG_CACHE_KEY
+): T | string {
   const state = getCurrentState(projectRoot);
-  if (state === getSavedState(projectRoot)) {
-    const config = loadConfigFromCache(projectRoot);
+  if (state === getSavedState(projectRoot, key)) {
+    const config = loadConfigFromCache<T>(projectRoot, key);
     if (config) {
       return config;
     }
@@ -130,6 +134,16 @@ export function readReactNativeConfig(
   packageDir: string,
   cwd = process.cwd()
 ): Record<string, unknown> | undefined {
+  const configCacheKey = "react-native.config";
+
+  const state = getConfigOrState<Record<string, unknown>>(
+    packageDir,
+    configCacheKey
+  );
+  if (typeof state !== "string") {
+    return state;
+  }
+
   for (const configFile of REACT_NATIVE_CONFIG_FILES) {
     const configPath = path.join(packageDir, configFile);
     if (fs.existsSync(configPath)) {
@@ -151,7 +165,13 @@ export function readReactNativeConfig(
       }
 
       const json = stdout?.toString().trim();
-      return json ? JSON.parse(json) : undefined;
+      if (!json) {
+        return undefined;
+      }
+
+      const config = JSON.parse(json);
+      saveConfigToCache(packageDir, state, config, configCacheKey);
+      return config;
     }
   }
 

--- a/packages/tools-react-native/src/platform.ts
+++ b/packages/tools-react-native/src/platform.ts
@@ -1,4 +1,7 @@
-import { findPackageDependencyDir } from "@rnx-kit/tools-node/package";
+import {
+  findPackageDependencyDir,
+  readPackage,
+} from "@rnx-kit/tools-node/package";
 import type { AllPlatforms } from "@rnx-kit/types-bundle-config";
 import { ALL_PLATFORM_VALUES } from "@rnx-kit/types-bundle-config";
 import * as fs from "node:fs";
@@ -98,9 +101,8 @@ export function getAvailablePlatformsUncached(
       : getAvailablePlatformsUncached(path.dirname(startDir), platformMap);
   }
 
-  const { dependencies, peerDependencies, devDependencies } = JSON.parse(
-    fs.readFileSync(packageJson, { encoding: "utf-8" })
-  );
+  const { dependencies, peerDependencies, devDependencies } =
+    readPackage(packageJson);
 
   const packages = new Set<string>(
     dependencies ? Object.keys(dependencies) : []

--- a/packages/tools-react-native/test/cache.test.mts
+++ b/packages/tools-react-native/test/cache.test.mts
@@ -5,6 +5,7 @@ import { deepEqual, equal, ok } from "node:assert/strict";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import {
+  CONFIG_CACHE_KEY,
   getSavedState,
   loadConfigFromCache,
   saveConfigToCache,
@@ -25,25 +26,25 @@ const stateFile = path.join(
 
 describe("getSavedState()", () => {
   it("returns false if there is no saved state", () => {
-    ok(!getSavedState("."));
+    ok(!getSavedState(".", CONFIG_CACHE_KEY));
   });
 
   it("returns saved state", () => {
     const fsMock = mockFS({ [stateFile]: stateHash });
 
-    equal(getSavedState(".", fsMock), stateHash);
+    equal(getSavedState(".", CONFIG_CACHE_KEY, fsMock), stateHash);
   });
 });
 
 describe("loadConfigFromCache()", () => {
   it("returns null if cache cannot be found", () => {
-    equal(loadConfigFromCache("."), null);
+    equal(loadConfigFromCache(".", CONFIG_CACHE_KEY), null);
   });
 
   it("returns cached config", () => {
     const fsMock = mockFS({ [cacheFile]: JSON.stringify(config) });
 
-    deepEqual(loadConfigFromCache(".", fsMock), config);
+    deepEqual(loadConfigFromCache(".", CONFIG_CACHE_KEY, fsMock), config);
   });
 });
 
@@ -51,7 +52,7 @@ describe("saveConfigToCache()", () => {
   it("writes the config and its state to disk", () => {
     const fs = mockFS();
 
-    saveConfigToCache(".", stateHash, config, fs);
+    saveConfigToCache(".", stateHash, config, CONFIG_CACHE_KEY, fs);
 
     equal(readText(stateFile, fs), stateHash);
     equal(readText(cacheFile, fs), JSON.stringify(config));


### PR DESCRIPTION
### Description

Cache `readReactNativeConfig` calls to speed up subsequent calls. It currently eats up close to 1 full second per invocation before any real work is performed. Caching brings this down to within 50 ms (mostly due to cache invalidation calculations).

This affects various commands including bundling and testing.

### Test plan

Existing tests should pass.