### PR TITLE
fix(metro-service): copy remaining scales after an unsupported one

### DIFF
--- a/.changeset/silver-moons-shake.md
+++ b/.changeset/silver-moons-shake.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/metro-service": patch
+---
+
+Fixed asset scales after an unsupported one being dropped when saving assets

--- a/packages/metro-service/src/asset/write.ts
+++ b/packages/metro-service/src/asset/write.ts
@@ -84,7 +84,7 @@ export function saveAssets(
     for (let i = 0; i < length; ++i) {
       const scale = asset.scales[i];
       if (!validScales.has(scale)) {
-        return;
+        continue;
       }
       const src = asset.files[i];
       const dest = path.join(assetsDest, getAssetDestPath(asset, scale));

--- a/packages/metro-service/test/asset/write.test.ts
+++ b/packages/metro-service/test/asset/write.test.ts
@@ -3,6 +3,7 @@ import { deepEqual, equal } from "node:assert/strict";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import { saveAssetsDefault } from "../../src/asset/default.ts";
+import { saveAssetsIOS } from "../../src/asset/ios.ts";
 import { saveAssets } from "../../src/asset/write.ts";
 import { makeAssetData, mockPath } from "./helper.ts";
 
@@ -91,5 +92,39 @@ describe("saveAssets", () => {
 
     equal(files[path.posix.join(dest, "icon.png")], "one");
     equal(files[path.posix.join(dest, "icon@2x.png")], undefined);
+  });
+
+  it("copies remaining scales after an unsupported one", async () => {
+    const fs = mockFS({
+      "icon.png": "one",
+      "icon@1.5x.png": "one and a half",
+      "icon@2x.png": "two",
+      "icon@3x.png": "three",
+    });
+
+    await saveAssets(
+      [
+        makeAssetData({
+          name: "icon",
+          type: "png",
+          httpServerLocation: "/assets/test",
+          scales: [1, 1.5, 2, 3],
+          files: ["icon.png", "icon@1.5x.png", "icon@2x.png", "icon@3x.png"],
+        }),
+      ],
+      "ios",
+      "dist",
+      undefined,
+      saveAssetsIOS,
+      fs
+    );
+
+    const files = getMockFSFiles(fs);
+    const dest = mockPath("dist", "assets", "test");
+
+    equal(files[path.posix.join(dest, "icon.png")], "one");
+    equal(files[path.posix.join(dest, "icon@1.5x.png")], undefined);
+    equal(files[path.posix.join(dest, "icon@2x.png")], "two");
+    equal(files[path.posix.join(dest, "icon@3x.png")], "three");
   });
 });


### PR DESCRIPTION
### Description

`saveAssets` builds its copy list in `addAssetToCopy`
([`packages/metro-service/src/asset/write.ts#L84-L92`](https://github.com/microsoft/rnx-kit/blob/main/packages/metro-service/src/asset/write.ts#L84-L92)).
The body was ported from the upstream `saveAssets.ts` cited at the top of the
file, where it was a `scales.forEach(...)` callback. In a `forEach` callback
`return` skips one element, but in the rewritten `for` loop it abandons the
whole loop, so the first scale outside the platform allowlist silently drops
every remaining variant of that asset.

Only iOS passes an allowlist (`ALLOWED_SCALES = [1, 2, 3]` in
`src/asset/ios.ts`); `saveAssetsAndroid` and `saveAssetsDefault` pass
`undefined`, which makes every scale valid. So an asset registered with
`scales: [1, 1.5, 2, 3]` bundled for iOS copies only `icon.png`, and
`icon@2x.png` and `icon@3x.png` never make it into the bundle. No warning is
emitted.

The intent is to skip the invalid scale, so `continue` is the correct keyword.

### Test plan

`packages/metro-service/test/asset/write.test.ts` gains a case that routes an
asset with `scales: [1, 1.5, 2, 3]` through `saveAssetsIOS` and asserts that
`1x`, `2x` and `3x` are all copied while `1.5x` is not. The invalid scale sits
before valid ones, which is what distinguishes `return` from `continue`; the
existing `[1, 2]` with `allowedScales: [1]` case cannot, because there the
invalid scale is last.

```
cd packages/metro-service
yarn test
```

Before the fix, the new test fails with `undefined !== 'two'` on
`icon@2x.png`. After it, all 23 tests pass.
