### PR TITLE
feat(align-deps): add `--check-overrides`

### DIFF
--- a/.changeset/lucky-mice-shake.md
+++ b/.changeset/lucky-mice-shake.md
@@ -1,0 +1,5 @@
+---
+"@rnx-kit/align-deps": minor
+---
+
+Added `--check-overrides` for warning about `resolutions`/`overrides` entries that pin a managed dependency outside the current profiles

--- a/packages/align-deps/README.md
+++ b/packages/align-deps/README.md
@@ -84,6 +84,49 @@ Examples:
   yarn rnx-align-deps --set-version
   ```
 
+### `--check-overrides`
+
+Warns when an entry in `resolutions` (Yarn) or `overrides` (npm) pins a
+dependency that is managed by `align-deps` to a version that is outside the
+profiles it is scoped to.
+
+The scope is defined by the `rnx-kit.alignDeps.requirements` field of the
+package declaring the overrides. If this configuration is missing, `align-deps`
+falls back to [`--requirements`](#--requirements):
+
+```sh
+yarn rnx-align-deps --check-overrides --requirements react-native@0.80
+```
+
+If there is neither, this check will be skipped and a warning will be emitted.
+The reason for this is `align-deps` would otherwise have to fall back to the
+union of the profiles of every package it checks. Libraries commonly support a
+wide range of versions, e.g. `react-native@>=0.62 <1.0`, so that union quickly
+grows wide enough that any pin is considered fine, at which point the check is
+no longer useful.
+
+Because overrides are commonly used to pin a dependency to a specific version,
+an entry is considered fine as long as it is within the expected range — even
+when `--diff-mode strict` is used. Only entries that fall outside, or are
+broader than, the managed range are flagged.
+
+Unlike the other checks, this one only checks the root `package.json` because
+that is the only file where you can declare overrides. Outside a monorepo, the
+package being checked acts as the root.
+
+> [!NOTE]
+>
+> This check is advisory only. It never modifies `resolutions`/`overrides` (not
+> even with `--write`), and it does not affect the exit code.
+>
+> Entries that don't resolve to a plain version range, e.g. `patch:` or
+> `workspace:` protocols, npm's `$` references, or aliases of other packages
+> such as `npm:preact@^10.0.0`, are skipped as `align-deps` cannot tell what
+> version they resolve to without involving the package manager. Since `npm:`
+> is the default protocol, `npm:^0.70.0` is treated the same as `^0.70.0`.
+
+Default: `false`
+
 ### `--diff-mode`
 
 Sets the algorithm used to determine if versions differ.

--- a/packages/align-deps/src/cli.ts
+++ b/packages/align-deps/src/cli.ts
@@ -15,13 +15,19 @@ import { makeInitializeCommand } from "./commands/initialize.ts";
 import { makeSetVersionCommand } from "./commands/setVersion.ts";
 import { defaultConfig } from "./config.ts";
 import { printError, printInfo } from "./errors.ts";
-import { isString } from "./helpers.ts";
+import { isEmptyArray, isString } from "./helpers.ts";
 import type { Args, Command, DiffMode } from "./types.ts";
 
 export const description =
   "Manage dependencies within a repository and across many repositories";
 
 export const cliOptions = {
+  "check-overrides": {
+    default: false,
+    description:
+      "Warns when 'resolutions'/'overrides' pin a managed dependency to a version that is outside the profiles satisfying '--requirements', or the configuration of the package declaring them. This check never modifies the manifest.",
+    type: "boolean",
+  },
   "diff-mode": {
     default: "strict",
     description:
@@ -99,12 +105,12 @@ export const cliOptions = {
 
 async function getManifests(
   packages: (string | number)[] | undefined
-): Promise<string[] | undefined> {
+): Promise<[string[], string | undefined] | undefined> {
   const cwd = process.cwd();
   // When positional arguments are not provided, we will get `undefined` if
   // invoked directly, and an empty array if invoked via
   // `@react-native-community/cli`.
-  if (Array.isArray(packages) && packages.length > 0) {
+  if (!isEmptyArray(packages)) {
     const manifests = packages.reduce<string[]>((result, input) => {
       const pkg = input.toString();
       if (!fs.existsSync(pkg)) {
@@ -120,7 +126,10 @@ async function getManifests(
       }
       return result;
     }, []);
-    return manifests.length === 0 ? undefined : manifests;
+
+    // We ignore `--check-overrides` here otherwise we would have to try to
+    // resolve workspace root for each package.
+    return manifests.length === 0 ? undefined : [manifests, undefined];
   }
 
   const packageDir = findPackageDir();
@@ -134,11 +143,14 @@ async function getManifests(
   const currentPackageJson = path.join(packageDir, "package.json");
   const manifestPath = path.relative(cwd, currentPackageJson);
   try {
-    if ((await findWorkspaceRoot()) !== packageDir) {
-      return [manifestPath];
+    const root = await findWorkspaceRoot();
+    if (!root) {
+      return [[manifestPath], manifestPath];
+    } else if (root !== packageDir) {
+      return [[manifestPath], undefined];
     }
   } catch (_) {
-    return [manifestPath];
+    return [[manifestPath], manifestPath];
   }
 
   try {
@@ -149,7 +161,7 @@ async function getManifests(
     if (!allPackages.includes(manifestPath)) {
       allPackages.push(manifestPath);
     }
-    return allPackages;
+    return [allPackages, manifestPath];
   } catch (e) {
     if (hasProperty(e, "message")) {
       error(e.message);
@@ -196,6 +208,7 @@ async function makeCommand(args: Args): Promise<Command | undefined> {
   }
 
   const {
+    "check-overrides": checkOverrides,
     "diff-mode": diffMode,
     "exclude-packages": excludePackages,
     "export-catalogs": exportCatalogs,
@@ -203,15 +216,20 @@ async function makeCommand(args: Args): Promise<Command | undefined> {
     loose,
     "migrate-config": migrateConfig,
     "no-unmanaged": noUnmanaged,
+    packages,
     presets,
     requirements,
     "set-version": setVersion,
     verbose,
     write,
   } = args;
+  if (checkOverrides && !isEmptyArray(packages)) {
+    warn("`--check-overrides` is ignored if packages are specified");
+  }
 
   const options = {
     presets: presets?.toString()?.split(",") ?? defaultConfig.presets,
+    checkOverrides,
     loose,
     migrateConfig,
     noUnmanaged,
@@ -243,7 +261,7 @@ async function makeCommand(args: Args): Promise<Command | undefined> {
   return makeCheckCommand(options);
 }
 
-export async function cli({ packages, ...args }: Args): Promise<void> {
+export async function cli(args: Args): Promise<void> {
   const command = await makeCommand(args);
   if (!command) {
     process.exitCode = 1;
@@ -255,11 +273,13 @@ export async function cli({ packages, ...args }: Args): Promise<void> {
     return;
   }
 
-  const manifests = await getManifests(packages);
-  if (!manifests) {
+  const result = await getManifests(args.packages);
+  if (!result) {
     process.exitCode = 1;
     return;
   }
+
+  const [manifests, rootManifest] = result;
 
   // We will optimistically run through all packages regardless of failures. In
   // most scenarios, this should be fine: Both init and check+write write to
@@ -282,6 +302,14 @@ export async function cli({ packages, ...args }: Args): Promise<void> {
     }
     return errors;
   }, 0);
+
+  if (rootManifest && command.finalize) {
+    try {
+      command.finalize(rootManifest);
+    } catch (e) {
+      warn(`${rootManifest}: could not check overrides: ${e}`);
+    }
+  }
 
   process.exitCode = errors;
 

--- a/packages/align-deps/src/commands/check.ts
+++ b/packages/align-deps/src/commands/check.ts
@@ -10,6 +10,7 @@ import { updatePackageManifest } from "../manifest.ts";
 import { resolve } from "../preset.ts";
 import { makeDefaultReporter, withGroupReporter } from "../reporter.ts";
 import type { Command, ErrorCode, Options } from "../types.ts";
+import { makeOverridesChecker } from "./overrides.ts";
 import { checkPackageManifestUnconfigured } from "./vigilant.ts";
 
 /**
@@ -102,25 +103,9 @@ export function checkPackageManifest(
   return "success";
 }
 
-/**
- * Creates the check command. This is the default command no other flags are
- * specified.
- *
- * In normal mode, `align-deps` will only check packages that have a
- * configuration, and only listed capabilities.
- *
- * In vigilant mode, `align-deps` will check all packages in the workspace,
- * regardless of whether they have a configuration. For packages that do have a
- * configuration, the listed capabilities will be checked first as usual. The
- * remaining capabilities will then be checked, but are treated as unconfigured.
- *
- * @see {@link checkPackageManifest}
- * @see {@link checkPackageManifestUnconfigured}
- *
- * @param options Command line options
- * @returns The check command
- */
-export function makeCheckCommand(options: Options): Command {
+function makeCheckCommandInternal(
+  options: Options
+): Extract<Command, { isRootCommand?: false }> {
   const { presets, requirements } = options;
   if (!requirements) {
     return (manifest: string) => checkPackageManifest(manifest, options);
@@ -176,4 +161,37 @@ export function makeCheckCommand(options: Options): Command {
 
     return config;
   };
+}
+
+/**
+ * Creates the check command. This is the default command no other flags are
+ * specified.
+ *
+ * In normal mode, `align-deps` will only check packages that have a
+ * configuration, and only listed capabilities.
+ *
+ * In vigilant mode, `align-deps` will check all packages in the workspace,
+ * regardless of whether they have a configuration. For packages that do have a
+ * configuration, the listed capabilities will be checked first as usual. The
+ * remaining capabilities will then be checked, but are treated as unconfigured.
+ *
+ * @see {@link checkPackageManifest}
+ * @see {@link checkPackageManifestUnconfigured}
+ *
+ * @param options Command line options
+ * @returns The check command
+ */
+export function makeCheckCommand(options: Options): Command {
+  const command = makeCheckCommandInternal(options);
+
+  const checkOverrides = makeOverridesChecker(options);
+  if (checkOverrides) {
+    command.finalize = (rootManifestPath: string) => {
+      withGroupReporter(rootManifestPath, (reporter) =>
+        checkOverrides(rootManifestPath, reporter)
+      );
+    };
+  }
+
+  return command;
 }

--- a/packages/align-deps/src/commands/overrides.ts
+++ b/packages/align-deps/src/commands/overrides.ts
@@ -1,0 +1,325 @@
+import { readPackage } from "@rnx-kit/tools-node/package";
+import type { PackageManifest } from "@rnx-kit/types-node";
+import * as nodefs from "node:fs";
+import * as path from "node:path";
+import semverValidRange from "semver/ranges/valid.js";
+import { isMetaPackage } from "../capabilities.ts";
+import { transformConfig } from "../compatibility/config.ts";
+import { defaultConfig, loadConfig } from "../config.ts";
+import { isSubset } from "../diff.ts";
+import { isError } from "../errors.ts";
+import { isEmptyArray } from "../helpers.ts";
+import { filterPreset, mergePresets } from "../preset.ts";
+import { makeDefaultReporter } from "../reporter.ts";
+import type { Reporter } from "../reporter.ts";
+import type { CommandFinalizer, Options, Preset } from "../types.ts";
+
+/**
+ * Managed dependencies, i.e. dependencies that are provided by capabilities,
+ * and the version ranges that they are allowed to be within.
+ */
+export type ManagedDependencies = Map<string, string[]>;
+
+export type OverrideEntry = {
+  section: string;
+  key: string;
+  name: string;
+  version: string;
+};
+
+/**
+ * Sections that package managers use to pin dependencies.
+ *
+ * @note We currently only support entries that resolve to a plain version
+ * range. Entries using protocols such as `patch:` or `workspace:`, or npm's `$`
+ * references, are skipped as we cannot tell what version they resolve to
+ * without involving the package manager.
+ *
+ * @todo pnpm declares its overrides `pnpm-workspace.yaml`:
+ *       https://pnpm.io/settings/dependency-resolution#overrides
+ *
+ * @see {@link versionRangeOf}
+ */
+const OVERRIDE_SECTIONS = ["overrides", "resolutions"] as const;
+
+const NPM_PROTOCOL = "npm:";
+
+/**
+ * Returns the name of the package that an override key refers to.
+ *
+ * Keys can be scoped to a dependency path, e.g. `parent/react`, in which case
+ * only the last segment is the package being overridden. The segment may also
+ * carry a version descriptor, e.g. `react@18.2.0`, which is not part of the
+ * name.
+ *
+ * @param key The override key to extract the package name from
+ * @returns The package name if the key has one; otherwise `undefined`
+ */
+export function packageNameOf(key: string): string | undefined {
+  const nameStart = key.lastIndexOf("/") + 1;
+
+  // A version descriptor cannot be empty, and cannot start the name
+  const versionStart = key.indexOf("@", nameStart + 1);
+  if (versionStart === key.length - 1) {
+    return undefined;
+  }
+
+  const name =
+    versionStart < 0
+      ? key.substring(nameStart)
+      : key.substring(nameStart, versionStart);
+  if (!name || name.startsWith("@")) {
+    return undefined;
+  }
+
+  // The preceding segment is part of the name only if it is a scope
+  const scopeStart = key.lastIndexOf("/", nameStart - 2) + 1;
+  const scope = key.substring(scopeStart, nameStart - 1);
+  const isScope =
+    scope.length > 1 && scope.startsWith("@") && !scope.includes("@", 1);
+  return isScope ? `${scope}/${name}` : name;
+}
+
+function getOrInsert(managed: ManagedDependencies, key: string): string[] {
+  const value = managed.get(key);
+  if (value) {
+    return value;
+  }
+
+  const val: string[] = [];
+  managed.set(key, val);
+  return val;
+}
+
+function visitOverrides(
+  section: string,
+  node: unknown,
+  entries: OverrideEntry[],
+  parent?: string
+): void {
+  if (!node || typeof node !== "object") {
+    return;
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    // npm allows nested overrides, where `.` refers to the parent package
+    const name = key === "." ? parent : packageNameOf(key);
+    if (typeof value === "string") {
+      if (name) {
+        entries.push({ section, key, name, version: value });
+      }
+    } else {
+      visitOverrides(section, value, entries, name);
+    }
+  }
+}
+
+/**
+ * Returns all resolutions/overrides declared in the specified manifest.
+ * @param manifest The package manifest to scan for overrides
+ * @returns A list of overridden packages
+ */
+export function findOverrides(manifest: PackageManifest): OverrideEntry[] {
+  const entries: OverrideEntry[] = [];
+
+  for (const section of OVERRIDE_SECTIONS) {
+    visitOverrides(section, manifest[section], entries);
+  }
+
+  return entries;
+}
+
+/**
+ * Returns the dependencies managed by the specified preset.
+ * @param preset The preset to gather managed dependencies from
+ * @returns The managed dependencies
+ */
+export function collectManagedDependencies(
+  preset: Preset
+): ManagedDependencies {
+  const managed: ManagedDependencies = new Map();
+
+  for (const profile of Object.values(preset)) {
+    for (const pkg of Object.values(profile)) {
+      if (isMetaPackage(pkg)) {
+        continue;
+      }
+
+      const versions = getOrInsert(managed, pkg.name);
+      if (!versions.includes(pkg.version)) {
+        versions.push(pkg.version);
+      }
+    }
+  }
+
+  return managed;
+}
+
+/**
+ * Returns the version range that the specified override resolves to.
+ *
+ * `npm:` is the default protocol, meaning that `npm:^0.70.0` is equivalent to
+ * `^0.70.0`. It can also be used to alias another package, e.g.
+ * `npm:preact@^10.0.0`. Only aliases that point back at the same package can be
+ * compared. The rest are treated as unknown, as are other protocols such as
+ * `patch:` and `workspace:`, and npm's `$` references.
+ *
+ * @param name The name of the package being overridden
+ * @param version The version descriptor of the override
+ * @returns The version range if it can be determined; `undefined` otherwise
+ */
+export function versionRangeOf(
+  name: string,
+  version: string
+): string | undefined {
+  if (semverValidRange(version)) {
+    return version;
+  }
+
+  if (!version.startsWith(NPM_PROTOCOL)) {
+    return undefined;
+  }
+
+  // `"react": "npm:^19.0.0"`
+  const descriptor = version.substring(NPM_PROTOCOL.length);
+  if (semverValidRange(descriptor)) {
+    return descriptor;
+  }
+
+  // `"react": "npm:react@^19.0.0"`
+  const index = descriptor.lastIndexOf("@");
+  if (index <= 0 || descriptor.substring(0, index) !== name) {
+    return undefined;
+  }
+
+  const range = descriptor.substring(index + 1);
+  return semverValidRange(range) ? range : undefined;
+}
+
+/**
+ * Checks that resolutions/overrides declared in the specified manifest do not
+ * pin managed dependencies to versions that are outside the current profiles.
+ *
+ * Overrides are commonly used to pin a dependency to a specific version. An
+ * entry is therefore considered fine as long as it stays within the expected
+ * range, even in strict diff mode.
+ *
+ * @note This check is advisory only. It never modifies the manifest, and only
+ * emits warnings.
+ *
+ * @param overrides Overrides declared in the package manifest
+ * @param manifestPath The path to the package manifest
+ * @param managed The dependencies that are currently managed
+ * @param reporter Function for outputting warnings
+ */
+export function checkOverrides(
+  overrides: OverrideEntry[],
+  manifestPath: string,
+  managed: ManagedDependencies,
+  reporter: Reporter
+): void {
+  for (const { section, key, name, version } of overrides) {
+    const versions = managed.get(name);
+    if (isEmptyArray(versions)) {
+      continue;
+    }
+
+    // Skip entries that we cannot compare, e.g. `patch:`/`workspace:` protocols
+    const pinned = versionRangeOf(name, version);
+    if (!pinned) {
+      continue;
+    }
+
+    const range = versions.join(" || ");
+    if (isSubset(pinned, range, { includePrerelease: true })) {
+      continue;
+    }
+
+    reporter.warn(
+      `${manifestPath}: ${section}["${key}"]: "${version}" pins '${name}' outside the expected version range: ${range}`
+    );
+  }
+}
+
+function resolveScope(
+  manifest: PackageManifest,
+  manifestPath: string,
+  options: Options,
+  /** @internal */ fs = nodefs
+): Pick<Options, "presets" | "requirements"> {
+  const inputConfig = loadConfig({ path: manifestPath, manifest }, options, fs);
+  if (isError(inputConfig)) {
+    return options;
+  }
+
+  const {
+    alignDeps: { presets, requirements },
+  } = "alignDeps" in inputConfig ? inputConfig : transformConfig(inputConfig);
+  return {
+    presets: presets || defaultConfig.presets,
+    requirements: Array.isArray(requirements)
+      ? requirements
+      : // We always prefer development requirements because you are only in the
+        // repository if you're working on something.
+        requirements.development || requirements.production,
+  };
+}
+
+/**
+ * Creates a check that verifies the resolutions/overrides declared in the
+ * workspace root, or in the current package if it is the only one.
+ *
+ * Unlike the other checks, this one runs once rather than once per package.
+ * Resolutions/overrides can only be declared in the root `package.json`, and
+ * the versions they are compared against are dictated by `requirements` — not
+ * by anything the individual packages declare.
+ *
+ * Requirements are what scopes this check. Without them, we would have to fall
+ * back to the union of every checked package's profiles. Because libraries
+ * commonly support a wide range of versions, e.g. `react-native@>=0.62 <1.0`,
+ * that union quickly grows wide enough for any pin to be considered fine —
+ * making the check useless. We therefore require that requirements are set.
+ *
+ * @param options Command line options
+ * @returns The check if it is enabled and can be scoped; otherwise `undefined`
+ */
+export function makeOverridesChecker(
+  options: Options,
+  /** @internal */ fs = nodefs
+): CommandFinalizer | undefined {
+  if (!options.checkOverrides) {
+    return undefined;
+  }
+
+  return (manifestPath, reporter = makeDefaultReporter(manifestPath)) => {
+    const manifest = readPackage(manifestPath, fs);
+    const overrides = findOverrides(manifest);
+    if (overrides.length === 0) {
+      return;
+    }
+
+    const scope = resolveScope(manifest, manifestPath, options, fs);
+    if (!scope.requirements) {
+      reporter.warn(
+        "`--check-overrides` needs `--requirements`, or an rnx-kit " +
+          "configuration in the package declaring requirements, to determine " +
+          "which versions they are expected to be within; skipping the check"
+      );
+      return;
+    }
+
+    const { presets, requirements } = scope;
+    const projectRoot = path.dirname(manifestPath);
+    const preset = filterPreset(
+      mergePresets(presets, projectRoot),
+      requirements
+    );
+
+    const managed = collectManagedDependencies(preset);
+    if (managed.size === 0) {
+      return;
+    }
+
+    checkOverrides(overrides, manifestPath, managed, reporter);
+  };
+}

--- a/packages/align-deps/src/compatibility/commander.ts
+++ b/packages/align-deps/src/compatibility/commander.ts
@@ -18,6 +18,7 @@ export const alignDepsCommand = {
   func: (_argv: string[], _config: Config, args: InputArgs) => {
     cli({
       ...pickValues(args, Object.values(optionsMap), Object.keys(optionsMap)),
+      "check-overrides": Boolean(args.checkOverrides),
       "diff-mode": args.diffMode?.toString(),
       loose: Boolean(args.loose),
       "migrate-config": Boolean(args.migrateConfig),

--- a/packages/align-deps/src/config.ts
+++ b/packages/align-deps/src/config.ts
@@ -9,6 +9,7 @@ import type { PackageManifest } from "@rnx-kit/types-node";
 import * as nodefs from "node:fs";
 import * as path from "node:path";
 import { findBadPackages } from "./bannedPackages.ts";
+import { isEmptyArray } from "./helpers.ts";
 import type {
   AlignDepsOptions,
   ErrorCode,
@@ -28,7 +29,7 @@ export const defaultConfig: AlignDepsOptions["alignDeps"] = {
 
 export function containsValidPresets(config: KitConfig["alignDeps"]): boolean {
   const presets = config?.presets;
-  return !presets || (Array.isArray(presets) && presets.length > 0);
+  return !presets || !isEmptyArray(presets);
 }
 
 export function findEmptyRequirements(
@@ -42,10 +43,7 @@ export function findEmptyRequirements(
       }
     } else if (typeof requirements === "object") {
       const environments = ["development", "production"] as const;
-      const key = environments.find(
-        (env) =>
-          !Array.isArray(requirements[env]) || requirements[env].length === 0
-      );
+      const key = environments.find((env) => isEmptyArray(requirements[env]));
       return key && `requirements.${key}`;
     }
   }

--- a/packages/align-deps/src/helpers.ts
+++ b/packages/align-deps/src/helpers.ts
@@ -56,6 +56,10 @@ export function dropPatchFromVersion(version: string): string {
     .join(" || ");
 }
 
+export function isEmptyArray<T>(arr: T[] | undefined): arr is undefined {
+  return !Array.isArray(arr) || arr.length === 0;
+}
+
 export function isString(str: unknown): str is string {
   return typeof str?.valueOf() === "string";
 }

--- a/packages/align-deps/src/types.ts
+++ b/packages/align-deps/src/types.ts
@@ -4,6 +4,7 @@ import type {
   KitType,
 } from "@rnx-kit/types-kit-config";
 import type { PackageManifest } from "@rnx-kit/types-node";
+import type { Reporter } from "./reporter.ts";
 
 export type AlignDepsOptions = {
   kitType: KitType;
@@ -27,6 +28,7 @@ export type DiffMode = "strict" | "allow-subset";
 
 export type Options = {
   presets: string[];
+  checkOverrides?: boolean;
   loose?: boolean;
   migrateConfig?: boolean;
   noUnmanaged?: boolean;
@@ -38,6 +40,7 @@ export type Options = {
 };
 
 export type Args = Pick<Options, "loose" | "verbose" | "write"> & {
+  "check-overrides"?: boolean;
   "diff-mode"?: string;
   "exclude-packages"?: string | number;
   "export-catalogs"?: string;
@@ -62,8 +65,20 @@ export type ErrorCode =
   | "not-configured"
   | "unsatisfied";
 
+export type CommandFinalizer = (
+  manifestPath: string,
+  reporter?: Reporter
+) => void;
+
 export type Command =
-  | (((manifest: string) => ErrorCode) & { isRootCommand?: false })
+  | (((manifest: string) => ErrorCode) & {
+      isRootCommand?: false;
+      /**
+       * Called after all packages have been checked, with the path to the
+       * manifest of the workspace root.
+       */
+      finalize?: CommandFinalizer;
+    })
   | ((() => ErrorCode) & { isRootCommand: true });
 
 export type MetaPackage = {

--- a/packages/align-deps/test/commands/overrides.test.ts
+++ b/packages/align-deps/test/commands/overrides.test.ts
@@ -1,0 +1,707 @@
+import { deepEqual, equal, fail, ok } from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import {
+  checkPackageManifest,
+  makeCheckCommand,
+} from "../../src/commands/check.ts";
+import {
+  checkOverrides,
+  collectManagedDependencies,
+  findOverrides,
+  makeOverridesChecker,
+  packageNameOf,
+  versionRangeOf,
+} from "../../src/commands/overrides.ts";
+import type { ManagedDependencies } from "../../src/commands/overrides.ts";
+import { defaultConfig, loadConfig } from "../../src/config.ts";
+import { profile as profile_0_70 } from "../../src/presets/microsoft/react-native/profile-0.70.ts";
+import { profile as profile_0_71 } from "../../src/presets/microsoft/react-native/profile-0.71.ts";
+import type { Reporter } from "../../src/reporter.ts";
+import type { Options } from "../../src/types.ts";
+import * as mockfs from "../__mocks__/fs.ts";
+import { defineRequire, undefineRequire } from "../helpers.ts";
+
+const fs = mockfs as unknown as typeof import("node:fs");
+
+const defaultOptions: Options = {
+  presets: defaultConfig.presets,
+  checkOverrides: true,
+  loose: false,
+  migrateConfig: false,
+  noUnmanaged: false,
+  verbose: false,
+  write: false,
+  requirements: ["react-native@0.70"],
+};
+
+function makeReporter(): Reporter & { warnings: string[] } {
+  const warnings: string[] = [];
+  return {
+    warnings,
+    info: fail,
+    warn: (message: string) => warnings.push(message),
+    error: fail,
+    close: fail,
+  };
+}
+
+describe("findOverrides()", () => {
+  it("returns nothing when there are no overrides", () => {
+    deepEqual(findOverrides({ name: "test", version: "1.0.0" }), []);
+  });
+
+  it("finds Yarn resolutions", () => {
+    const resolutions = {
+      react: "18.1.0",
+      "**/@types/react": "^18.0.0",
+      "@rnx-kit/align-deps": "^4.0.0",
+      "some-package/react-native@^0.70.0": "0.70.6",
+    };
+    const manifest = {
+      name: "test",
+      version: "1.0.0",
+      resolutions,
+    };
+
+    deepEqual(
+      findOverrides(manifest).map(({ name, version }) => [name, version]),
+      [
+        ["react", resolutions.react],
+        ["@types/react", resolutions["**/@types/react"]],
+        ["@rnx-kit/align-deps", resolutions["@rnx-kit/align-deps"]],
+        ["react-native", resolutions["some-package/react-native@^0.70.0"]],
+      ]
+    );
+  });
+
+  it("finds npm overrides, including nested ones", () => {
+    const overrides = {
+      "react@18.x": "18.1.0",
+      "some-package": {
+        ".": "1.0.0",
+        "react-native": "0.70.6",
+      },
+    };
+    const manifest = {
+      name: "test",
+      version: "1.0.0",
+      overrides,
+    };
+
+    deepEqual(
+      findOverrides(manifest).map(({ name, version }) => [name, version]),
+      [
+        ["react", overrides["react@18.x"]],
+        ["some-package", overrides["some-package"]["."]],
+        ["react-native", overrides["some-package"]["react-native"]],
+      ]
+    );
+  });
+
+  it("returns entries using unsupported protocols", () => {
+    const manifest = {
+      name: "test",
+      version: "1.0.0",
+      resolutions: {
+        alias: "npm:preact@^10.0.0",
+        patch: "patch:react-native@^0.70.0#./rn.patch",
+        workspace: "workspace:*",
+        reference: "$react",
+        file: "file:./vendor/react",
+        git: "github:facebook/react#main",
+        url: "https://example.com/react.tgz",
+      },
+    };
+
+    // Unsupported entries are still returned; they are dropped later, when we
+    // fail to determine what version they resolve to.
+    deepEqual(
+      findOverrides(manifest).map(({ name, version }) => [
+        name,
+        versionRangeOf(name, version),
+      ]),
+      [
+        ["alias", undefined],
+        ["patch", undefined],
+        ["workspace", undefined],
+        ["reference", undefined],
+        ["file", undefined],
+        ["git", undefined],
+        ["url", undefined],
+      ]
+    );
+  });
+
+  it("finds entries whose key includes a protocol", () => {
+    const manifest = {
+      name: "test",
+      version: "1.0.0",
+      resolutions: {
+        "react-native@npm:^0.70.0": "0.70.6",
+        "@types/react@npm:^18.0.0": "18.0.28",
+        "some-package/react@npm:^18.0.0": "18.1.0",
+      },
+    };
+
+    deepEqual(
+      findOverrides(manifest).map(({ name, version }) => [name, version]),
+      [
+        ["react-native", "0.70.6"],
+        ["@types/react", "18.0.28"],
+        ["react", "18.1.0"],
+      ]
+    );
+  });
+});
+
+describe("packageNameOf()", () => {
+  it("returns the name of unscoped packages", () => {
+    equal(packageNameOf("react"), "react");
+    equal(packageNameOf("react-native"), "react-native");
+  });
+
+  it("returns the name of scoped packages", () => {
+    equal(packageNameOf("@types/react"), "@types/react");
+    equal(
+      packageNameOf("@react-native/metro-config"),
+      "@react-native/metro-config"
+    );
+  });
+
+  it("strips version descriptors", () => {
+    equal(packageNameOf("react@18.2.0"), "react");
+    equal(packageNameOf("react@^18"), "react");
+    equal(packageNameOf("@types/react@18.2.0"), "@types/react");
+  });
+
+  it("returns the last segment of nested keys", () => {
+    equal(packageNameOf("**/react"), "react");
+    equal(packageNameOf("**/@types/react"), "@types/react");
+    equal(packageNameOf("react-native/react"), "react");
+    equal(packageNameOf("a/b/c/react"), "react");
+  });
+
+  it("returns the last segment of nested keys with version descriptors", () => {
+    equal(packageNameOf("**/react@^18"), "react");
+    equal(packageNameOf("parent/@types/react@18.2.0"), "@types/react");
+  });
+
+  it("returns nothing when there is no name to extract", () => {
+    equal(packageNameOf(""), undefined);
+    equal(packageNameOf("react/"), undefined);
+    equal(packageNameOf("@types/"), undefined);
+    equal(packageNameOf("**/"), undefined);
+  });
+
+  it("returns nothing when the version descriptor is empty", () => {
+    equal(packageNameOf("react@"), undefined);
+    equal(packageNameOf("**/react@"), undefined);
+    equal(packageNameOf("@types/react@"), undefined);
+  });
+
+  it("ignores preceding segments that are not scopes", () => {
+    equal(packageNameOf("@/react"), "react");
+    equal(packageNameOf("@a@b/react"), "react");
+    equal(packageNameOf("parent/react"), "react");
+  });
+});
+
+describe("checkOverrides()", () => {
+  const managed: ManagedDependencies = new Map([
+    ["react", ["18.1.0"]],
+    ["react-native", ["^0.70.0"]],
+  ]);
+
+  it("warns when an override is outside the managed range", () => {
+    const reporter = makeReporter();
+    const resolutions = [
+      {
+        section: "resolutions",
+        key: "react-native",
+        name: "react-native",
+        version: "0.71.0",
+      },
+    ];
+
+    checkOverrides(resolutions, "package.json", managed, reporter);
+
+    equal(reporter.warnings.length, 1);
+    ok(reporter.warnings[0].includes(`resolutions["react-native"]`));
+    ok(reporter.warnings[0].endsWith("^0.70.0"));
+  });
+
+  it("warns when an override is broader than the managed range", () => {
+    const reporter = makeReporter();
+    const overrides = [
+      {
+        section: "overrides",
+        key: "react",
+        name: "react",
+        version: "^18.1.0",
+      },
+    ];
+
+    checkOverrides(overrides, "package.json", managed, reporter);
+
+    equal(reporter.warnings.length, 1);
+    ok(reporter.warnings[0].includes(`overrides["react"]`));
+    ok(reporter.warnings[0].endsWith("18.1.0"));
+  });
+
+  it("accepts concrete versions within the managed range", () => {
+    const reporter = makeReporter();
+    const resolutions = [
+      {
+        section: "resolutions",
+        key: "react-native",
+        name: "react-native",
+        version: "0.70.6",
+      },
+      {
+        section: "resolutions",
+        key: "react",
+        name: "react",
+        version: "18.1.0",
+      },
+    ];
+
+    checkOverrides(resolutions, "package.json", managed, reporter);
+
+    equal(reporter.warnings.length, 0);
+  });
+
+  it("ignores unmanaged packages and unsupported protocols", () => {
+    const reporter = makeReporter();
+    const resolutions = [
+      {
+        section: "resolutions",
+        key: "some-package",
+        name: "some-package",
+        version: "0.0.1",
+      },
+      {
+        section: "resolutions",
+        key: "react",
+        name: "react",
+        version: "npm:preact@^10.0.0",
+      },
+      {
+        section: "resolutions",
+        key: "react-native",
+        name: "react-native",
+        version: "patch:react-native@^0.70.0#./rn.patch",
+      },
+    ];
+
+    checkOverrides(resolutions, "package.json", managed, reporter);
+
+    equal(reporter.warnings.length, 0);
+  });
+
+  it("accepts entries using the default `npm:` protocol", () => {
+    const reporter = makeReporter();
+    const resolutions = [
+      {
+        section: "resolutions",
+        key: "react",
+        name: "react",
+        version: "npm:react@18.1.0",
+      },
+      {
+        section: "resolutions",
+        key: "react-native",
+        name: "react-native",
+        version: "npm:0.70.6",
+      },
+    ];
+
+    checkOverrides(resolutions, "package.json", managed, reporter);
+
+    equal(reporter.warnings.length, 0);
+  });
+
+  it("warns when an entry using the default `npm:` protocol is misaligned", () => {
+    const reporter = makeReporter();
+    const resolutions = [
+      {
+        section: "resolutions",
+        key: "react-native",
+        name: "react-native",
+        version: "npm:react-native@0.71.0",
+      },
+    ];
+
+    checkOverrides(resolutions, "package.json", managed, reporter);
+
+    equal(reporter.warnings.length, 1);
+    ok(
+      reporter.warnings[0].includes(
+        `resolutions["react-native"]: "npm:react-native@0.71.0"`
+      )
+    );
+  });
+
+  it("ignores overrides when nothing is managed", () => {
+    const reporter = makeReporter();
+    const resolutions = [
+      {
+        section: "resolutions",
+        key: "react-native",
+        name: "react-native",
+        version: "0.71.0",
+      },
+    ];
+
+    checkOverrides(resolutions, "package.json", new Map(), reporter);
+
+    equal(reporter.warnings.length, 0);
+  });
+});
+
+describe("versionRangeOf()", () => {
+  it("returns plain version ranges as-is", () => {
+    equal(versionRangeOf("react-native", "^0.70.0"), "^0.70.0");
+    equal(versionRangeOf("react-native", "0.70.6"), "0.70.6");
+  });
+
+  it("strips the default `npm:` protocol", () => {
+    equal(versionRangeOf("react-native", "npm:^0.70.0"), "^0.70.0");
+    equal(
+      versionRangeOf("react-native", "npm:react-native@^0.70.0"),
+      "^0.70.0"
+    );
+    equal(
+      versionRangeOf("@types/react", "npm:@types/react@^18.0.0"),
+      "^18.0.0"
+    );
+  });
+
+  it("returns nothing for aliases of other packages", () => {
+    equal(versionRangeOf("react", "npm:preact@^10.0.0"), undefined);
+    equal(versionRangeOf("react", "npm:preact"), undefined);
+    equal(versionRangeOf("react", "npm:preact@latest"), undefined);
+    equal(versionRangeOf("react", "npm:react@latest"), undefined);
+  });
+
+  it("returns nothing for unsupported protocols", () => {
+    equal(
+      versionRangeOf("react-native", "patch:react-native@^0.70.0#./rn.patch"),
+      undefined
+    );
+    equal(versionRangeOf("react-native", "workspace:*"), undefined);
+    equal(versionRangeOf("react", "$react"), undefined);
+  });
+});
+
+describe("collectManagedDependencies()", () => {
+  it("gathers versions from all profiles in the preset", () => {
+    const managed = collectManagedDependencies({
+      "0.70": profile_0_70,
+      "0.71": profile_0_71,
+    });
+
+    deepEqual(managed.get("react-native"), ["^0.70.0", "^0.71.0"]);
+    deepEqual(managed.get("react"), ["18.1.0", "18.2.0"]);
+  });
+
+  it("gathers packages that no capability in the workspace provides", () => {
+    const managed = collectManagedDependencies({ "0.70": profile_0_70 });
+
+    // `core` only resolves to `react-native`, but the profile manages more
+    ok(managed.size > 2);
+    deepEqual(managed.get("react-dom"), ["^18.1.0"]);
+    deepEqual(managed.get("metro"), ["^0.72.1"]);
+  });
+
+  it("skips meta packages", () => {
+    const managed = collectManagedDependencies({ "0.70": profile_0_70 });
+
+    equal(managed.get("#meta"), undefined);
+  });
+
+  it("returns nothing for an empty preset", () => {
+    equal(collectManagedDependencies({}).size, 0);
+  });
+});
+
+describe("makeOverridesChecker()", () => {
+  const presets = defaultConfig.presets;
+
+  const enabled: Options = {
+    presets,
+    checkOverrides: true,
+    requirements: ["react-native@0.70"],
+  };
+
+  function makeChecker(options: Options) {
+    const check = makeOverridesChecker(options, fs);
+    ok(check);
+    return check;
+  }
+
+  before(() => {
+    defineRequire("../../src/preset.ts", import.meta.url);
+  });
+
+  after(() => {
+    undefineRequire();
+    mockfs.__setMockContent({});
+  });
+
+  it("is disabled unless `--check-overrides` is specified", () => {
+    equal(makeOverridesChecker({ presets }), undefined);
+    equal(makeOverridesChecker({ presets, checkOverrides: false }), undefined);
+  });
+
+  it("is skipped when there are neither requirements nor a configuration", () => {
+    const check = makeChecker({ presets, checkOverrides: true });
+
+    mockfs.__setMockContent({
+      name: "workspace-root",
+      version: "1.0.0",
+      private: true,
+      resolutions: { "react-native": "0.71.0" },
+    });
+
+    const reporter = makeReporter();
+    check("package.json", reporter);
+
+    equal(reporter.warnings.length, 1);
+    ok(reporter.warnings[0].includes("skipping"));
+  });
+
+  it("prefers the package configuration declaring the overrides", () => {
+    const check = makeChecker({
+      presets,
+      checkOverrides: true,
+      requirements: ["react-native@0.71"],
+    });
+
+    mockfs.__setMockContent({
+      name: "workspace-root",
+      version: "1.0.0",
+      private: true,
+      resolutions: { "react-native": "0.71.0" },
+      "rnx-kit": {
+        alignDeps: {
+          requirements: ["react-native@0.70"],
+          capabilities: ["core"],
+        },
+      },
+    });
+
+    const reporter = makeReporter();
+    check("package.json", reporter);
+
+    equal(reporter.warnings.length, 1);
+    ok(reporter.warnings[0].includes(`resolutions["react-native"]`));
+    ok(reporter.warnings[0].endsWith("^0.70.0"));
+  });
+
+  it("accepts pins matching the development requirements", () => {
+    const check = makeChecker({ presets, checkOverrides: true });
+
+    mockfs.__setMockContent({
+      name: "workspace-root",
+      version: "1.0.0",
+      private: true,
+      resolutions: { "react-native": "0.71.0" },
+      "rnx-kit": {
+        alignDeps: {
+          requirements: {
+            development: ["react-native@0.71"],
+            production: ["react-native@0.70"],
+          },
+          capabilities: ["core"],
+        },
+      },
+    });
+
+    const reporter = makeReporter();
+    check("package.json", reporter);
+
+    equal(reporter.warnings.length, 0);
+  });
+
+  it("falls back to a legacy configuration", (t) => {
+    t.mock.method(console, "warn", () => undefined);
+
+    const check = makeChecker({ presets, checkOverrides: true });
+
+    mockfs.__setMockContent({
+      name: "workspace-root",
+      version: "1.0.0",
+      private: true,
+      resolutions: { "react-native": "0.71.0" },
+      "rnx-kit": {
+        reactNativeVersion: "^0.70.0",
+        capabilities: ["core"],
+      },
+    });
+
+    const reporter = makeReporter();
+    check("package.json", reporter);
+
+    equal(reporter.warnings.length, 1);
+    ok(reporter.warnings[0].includes(`resolutions["react-native"]`));
+    ok(reporter.warnings[0].endsWith("^0.70.0"));
+  });
+
+  it("scopes managed versions to the profiles satisfying the requirements", () => {
+    const check = makeChecker(enabled);
+
+    mockfs.__setMockContent({
+      name: "workspace-root",
+      version: "1.0.0",
+      private: true,
+      resolutions: { "react-native": "0.71.0", react: "18.1.0" },
+    });
+
+    const reporter = makeReporter();
+    check("package.json", reporter);
+
+    equal(reporter.warnings.length, 1);
+    ok(reporter.warnings[0].includes(`resolutions["react-native"]`));
+  });
+
+  it("accepts pins matching any profile satisfying the requirements", () => {
+    const check = makeChecker({
+      ...enabled,
+      requirements: ["react-native@>=0.70 <0.72"],
+    });
+
+    mockfs.__setMockContent({
+      name: "workspace-root",
+      version: "1.0.0",
+      private: true,
+      resolutions: { "react-native": "0.71.0" },
+    });
+
+    const reporter = makeReporter();
+    check("package.json", reporter);
+
+    equal(reporter.warnings.length, 0);
+  });
+
+  it("checks the workspace root even if it is unconfigured", () => {
+    const check = makeChecker(enabled);
+
+    mockfs.__setMockContent({
+      name: "workspace-root",
+      version: "1.0.0",
+      private: true,
+      resolutions: { "react-native": "0.86.0" },
+    });
+
+    const reporter = makeReporter();
+    check("package.json", reporter);
+
+    equal(reporter.warnings.length, 1);
+    ok(reporter.warnings[0].includes(`resolutions["react-native"]`));
+  });
+
+  it("does nothing when no profile satisfies the requirements", () => {
+    const check = makeChecker({
+      ...enabled,
+      requirements: ["react-native@0.0.1"],
+    });
+
+    mockfs.__setMockContent({
+      name: "workspace-root",
+      version: "1.0.0",
+      private: true,
+      resolutions: { "react-native": "0.71.0" },
+    });
+
+    const reporter = makeReporter();
+    check("package.json", reporter);
+
+    equal(reporter.warnings.length, 0);
+  });
+
+  it("does nothing when the root declares no overrides", () => {
+    const check = makeChecker(enabled);
+
+    mockfs.__setMockContent({
+      name: "workspace-root",
+      version: "1.0.0",
+      private: true,
+    });
+
+    const reporter = makeReporter();
+    check("package.json", reporter);
+
+    equal(reporter.warnings.length, 0);
+  });
+});
+
+describe("makeCheckCommand() with `--check-overrides`", () => {
+  const manifest = {
+    name: "@rnx-kit/align-deps",
+    version: "0.0.1",
+    dependencies: { react: "18.1.0", "react-native": "^0.70.0" },
+    resolutions: { "react-native": "0.71.0" },
+    "rnx-kit": {
+      kitType: "app" as const,
+      alignDeps: {
+        requirements: ["react-native@0.70"],
+        capabilities: ["core"],
+      },
+    },
+  };
+
+  before(() => {
+    defineRequire("../../src/preset.ts", import.meta.url);
+  });
+
+  after(() => {
+    undefineRequire();
+    mockfs.__setMockContent({});
+    mockfs.__setMockFileWriter(() => undefined);
+  });
+
+  it("does not add a finalize step when `--check-overrides` is unspecified", () => {
+    const uncheckedCommand = makeCheckCommand({
+      ...defaultOptions,
+      checkOverrides: false,
+    });
+
+    ok(!uncheckedCommand.isRootCommand);
+    equal(uncheckedCommand.finalize, undefined);
+  });
+
+  it("adds a finalize step when `--check-overrides` is specified", () => {
+    const command = makeCheckCommand(defaultOptions);
+
+    ok(!command.isRootCommand);
+    equal(typeof command.finalize, "function");
+  });
+
+  it("never rewrites overrides, not even with `--write`", () => {
+    mockfs.__setMockContent({
+      ...manifest,
+      dependencies: { react: "18.1.0", "react-native": "^0.69.0" },
+    });
+
+    let updatedManifest = "";
+    mockfs.__setMockFileWriter((_, content) => {
+      updatedManifest = content.toString();
+    });
+
+    const options = { ...defaultOptions, write: true };
+    const result = checkPackageManifest(
+      "package.json",
+      options,
+      loadConfig("package.json", options, fs),
+      undefined,
+      fs
+    );
+
+    equal(result, "success");
+
+    const written = JSON.parse(updatedManifest);
+
+    deepEqual(written.resolutions, manifest.resolutions);
+    equal(written.dependencies["react-native"], "^0.70.0");
+  });
+});

--- a/scripts/rnx-align-deps.js
+++ b/scripts/rnx-align-deps.js
@@ -9,6 +9,7 @@ cli({
     "microsoft/react-native",
     fileURLToPath(new URL("align-deps-preset.cjs", import.meta.url)),
   ],
+  "check-overrides": true,
   "no-unmanaged": true,
   requirements: ["react-native@0.85"],
   write: process.argv.includes("--write"),


### PR DESCRIPTION
### Description

Added `--check-overrides` for warning about `resolutions`/`overrides` entries that pin a managed dependency outside the current profiles.

Resolves #492

### Test plan

Run `node --run rnx-align-deps` at root. Verify the warnings.