### PR TITLE
fix(cli): enable Node compile cache

### DIFF
--- a/.changeset/pretty-actors-study.md
+++ b/.changeset/pretty-actors-study.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/cli": patch
+---
+
+Enable Node's compile cache to speed up startup on subsequent runs

--- a/packages/cli/bin/rnx-cli.cjs
+++ b/packages/cli/bin/rnx-cli.cjs
@@ -1,2 +1,5 @@
 #!/usr/bin/env node
+// Enable the V8 compile cache (on Node >=22.8.0) before loading the CLI so that
+// the (large) module graph is compiled from cached bytecode on subsequent runs.
+require("node:module").enableCompileCache?.();
 require("../lib/bin/rnx-cli.js").main();


### PR DESCRIPTION
### Description

After several measurements, only `cli` seems to benefit from enabling compile cache because of the number of modules loaded. See https://github.com/microsoft/rnx-kit/issues/3598#issuecomment-5426582562 for details.

Resolves #3598.

### Test plan

n/a