### PR TITLE
fix(align-deps): address potential ReDoS vulnerability

### DIFF
--- a/.changeset/cold-steaks-beam.md
+++ b/.changeset/cold-steaks-beam.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": patch
+---
+
+Address potential ReDoS vulnerability in `--init` command

--- a/packages/align-deps/src/helpers.ts
+++ b/packages/align-deps/src/helpers.ts
@@ -34,9 +34,11 @@ export function dropPatchFromVersion(version: string): string {
       }
 
       // `>= 1.0.0` is equivalent to `>=1.0.0`, but only the latter survives
-      // being split into comparators below
+      // being split into comparators below. We limit the number of comparator
+      // characters to avoid quadratic backtracking on inputs such as `<<<<…`
+      // https://github.com/microsoft/rnx-kit/security/code-scanning/37
       return versionRange
-        .replace(/([<>=~^]+)\s+/g, "$1")
+        .replace(/([<>=~^]{1,2})\s+/g, "$1")
         .split(/\s+/)
         .map((v) => {
           if (v === "*" || v === "-") {


### PR DESCRIPTION
### Description

Technically, this shouldn't be possible because we check whether the input is a valid version range before parsing it. But our scanner flagged it so we need to fix it: https://github.com/microsoft/rnx-kit/security/code-scanning/37

### Test plan

n/a